### PR TITLE
Harden cross-platform kernel builds and add boot-time configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ CMakeCache.txt
 CMakeFiles/
 Makefile
 *.cmake
+!cmake/toolchains/*.cmake
 cmake_install.cmake
 compile_commands.json
 .cache/

--- a/BUILD.md
+++ b/BUILD.md
@@ -65,6 +65,7 @@ Setting `CMAKE_SYSTEM_NAME=Generic` in the toolchain file is what prevents CMake
 cmake/toolchains/
   x86_64-elf.cmake   ← x86_64 bare-metal (QEMU)
   riscv64-elf.cmake  ← RISC-V 64-bit bare-metal (QEMU)
+  arm64-elf.cmake    ← ARM64 bare-metal (compile validation)
 ```
 
 ---
@@ -89,6 +90,12 @@ chmod +x tools/build.sh
 
 # Build RISC-V 64-bit
 ./tools/build.sh riscv64
+
+# Build ARM64 (compile-only scaffold)
+./tools/build.sh arm64
+
+# Override boot knobs
+./tools/build.sh x86_64 --boot-gui=OFF --hw=vm
 ```
 
 **Windows (PowerShell 5+ or pwsh)**
@@ -105,6 +112,12 @@ chmod +x tools/build.sh
 
 # Build RISC-V 64-bit
 .\tools\build.ps1 -Arch riscv64
+
+# Build ARM64 (compile-only scaffold)
+.\tools\build.ps1 -Arch arm64
+
+# Override boot knobs
+.\tools\build.ps1 -Arch x86_64 -BootGui OFF -HardwareProfile vm
 ```
 
 ---
@@ -167,11 +180,11 @@ qemu-system-riscv64 -machine virt \
 
 ## Supported Architectures
 
-| Arch      | Status                                    | QEMU Machine                        |
-| --------- | ----------------------------------------- | ----------------------------------- |
-| `x86_64`  | ✅ Active                                 | `qemu-system-x86_64 -kernel`        |
-| `riscv64` | 🔧 Planned (RISC-V SBI boot stub pending) | `qemu-system-riscv64 -machine virt` |
-| `arm64`   | 🔬 Experimental stub only                 | N/A                                 |
+| Arch      | Status                                     | QEMU Machine                        |
+| --------- | ------------------------------------------ | ----------------------------------- |
+| `x86_64`  | ✅ Active                                  | `qemu-system-x86_64 -kernel`        |
+| `riscv64` | ✅ Cross-compile validated                  | `qemu-system-riscv64 -machine virt` |
+| `arm64`   | ✅ Cross-compile validated (runtime pending) | N/A                                 |
 
 ---
 
@@ -188,3 +201,13 @@ qemu-system-riscv64 -machine virt \
 
 **Windows: `ninja` not found by CMake**
 → Install Ninja via winget (see above) or set path: `$env:Path += ";C:\path\to\ninja"`.
+
+
+## Boot-time configuration
+
+You can tune early boot behavior without source edits:
+
+- `BHARAT_BOOT_GUI` (`ON`/`OFF`): enables boot-to-GUI handoff metadata.
+- `BHARAT_BOOT_HW_PROFILE` (`generic`, `desktop`, `server`, `vm`, `laptop`): picks hardware profile compile definitions for boot policy and defaults.
+
+These are wired through both build scripts and raw CMake cache entries.

--- a/cmake/toolchains/arm64-elf.cmake
+++ b/cmake/toolchains/arm64-elf.cmake
@@ -1,0 +1,20 @@
+set(CMAKE_SYSTEM_NAME Generic)
+set(CMAKE_SYSTEM_PROCESSOR aarch64)
+
+set(CMAKE_C_COMPILER clang)
+set(CMAKE_ASM_COMPILER clang)
+set(CMAKE_LINKER ld.lld)
+
+set(CMAKE_C_COMPILER_TARGET aarch64-unknown-none-elf)
+set(CMAKE_ASM_COMPILER_TARGET aarch64-unknown-none-elf)
+
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS ON)
+
+set(CMAKE_C_FLAGS_INIT "-ffreestanding -fno-builtin -fno-stack-protector -fno-pic -fno-pie")
+set(CMAKE_ASM_FLAGS_INIT "-ffreestanding -fno-pic -fno-pie")
+
+set(CMAKE_EXE_LINKER_FLAGS_INIT "-fuse-ld=lld -nostdlib")

--- a/cmake/toolchains/riscv64-elf.cmake
+++ b/cmake/toolchains/riscv64-elf.cmake
@@ -1,0 +1,20 @@
+set(CMAKE_SYSTEM_NAME Generic)
+set(CMAKE_SYSTEM_PROCESSOR riscv64)
+
+set(CMAKE_C_COMPILER clang)
+set(CMAKE_ASM_COMPILER clang)
+set(CMAKE_LINKER ld.lld)
+
+set(CMAKE_C_COMPILER_TARGET riscv64-unknown-none-elf)
+set(CMAKE_ASM_COMPILER_TARGET riscv64-unknown-none-elf)
+
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS ON)
+
+set(CMAKE_C_FLAGS_INIT "-ffreestanding -fno-builtin -fno-stack-protector -fno-pic -fno-pie -mcmodel=medany")
+set(CMAKE_ASM_FLAGS_INIT "-ffreestanding -fno-pic -fno-pie")
+
+set(CMAKE_EXE_LINKER_FLAGS_INIT "-fuse-ld=lld -nostdlib")

--- a/cmake/toolchains/x86_64-elf.cmake
+++ b/cmake/toolchains/x86_64-elf.cmake
@@ -1,0 +1,20 @@
+set(CMAKE_SYSTEM_NAME Generic)
+set(CMAKE_SYSTEM_PROCESSOR x86_64)
+
+set(CMAKE_C_COMPILER clang)
+set(CMAKE_ASM_COMPILER clang)
+set(CMAKE_LINKER ld.lld)
+
+set(CMAKE_C_COMPILER_TARGET x86_64-unknown-none-elf)
+set(CMAKE_ASM_COMPILER_TARGET x86_64-unknown-none-elf)
+
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS ON)
+
+set(CMAKE_C_FLAGS_INIT "-ffreestanding -fno-builtin -fno-stack-protector -fno-pic -fno-pie -mno-red-zone")
+set(CMAKE_ASM_FLAGS_INIT "-ffreestanding -fno-pic -fno-pie")
+
+set(CMAKE_EXE_LINKER_FLAGS_INIT "-fuse-ld=lld -nostdlib")

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -1,16 +1,34 @@
 cmake_minimum_required(VERSION 3.20)
 project(BharatOS_Kernel C ASM)
 
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+
 # ── Toolchain file provides all compiler/linker settings.
 # Pass -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/<arch>-elf.cmake at configure time.
 # See BUILD.md for exact commands for each platform.
 
 include_directories(include)
 
+option(BHARAT_BOOT_GUI "Enable boot-time GUI handoff metadata" ON)
+set(BHARAT_BOOT_HW_PROFILE "generic" CACHE STRING "Boot hardware profile (generic, desktop, server, vm, laptop)")
+set_property(CACHE BHARAT_BOOT_HW_PROFILE PROPERTY STRINGS generic desktop server vm laptop)
+
+if(BHARAT_BOOT_GUI)
+    add_compile_definitions(BHARAT_BOOT_GUI=1)
+else()
+    add_compile_definitions(BHARAT_BOOT_GUI=0)
+endif()
+
+if(NOT BHARAT_BOOT_HW_PROFILE MATCHES "^(generic|desktop|server|vm|laptop)$")
+    message(FATAL_ERROR "Invalid BHARAT_BOOT_HW_PROFILE='${BHARAT_BOOT_HW_PROFILE}'. Allowed: generic, desktop, server, vm, laptop")
+endif()
+
+add_compile_definitions(BHARAT_BOOT_HW_PROFILE_${BHARAT_BOOT_HW_PROFILE}=1)
+
 # ── Architecture selection ──────────────────────────────────────────────────
 # Inferred from the toolchain file's CMAKE_SYSTEM_PROCESSOR, or set explicitly.
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "riscv")
-    set(ARCH "riscv")
+    set(ARCH "riscv64")
 elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
     set(ARCH "arm64")
 else()
@@ -21,12 +39,20 @@ endif()
 if(ARCH STREQUAL "x86_64")
     set(BOOT_SRC src/boot/x86_64/boot.S)
     set(ARCH_HAL src/hal/x86_64/hal_cpu.c)
-elseif(ARCH STREQUAL "riscv")
+elseif(ARCH STREQUAL "riscv64")
     set(BOOT_SRC "")  # RISC-V SBI boot stub — future milestone
     set(ARCH_HAL src/hal/riscv/hal_cpu.c)
 elseif(ARCH STREQUAL "arm64")
     set(BOOT_SRC "")  # ARM64 EFI boot stub — future milestone
     set(ARCH_HAL src/hal/arm64/hal_cpu.c)
+endif()
+
+if(ARCH STREQUAL "x86_64")
+    set(LINKER_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/linker.ld")
+elseif(ARCH STREQUAL "riscv64")
+    set(LINKER_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/linker_riscv64.ld")
+elseif(ARCH STREQUAL "arm64")
+    set(LINKER_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/linker_arm64.ld")
 endif()
 
 # ── Core kernel sources ──────────────────────────────────────────────────────
@@ -51,15 +77,26 @@ set_target_properties(kernel.elf PROPERTIES
 
 # Extra warnings for C sources only
 target_compile_options(kernel.elf PRIVATE
+    $<$<COMPILE_LANGUAGE:C>:-ffreestanding>
+    $<$<COMPILE_LANGUAGE:C>:-fno-builtin>
+    $<$<COMPILE_LANGUAGE:C>:-fno-stack-protector>
+    $<$<COMPILE_LANGUAGE:C>:-fno-pic>
     $<$<COMPILE_LANGUAGE:C>:-Wall>
     $<$<COMPILE_LANGUAGE:C>:-Wextra>
     $<$<COMPILE_LANGUAGE:C>:-Werror=implicit-function-declaration>
 )
 
+target_link_options(kernel.elf PRIVATE
+    "-nostdlib"
+    "-static"
+    "LINKER:-no-pie"
+    "LINKER:--fatal-warnings"
+)
+
 # Linker script
 # Linker script + options
 target_link_options(kernel.elf PRIVATE
-    "-T" "${CMAKE_CURRENT_SOURCE_DIR}/linker.ld"
-    "--build-id=none"
-    "--no-dynamic-linker"
+    "LINKER:-T,${LINKER_SCRIPT}"
+    "LINKER:--build-id=none"
+    "LINKER:--no-dynamic-linker"
 )

--- a/kernel/linker_arm64.ld
+++ b/kernel/linker_arm64.ld
@@ -1,0 +1,42 @@
+OUTPUT_FORMAT("elf64-littleaarch64")
+OUTPUT_ARCH(aarch64)
+ENTRY(kernel_main)
+
+SECTIONS
+{
+    . = 0x40080000;
+
+    .text ALIGN(4096) :
+    {
+        *(.text)
+        *(.text.*)
+    }
+
+    .rodata ALIGN(4096) :
+    {
+        *(.rodata)
+        *(.rodata.*)
+    }
+
+    .data ALIGN(4096) :
+    {
+        *(.data)
+        *(.data.*)
+    }
+
+    .bss ALIGN(4096) :
+    {
+        bss_start = .;
+        *(.bss)
+        *(.bss.*)
+        *(COMMON)
+        bss_end = .;
+    }
+
+    /DISCARD/ :
+    {
+        *(.comment)
+        *(.eh_frame)
+        *(.note*)
+    }
+}

--- a/kernel/linker_riscv64.ld
+++ b/kernel/linker_riscv64.ld
@@ -1,0 +1,42 @@
+OUTPUT_FORMAT("elf64-littleriscv")
+OUTPUT_ARCH(riscv)
+ENTRY(kernel_main)
+
+SECTIONS
+{
+    . = 0x80200000;
+
+    .text ALIGN(4096) :
+    {
+        *(.text)
+        *(.text.*)
+    }
+
+    .rodata ALIGN(4096) :
+    {
+        *(.rodata)
+        *(.rodata.*)
+    }
+
+    .data ALIGN(4096) :
+    {
+        *(.data)
+        *(.data.*)
+    }
+
+    .bss ALIGN(4096) :
+    {
+        bss_start = .;
+        *(.bss)
+        *(.bss.*)
+        *(COMMON)
+        bss_end = .;
+    }
+
+    /DISCARD/ :
+    {
+        *(.comment)
+        *(.eh_frame)
+        *(.note*)
+    }
+}

--- a/kernel/src/hal/arm64/hal_cpu.c
+++ b/kernel/src/hal/arm64/hal_cpu.c
@@ -17,6 +17,13 @@ void hal_cpu_disable_interrupts(void) {
     __asm__ volatile("msr daifset, #3");
 }
 
+
+void hal_send_ipi_payload(uint32_t target_core, uint64_t payload) {
+    (void)target_core;
+    (void)payload;
+    // TODO: wire to GIC SGI path for ARM64 SMP systems.
+}
+
 void hal_init(void) {
     // Set Vector Base Address Register (VBAR_EL1)
     // Configure MMU (TCR_EL1, MAIR_EL1)

--- a/kernel/src/main.c
+++ b/kernel/src/main.c
@@ -1,16 +1,37 @@
 #include "kernel.h"
 #include "hal/hal.h"
 
+static const char* kernel_boot_hw_profile(void) {
+#if defined(BHARAT_BOOT_HW_PROFILE_desktop)
+    return "desktop";
+#elif defined(BHARAT_BOOT_HW_PROFILE_server)
+    return "server";
+#elif defined(BHARAT_BOOT_HW_PROFILE_vm)
+    return "vm";
+#elif defined(BHARAT_BOOT_HW_PROFILE_laptop)
+    return "laptop";
+#else
+    return "generic";
+#endif
+}
+
 // Basic entry point for the microkernel
 void kernel_main(void) {
+    (void)kernel_boot_hw_profile();
+
     // 1. Initialize hardware architecture (CPU)
     hal_init();
 
+#if BHARAT_BOOT_GUI
+    // Boot GUI hand-off point for a future userspace compositor.
+    // Intentionally lightweight in ring-0 to preserve fast boot and small TCB.
+#endif
+
     // 2. Initialize memory management (Paging, Physical Allocator)
     // 3. Initialize IPC mechanisms and threading
-    
+
     // Halt the CPU loop
-    while(1) {
+    while (1) {
         hal_cpu_halt();
     }
 }

--- a/tools/build.ps1
+++ b/tools/build.ps1
@@ -12,12 +12,15 @@
     .\tools\build.ps1
     .\tools\build.ps1 -Arch riscv64
     .\tools\build.ps1 -Arch x86_64 -Clean -Run
+    .\tools\build.ps1 -Arch x86_64 -BootGui OFF -HardwareProfile vm
 #>
 param(
-    [ValidateSet("x86_64", "riscv64")]
+    [ValidateSet("x86_64", "riscv64", "arm64")]
     [string]$Arch = "x86_64",
     [switch]$Clean = $false,
-    [switch]$Run = $false
+    [switch]$Run = $false,
+    [ValidateSet("ON", "OFF")][string]$BootGui = "ON",
+    [ValidateSet("generic", "desktop", "server", "vm", "laptop")][string]$HardwareProfile = "generic"
 )
 
 Set-StrictMode -Version Latest
@@ -59,6 +62,8 @@ if (-not (Test-Path "$BuildDir\CMakeCache.txt")) {
         "-S", "$Root\kernel",
         "-B", $BuildDir,
         "-DCMAKE_TOOLCHAIN_FILE=$Toolchain",
+        "-DBHARAT_BOOT_GUI=$BootGui",
+        "-DBHARAT_BOOT_HW_PROFILE=$HardwareProfile",
         "-G", "Ninja",
         "--no-warn-unused-cli"
     )
@@ -79,7 +84,9 @@ if ($Run) {
     $qemuExe = switch ($Arch) {
         "x86_64" { "C:\Program Files\qemu\qemu-system-x86_64.exe" }
         "riscv64" { "C:\Program Files\qemu\qemu-system-riscv64.exe" }
+        "arm64" { "" }
     }
+    if ($Arch -eq "arm64") { fail "QEMU run is not wired for arm64 yet; build completed successfully." }
     if (-not (Test-Path $qemuExe)) { fail "QEMU not found at: $qemuExe" }
 
     Write-Host ""
@@ -89,6 +96,7 @@ if ($Run) {
     $qemuArgs = switch ($Arch) {
         "x86_64" { @("-kernel", $OutELF, "-m", "256M", "-nographic", "-serial", "mon:stdio", "-no-reboot") }
         "riscv64" { @("-machine", "virt", "-kernel", $OutELF, "-m", "256M", "-nographic", "-serial", "mon:stdio", "-no-reboot") }
+        "arm64" { @() }
     }
     & $qemuExe @qemuArgs
 }

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -2,10 +2,12 @@
 # tools/build.sh — Bharat-OS build + QEMU run script for Linux / macOS / WSL / BSD
 #
 # Usage:
-#   ./tools/build.sh                        # build x86_64 (default)
-#   ./tools/build.sh riscv64               # build RISC-V 64-bit
-#   ./tools/build.sh x86_64 --run          # build and boot in QEMU
-#   ./tools/build.sh x86_64 --clean --run  # clean build + QEMU
+#   ./tools/build.sh                                  # build x86_64 (default)
+#   ./tools/build.sh riscv64                         # build RISC-V 64-bit
+#   ./tools/build.sh arm64                           # build ARM64 (compile-only)
+#   ./tools/build.sh x86_64 --run                    # build and boot in QEMU
+#   ./tools/build.sh x86_64 --clean --run            # clean build + QEMU
+#   ./tools/build.sh x86_64 --boot-gui=ON --hw=vm    # configure boot knobs
 
 set -euo pipefail
 
@@ -15,10 +17,14 @@ if [ $# -ge 1 ]; then shift; SHIFT_DONE=true; fi
 
 CLEAN=false
 RUN=false
+BOOT_GUI="ON"
+BOOT_HW="generic"
 for arg in "$@"; do
     case "$arg" in
         --clean) CLEAN=true ;;
         --run)   RUN=true   ;;
+        --boot-gui=*) BOOT_GUI="${arg#*=}" ;;
+        --hw=*) BOOT_HW="${arg#*=}" ;;
     esac
 done
 
@@ -44,7 +50,8 @@ echo ""
 case "${ARCH}" in
     x86_64)  TOOLCHAIN="cmake/toolchains/x86_64-elf.cmake" ;;
     riscv64) TOOLCHAIN="cmake/toolchains/riscv64-elf.cmake" ;;
-    *)        err "Unknown arch: ${ARCH}. Supported: x86_64, riscv64" ;;
+    arm64)   TOOLCHAIN="cmake/toolchains/arm64-elf.cmake" ;;
+    *)        err "Unknown arch: ${ARCH}. Supported: x86_64, riscv64, arm64" ;;
 esac
 
 # ── Clean ────────────────────────────────────────────────────────────────────
@@ -59,6 +66,8 @@ if [ ! -f "${BUILD_DIR}/CMakeCache.txt" ]; then
     cmake -S "${BHARAT_ROOT}/kernel" \
           -B "${BUILD_DIR}" \
           -DCMAKE_TOOLCHAIN_FILE="${BHARAT_ROOT}/${TOOLCHAIN}" \
+          -DBHARAT_BOOT_GUI="${BOOT_GUI}" \
+          -DBHARAT_BOOT_HW_PROFILE="${BOOT_HW}" \
           -G Ninja \
           --no-warn-unused-cli
 fi
@@ -92,6 +101,9 @@ if [ "${RUN}" = "true" ]; then
                 -nographic \
                 -serial mon:stdio \
                 -no-reboot
+            ;;
+        arm64)
+            err "QEMU run is not wired for arm64 yet; build completed successfully."
             ;;
     esac
 fi


### PR DESCRIPTION
### Motivation
- Ensure the kernel reliably cross-compiles on Windows, Linux/WSL, and macOS and avoid host-specific linker/flag leakage by providing in-repo bare-metal toolchain files and per-arch linker scripts.
- Provide simple compile-time knobs to tune early boot behavior (GUI handoff and hardware profile) without changing source, so boot policy can be selected per-target/profile.
- Remove implicit x86_64 assumptions during cross-linking and make build scripts usable for `x86_64`, `riscv64` and an ARM64 compile-validation workflow.

### Description
- Added per-architecture bare-metal toolchain files under `cmake/toolchains/` (`x86_64-elf.cmake`, `riscv64-elf.cmake`, `arm64-elf.cmake`) that set `CMAKE_SYSTEM_NAME=Generic`, use Clang/LLD, and apply freestanding flags (e.g. `-ffreestanding`, `-fno-builtin`, `-fno-pic`, `-fno-pie`, `-mcmodel=medany` for RISC-V). 
- Hardened `kernel/CMakeLists.txt` by introducing `BHARAT_BOOT_GUI` and `BHARAT_BOOT_HW_PROFILE` knobs, aligning arch detection to `riscv64`, selecting arch-specific linker scripts via a `LINKER_SCRIPT` variable, and enforcing freestanding/static/no-pie link options for correct cross-arch linking.  
- Added two architecture linker scripts `kernel/linker_riscv64.ld` and `kernel/linker_arm64.ld` and updated linking to use the selected `LINKER_SCRIPT` to avoid incorrectly using the x86_64 layout for other targets. 
- Extended build scaffolding: updated `tools/build.sh` and `tools/build.ps1` to accept `arm64` (compile-only validation), pass the boot knobs (`--boot-gui` / `-BootGui` and `--hw` / `-HardwareProfile`) into CMake, and keep QEMU runtime execution limited to supported architectures. 
- Kept ring‑0 scope small by adding a compile-time boot profile hook in `kernel/src/main.c` (returns the selected `BHARAT_BOOT_HW_PROFILE`) and a conditional boot-to-GUI handoff marker guarded by `BHARAT_BOOT_GUI`. 
- Added an ARM64 `hal_send_ipi_payload` stub in `kernel/src/hal/arm64/hal_cpu.c` to satisfy IPC fast-path symbol resolution so ARM64 builds link cleanly until a runtime implementation is provided. 
- Tracked the new toolchain files in the repo and updated `.gitignore` to allow `cmake/toolchains/*.cmake`, and refreshed `BUILD.md` to document the new toolchains, ARM64 compile validation, and boot-time configuration options. 

### Testing
- Ran `bash ./tools/build.sh x86_64 --clean` and the build produced `build/x86_64/kernel.elf` successfully. (succeeded)
- Ran `bash ./tools/build.sh riscv64 --clean` and the cross-compile completed and produced `build/riscv64/kernel.elf`; addressed RISC-V relocation range by setting `-mcmodel=medany`. (succeeded)
- Ran `bash ./tools/build.sh arm64 --clean` as a compile-only validation and the cross-compile produced `build/arm64/kernel.elf` after adding the ARM64 HAL stub. (succeeded)

All automated build validations above completed and produced `kernel.elf` artifacts in this environment; QEMU runtime booting remains wired for `x86_64` and `riscv64` only, while `arm64` is compile-validated (runtime wiring pending).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab2909734c832083d752b784ac2699)