### PR TITLE
Add high-performance GUI model, HAL extensions for GPU and power, and driver-model patterns

### DIFF
--- a/docs/architecture/driver-model.md
+++ b/docs/architecture/driver-model.md
@@ -12,3 +12,37 @@ In Bharat-OS, **all device drivers execute strictly in unprivileged user-space (
 - **VMM/IOMMU Enforcement**: The IOMMU (Intel VT-d, AMD-Vi, ARM SMMU) is strictly configured by the microkernel to prevent malicious or malfunctioning devices from performing DMA (Direct Memory Access) attacks on arbitrary physical memory.
 - **IPC Wrapping**: Applications do not talk to hardware. They talk to the Driver Task via fast Synchronous IPC or URPC ring buffers.
 - **Recovery**: If a network driver crashes due to a vulnerability, the microkernel merely tears down the isolated task space and transparently restarts the driver. The core OS remains entirely unaffected.
+
+---
+
+
+## High-Performance Service Patterns
+
+### Message-based USB stack (plug-and-play safe)
+
+In line with ADR-003 multikernel messaging, USB is modeled as a distributed user-space service:
+
+- A root USB bus manager owns host-controller capabilities.
+- Each enumerated USB device is bound to a dedicated micro-driver thread/task.
+- Driver tasks communicate with the bus manager and clients over capability IPC/URPC queues.
+- A malfunctioning USB function driver can be restarted without taking down the entire I/O subsystem.
+
+### XDP-like network fast-path
+
+For high-throughput AI and storage traffic, NIC drivers may expose an early packet fast-path:
+
+- Stateless filters/classifiers execute at RX ingress before full protocol-stack handoff.
+- Eligible flows can be steered into zero-copy rings or direct service endpoints.
+- Non-matching traffic always falls back to the regular user-space network stack.
+
+This provides line-rate packet handling for simple routes without weakening isolation.
+
+### Automated HAL matching via capability tree
+
+Plug-and-play device bring-up is metadata-driven:
+
+- Device IDs (PCI/USB/ACPI/DT) are matched against a signed capability policy tree.
+- The kernel grants only the minimal capabilities required to the selected driver service.
+- Optional blocks (NPU, specialty USB controller, secondary NIC) remain inaccessible until matched and explicitly delegated.
+
+This keeps enumeration deterministic and least-privilege by default.

--- a/docs/architecture/gui-strategy.md
+++ b/docs/architecture/gui-strategy.md
@@ -20,6 +20,28 @@ The Bharat-OS microkernel provides **no graphics primitives**. A display server 
 
 ---
 
+
+## Performance Model for Deferred User-Space GUI
+
+To preserve microkernel isolation while delivering desktop/mobile-class graphics performance, Bharat-OS adopts a split execution model:
+
+1. **Zero-copy framebuffer sharing**
+   - GPU memory allocations remain kernel-tracked objects, but are exported to `fbsrv`/`bharat-wm` as revocable capabilities.
+   - User-space maps the shared surfaces directly and performs all scene graph + draw logic out of kernel.
+   - Buffer handoff between Wayland clients and compositor is done by shared memory handle passing (capability transfer), not memcpy.
+
+2. **Kernel compositing fast-path**
+   - Normal composition policy stays in user-space, but the kernel may expose a hardware-overlay submission fast-path for trivial layers (cursor plane, full-screen video plane, static background).
+   - This avoids extra round-trips for simple flips while still enforcing capability checks on which task can target which plane.
+
+3. **GPU-accelerated render backend**
+   - `gpu.h` HAL is expected to support explicit modern APIs (Vulkan-class queue model) so the compositor can do blur, transparency, and HiDPI scaling in shaders.
+   - Software fallback remains possible for bring-up, but not as the steady-state desktop/mobile path.
+
+This keeps GUI policy out of Ring-0 while allowing near-native throughput on modern SoCs.
+
+---
+
 ## Phase 1 — Framebuffer Output (Bring-up)
 
 The first graphics milestone is a simple linear framebuffer:

--- a/kernel/include/hal/gpu.h
+++ b/kernel/include/hal/gpu.h
@@ -4,8 +4,8 @@
 #include "hal/hal.h"
 #include "../advanced/formal_verif.h"
 
-/* 
- * GPU Hardware Abstraction Layer Base 
+/*
+ * GPU Hardware Abstraction Layer Base
  * GPUs are treated as peripheral compute nodes in Bharat-OS.
  */
 
@@ -16,15 +16,47 @@ typedef struct {
     void* mmio_base;
 } gpu_device_t;
 
+typedef enum {
+    GPU_API_NONE = 0,
+    GPU_API_VULKAN = 1,
+    GPU_API_MODERN_EXPLICIT = 2
+} gpu_api_t;
+
+typedef enum {
+    GPU_PLANE_PRIMARY = 0,
+    GPU_PLANE_OVERLAY = 1,
+    GPU_PLANE_CURSOR = 2
+} gpu_plane_t;
+
+typedef struct {
+    uint64_t phys_addr;
+    uint64_t size_bytes;
+    uint32_t width;
+    uint32_t height;
+    uint32_t stride;
+    uint32_t format;
+} gpu_buffer_t;
+
 // Discover available GPUs on the system bus (e.g., PCIe)
 int hal_gpu_enumerate(gpu_device_t* devices, int max_devices);
 
 // Initialize a specific GPU context
 int hal_gpu_init(gpu_device_t* gpu, capability_t* cap);
 
+// Query preferred user-space render API for this device (Vulkan-class expected)
+int hal_gpu_get_supported_api(gpu_device_t* gpu, gpu_api_t* out_api, capability_t* cap);
+
 // Basic graphics output (Framebuffer) if supported
 int hal_gpu_set_mode(gpu_device_t* gpu, uint32_t width, uint32_t height, uint32_t bpp);
 void* hal_gpu_get_framebuffer(gpu_device_t* gpu);
+
+// Allocate/share scanout-capable buffers with capability-controlled zero-copy mapping
+int hal_gpu_alloc_shared_buffer(gpu_device_t* gpu, gpu_buffer_t* out_buffer, uint32_t width, uint32_t height, uint32_t format, capability_t* cap);
+int hal_gpu_map_shared_buffer(gpu_device_t* gpu, gpu_buffer_t* buffer, void** out_user_ptr, capability_t* cap);
+int hal_gpu_present_buffer(gpu_device_t* gpu, gpu_buffer_t* buffer, capability_t* cap);
+
+// Optional compositing fast-path for simple overlay/cursor planes
+int hal_gpu_bind_plane(gpu_device_t* gpu, gpu_plane_t plane, gpu_buffer_t* buffer, capability_t* cap);
 
 // Submit raw compute queue standard instruction buffer (abstracted OpenCL/Vulkan backend queue)
 int hal_gpu_submit_compute(gpu_device_t* gpu, void* cmd_buffer, uint32_t size, capability_t* cap);

--- a/kernel/include/hal/power.h
+++ b/kernel/include/hal/power.h
@@ -2,6 +2,7 @@
 #define BHARAT_HAL_POWER_H
 
 #include <stdint.h>
+#include "../advanced/formal_verif.h"
 
 /*
  * Bharat-OS Intelligent Power Management Interface
@@ -12,14 +13,38 @@
 // Lower values indicate higher performance and power draw
 typedef uint32_t pstate_t;
 
+typedef enum {
+    POWER_DEVICE_CPU = 0,
+    POWER_DEVICE_GPU = 1,
+    POWER_DEVICE_NPU = 2,
+    POWER_DEVICE_USB = 3,
+    POWER_DEVICE_NIC = 4,
+    POWER_DEVICE_OTHER = 255
+} power_device_class_t;
+
+typedef struct {
+    uint32_t process_id;
+    uint32_t workload_class; // e.g., compiler, game, inference, idle
+    uint32_t latency_sensitivity;
+    uint32_t expected_burst_us;
+} dvfs_prediction_hint_t;
+
 // Set the CPU core P-state
 // Returns 0 on success, <0 on failure
 int hal_power_set_pstate(uint32_t core_id, pstate_t state);
+
+// Request predictive DVFS ramp-up/down from governor hints
+// Returns 0 on success, <0 on failure
+int hal_power_apply_dvfs_hint(uint32_t core_id, dvfs_prediction_hint_t* hint, capability_t* cap);
 
 // Completely gate the clock to a peripheral or capability block
 // to eliminate dynamic power consumption.
 // Returns 0 on success, <0 on failure
 int hal_power_clock_gate(uint32_t device_id, int enable);
+
+// Power gate a hardware block when no active capability lease exists.
+// Returns 0 on success, <0 on failure
+int hal_power_set_device_power_state(uint32_t device_id, power_device_class_t class_id, int powered_on, capability_t* cap);
 
 // Enter deeper sleep states (e.g. C-states in x86)
 // Returns 0 on success, <0 on failure


### PR DESCRIPTION
### Motivation
- Provide a concrete high-performance execution model for the deferred user-space GUI so compositors can reach near-native throughput while keeping policy out of Ring-0.
- Expose HAL surface and control points so user-space can perform GPU-accelerated rendering and kernel-assisted fast-path composition without leaking authority.
- Surface power-management primitives to enable predictive DVFS and capability-aware per-device gating, and document safer, high-throughput driver patterns (USB, NIC, PnP). 

### Description
- Add a `Performance Model for Deferred User-Space GUI` section to `docs/architecture/gui-strategy.md` describing zero-copy framebuffer sharing, a kernel overlay compositing fast-path, and expectations for a Vulkan-class render backend.
- Extend `docs/architecture/driver-model.md` with `High-Performance Service Patterns` describing a message-based USB micro-driver approach, an XDP-like NIC ingress fast-path, and metadata-driven HAL matching via a capability tree.
- Expand `kernel/include/hal/gpu.h` with explicit API discovery and zero-copy scanout buffer lifecycle types/functions including `gpu_api_t`, `gpu_buffer_t`, `hal_gpu_get_supported_api`, `hal_gpu_alloc_shared_buffer`, `hal_gpu_map_shared_buffer`, `hal_gpu_present_buffer`, and `hal_gpu_bind_plane` to enable shared scanout and overlay planes.
- Extend `kernel/include/hal/power.h` with predictive/DVFS and per-device power control types/functions including `power_device_class_t`, `dvfs_prediction_hint_t`, `hal_power_apply_dvfs_hint`, and `hal_power_set_device_power_state` for capability-aware power gating.

### Testing
- Ran configuration with `cmake -S . -B build`, which completed successfully.
- Attempted a parallel build with `cmake --build build -j4`, which failed due to unrelated repository baseline issues (missing `ai_sched.h` in `subsys` and a kernel link error) and not because of the header and doc changes in this patch.
- No unit tests were added or run; changes are API/documentation and header-surface only and do not implement runtime behavior yet.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab2be0813c8320bf98ead10e854915)