### PR TITLE
Add storage & sandbox strategy doc and VFS/sandbox policy primitives

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -23,6 +23,7 @@ This folder captures the current architectural baseline for Bharat-OS.
 - [`ipc-model.md`](ipc-model.md)
 - [`memory-model.md`](memory-model.md)
 - [`driver-model.md`](driver-model.md)
+- [`storage-and-sandbox-strategy.md`](storage-and-sandbox-strategy.md)
 - [`verification-scope.md`](verification-scope.md)
 
 ### User-space strategy and deferred surfaces

--- a/docs/architecture/storage-and-sandbox-strategy.md
+++ b/docs/architecture/storage-and-sandbox-strategy.md
@@ -1,0 +1,124 @@
+# Storage & Filesystem Strategy (Advanced)
+
+## Goals
+
+Bharat-OS should expose a single, capability-safe storage model that can host:
+
+1. **POSIX file systems** (ext-like, FAT-like, network FS).
+2. **Raw block storage** (NVMe namespaces, virtio-blk, flash translation layers).
+3. **Object/blob storage** (local content-addressed blobs and remote cloud buckets).
+4. **Application sandboxes** that can strictly limit path visibility, mutation, and storage classes.
+
+The design should keep Linux-personality compatibility while preserving microkernel isolation.
+
+## Layered model
+
+- **Layer 0: Device & transport**
+  - block: NVMe, virtio-blk, eMMC/UFS
+  - object transport: HTTP/S3-compatible gateways, cluster blob transport
+- **Layer 1: Storage service**
+  - provides normalized block and blob APIs to upper layers
+  - supports QoS classes (latency, throughput, burst)
+- **Layer 2: VFS core**
+  - unified namespace and descriptor model
+  - mount graph with per-mount capabilities
+- **Layer 3: Personality adapters**
+  - POSIX ABI adapter (`open/read/write/mmap/fcntl/stat`)
+  - optional Linux personality compatibility shims
+- **Layer 4: Sandbox policy engine**
+  - per-process mount namespaces
+  - path capabilities (read/write/exec/create/delete)
+  - storage-class allowlists (block/blob/fs)
+
+## Unifying block, blob, and filesystems
+
+### Block storage
+
+Treat block devices as first-class VFS nodes with explicit queue-depth and I/O mode hints:
+
+- `sync`, `direct`, `buffered`, `polling`
+- scheduler hints (`latency-first`, `throughput-first`)
+
+This allows one policy engine to manage both `/dev/nvme0n1` and mounted filesystems.
+
+### Blob storage
+
+Represent blobs using URI-backed mount points:
+
+- `/blob/local/<bucket>/<object-id>`
+- `/blob/remote/<provider>/<bucket>/<key>`
+
+Provide metadata-rich handles (etag, content hash, retention class).
+For POSIX apps, expose a compatibility projection:
+
+- read-only files as immutable objects
+- write flows via staged temp objects + commit/rename transaction
+
+### Multiple filesystem types
+
+Use a driver registry with capability descriptors:
+
+- supports journaling, snapshots, xattrs, ACLs, case-sensitivity, checksums
+- advertises whether it can back POSIX hard links, sparse files, `mmap`
+
+The VFS mount path negotiates required features from caller/sandbox policy against filesystem capabilities.
+
+## POSIX-first compatibility path
+
+Prioritize the minimum high-value POSIX set early:
+
+- file descriptors, `openat*`, `stat*`, `read/write/pread/pwrite`, `fcntl`
+- directories and `renameat2` semantics
+- symlink and hardlink behavior
+- robust errno mapping across native microkernel IPC
+
+Then phase in advanced features:
+
+- `mmap` consistency model
+- file locks (`flock`/`fcntl`)
+- async I/O (`io_uring`-like personality endpoint)
+
+## Sandboxing model for filesystem restriction
+
+Each sandbox context should carry filesystem policy in three dimensions:
+
+1. **Namespace view**: what mount roots are visible.
+2. **Path rights**: R/W/X/Create/Delete/Metadata per prefix.
+3. **Storage class rights**: whether block, blob, tmpfs, network FS are permitted.
+
+Recommended defaults:
+
+- deny block-device raw access unless explicitly granted
+- allow blob read for untrusted workloads, restrict blob write to designated buckets
+- force `noexec,nodev,nosuid` on writable app mounts
+
+## Innovative extensions
+
+1. **Capability-anchored mount tokens**
+   - mounts are created from signed capability tokens
+   - token includes TTL, allowed path prefix, and storage-class constraints
+2. **Intent-aware I/O contracts**
+   - application can declare workload intent (`db-log`, `media-stream`, `ml-checkpoint`)
+   - storage service maps intent to queue policy and caching strategy
+3. **Dual-path persistence**
+   - write critical metadata to local block journal + async blob checkpoint
+   - improves recovery and fleet portability
+4. **Policy-verifiable descriptors**
+   - file descriptors carry sandbox provenance tags
+   - kernel can prove an fd originated from an allowed namespace and mount policy
+
+## Suggested implementation milestones
+
+1. Extend VFS metadata to identify backend type (filesystem, block, blob).
+2. Add filesystem driver capability registry.
+3. Introduce sandbox filesystem policies with path-prefix rules.
+4. Implement mount namespace + mount option enforcement.
+5. Expand POSIX layer with `openat`/`statat` and errno parity tests.
+6. Add blob mount prototype with immutable object reads.
+
+## Success metrics
+
+- POSIX test subset pass rate for file and directory operations.
+- Measured policy enforcement coverage (blocked unauthorized path/storage accesses).
+- p99 latency targets for block and blob reads under sandbox constraints.
+- Reproducible crash recovery for mixed block+blob persistence mode.

--- a/kernel/include/fs/vfs.h
+++ b/kernel/include/fs/vfs.h
@@ -12,6 +12,33 @@
 
 typedef struct vfs_node vfs_node_t;
 
+// Backing storage class for a node/mount
+typedef enum {
+    VFS_BACKEND_FILESYSTEM = 0,
+    VFS_BACKEND_BLOCK,
+    VFS_BACKEND_BLOB,
+    VFS_BACKEND_PSEUDO
+} vfs_backend_type_t;
+
+// Mount feature capabilities for FS and storage providers
+typedef struct {
+    uint32_t supports_journaling;
+    uint32_t supports_snapshots;
+    uint32_t supports_xattrs;
+    uint32_t supports_acls;
+    uint32_t supports_posix_hardlinks;
+    uint32_t supports_sparse_files;
+    uint32_t supports_mmap;
+} vfs_feature_caps_t;
+
+// Driver descriptor used by VFS registration and mount negotiation
+typedef struct {
+    const char* name;
+    vfs_backend_type_t backend_type;
+    vfs_feature_caps_t features;
+} vfs_driver_info_t;
+
+
 // File operations function pointers (Linux inode_operations style)
 typedef struct {
     int (*read)(vfs_node_t* node, uint64_t offset, void* buffer, size_t size);
@@ -31,6 +58,7 @@ struct vfs_node {
     uint32_t gid;
     uint64_t size; // File size in bytes
     uint64_t inode; // FS specific inode number
+    vfs_backend_type_t backend_type; // Filesystem, block, blob, pseudo
     
     // Function table routing calls to the specific file system implementation
     vfs_operations_t* ops;
@@ -49,5 +77,11 @@ int vfs_mount(const char* target_path, vfs_node_t* fs_root);
 int vfs_open(const char* path, int flags);
 int vfs_read(int fd, void* buffer, size_t size);
 int vfs_write(int fd, const void* buffer, size_t size);
+
+// Register a filesystem/storage driver with the VFS core.
+int vfs_register_driver(const vfs_driver_info_t* info);
+
+// Lookup a registered driver descriptor by name.
+const vfs_driver_info_t* vfs_get_driver(const char* name);
 
 #endif // BHARAT_VFS_H

--- a/kernel/include/sandbox.h
+++ b/kernel/include/sandbox.h
@@ -25,6 +25,42 @@ typedef struct {
     int isolate_ipc;
 } namespace_config_t;
 
+
+// Filesystem/storage classes managed by sandbox policy
+typedef enum {
+    SANDBOX_STORAGE_FS = 0,
+    SANDBOX_STORAGE_BLOCK,
+    SANDBOX_STORAGE_BLOB,
+    SANDBOX_STORAGE_TMPFS,
+    SANDBOX_STORAGE_NETWORK_FS
+} sandbox_storage_class_t;
+
+// Path capability mask bits
+#define SANDBOX_PATH_READ      (1U << 0)
+#define SANDBOX_PATH_WRITE     (1U << 1)
+#define SANDBOX_PATH_EXEC      (1U << 2)
+#define SANDBOX_PATH_CREATE    (1U << 3)
+#define SANDBOX_PATH_DELETE    (1U << 4)
+#define SANDBOX_PATH_METADATA  (1U << 5)
+
+#define SANDBOX_MAX_PATH_RULES 16
+
+// Per-prefix filesystem rule
+typedef struct {
+    char prefix[128];
+    uint32_t allowed_ops_mask;
+} sandbox_path_rule_t;
+
+// Filesystem policy for mount/path/storage restrictions
+typedef struct {
+    uint32_t allowed_storage_classes_mask;
+    int enforce_noexec_on_writable_mounts;
+    int enforce_nodev_on_writable_mounts;
+    int enforce_nosuid_on_writable_mounts;
+    uint32_t path_rule_count;
+    sandbox_path_rule_t path_rules[SANDBOX_MAX_PATH_RULES];
+} sandbox_fs_policy_t;
+
 // Capability Security Context
 typedef struct {
     uint64_t allow_syscalls_mask;
@@ -34,6 +70,7 @@ typedef struct {
     
     namespace_config_t namespaces;
     resource_limits_t limits;
+    sandbox_fs_policy_t fs_policy;
 } sandbox_ctx_t;
 
 // Create a new strict security capability context
@@ -44,5 +81,11 @@ int sandbox_apply(kprocess_t* process, sandbox_ctx_t* ctx);
 
 // Verify if a process has a specific capability 
 int sandbox_check_capability(kprocess_t* process, uint64_t requested_capability);
+
+// Add or replace a path capability rule in a sandbox context.
+int sandbox_allow_path(sandbox_ctx_t* ctx, const char* prefix, uint32_t allowed_ops_mask);
+
+// Allow a storage class (filesystem/block/blob/tmpfs/network fs) in the sandbox.
+int sandbox_allow_storage_class(sandbox_ctx_t* ctx, sandbox_storage_class_t storage_class);
 
 #endif // BHARAT_SANDBOX_H


### PR DESCRIPTION
### Motivation
- Provide a unified storage model that supports POSIX filesystems, raw block devices, and object/blob stores while preserving microkernel isolation.
- Enable per-process sandboxing to restrict mount visibility, path-level rights, and allowed storage classes for stronger capability-based security.
- Prepare the VFS to negotiate features with diverse drivers and to project different storage backends into a single namespace for POSIX compatibility.

### Description
- Add an architecture design document `docs/architecture/storage-and-sandbox-strategy.md` that describes a layered model for block/blob/filesystem unification, sandbox policy, and suggested implementation milestones.
- Link the new strategy doc from the architecture index in `docs/architecture/README.md` for discoverability.
- Extend `kernel/include/fs/vfs.h` with `vfs_backend_type_t`, `vfs_feature_caps_t`, and `vfs_driver_info_t` plus registration/lookup APIs `vfs_register_driver` and `vfs_get_driver`, and add a `backend_type` field to `vfs_node_t` to identify backend kind.
- Extend `kernel/include/sandbox.h` with storage-class enum `sandbox_storage_class_t`, path capability mask definitions (`SANDBOX_PATH_*`), per-prefix rule type `sandbox_path_rule_t`, `sandbox_fs_policy_t` storage policy, add `fs_policy` to `sandbox_ctx_t`, and new helper APIs `sandbox_allow_path` and `sandbox_allow_storage_class`.

### Testing
- Ran the build with `cmake -S . -B build && cmake --build build -j2` which configured and compiled most targets but failed during final link of `kernel.elf` with the linker exiting non-zero. 
- Compilation produced only warnings prior to the linker failure, indicating the new headers integrate cleanly with existing translation units.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab2f34f6488320878c52f95cb94265)