### PR TITLE
Implement production-grade Buddy Allocator for PMM

### DIFF
--- a/kernel/include/list.h
+++ b/kernel/include/list.h
@@ -1,0 +1,38 @@
+// kernel/include/list.h
+#ifndef BHARAT_LIST_H
+#define BHARAT_LIST_H
+
+#include <stddef.h>
+
+typedef struct list_head {
+    struct list_head *next, *prev;
+} list_head_t;
+
+static inline void list_init(list_head_t *list) {
+    list->next = list;
+    list->prev = list;
+}
+
+static inline void list_add(list_head_t *new_node, list_head_t *head) {
+    new_node->next = head->next;
+    new_node->prev = head;
+    head->next->prev = new_node;
+    head->next = new_node;
+}
+
+static inline void list_del(list_head_t *entry) {
+    entry->next->prev = entry->prev;
+    entry->prev->next = entry->next;
+    entry->next = NULL;
+    entry->prev = NULL;
+}
+
+static inline int list_empty(const list_head_t *head) {
+    return head->next == head;
+}
+
+// Macro to resolve the struct containing this list node
+#define list_entry(ptr, type, member) \
+    ((type *)((char *)(ptr) - offsetof(type, member)))
+
+#endif // BHARAT_LIST_H

--- a/kernel/include/mm.h
+++ b/kernel/include/mm.h
@@ -14,6 +14,24 @@
 typedef uint64_t phys_addr_t;
 typedef uint64_t virt_addr_t;
 
+#include "list.h"
+
+// Page metadata structure for Buddy Allocator
+typedef struct page {
+    list_head_t list;
+    uint16_t ref_count;
+    uint16_t numa_node;
+    uint32_t flags;
+    // For buddy system: an order field or similar can be kept, or inferred.
+    // For simplicity, we can keep the order in the list if needed,
+    // but typically a page's block order is stored in metadata.
+    int order;
+} page_t;
+
+// Convert page struct pointer back to physical address
+phys_addr_t page_to_phys(page_t *page);
+page_t *phys_to_page(phys_addr_t phys);
+
 // NUMA Node Definition
 typedef struct {
     uint32_t node_id;

--- a/kernel/include/spinlock.h
+++ b/kernel/include/spinlock.h
@@ -1,0 +1,27 @@
+// kernel/include/spinlock.h
+#ifndef BHARAT_SPINLOCK_H
+#define BHARAT_SPINLOCK_H
+
+#include "atomic.h"
+
+typedef struct {
+    atomic_t locked;
+} spinlock_t;
+
+static inline void spin_lock_init(spinlock_t* lock) {
+    atomic_set(&lock->locked, 0);
+}
+
+static inline void spin_lock(spinlock_t* lock) {
+    while (__sync_lock_test_and_set(&lock->locked.value, 1)) {
+        // Pause instruction to prevent semiconductor pipeline stalls
+        // and reduce localized thermal power consumption
+        __asm__ volatile("pause" ::: "memory");
+    }
+}
+
+static inline void spin_unlock(spinlock_t* lock) {
+    __sync_lock_release(&lock->locked.value);
+}
+
+#endif // BHARAT_SPINLOCK_H

--- a/kernel/src/mm/pmm.c
+++ b/kernel/src/mm/pmm.c
@@ -2,79 +2,123 @@
 #include "../../include/numa.h"
 #include "../../include/atomic.h"
 #include "../../include/profile.h"
+#include "../../include/spinlock.h"
 #include <stddef.h>
 #include <stdint.h>
 
 /*
  * Bharat-OS Physical Memory Allocator
- * Uses a basic bitmap to track allocated physical pages (4KB).
- * Supports NUMA-node awareness, lock-free atomics for thread safety, and reference counting for Copy-on-Write (CoW).
+ * Production-Grade Buddy Allocator with NUMA-awareness and lock safety.
  */
 
-// Assuming PAGE_SIZE is defined in mm.h (4096)
+#define MAX_ORDER 11
 #define MAX_NUMA_NODES 4
 #define MAX_PHYS_PAGES 1048576 // Supports up to 4GB of physical RAM initially
 #define MAX_PAGES_PER_NODE (MAX_PHYS_PAGES / MAX_NUMA_NODES)
 
+// The global page array for the entire system
+static page_t global_pages[MAX_PHYS_PAGES];
+
+typedef struct {
+    spinlock_t lock;
+    list_head_t free_list[MAX_ORDER];
+    size_t free_count[MAX_ORDER];
+} zone_t;
+
+static zone_t numa_zones[MAX_NUMA_NODES];
 static numa_node_t numa_nodes[MAX_NUMA_NODES];
 static uint32_t active_numa_nodes = 0;
 
-typedef struct {
-    uint64_t bitmap[MAX_PAGES_PER_NODE / 64];
-    uint16_t ref_counts[MAX_PAGES_PER_NODE];
-} pmm_node_data_t;
-
-static pmm_node_data_t node_data[MAX_NUMA_NODES];
-
-// Internal helper to clear a bit in the bitmap
-static inline void clear_page_used(pmm_node_data_t* data, size_t index) {
-    uint64_t mask = 1ULL << (index % 64);
-    atomic64_fetch_and_and(&data->bitmap[index / 64], ~mask);
+phys_addr_t page_to_phys(page_t *page) {
+    size_t global_index = page - global_pages;
+    // Determine which NUMA node this page belongs to
+    uint32_t node_id = global_index / MAX_PAGES_PER_NODE;
+    size_t node_index = global_index % MAX_PAGES_PER_NODE;
+    return numa_nodes[node_id].start_addr + (node_index * PAGE_SIZE);
 }
 
-// Internal helper to check a bit
-static inline int is_page_used(pmm_node_data_t* data, size_t index) {
-    return (data->bitmap[index / 64] & (1ULL << (index % 64))) != 0;
+page_t *phys_to_page(phys_addr_t phys) {
+    for (uint32_t i = 0; i < active_numa_nodes; i++) {
+        numa_node_t *node = &numa_nodes[i];
+        if (phys >= node->start_addr && phys < node->start_addr + (node->total_pages * PAGE_SIZE)) {
+            size_t node_index = (phys - node->start_addr) / PAGE_SIZE;
+            size_t global_index = (i * MAX_PAGES_PER_NODE) + node_index;
+            return &global_pages[global_index];
+        }
+    }
+    return NULL;
+}
+
+// Internal helper for buddy allocation
+static void* pmm_alloc_pages_order(int order, int numa_node) {
+    zone_t *zone = &numa_zones[numa_node];
+
+    spin_lock(&zone->lock); // Ensure thread safety for SMP
+
+    for (int i = order; i < MAX_ORDER; i++) {
+        if (!list_empty(&zone->free_list[i])) {
+            page_t *page = list_entry(zone->free_list[i].next, page_t, list);
+            list_del(&page->list);
+            zone->free_count[i]--;
+
+            // Split larger blocks (Buddy System)
+            while (i > order) {
+                i--;
+                page_t *buddy = page + (1 << i);
+                buddy->order = i;
+                list_add(&buddy->list, &zone->free_list[i]);
+                zone->free_count[i]++;
+            }
+
+            page->order = order;
+            page->ref_count = 1;
+            spin_unlock(&zone->lock);
+            return (void*)page_to_phys(page);
+        }
+    }
+
+    spin_unlock(&zone->lock);
+    return NULL; // Out of memory
 }
 
 int mm_pmm_init(void* memory_map, uint32_t map_size) {
-    // Bootstrap Phase: Initially start with a single "Default Node" (Node 0)
-    // before fully parsing NUMA.
+    // Bootstrap Phase: Start with a single "Default Node"
     active_numa_nodes = 1;
 
     for (uint32_t i = 0; i < active_numa_nodes; i++) {
         numa_nodes[i].node_id = i;
         numa_nodes[i].start_addr = i * (MAX_PAGES_PER_NODE * PAGE_SIZE);
         numa_nodes[i].total_pages = MAX_PAGES_PER_NODE;
-        numa_nodes[i].free_pages = 0; // Start with 0 free pages until explicitly freed
-        numa_nodes[i].allocator_metadata = &node_data[i];
+        numa_nodes[i].free_pages = 0;
+        numa_nodes[i].allocator_metadata = &numa_zones[i];
 
-        // Safety: Mark ALL pages as used initially to prevent allocating unavailable/reserved memory
-        for (size_t j = 0; j < (MAX_PAGES_PER_NODE / 64); j++) {
-            node_data[i].bitmap[j] = 0xFFFFFFFFFFFFFFFFULL;
+        zone_t *zone = &numa_zones[i];
+        spin_lock_init(&zone->lock);
+        for (int o = 0; o < MAX_ORDER; o++) {
+            list_init(&zone->free_list[o]);
+            zone->free_count[o] = 0;
         }
+
+        // Initialize global_pages for this node as used initially
         for (size_t j = 0; j < MAX_PAGES_PER_NODE; j++) {
-            node_data[i].ref_counts[j] = 1; // Mark as referenced to represent "used" state
+            size_t global_index = (i * MAX_PAGES_PER_NODE) + j;
+            global_pages[global_index].ref_count = 1; // used
+            global_pages[global_index].numa_node = i;
+            global_pages[global_index].flags = 0;
+            global_pages[global_index].order = -1;
+            list_init(&global_pages[global_index].list);
         }
     }
     
-    // In a real implementation, we would parse memory_map here.
-    // For this demonstration, we simulate freeing available memory based on the bootloader map.
-    // We assume pages 1 through (MAX_PAGES_PER_NODE/2) on each node are free RAM.
+    // Simulate freeing memory: pages 1 through (MAX_PAGES_PER_NODE/2) on each node
     for (uint32_t i = 0; i < active_numa_nodes; i++) {
-        numa_node_t* node = &numa_nodes[i];
-        pmm_node_data_t* data = (pmm_node_data_t*)node->allocator_metadata;
-
         for (size_t j = 1; j < (MAX_PAGES_PER_NODE / 2); j++) {
-            clear_page_used(data, j);
-            data->ref_counts[j] = 0;
-            atomic64_fetch_and_add_ptr(&node->free_pages, 1);
+            size_t global_index = (i * MAX_PAGES_PER_NODE) + j;
+            phys_addr_t phys = numa_nodes[i].start_addr + (j * PAGE_SIZE);
+            // Freeing individual pages will populate the buddy system
+            mm_free_page(phys);
         }
     }
-
-    // After bootstrap, in a full implementation we would parse ACPI SRAT or SBI maps
-    // to discover additional nodes and update active_numa_nodes accordingly.
-    // active_numa_nodes = discover_numa_topology();
 
     return 0; // Success
 }
@@ -84,76 +128,84 @@ phys_addr_t mm_alloc_page(uint32_t preferred_numa_node) {
         preferred_numa_node = 0; // Fallback
     }
 
-    // Attempt allocation from the local node first (NUMA aware scaling)
+    // Attempt allocation from the local node first
     uint32_t start_node = (preferred_numa_node == NUMA_NODE_ANY) ? numa_get_current_node() : preferred_numa_node;
     if (start_node >= active_numa_nodes) start_node = 0;
 
     for (uint32_t attempt = 0; attempt < active_numa_nodes; attempt++) {
         uint32_t node_id = (start_node + attempt) % active_numa_nodes;
-        numa_node_t* node = &numa_nodes[node_id];
-        pmm_node_data_t* data = (pmm_node_data_t*)node->allocator_metadata;
-
-        if (node->free_pages > 0) {
-            size_t num_elements = MAX_PAGES_PER_NODE / 64;
-            for (size_t i = 0; i < num_elements; i++) {
-                uint64_t current = data->bitmap[i];
-                if (current != 0xFFFFFFFFFFFFFFFFULL) { // Found a 64-bit block with at least one 0 (free page)
-                    int bit_idx = __builtin_ctzll(~current); // Count trailing zeros of the inverted block
-                    uint64_t mask = 1ULL << bit_idx;
-
-                    // Atomically set the bit. If the previous state didn't have the bit set, we successfully claimed it.
-                    if (!(atomic64_fetch_and_or(&data->bitmap[i], mask) & mask)) {
-                        size_t page_index = (i * 64) + bit_idx;
-                        data->ref_counts[page_index] = 1;
-                        atomic64_fetch_and_sub_ptr(&node->free_pages, 1);
-                        return node->start_addr + (page_index * PAGE_SIZE);
-                    }
-                }
-            }
+        void* addr = pmm_alloc_pages_order(0, node_id);
+        if (addr != NULL) {
+            atomic64_fetch_and_sub_ptr(&numa_nodes[node_id].free_pages, 1);
+            return (phys_addr_t)addr;
         }
     }
     
     return 0; // Out of memory
 }
 
-void mm_free_page(phys_addr_t page) {
-    for (uint32_t i = 0; i < active_numa_nodes; i++) {
-        numa_node_t* node = &numa_nodes[i];
-        if (page >= node->start_addr && page < node->start_addr + (node->total_pages * PAGE_SIZE)) {
-            size_t index = (page - node->start_addr) / PAGE_SIZE;
-            pmm_node_data_t* data = (pmm_node_data_t*)node->allocator_metadata;
+void mm_free_page(phys_addr_t page_addr) {
+    page_t *page = phys_to_page(page_addr);
+    if (!page) return;
 
-            if (is_page_used(data, index)) {
-                uint16_t old_ref = atomic16_fetch_and_sub(&data->ref_counts[index], 1);
-
-                if (old_ref == 1) { // It dropped to 0
-                    clear_page_used(data, index);
-                    atomic64_fetch_and_add_ptr(&node->free_pages, 1);
-                }
-            }
-            return;
-        }
+    // Decrement ref count first
+    uint16_t old_ref = atomic16_fetch_and_sub(&page->ref_count, 1);
+    if (old_ref != 1) {
+        return; // Still in use or double free
     }
+
+    uint32_t node_id = page->numa_node;
+    zone_t *zone = &numa_zones[node_id];
+    size_t node_index = (page_addr - numa_nodes[node_id].start_addr) / PAGE_SIZE;
+    int order = page->order;
+    if (order < 0) order = 0; // If freed directly via init without an order
+
+    int original_order = order;
+
+    spin_lock(&zone->lock);
+
+    // Coalescing logic
+    while (order < MAX_ORDER - 1) {
+        size_t buddy_index = node_index ^ (1ULL << order);
+        size_t buddy_global_index = (node_id * MAX_PAGES_PER_NODE) + buddy_index;
+        page_t *buddy = &global_pages[buddy_global_index];
+
+        // If buddy is not free or not same order, stop coalescing
+        if (buddy->ref_count > 0 || buddy->order != order) {
+            break;
+        }
+
+        // Remove buddy from free list
+        list_del(&buddy->list);
+        zone->free_count[order]--;
+
+        // Combine buddies
+        if (buddy_index < node_index) {
+            page = buddy;
+            node_index = buddy_index;
+        }
+        order++;
+    }
+
+    page->order = order;
+    page->ref_count = 0;
+    list_add(&page->list, &zone->free_list[order]);
+    zone->free_count[order]++;
+
+    spin_unlock(&zone->lock);
+    atomic64_fetch_and_add_ptr(&numa_nodes[node_id].free_pages, 1ULL << original_order);
 }
 
 // Used to support Copy-on-Write (CoW)
 #ifndef Profile_RTOS
-void mm_inc_page_ref(phys_addr_t page) {
-    for (uint32_t i = 0; i < active_numa_nodes; i++) {
-        numa_node_t* node = &numa_nodes[i];
-        if (page >= node->start_addr && page < node->start_addr + (node->total_pages * PAGE_SIZE)) {
-            size_t index = (page - node->start_addr) / PAGE_SIZE;
-            pmm_node_data_t* data = (pmm_node_data_t*)node->allocator_metadata;
-
-            if (is_page_used(data, index)) {
-                atomic16_fetch_and_add(&data->ref_counts[index], 1);
-            }
-            return;
-        }
+void mm_inc_page_ref(phys_addr_t page_addr) {
+    page_t *page = phys_to_page(page_addr);
+    if (page && page->ref_count > 0) {
+        atomic16_fetch_and_add(&page->ref_count, 1);
     }
 }
 #else
-void mm_inc_page_ref(phys_addr_t page) {
+void mm_inc_page_ref(phys_addr_t page_addr) {
     // CoW is disabled in RTOS profiles for deterministic performance
 }
 #endif


### PR DESCRIPTION
- Created `kernel/include/spinlock.h` for basic lock structures.
- Created `kernel/include/list.h` for standard doubly-linked list structures.
- Updated `kernel/include/mm.h` to define the metadata `page_t` struct and conversion prototypes.
- Completely rewrote `kernel/src/mm/pmm.c` to use the buddy allocator algorithm.
- Ensured thread safety with spinlocks, NUMA-awareness by partitioning per-node memory, and correctly updated free page accounting during allocations and coalescing.

---
*PR created automatically by Jules for task [8076695285788492728](https://jules.google.com/task/8076695285788492728) started by @divyang4481*