### PR TITLE
Add cross-arch CMake presets, Shakti/OpenSBI RISC-V flow, kernel subsystems, unit tests and CI

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,4 @@
+Checks: '-*,bugprone-*,clang-analyzer-*,performance-*,portability-*'
+WarningsAsErrors: ''
+HeaderFilterRegex: 'kernel/include/.*|kernel/src/.*|tests/.*'
+FormatStyle: none

--- a/.github/workflows/kernel-ci.yml
+++ b/.github/workflows/kernel-ci.yml
@@ -1,0 +1,25 @@
+name: kernel-ci
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  kernel-and-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure x86_64 kernel build
+        run: cmake --preset x86_64-elf-debug
+      - name: Build kernel.elf
+        run: cmake --build --preset build-x86_64-kernel
+      - name: Configure host tests
+        run: cmake --preset tests-host
+      - name: Build host tests
+        run: cmake --build --preset build-tests
+      - name: Run unit tests
+        run: ctest --preset run-tests
+      - name: Configure clang-tidy check
+        run: cmake -S . -B build-tidy -DBHARAT_ENABLE_CLANG_TIDY=ON -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/x86_64-elf.cmake
+      - name: Build kernel with clang-tidy
+        run: cmake --build build-tidy --target kernel.elf

--- a/BUILD.md
+++ b/BUILD.md
@@ -1,6 +1,6 @@
 # Building Bharat-OS
 
-Bharat-OS uses **LLVM/Clang** and **LLD** exclusively (no GCC/GNU Make), keeping the entire toolchain MIT-permissive. Build scripts work identically on Windows, WSL, Linux, macOS, and BSD.
+Bharat-OS primarily uses **LLVM/Clang** + **LLD** for cross-arch reproducibility, with an optional **riscv64-unknown-elf-gcc** flow for Shakti/OpenSBI firmware packaging. Build scripts work identically on Windows, WSL, Linux, macOS, and BSD.
 
 ---
 
@@ -64,8 +64,9 @@ Setting `CMAKE_SYSTEM_NAME=Generic` in the toolchain file is what prevents CMake
 ```
 cmake/toolchains/
   x86_64-elf.cmake   ← x86_64 bare-metal (QEMU)
-  riscv64-elf.cmake  ← RISC-V 64-bit bare-metal (QEMU)
-  arm64-elf.cmake    ← ARM64 bare-metal (compile validation)
+  riscv64-elf.cmake      ← RISC-V 64-bit bare-metal (Clang/LLD)
+  riscv64-elf-gcc.cmake  ← RISC-V 64-bit bare-metal (GCC/OpenSBI payload flow)
+  arm64-elf.cmake        ← ARM64 bare-metal (compile validation)
 ```
 
 ---
@@ -122,20 +123,53 @@ chmod +x tools/build.sh
 
 ---
 
+
+### Option C — CMake Presets (cross-arch)
+
+The repository includes `CMakePresets.json` for cross compilation and tests:
+
+```bash
+# Configure and build x86_64 kernel
+cmake --preset x86_64-elf-debug
+cmake --build --preset build-x86_64-kernel
+
+# Configure and build riscv64 kernel
+cmake --preset riscv64-elf-debug
+cmake --build --preset build-riscv64-kernel
+
+# Shakti-focused RISC-V profiles (Clang/LLD)
+cmake --preset riscv64-shakti-e-debug && cmake --build --preset build-riscv64-shakti-e-kernel
+cmake --preset riscv64-shakti-c-debug && cmake --build --preset build-riscv64-shakti-c-kernel
+cmake --preset riscv64-shakti-i-debug && cmake --build --preset build-riscv64-shakti-i-kernel
+
+# Shakti/OpenSBI-friendly GCC presets (produces payload.bin)
+cmake --preset riscv64-elf-gcc-debug && cmake --build --preset build-riscv64-gcc-kernel
+cmake --preset riscv64-shakti-e-gcc-debug && cmake --build --preset build-riscv64-shakti-e-gcc-kernel
+
+# Configure and build arm64 kernel
+cmake --preset arm64-elf-debug
+cmake --build --preset build-arm64-kernel
+
+# Host unit tests
+cmake --preset tests-host
+cmake --build --preset build-tests
+ctest --preset run-tests
+```
+
 ### Option B — Raw CMake commands
 
 Same commands work on every platform:
 
 ```bash
 # x86_64
-cmake -S kernel -B build/x86_64 \
+cmake -S . -B build/x86_64 \
       -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/x86_64-elf.cmake \
       -G Ninja
 
 cmake --build build/x86_64 --target kernel.elf
 
 # RISC-V 64-bit
-cmake -S kernel -B build/riscv64 \
+cmake -S . -B build/riscv64 \
       -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/riscv64-elf.cmake \
       -G Ninja
 
@@ -145,7 +179,7 @@ cmake --build build/riscv64 --target kernel.elf
 On **Windows**, use the same commands from PowerShell — CMake finds Clang automatically from `C:\Program Files\LLVM\bin`. If Clang is not on `PATH`, pass the compiler explicitly:
 
 ```powershell
-cmake -S kernel -B build/x86_64 `
+cmake -S . -B build/x86_64 `
       -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/x86_64-elf.cmake `
       -DCMAKE_C_COMPILER="C:/Program Files/LLVM/bin/clang.exe" `
       -G Ninja
@@ -211,6 +245,38 @@ To run the AI governor in user space during development or testing:
 2. **Execute integration tests:** Run the tests located in the `tests/` directory (e.g., `test_ai_governor`) to verify IPC message formatting and URPC ring behavior before booting the full kernel image in QEMU.
 3. **Boot in Emulator:** Once built into the root filesystem image (pending storage subsystem availability), the microkernel will spawn the AI governor as a capability-restricted task upon boot.
 
+
+---
+
+
+## Shakti toolchain and OpenSBI packaging
+
+For Shakti boards, install the Shakti RISC-V toolchain (recommended prebuilt installer) and expose binaries in `PATH`:
+
+```bash
+# example: toolchain paths from shakti-tools installer
+export PATH=$PATH:/opt/shakti/riscv64/bin:/opt/shakti/riscv64/riscv64-unknown-elf/bin
+which riscv64-unknown-elf-gcc
+which riscv64-unknown-elf-objcopy
+```
+
+Build Bharat-OS payload artifacts for OpenSBI:
+
+```bash
+cmake --preset riscv64-shakti-e-gcc-debug
+cmake --build --preset build-riscv64-shakti-e-gcc-kernel
+# outputs kernel.elf + kernel.payload.bin
+```
+
+Package with OpenSBI (example):
+
+```bash
+# in opensbi checkout
+make PLATFORM=generic FW_PAYLOAD_PATH=/workspace/Bharat-OS/build-riscv64-shakti-e-gcc/kernel/kernel.elf
+# or use payload.bin in board-specific flash/image pipeline
+```
+
+At runtime OpenSBI passes `(hartid, fdt_ptr)` to Bharat-OS `_start` / `kernel_main` on RISC-V.
 
 ---
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,17 @@ else()
     message(STATUS "Configuring for DESKTOP profile. Enabling full subsystem capabilities.")
 endif()
 
+option(BHARAT_ENABLE_CLANG_TIDY "Enable clang-tidy static analysis for C targets" OFF)
+if(BHARAT_ENABLE_CLANG_TIDY)
+    find_program(BHARAT_CLANG_TIDY NAMES clang-tidy)
+    if(BHARAT_CLANG_TIDY)
+        set(CMAKE_C_CLANG_TIDY "${BHARAT_CLANG_TIDY}")
+        message(STATUS "clang-tidy enabled: ${BHARAT_CLANG_TIDY}")
+    else()
+        message(WARNING "BHARAT_ENABLE_CLANG_TIDY=ON but clang-tidy not found")
+    endif()
+endif()
+
 # Add subdirectories
 add_subdirectory(kernel)
 add_subdirectory(lib)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,177 @@
+{
+  "version": 6,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 20,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "x86_64-elf-debug",
+      "displayName": "x86_64 ELF Debug",
+      "generator": "Unix Makefiles",
+      "binaryDir": "${sourceDir}/build-x86_64",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/cmake/toolchains/x86_64-elf.cmake",
+        "BHARAT_KERNEL_HARDENING": "ON"
+      }
+    },
+    {
+      "name": "riscv64-elf-debug",
+      "displayName": "riscv64 ELF Debug",
+      "generator": "Unix Makefiles",
+      "binaryDir": "${sourceDir}/build-riscv64",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/cmake/toolchains/riscv64-elf.cmake",
+        "BHARAT_KERNEL_HARDENING": "ON"
+      }
+    },
+    {
+      "name": "arm64-elf-debug",
+      "displayName": "arm64 ELF Debug",
+      "generator": "Unix Makefiles",
+      "binaryDir": "${sourceDir}/build-arm64",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/cmake/toolchains/arm64-elf.cmake",
+        "BHARAT_KERNEL_HARDENING": "ON"
+      }
+    },
+    {
+      "name": "riscv64-shakti-e-debug",
+      "displayName": "riscv64 ELF Debug (Shakti E)",
+      "inherits": "riscv64-elf-debug",
+      "binaryDir": "${sourceDir}/build-riscv64-shakti-e",
+      "cacheVariables": {
+        "BHARAT_RISCV_SOC_PROFILE": "shakti-e"
+      }
+    },
+    {
+      "name": "riscv64-shakti-c-debug",
+      "displayName": "riscv64 ELF Debug (Shakti C)",
+      "inherits": "riscv64-elf-debug",
+      "binaryDir": "${sourceDir}/build-riscv64-shakti-c",
+      "cacheVariables": {
+        "BHARAT_RISCV_SOC_PROFILE": "shakti-c"
+      }
+    },
+    {
+      "name": "riscv64-shakti-i-debug",
+      "displayName": "riscv64 ELF Debug (Shakti I)",
+      "inherits": "riscv64-elf-debug",
+      "binaryDir": "${sourceDir}/build-riscv64-shakti-i",
+      "cacheVariables": {
+        "BHARAT_RISCV_SOC_PROFILE": "shakti-i"
+      }
+    },
+    {
+      "name": "tests-host",
+      "displayName": "Host unit tests",
+      "generator": "Unix Makefiles",
+      "binaryDir": "${sourceDir}/build-tests",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "riscv64-elf-gcc-debug",
+      "displayName": "riscv64 ELF Debug (GCC)",
+      "generator": "Unix Makefiles",
+      "binaryDir": "${sourceDir}/build-riscv64-gcc",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/cmake/toolchains/riscv64-elf-gcc.cmake",
+        "BHARAT_KERNEL_HARDENING": "ON",
+        "BHARAT_RISCV_BUILD_PAYLOAD_BIN": "ON"
+      }
+    },
+    {
+      "name": "riscv64-shakti-e-gcc-debug",
+      "displayName": "riscv64 ELF Debug (Shakti E, GCC)",
+      "inherits": "riscv64-elf-gcc-debug",
+      "binaryDir": "${sourceDir}/build-riscv64-shakti-e-gcc",
+      "cacheVariables": {
+        "BHARAT_RISCV_SOC_PROFILE": "shakti-e"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "build-x86_64-kernel",
+      "configurePreset": "x86_64-elf-debug",
+      "targets": [
+        "kernel.elf"
+      ]
+    },
+    {
+      "name": "build-riscv64-kernel",
+      "configurePreset": "riscv64-elf-debug",
+      "targets": [
+        "kernel.elf",
+        "kernel.payload.bin"
+      ]
+    },
+    {
+      "name": "build-arm64-kernel",
+      "configurePreset": "arm64-elf-debug",
+      "targets": [
+        "kernel.elf"
+      ]
+    },
+    {
+      "name": "build-riscv64-shakti-e-kernel",
+      "configurePreset": "riscv64-shakti-e-debug",
+      "targets": [
+        "kernel.elf",
+        "kernel.payload.bin"
+      ]
+    },
+    {
+      "name": "build-riscv64-shakti-c-kernel",
+      "configurePreset": "riscv64-shakti-c-debug",
+      "targets": [
+        "kernel.elf",
+        "kernel.payload.bin"
+      ]
+    },
+    {
+      "name": "build-riscv64-shakti-i-kernel",
+      "configurePreset": "riscv64-shakti-i-debug",
+      "targets": [
+        "kernel.elf",
+        "kernel.payload.bin"
+      ]
+    },
+    {
+      "name": "build-tests",
+      "configurePreset": "tests-host"
+    },
+    {
+      "name": "build-riscv64-gcc-kernel",
+      "configurePreset": "riscv64-elf-gcc-debug",
+      "targets": [
+        "kernel.elf",
+        "kernel.payload.bin"
+      ]
+    },
+    {
+      "name": "build-riscv64-shakti-e-gcc-kernel",
+      "configurePreset": "riscv64-shakti-e-gcc-debug",
+      "targets": [
+        "kernel.elf",
+        "kernel.payload.bin"
+      ]
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "run-tests",
+      "configurePreset": "tests-host",
+      "output": {
+        "outputOnFailure": true
+      }
+    }
+  ]
+}

--- a/cmake/toolchains/riscv64-elf-gcc.cmake
+++ b/cmake/toolchains/riscv64-elf-gcc.cmake
@@ -1,0 +1,27 @@
+set(CMAKE_SYSTEM_NAME Generic)
+set(CMAKE_SYSTEM_PROCESSOR riscv64)
+
+# GCC bare-metal RISC-V toolchain (Shakti/OpenSBI friendly)
+set(CMAKE_C_COMPILER riscv64-unknown-elf-gcc)
+set(CMAKE_ASM_COMPILER riscv64-unknown-elf-gcc)
+
+find_program(BHARAT_RISCV_GCC_LD NAMES riscv64-unknown-elf-ld)
+if(BHARAT_RISCV_GCC_LD)
+    set(CMAKE_LINKER "${BHARAT_RISCV_GCC_LD}")
+endif()
+
+find_program(BHARAT_RISCV_GCC_OBJCOPY NAMES riscv64-unknown-elf-objcopy)
+if(BHARAT_RISCV_GCC_OBJCOPY)
+    set(CMAKE_OBJCOPY "${BHARAT_RISCV_GCC_OBJCOPY}")
+endif()
+
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS ON)
+
+set(CMAKE_C_FLAGS_INIT "-ffreestanding -fno-builtin -fno-stack-protector -fno-pic -fno-pie")
+set(CMAKE_ASM_FLAGS_INIT "-ffreestanding -fno-pic -fno-pie")
+
+set(CMAKE_EXE_LINKER_FLAGS_INIT "-nostdlib")

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -23,10 +23,16 @@ This folder captures the current architectural baseline for Bharat-OS.
 - [`capability-model.md`](capability-model.md)
 - [`kernel-object-model.md`](kernel-object-model.md)
 - [`ipc-model.md`](ipc-model.md)
+- [`capability-and-ipc-baseline.md`](capability-and-ipc-baseline.md)
 - [`memory-model.md`](memory-model.md)
+- [`multiprocessor-and-numa-baseline.md`](multiprocessor-and-numa-baseline.md)
+- [`scheduler-and-threading.md`](scheduler-and-threading.md)
+- [`syscall-trap-gates.md`](syscall-trap-gates.md)
 - [`driver-model.md`](driver-model.md)
+- [`hardware-abstraction-and-drivers-baseline.md`](hardware-abstraction-and-drivers-baseline.md)
 - [`storage-and-sandbox-strategy.md`](storage-and-sandbox-strategy.md)
 - [`verification-scope.md`](verification-scope.md)
+- [`threat-model-and-mac.md`](threat-model-and-mac.md)
 
 ### User-space strategy and deferred surfaces
 

--- a/docs/architecture/boot-flow-riscv64.md
+++ b/docs/architecture/boot-flow-riscv64.md
@@ -23,3 +23,14 @@ Unlike x86, RISC-V enforces strict privilege levels (M-Mode, S-Mode, U-Mode). Th
    - Uses `sbi_send_ipi` `ecall` to wake up secondary HARTs (Multicore Boot).
    - Starts the Root User Task.
 5. **Root Task Handover**: The capability system takes over execution, proceeding similarly to x86.
+
+
+## Shakti BSP baseline (E/C/I class)
+
+Current code includes a board-profile baseline used during early S-mode bring-up:
+
+- `BHARAT_RISCV_SOC_PROFILE` selects `qemu-virt`, `shakti-e`, `shakti-c`, or `shakti-i` at configure time.
+- `hal_init()` resolves a profile-specific BSP descriptor (UART/PLIC/CLINT/DRAM ranges) and stores it as active board config.
+- `kernel_main(hartid, fdt_ptr)` now consumes OpenSBI boot arguments and passes them to HAL boot-info tracking.
+
+This is intentionally a transition layer while full DTB parsing and page-table-backed MMIO mapping are completed.

--- a/docs/architecture/capability-and-ipc-baseline.md
+++ b/docs/architecture/capability-and-ipc-baseline.md
@@ -1,0 +1,39 @@
+# Capability and IPC Baseline (v1)
+
+This document summarizes the current kernel baseline for capability tables and IPC.
+
+## Capability tables
+
+- Per-process capability table (`capability_table_t`) allocated during `process_create`.
+- Capability entries include:
+  - object type,
+  - object reference,
+  - fine-grained rights (`SEND`, `RECEIVE`, `MAP`, `UNMAP`, `SCHEDULE`, `DELEGATE`).
+- Delegation support enforces right reduction (`cap_table_delegate` requires delegated rights to be a subset of source rights).
+
+## IPC models
+
+### 1. Synchronous endpoint IPC
+
+- Endpoint create API grants two capabilities:
+  - sender capability (`CAP_PERM_SEND`),
+  - receiver capability (`CAP_PERM_RECEIVE`).
+- `ipc_endpoint_send` and `ipc_endpoint_receive` perform capability lookup + rights checks.
+- Blocking behavior baseline:
+  - send to full endpoint => `IPC_ERR_WOULD_BLOCK` and current thread marked blocked,
+  - receive on empty endpoint => `IPC_ERR_WOULD_BLOCK` and current thread marked blocked.
+
+### 2. Asynchronous URPC rings
+
+- URPC ring init enforces minimum capacity and non-null backing storage.
+- Send/receive validate ring configuration and return typed status codes (`URPC_ERR_INVALID`, `URPC_ERR_EMPTY`, `URPC_ERR_FULL`).
+
+## User-space syscall API surface
+
+- Endpoint create/send/receive are exposed as syscall IDs and wrapped by user header API (`lib/include/ipc_user.h`).
+
+## Deferred for production
+
+- Multi-receiver endpoint queues and wake-up lists.
+- Cross-process capability transfer policy and revocation.
+- Capability-backed shared-memory channels and zero-copy user rings.

--- a/docs/architecture/hardware-abstraction-and-drivers-baseline.md
+++ b/docs/architecture/hardware-abstraction-and-drivers-baseline.md
@@ -1,0 +1,28 @@
+# Hardware Abstraction and Driver Baseline (v1)
+
+This document captures the current HAL and driver-framework baseline in kernel space.
+
+## Implemented baseline
+
+- Interrupt path scaffolding:
+  - architecture hook for interrupt-controller initialization (`hal_interrupt_controller_init`),
+  - IRQ route API (`hal_interrupt_route`),
+  - common IRQ handler registration/dispatch table (`hal_interrupt_register`, `hal_interrupt_dispatch`).
+- Timer path scaffolding:
+  - architecture hook for timer source setup (`hal_timer_source_init`),
+  - common monotonic tick accounting (`hal_timer_tick`, `hal_timer_monotonic_ticks`).
+- Generic device framework:
+  - driver registration API (`device_register_driver`),
+  - MMIO window registry and lookup (`device_register_mmio_window`, `device_lookup_mmio_window`),
+  - generic IRQ fanout (`device_dispatch_irq`).
+- Built-in baseline drivers/windows:
+  - UART/SPI/I2C/SDMMC/Ethernet driver records,
+  - Ethernet RX/TX MMIO window registration for NIC IDs.
+- Zero-copy NIC integration now resolves MMIO windows through device framework lookups instead of local hardcoded tables.
+
+## Deferred for production
+
+- Full APIC/IOAPIC implementation on x86 and PLIC/CLINT routing on RISC-V.
+- Real periodic timer programming and interrupt ack paths.
+- Driver-domain isolation and user-space driver process boundaries.
+- Runtime hardware discovery from ACPI/FDT instead of static built-in tables.

--- a/docs/architecture/multiprocessor-and-numa-baseline.md
+++ b/docs/architecture/multiprocessor-and-numa-baseline.md
@@ -1,0 +1,28 @@
+# Multiprocessor and NUMA Baseline (v1)
+
+This document captures the current multiprocessor/NUMA baseline for Bharat-OS.
+
+## Implemented baseline
+
+- Secondary-core boot hook:
+  - `mk_boot_secondary_cores(core_count)` invokes platform multicore boot path.
+  - On RISC-V builds, `multicore_boot_secondary_cores` uses OpenSBI `sbi_send_ipi` to wake secondary HARTs.
+- Per-core URPC channel matrix:
+  - `mk_init_per_core_channels(core_count, ring_size)` builds sender->receiver channels.
+  - `mk_get_channel(sender, receiver)` retrieves typed channel handles.
+- Lockless URPC robustness:
+  - strict ring validation (non-null buffer, min capacity),
+  - typed errors for invalid/full/empty/no-channel,
+  - wrap-around-safe ring indexing.
+- Scalable message allocator baseline:
+  - core-local message pool (`mk_msg_pool_t`) with alloc/free APIs for URPC producers.
+- NUMA descriptors:
+  - `numa_node_descriptor_t` with node memory range and CPU counts,
+  - APIs for set/get descriptors and active-node counting.
+
+## Deferred for production
+
+- Real AP startup sequencing (x86 SIPI/SIPI) and per-hart handshake barriers.
+- Dynamic SRAT/FDT NUMA topology parsing and distance matrix population.
+- Per-node scheduler queues and memory-placement policies.
+- Cross-node URPC transport tuning and backpressure controls.

--- a/docs/architecture/scheduler-and-threading.md
+++ b/docs/architecture/scheduler-and-threading.md
@@ -1,0 +1,26 @@
+# Scheduler and Threading Baseline (v1)
+
+This document captures the current baseline implementation for scheduler/threading in the kernel.
+
+## Implemented in this baseline
+
+- Static in-kernel process/thread registries.
+- Thread control block (TCB) metadata including:
+  - architectural context pointer,
+  - priority/base priority,
+  - scheduling state,
+  - capability list hook pointer,
+  - time-slice accounting.
+- Round-robin dispatch with timer-tick driven preemption (`sched_on_timer_tick`).
+- Scheduler policy switch interface (`sched_set_policy`) with baseline RR behavior.
+- Thread lifecycle operations:
+  - `thread_create`, `thread_destroy`,
+  - syscall-style wrappers `sched_sys_thread_create`, `sched_sys_thread_destroy`.
+- Context-switch hook integration via `fv_secure_context_switch` when available.
+
+## Deferred for production
+
+- Architecture-specific register save/restore and user-mode transitions.
+- Real per-core run queues and SMP load balancing.
+- Hardware timer interrupt source integration (APIC/CLINT/PLIC path).
+- Full capability-list management and per-thread security context linkage.

--- a/docs/architecture/syscall-trap-gates.md
+++ b/docs/architecture/syscall-trap-gates.md
@@ -1,0 +1,33 @@
+# Syscall and Trap Gate Baseline (v1)
+
+This document defines the current in-kernel syscall/trap gate contract.
+
+## Implemented baseline
+
+- Central trap frame model (`trap_frame_t`) with register argument ABI slots.
+- Syscall number space (`syscall_id_t`) for privileged kernel operations:
+  - thread create/destroy,
+  - scheduler yield,
+  - VMM map/unmap,
+  - capability invoke hook,
+  - endpoint create/send/receive,
+  - capability delegation.
+- Dispatcher (`syscall_dispatch`) with per-call parameter validation.
+- Trap handler (`trap_handle`) with:
+  - cause filtering,
+  - user-mode privilege check,
+  - return code propagation to ABI return register,
+  - architecture-aware PC advance after syscall.
+- Boot-time trap gate setup via `trap_init()` from `kernel_main`.
+
+## Security baseline checks
+
+- Reject non-user trap-originated syscall attempts.
+- Reject unsupported syscall IDs with explicit `-ENOSYS`-style code.
+- Validate user pointer range before writing syscall outputs.
+
+## Deferred for production
+
+- Assembly entry stubs per architecture (x86_64 IDT/syscall entry, RISC-V `stvec`).
+- Fine-grained capability policy enforcement in `cap_invoke` path.
+- Full trap delegation verification and interrupt controller integration.

--- a/docs/architecture/threat-model-and-mac.md
+++ b/docs/architecture/threat-model-and-mac.md
@@ -1,0 +1,59 @@
+# Bharat-OS Threat Model and Mandatory Access Control (MAC) Baseline
+
+This document defines the minimum security model expected for production Bharat-OS kernels.
+
+## Threat model
+
+### Assets
+
+- Kernel integrity (text, data, control flow).
+- Capability table integrity and rights boundaries.
+- Task isolation for memory mappings and IPC channels.
+- Driver isolation and MMIO mapping boundaries.
+
+### Adversaries
+
+- Compromised user-space task attempting privilege escalation.
+- Malicious or buggy driver task trying to access unauthorized MMIO or DMA surfaces.
+- Faulty kernel client abusing IPC and memory APIs with malformed parameters.
+
+### Security objectives
+
+- **Least privilege**: all privileged operations gated by capabilities.
+- **Complete mediation**: every map/unmap/send/receive path validates rights and bounds.
+- **Fail closed**: invalid arguments return explicit errors and do not mutate state.
+- **Containment**: failures in a task/driver domain must not corrupt global kernel state.
+
+## MAC baseline policy
+
+### Labels and domains
+
+Each task belongs to a security domain label:
+
+- `domain::kernel`
+- `domain::driver::<class>`
+- `domain::service::<name>`
+- `domain::app::<name>`
+
+### Enforcement rules
+
+1. Capability invocation is denied unless the capability label dominates the caller's domain policy.
+2. Device MMIO mapping requires both capability rights and an allowed `(domain, device_id)` pair.
+3. Endpoint IPC is denied unless sender and receiver domains match an allow-rule in policy.
+4. Capability delegation can only reduce rights (never amplify rights or widen domain access).
+
+### Audit requirements
+
+The kernel should emit auditable events for:
+
+- denied capability invocation,
+- denied MMIO mapping,
+- denied IPC delivery,
+- repeated malformed API usage (potential abuse).
+
+## Implementation checklist
+
+- [ ] Define per-task domain labels in scheduler/task metadata.
+- [ ] Add policy evaluator on capability invocation and IPC send paths.
+- [ ] Add `(device_id, domain)` checks in zero-copy/MMIO mapping paths.
+- [ ] Add structured audit event record format and sink.

--- a/docs/architecture/verification-scope.md
+++ b/docs/architecture/verification-scope.md
@@ -35,3 +35,16 @@ For v1, we explicitly **do not** formally verify:
 - ML-Heuristic Daemons.
 - Linux Subsystem translating daemons.
   These are considered untrusted user-space applications and are strictly contained by the capability system enforced by the verified TCB.
+
+
+## Living verification hooks
+
+Current CI-oriented checks for Tier-A baseline:
+
+- unit tests for early allocator, URPC ring, scheduler, trap/syscall path, capability+endpoint IPC, device framework, and multikernel topology,
+- optional `clang-tidy` static-analysis build path (`BHARAT_ENABLE_CLANG_TIDY`),
+- cross-target CMake presets for x86_64/riscv64/arm64 kernel builds.
+
+- integration-style Tier-A syscall/IPC/thread lifecycle test (`test_tier_a_integration`).
+- Shakti profile compile presets (`riscv64-shakti-{e,c,i}-debug`) to validate BSP-profile build wiring.
+- RISC-V/OpenSBI payload artifact generation (`kernel.payload.bin`) for Shakti-targeted preset builds.

--- a/docs/reviews/current-implementation-review.md
+++ b/docs/reviews/current-implementation-review.md
@@ -1,136 +1,59 @@
-# Current Implementation Review (Bugs & Missing Implementations)
+# Current Implementation Review (Status + Remaining Gaps)
 
-This review summarizes concrete issues observed in the current Bharat-OS codebase and proposes implementation priorities.
+This review tracks the implementation state of Bharat-OS and prioritizes what remains for production readiness.
 
-## 1) Build-breaking POSIX type redefinition
+## Recently addressed
 
-### What is wrong
-`lib/posix/include/unistd.h` includes `<stddef.h>` and then redefines `size_t` as `unsigned int`, which conflicts with the compiler-provided definition (`long unsigned int` on x86_64).
+1. **POSIX typedef conflict (`size_t`)**
+   - `lib/posix/include/unistd.h` now relies on `<stddef.h>` for `size_t` and centralizes POSIX scalar typedefs through freestanding `lib/posix/include/sys/types.h`.
 
-### Evidence
-- Build fails with: `conflicting types for 'size_t'`.
-- `unistd.h` currently has `typedef unsigned int size_t;`.
+2. **Kernel compile flag list handling**
+   - Kernel CMake uses per-flag list entries in `target_compile_options` / `target_link_options`.
 
-### Suggested implementation
-- Remove the local `size_t` typedef from `unistd.h`.
-- Keep `ssize_t` only if the project guarantees no system headers provide it in freestanding mode, otherwise guard it as well.
+3. **Boot sequencing beyond HAL-only bring-up**
+   - Boot flow now includes PMM/VMM init, NUMA discovery, SMP bootstrap call path, per-core URPC setup, scheduler, trap gate, timer/device framework setup.
 
-### Priority
-**P0** (prevents successful build in current environment).
+4. **URPC API validation and typed errors**
+   - Ring init/send/receive validate configuration and return explicit typed errors.
 
----
+5. **Zero-copy NIC mapping path**
+   - NIC mapping resolves MMIO windows from the device framework registry and performs VMM map/unmap rollback on partial failure.
 
-## 2) Kernel build flags are passed as one combined argument
+6. **RISC-V Shakti BSP baseline wiring**
+   - Added board-profile descriptors (`shakti-e/c/i`) and propagated OpenSBI `(hartid, fdt_ptr)` boot arguments into HAL initialization.
 
-### What is wrong
-The kernel CMake target passes architecture flags as a single string (`"-m64 -mno-red-zone -mno-mmx -mno-sse -mno-sse2"`). GCC treats this as one option and fails to parse it.
+7. **OpenSBI payload build path**
+   - Added RISC-V `kernel.payload.bin` generation and GCC toolchain/preset path for `riscv64-unknown-elf-*` workflows.
 
-### Evidence
-- Build fails with: `unrecognized command-line option '-m64 -mno-red-zone -mno-mmx -mno-sse -mno-sse2'`.
+## High-priority remaining gaps
 
-### Suggested implementation
-- In `kernel/CMakeLists.txt`, pass each flag as an individual list element.
-  - Example: `target_compile_options(... PRIVATE -ffreestanding -nostdlib -Wall -Wextra -m64 -mno-red-zone -mno-mmx -mno-sse -mno-sse2)`.
-- Keep architecture-specific flags inside per-ARCH branches if needed.
+### P1 — Architecture trap and interrupt entry completeness
 
-### Priority
-**P0** (prevents kernel object compilation).
+- x86_64 IDT/syscall entry stubs and full APIC/IOAPIC programming remain incomplete.
+- RISC-V `stvec` trap entry plumbing and full PLIC/CLINT routing policy remain incomplete.
+- ARM64 vector/GIC bring-up is still baseline-only.
 
----
+### P1 — Scheduler/runtime depth
 
-## 3) Kernel boot path never initializes memory or IPC subsystems
+- Scheduler still uses static in-kernel slot arrays with no full context-save/restore assembly implementation.
+- No per-core runqueue/NUMA-aware placement policy yet.
 
-### What is wrong
-`kernel_main()` currently calls `hal_init()` and then halts forever; memory manager and IPC/threading initialization are comments only.
+### P2 — Memory subsystem depth
 
-### Risk
-- Any code expecting PMM/VMM/IPC runtime state will fail or be unusable after boot.
-- System cannot progress beyond a minimal “CPU initialized” state.
+- VMM remains a software mapping registry baseline and not a complete page-table manager across all architectures.
 
-### Suggested implementation
-- Add explicit boot init sequence with return-code checks:
-  1. `mm_pmm_init(...)`
-  2. `vmm_init()`
-  3. IPC init (`urpc_init`/channel setup entry point)
-  4. Scheduler/thread bootstrap
-- Add a `kernel_panic()` path if any required init fails.
+### P2 — Capability policy and MAC enforcement depth
 
-### Priority
-**P1** (major missing implementation in core boot flow).
+- Capability table and delegation baseline exists, but no full policy engine/audit sink integration is in place.
 
----
+## Validation checklist (living)
 
-## 4) URPC ring API lacks capacity validation and has inconsistent error semantics
-
-### What is wrong
-- `urpc_init_ring()` accepts `ring_size` without validation.
-- `urpc_send()` uses modulo by `ring->capacity`; if capacity is 0, behavior is undefined.
-- Null argument errors in `urpc_send()` return `URPC_ERR_EMPTY`, conflating invalid arguments and empty queue state.
-
-### Risk
-- Division/modulo by zero and incorrect diagnostics for callers.
-
-### Suggested implementation
-- Validate `ring_size >= 2` in init and publish an explicit init status.
-- Introduce `URPC_ERR_INVAL` for invalid args/config.
-- Ensure `urpc_send()`/`urpc_receive()` both check `ring->capacity` and `ring->buffer` before use.
-
-### Priority
-**P1** (runtime correctness issue in IPC core path).
-
----
-
-## 5) Zero-copy NIC setup ignores device identity and does not map MMIO
-
-### What is wrong
-`io_setup_zero_copy_nic_ring()`:
-- Ignores `nic_device_id`.
-- Uses hardcoded physical/virtual addresses.
-- Comments out the actual VMM map calls.
-
-### Risk
-- Incorrect behavior on real hardware.
-- Security/isolation assumptions are not actually enforced at mapping time.
-
-### Suggested implementation
-- Resolve BAR/queue addresses from PCI/driver registry using `nic_device_id`.
-- Perform real `vmm_map_device_mmio()` calls and propagate errors.
-- Return a typed error code when device lookup or mapping fails.
-
-### Priority
-**P2** (major missing implementation for data plane).
-
----
-
-## 6) VMM map/unmap are currently stubs
-
-### What is wrong
-`vmm_map_page()` and `vmm_unmap_page()` return success without creating/removing actual page table entries (unmap only flushes TLB).
-
-### Risk
-- Callers may believe mappings exist when they do not.
-- Subsequent memory accesses or device map operations can fail unpredictably.
-
-### Suggested implementation
-- Implement architecture-specific page-table walk/create/remove via HAL hooks.
-- Add minimal mapping invariants tests (map success, remap rejection policy, unmap correctness).
-
-### Priority
-**P2** (fundamental MM functionality incomplete).
-
----
-
-## Recommended implementation order
-
-1. **P0**: Fix header typedef conflict and kernel compile flags.
-2. **P1**: Complete boot initialization sequence with hard failure handling.
-3. **P1**: Harden URPC ring API validation and error codes.
-4. **P2**: Implement real VMM mapping/unmapping.
-5. **P2**: Replace zero-copy NIC stubs with device-driven mapping.
-
-## Validation checklist after fixes
-
-- `cmake -S . -B build`
-- `cmake --build build -j4`
-- Add focused unit/integration checks for URPC ring edge-cases (`capacity=0`, null buffer, full/empty transitions).
-- Add smoke test for boot init sequence progression and panic-on-failure.
+- `cmake --preset x86_64-elf-debug`
+- `cmake --build --preset build-x86_64-kernel`
+- `cmake --preset riscv64-shakti-e-gcc-debug`
+- `cmake --build --preset build-riscv64-shakti-e-gcc-kernel`
+- `cmake --preset tests-host`
+- `cmake --build --preset build-tests`
+- `ctest --preset run-tests`
+- `cmake -S . -B build-tidy -DBHARAT_ENABLE_CLANG_TIDY=ON -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/x86_64-elf.cmake`
+- `cmake --build build-tidy --target kernel.elf`

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -3,18 +3,21 @@ project(BharatOS_Kernel C ASM)
 
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 
-# ── Force ld.lld as the linker — MUST be set in CMakeLists (not toolchain)
-# to survive CMake's platform-specific link rule generation.
-find_program(LLD_LINKER NAMES ld.lld HINTS
-    "C:/Program Files/LLVM/bin"
-    "/usr/bin" "/usr/local/bin" "/opt/homebrew/bin"
-)
-if(NOT LLD_LINKER)
-    message(FATAL_ERROR "ld.lld not found, install LLD (see BUILD.md)")
+# ── Linker selection (toolchain-provided linker preferred)
+# If the toolchain did not define CMAKE_LINKER, fallback to ld.lld.
+if(NOT CMAKE_LINKER)
+    find_program(LLD_LINKER NAMES ld.lld HINTS
+        "C:/Program Files/LLVM/bin"
+        "/usr/bin" "/usr/local/bin" "/opt/homebrew/bin"
+    )
+    if(NOT LLD_LINKER)
+        message(FATAL_ERROR "No linker configured and ld.lld not found (see BUILD.md)")
+    endif()
+    set(CMAKE_LINKER "${LLD_LINKER}")
 endif()
+
 set(CMAKE_C_LINK_EXECUTABLE   "<CMAKE_LINKER> <LINK_FLAGS> <OBJECTS> -o <TARGET>")
 set(CMAKE_ASM_LINK_EXECUTABLE "<CMAKE_LINKER> <LINK_FLAGS> <OBJECTS> -o <TARGET>")
-set(CMAKE_LINKER "${LLD_LINKER}")
 
 # ── Toolchain file provides all compiler/linker settings.
 # Pass -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/<arch>-elf.cmake at configure time.
@@ -55,6 +58,7 @@ if(ARCH STREQUAL "x86_64")
 elseif(ARCH STREQUAL "riscv64")
     set(BOOT_SRC src/boot/riscv64/boot.S)
     set(ARCH_HAL src/hal/riscv/hal_cpu.c)
+    set(ARCH_HAL_EXTRA src/hal/riscv/shakti_bsp.c)
 elseif(ARCH STREQUAL "arm64")
     set(BOOT_SRC src/boot/arm64/boot.S)
     set(ARCH_HAL src/hal/arm64/hal_cpu.c)
@@ -68,6 +72,18 @@ elseif(ARCH STREQUAL "arm64")
     set(LINKER_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/linker_arm64.ld")
 endif()
 
+if(ARCH STREQUAL "riscv64")
+    option(BHARAT_RISCV_BUILD_PAYLOAD_BIN "Emit payload.bin from kernel.elf for OpenSBI packaging" ON)
+    set(BHARAT_RISCV_SOC_PROFILE "qemu-virt" CACHE STRING "RISC-V SoC profile (qemu-virt, shakti-e, shakti-c, shakti-i)")
+    set_property(CACHE BHARAT_RISCV_SOC_PROFILE PROPERTY STRINGS qemu-virt shakti-e shakti-c shakti-i)
+
+    if(NOT BHARAT_RISCV_SOC_PROFILE MATCHES "^(qemu-virt|shakti-e|shakti-c|shakti-i)$")
+        message(FATAL_ERROR "Invalid BHARAT_RISCV_SOC_PROFILE='${BHARAT_RISCV_SOC_PROFILE}'. Allowed: qemu-virt, shakti-e, shakti-c, shakti-i")
+    endif()
+
+    add_compile_definitions(BHARAT_RISCV_SOC_PROFILE_STR="${BHARAT_RISCV_SOC_PROFILE}")
+endif()
+
 # ── Core kernel sources ──────────────────────────────────────────────────────
 set(KERNEL_SRCS
     ${BOOT_SRC}
@@ -75,12 +91,22 @@ set(KERNEL_SRCS
     src/panic.c
     src/sched_stub.c
     ${ARCH_HAL}
+    ${ARCH_HAL_EXTRA}
     src/mm/pmm.c
     src/mm/early_alloc.c
     src/mm/vmm.c
     src/mm/numa.c
+    src/ipc/endpoint_ipc.c
+    src/capability.c
     src/ipc/multikernel.c
     src/lib/string.c
+    src/stack_protector.c
+    src/device/builtin_drivers.c
+    src/device/device_manager.c
+    src/hal/timer_common.c
+    src/hal/interrupt_common.c
+    src/trap/trap.c
+    src/multicore.c
 )
 
 # ── Kernel ELF ──────────────────────────────────────────────────────────────
@@ -95,12 +121,46 @@ set_target_properties(kernel.elf PROPERTIES
 target_compile_options(kernel.elf PRIVATE
     $<$<COMPILE_LANGUAGE:C>:-ffreestanding>
     $<$<COMPILE_LANGUAGE:C>:-fno-builtin>
-    $<$<COMPILE_LANGUAGE:C>:-fno-stack-protector>
     $<$<COMPILE_LANGUAGE:C>:-fno-pic>
     $<$<COMPILE_LANGUAGE:C>:-Wall>
     $<$<COMPILE_LANGUAGE:C>:-Wextra>
     $<$<COMPILE_LANGUAGE:C>:-Werror=implicit-function-declaration>
 )
+
+option(BHARAT_KERNEL_HARDENING "Enable kernel hardening compile/link options" ON)
+option(BHARAT_KERNEL_ASLR "Build kernel as PIE for KASLR-friendly relocation experiments" OFF)
+
+if(BHARAT_KERNEL_HARDENING)
+    target_compile_options(kernel.elf PRIVATE
+        $<$<COMPILE_LANGUAGE:C>:-fstack-protector-strong>
+        $<$<COMPILE_LANGUAGE:C>:-fno-strict-aliasing>
+        $<$<COMPILE_LANGUAGE:C>:-fno-delete-null-pointer-checks>
+    )
+    target_link_options(kernel.elf PRIVATE
+        "-z"
+        "noexecstack"
+    )
+else()
+    target_compile_options(kernel.elf PRIVATE
+        $<$<COMPILE_LANGUAGE:C>:-fno-stack-protector>
+    )
+endif()
+
+if(BHARAT_KERNEL_ASLR)
+    target_compile_options(kernel.elf PRIVATE
+        $<$<COMPILE_LANGUAGE:C>:-fpie>
+    )
+    target_link_options(kernel.elf PRIVATE
+        "--pie"
+    )
+else()
+    target_compile_options(kernel.elf PRIVATE
+        $<$<COMPILE_LANGUAGE:C>:-fno-pie>
+    )
+    target_link_options(kernel.elf PRIVATE
+        "--no-pie"
+    )
+endif()
 
 if(ARCH STREQUAL "x86_64")
     target_compile_options(kernel.elf PRIVATE
@@ -121,9 +181,28 @@ endif()
 # Use native ld.lld flags directly: --nopie, -T, --build-id, --fatal-warnings
 target_link_options(kernel.elf PRIVATE
     "-nostdlib"
-    "--no-pie"
     "--fatal-warnings"
     "-T" "${LINKER_SCRIPT}"
     "--build-id=none"
     "--no-dynamic-linker"
 )
+
+
+if(ARCH STREQUAL "riscv64" AND BHARAT_RISCV_BUILD_PAYLOAD_BIN)
+    if(NOT CMAKE_OBJCOPY)
+        find_program(CMAKE_OBJCOPY NAMES llvm-objcopy riscv64-unknown-elf-objcopy)
+    endif()
+
+    if(NOT CMAKE_OBJCOPY)
+        message(WARNING "objcopy not found; payload.bin target disabled")
+    else()
+        add_custom_command(
+            OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/payload.bin"
+            COMMAND ${CMAKE_OBJCOPY} -O binary $<TARGET_FILE:kernel.elf> "${CMAKE_CURRENT_BINARY_DIR}/payload.bin"
+            DEPENDS kernel.elf
+            COMMENT "Generating OpenSBI payload.bin from kernel.elf"
+            VERBATIM
+        )
+        add_custom_target(kernel.payload.bin ALL DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/payload.bin")
+    endif()
+endif()

--- a/kernel/include/advanced/multikernel.h
+++ b/kernel/include/advanced/multikernel.h
@@ -4,7 +4,6 @@
 #include "../sched.h"
 #include <stdint.h>
 
-
 /*
  * Bharat-OS Multikernel Architecture (Barrelfish Inspired)
  * Replaces traditional shared-state kernels with a distributed message-passing
@@ -18,12 +17,30 @@ typedef struct {
   uint64_t payload_data[8]; // Max 64 bytes in shared memory ring
 } urpc_msg_t;
 
+typedef enum {
+  URPC_SUCCESS = 0,
+  URPC_ERR_FULL = -1,
+  URPC_ERR_EMPTY = -2,
+  URPC_ERR_INVALID = -3,
+  URPC_ERR_NO_CHANNEL = -4,
+} urpc_status_t;
+
 typedef struct {
   urpc_msg_t *buffer;
   uint32_t capacity;
   volatile uint32_t head;
   volatile uint32_t tail;
 } urpc_ring_t;
+
+typedef struct {
+  uint8_t in_use;
+  urpc_msg_t msg;
+} mk_message_slot_t;
+
+typedef struct {
+  mk_message_slot_t* slots;
+  uint32_t capacity;
+} mk_msg_pool_t;
 
 // A Message Channel connecting two independent kernel instances on different
 // cores
@@ -37,6 +54,11 @@ typedef struct {
   uint32_t ring_size;
 } mk_channel_t;
 
+// Multicore boot and channel matrix setup
+int mk_boot_secondary_cores(uint32_t core_count);
+int mk_init_per_core_channels(uint32_t core_count, uint32_t ring_size);
+int mk_get_channel(uint32_t sender_core, uint32_t receiver_core, mk_channel_t* out_channel);
+
 // Establishes a high-throughput lockless IPC channel between two CPU cores
 int mk_establish_channel(uint32_t target_core, mk_channel_t *out_channel);
 
@@ -47,9 +69,14 @@ int mk_send_message(mk_channel_t *channel, uint32_t msg_type, void *payload,
 // Poll the core-local URPC ring for incoming messages from other OS instances
 int mk_poll_messages(mk_channel_t *channel);
 
+// Scalable message pool allocator used by core-local URPC producers
+int mk_msg_pool_init(mk_msg_pool_t* pool, mk_message_slot_t* slots, uint32_t capacity);
+urpc_msg_t* mk_msg_alloc(mk_msg_pool_t* pool);
+void mk_msg_free(mk_msg_pool_t* pool, urpc_msg_t* msg);
+
 // Low-level Lockless URPC messaging spine API
-void urpc_init_ring(urpc_ring_t* ring, urpc_msg_t* buffer_ptr, uint32_t ring_size);
-int urpc_send(urpc_ring_t* ring, urpc_msg_t* msg);
+int urpc_init_ring(urpc_ring_t* ring, urpc_msg_t* buffer_ptr, uint32_t ring_size);
+int urpc_send(urpc_ring_t* ring, const urpc_msg_t* msg);
 int urpc_receive(urpc_ring_t* ring, urpc_msg_t* out_msg);
 
 #endif // BHARAT_MULTIKERNEL_H

--- a/kernel/include/capability.h
+++ b/kernel/include/capability.h
@@ -1,0 +1,57 @@
+#ifndef BHARAT_CAPABILITY_H
+#define BHARAT_CAPABILITY_H
+
+#include <stdint.h>
+
+#include "sched.h"
+
+typedef enum {
+    CAP_OBJ_NONE = 0,
+    CAP_OBJ_ENDPOINT = 1,
+    CAP_OBJ_MEMORY = 2,
+    CAP_OBJ_SCHED = 3,
+    CAP_OBJ_PROCESS = 4,
+} cap_object_type_t;
+
+typedef enum {
+    CAP_PERM_NONE      = 0,
+    CAP_PERM_SEND      = (1U << 0),
+    CAP_PERM_RECEIVE   = (1U << 1),
+    CAP_PERM_MAP       = (1U << 2),
+    CAP_PERM_UNMAP     = (1U << 3),
+    CAP_PERM_SCHEDULE  = (1U << 4),
+    CAP_PERM_DELEGATE  = (1U << 5),
+} cap_perm_t;
+
+typedef struct {
+    uint32_t id;
+    cap_object_type_t type;
+    uint32_t rights;
+    uint64_t object_ref;
+    uint8_t in_use;
+} capability_entry_t;
+
+typedef struct {
+    capability_entry_t entries[64];
+    uint32_t next_id;
+} capability_table_t;
+
+capability_table_t* cap_table_create(void);
+int cap_table_init_for_process(kprocess_t* proc);
+int cap_table_grant(capability_table_t* table,
+                    cap_object_type_t type,
+                    uint64_t object_ref,
+                    uint32_t rights,
+                    uint32_t* out_cap_id);
+int cap_table_lookup(const capability_table_t* table,
+                     uint32_t cap_id,
+                     cap_object_type_t required_type,
+                     uint32_t required_rights,
+                     capability_entry_t* out_entry);
+int cap_table_delegate(capability_table_t* src,
+                       capability_table_t* dst,
+                       uint32_t cap_id,
+                       uint32_t delegated_rights,
+                       uint32_t* out_new_cap_id);
+
+#endif // BHARAT_CAPABILITY_H

--- a/kernel/include/device.h
+++ b/kernel/include/device.h
@@ -1,0 +1,47 @@
+#ifndef BHARAT_DEVICE_H
+#define BHARAT_DEVICE_H
+
+#include <stdint.h>
+
+#include "mm.h"
+
+typedef enum {
+    DEVICE_CLASS_UART = 0,
+    DEVICE_CLASS_SPI,
+    DEVICE_CLASS_I2C,
+    DEVICE_CLASS_SDMMC,
+    DEVICE_CLASS_ETHERNET,
+} device_class_t;
+
+typedef struct {
+    device_class_t class_id;
+    uint32_t device_id;
+    uint32_t window_id;
+    phys_addr_t phys_base;
+    virt_addr_t virt_base;
+    uint32_t size_bytes;
+    uint32_t irq;
+    uint8_t in_use;
+} device_mmio_window_t;
+
+typedef struct {
+    const char* name;
+    device_class_t class_id;
+    uint32_t device_id;
+    int (*probe)(void);
+    void (*irq_handler)(uint32_t irq, void* ctx);
+    void* ctx;
+} device_driver_t;
+
+int device_framework_init(void);
+int device_register_driver(const device_driver_t* driver);
+int device_register_mmio_window(const device_mmio_window_t* window);
+int device_lookup_mmio_window(device_class_t class_id,
+                              uint32_t device_id,
+                              uint32_t window_id,
+                              device_mmio_window_t* out_window);
+int device_dispatch_irq(uint32_t irq);
+
+int device_register_builtin_drivers(void);
+
+#endif // BHARAT_DEVICE_H

--- a/kernel/include/hal/hal.h
+++ b/kernel/include/hal/hal.h
@@ -3,6 +3,9 @@
 
 #include <stdint.h>
 
+#include "interrupt.h"
+#include "timer.h"
+
 /* Hardware Abstraction Layer Base Definitions */
 
 // CPU operations that must be implemented by each target architecture
@@ -19,6 +22,11 @@ void hal_serial_init(void);
 void hal_serial_write_char(char c);
 void hal_serial_write(const char* s);
 int hal_serial_read_char(void);
+
+// Interrupt and timer controller
+int hal_interrupt_controller_init(void);
+int hal_interrupt_route(uint32_t irq, uint32_t target_core);
+int hal_timer_source_init(uint32_t tick_hz);
 
 // TLB Coherency
 void hal_tlb_flush(unsigned long long vaddr);

--- a/kernel/include/hal/interrupt.h
+++ b/kernel/include/hal/interrupt.h
@@ -1,0 +1,12 @@
+#ifndef BHARAT_HAL_INTERRUPT_H
+#define BHARAT_HAL_INTERRUPT_H
+
+#include <stdint.h>
+
+typedef void (*hal_irq_handler_t)(void* ctx);
+
+int hal_interrupt_register(uint32_t irq, hal_irq_handler_t handler, void* ctx);
+int hal_interrupt_unregister(uint32_t irq);
+void hal_interrupt_dispatch(uint32_t irq);
+
+#endif // BHARAT_HAL_INTERRUPT_H

--- a/kernel/include/hal/riscv_bsp.h
+++ b/kernel/include/hal/riscv_bsp.h
@@ -1,0 +1,31 @@
+#ifndef BHARAT_HAL_RISCV_BSP_H
+#define BHARAT_HAL_RISCV_BSP_H
+
+#include <stdint.h>
+
+typedef enum {
+    RISCV_SOC_QEMU_VIRT = 0,
+    RISCV_SOC_SHAKTI_E,
+    RISCV_SOC_SHAKTI_C,
+    RISCV_SOC_SHAKTI_I,
+} riscv_soc_profile_t;
+
+typedef struct {
+    riscv_soc_profile_t soc_profile;
+    uint64_t fdt_ptr;
+    uint64_t uart_base;
+    uint64_t plic_base;
+    uint64_t clint_base;
+    uint64_t dram_base;
+    uint64_t dram_size;
+} riscv_bsp_config_t;
+
+int hal_riscv_bsp_detect(const char* profile, uint64_t fdt_ptr, riscv_bsp_config_t* out_cfg);
+int hal_riscv_bsp_init(const riscv_bsp_config_t* cfg);
+const riscv_bsp_config_t* hal_riscv_bsp_active(void);
+
+void hal_riscv_set_boot_info(uint64_t hart_id, uint64_t fdt_ptr);
+uint64_t hal_riscv_boot_hart_id(void);
+uint64_t hal_riscv_boot_fdt_ptr(void);
+
+#endif // BHARAT_HAL_RISCV_BSP_H

--- a/kernel/include/hal/timer.h
+++ b/kernel/include/hal/timer.h
@@ -1,0 +1,11 @@
+#ifndef BHARAT_HAL_TIMER_H
+#define BHARAT_HAL_TIMER_H
+
+#include <stdint.h>
+
+int hal_timer_init(uint32_t tick_hz);
+int hal_timer_set_periodic(uint32_t tick_hz);
+uint64_t hal_timer_monotonic_ticks(void);
+void hal_timer_tick(void);
+
+#endif // BHARAT_HAL_TIMER_H

--- a/kernel/include/ipc_endpoint.h
+++ b/kernel/include/ipc_endpoint.h
@@ -1,0 +1,25 @@
+#ifndef BHARAT_IPC_ENDPOINT_H
+#define BHARAT_IPC_ENDPOINT_H
+
+#include <stdint.h>
+
+#include "capability.h"
+
+typedef struct {
+    uint32_t msg_len;
+    uint8_t payload[64];
+} ipc_message_t;
+
+typedef enum {
+    IPC_OK = 0,
+    IPC_ERR_INVALID = -1,
+    IPC_ERR_NO_SPACE = -2,
+    IPC_ERR_WOULD_BLOCK = -3,
+    IPC_ERR_PERM = -4,
+} ipc_status_t;
+
+int ipc_endpoint_create(capability_table_t* table, uint32_t* out_send_cap, uint32_t* out_recv_cap);
+int ipc_endpoint_send(capability_table_t* table, uint32_t send_cap, const void* payload, uint32_t payload_len);
+int ipc_endpoint_receive(capability_table_t* table, uint32_t recv_cap, void* out_payload, uint32_t out_payload_capacity, uint32_t* out_received_len);
+
+#endif // BHARAT_IPC_ENDPOINT_H

--- a/kernel/include/kernel.h
+++ b/kernel/include/kernel.h
@@ -7,6 +7,9 @@
 #if defined(__x86_64__)
 #include "../src/boot/x86_64/multiboot2.h"
 void kernel_main(uint32_t magic, multiboot_information_t* mb_info);
+#elif defined(__riscv)
+#include <stdint.h>
+void kernel_main(uint64_t hart_id, uintptr_t fdt_ptr);
 #else
 void kernel_main(void);
 #endif

--- a/kernel/include/kernel_safety.h
+++ b/kernel/include/kernel_safety.h
@@ -1,0 +1,19 @@
+#ifndef BHARAT_KERNEL_SAFETY_H
+#define BHARAT_KERNEL_SAFETY_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define BHARAT_ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
+
+#define BHARAT_IS_ALIGNED(value, alignment) \
+    (((alignment) != 0U) && (((value) & ((alignment) - 1U)) == 0U))
+
+#define BHARAT_BOUNDS_CHECK(index, count) ((size_t)(index) < (size_t)(count))
+
+#define BHARAT_PTR_NON_NULL(ptr) ((ptr) != NULL)
+
+#define BHARAT_RANGE_VALID(value, minv, maxv) \
+    ((uint64_t)(value) >= (uint64_t)(minv) && (uint64_t)(value) <= (uint64_t)(maxv))
+
+#endif // BHARAT_KERNEL_SAFETY_H

--- a/kernel/include/multicore.h
+++ b/kernel/include/multicore.h
@@ -1,0 +1,8 @@
+#ifndef BHARAT_MULTICORE_H
+#define BHARAT_MULTICORE_H
+
+#include <stdint.h>
+
+int multicore_boot_secondary_cores(uint32_t core_count);
+
+#endif // BHARAT_MULTICORE_H

--- a/kernel/include/numa.h
+++ b/kernel/include/numa.h
@@ -6,40 +6,41 @@
 
 /**
  * NUMA-Ready Interface Definitions (ADR-006)
- * Bharat-OS v1 implements single-node allocators but passes these
- * topology hints via the API to ensure forward capability for Bharat-Cloud
- * deployments on massively scaled multi-socket servers.
  */
 
-// A distinct memory or compute node in the topology.
 typedef uint16_t memory_node_id_t;
 
 #define NUMA_NODE_LOCAL 0
 #define NUMA_NODE_ANY   0xFFFF
+#define NUMA_MAX_NODES 8
 
-/**
- * NUMA distance matrix stub.
- * Represents the relative latency between two nodes.
- * Local node distance is typically 10.
- */
 typedef struct {
     memory_node_id_t node_a;
     memory_node_id_t node_b;
     uint32_t distance_cost;
 } numa_distance_t;
 
-/**
- * Affinity definition for scheduler hints.
- */
 typedef struct {
     memory_node_id_t preferred_node;
-    uint8_t strict_bind; // If 1, fail if memory isn't available on preferred node
+    uint8_t strict_bind;
 } numa_affinity_t;
 
-// Forward declaration of topology discovery (to be filled by ACPI/SRAT later)
-int numa_discover_topology();
+typedef struct {
+    memory_node_id_t node_id;
+    uint64_t start_addr;
+    uint64_t size_bytes;
+    uint32_t cpu_count;
+    uint8_t active;
+} numa_node_descriptor_t;
 
-// Gets the ID of the node currently executing the thread
+int numa_discover_topology();
 memory_node_id_t numa_get_current_node();
+
+int numa_set_node_descriptor(memory_node_id_t node_id,
+                             uint64_t start_addr,
+                             uint64_t size_bytes,
+                             uint32_t cpu_count);
+int numa_get_node_descriptor(memory_node_id_t node_id, numa_node_descriptor_t* out_desc);
+uint32_t numa_active_node_count(void);
 
 #endif // BHARAT_OS_NUMA_H

--- a/kernel/include/sched.h
+++ b/kernel/include/sched.h
@@ -16,24 +16,36 @@ typedef enum {
     THREAD_STATE_TERMINATED
 } thread_state_t;
 
+typedef enum {
+    SCHED_POLICY_ROUND_ROBIN = 0,
+    SCHED_POLICY_CLOUD_FAIR  = 1
+} sched_policy_t;
+
+typedef struct {
+    uint64_t regs[16];
+    uint64_t pc;
+    uint64_t sp;
+} cpu_context_t;
+
 typedef struct {
     uint64_t thread_id;
     uint64_t process_id;
-    
+
     // CPU Architectural Context (Registers)
     void* cpu_context;
-    
+
     // Kernel Stack
     virt_addr_t kernel_stack;
-    
+
     thread_state_t state;
     uint32_t priority;
-    
+
     // Priority Inheritance (Hard-RT / OpenRAN profile)
     uint32_t base_priority;
     void* waiting_on_lock; // Mutex the thread is waiting for
 
-    // Time slicing metadata
+    // Capability and accounting metadata
+    void* capability_list;
     uint64_t time_slice_ms;
     uint64_t cpu_time_consumed;
 } kthread_t;
@@ -42,7 +54,7 @@ typedef struct {
     uint64_t process_id;
     address_space_t* addr_space;
     kthread_t* main_thread;
-    
+
     // Capability-based security context would be linked here
     void* security_sandbox_ctx;
 } kprocess_t;
@@ -53,9 +65,17 @@ void sched_init(void);
 // Create process and main thread
 kprocess_t* process_create(const char* name);
 kthread_t* thread_create(kprocess_t* parent, void (*entry_point)(void));
+int thread_destroy(kthread_t* thread);
 
 // Context Switching
 void sched_yield(void);
+void sched_on_timer_tick(void);
+kthread_t* sched_current_thread(void);
+void sched_set_policy(sched_policy_t policy);
+
+// System-call style entry points used by trap/syscall layer
+int sched_sys_thread_create(kprocess_t* parent, void (*entry_point)(void), uint64_t* out_tid);
+int sched_sys_thread_destroy(uint64_t tid);
 
 // Priority Inheritance support
 void sched_inherit_priority(kthread_t* thread, uint32_t new_priority);

--- a/kernel/include/trap.h
+++ b/kernel/include/trap.h
@@ -1,0 +1,41 @@
+#ifndef BHARAT_TRAP_H
+#define BHARAT_TRAP_H
+
+#include <stdint.h>
+
+#include "sched.h"
+
+typedef enum {
+    SYSCALL_NOP = 0,
+    SYSCALL_THREAD_CREATE = 1,
+    SYSCALL_THREAD_DESTROY = 2,
+    SYSCALL_SCHED_YIELD = 3,
+    SYSCALL_VMM_MAP_PAGE = 4,
+    SYSCALL_VMM_UNMAP_PAGE = 5,
+    SYSCALL_CAPABILITY_INVOKE = 6,
+    SYSCALL_ENDPOINT_CREATE = 7,
+    SYSCALL_ENDPOINT_SEND = 8,
+    SYSCALL_ENDPOINT_RECEIVE = 9,
+    SYSCALL_CAPABILITY_DELEGATE = 10,
+} syscall_id_t;
+
+typedef struct {
+    uint64_t gpr[31];
+    uint64_t sp;
+    uint64_t pc;
+    uint64_t cause;
+    uint64_t status;
+    uint8_t from_user;
+} trap_frame_t;
+
+int trap_init(void);
+long syscall_dispatch(syscall_id_t id,
+                      uint64_t arg0,
+                      uint64_t arg1,
+                      uint64_t arg2,
+                      uint64_t arg3,
+                      uint64_t arg4,
+                      uint64_t arg5);
+long trap_handle(trap_frame_t* frame);
+
+#endif // BHARAT_TRAP_H

--- a/kernel/src/boot/riscv64/boot.S
+++ b/kernel/src/boot/riscv64/boot.S
@@ -10,9 +10,10 @@
 .section .text.init
 .global _start
 _start:
-    /* Only allow hart 0 to boot the kernel initially */
-    csrr t0, mhartid
-    bnez t0, .halt_loop
+    /* Only allow hart 0 to boot the kernel initially.
+     * OpenSBI passes hartid in a0.
+     */
+    bnez a0, .halt_loop
 
     /* Setup stack */
     la sp, stack_top

--- a/kernel/src/capability.c
+++ b/kernel/src/capability.c
@@ -1,0 +1,157 @@
+#include "capability.h"
+#include "kernel_safety.h"
+
+#include <stddef.h>
+
+#define MAX_CAP_TABLES 32U
+
+static capability_table_t g_cap_tables[MAX_CAP_TABLES];
+static uint8_t g_cap_tables_used[MAX_CAP_TABLES];
+
+
+static int cap_rights_valid(cap_object_type_t type, uint32_t rights) {
+    switch (type) {
+    case CAP_OBJ_ENDPOINT:
+        return (rights & ~(CAP_PERM_SEND | CAP_PERM_RECEIVE | CAP_PERM_DELEGATE)) == 0U;
+    case CAP_OBJ_MEMORY:
+        return (rights & ~(CAP_PERM_MAP | CAP_PERM_UNMAP | CAP_PERM_DELEGATE)) == 0U;
+    case CAP_OBJ_SCHED:
+        return (rights & ~(CAP_PERM_SCHEDULE | CAP_PERM_DELEGATE)) == 0U;
+    case CAP_OBJ_PROCESS:
+        return (rights & ~(CAP_PERM_DELEGATE)) == 0U;
+    default:
+        return 0;
+    }
+}
+
+static capability_entry_t* cap_find_entry(capability_table_t* table, uint32_t cap_id) {
+    if (!BHARAT_PTR_NON_NULL(table) || cap_id == 0U) {
+        return NULL;
+    }
+
+    for (size_t i = 0; i < BHARAT_ARRAY_SIZE(table->entries); ++i) {
+        capability_entry_t* e = &table->entries[i];
+        if (e->in_use != 0U && e->id == cap_id) {
+            return e;
+        }
+    }
+    return NULL;
+}
+
+capability_table_t* cap_table_create(void) {
+    for (size_t i = 0; i < BHARAT_ARRAY_SIZE(g_cap_tables); ++i) {
+        if (g_cap_tables_used[i] == 0U) {
+            g_cap_tables_used[i] = 1U;
+            capability_table_t* t = &g_cap_tables[i];
+            t->next_id = 1U;
+            for (size_t j = 0; j < BHARAT_ARRAY_SIZE(t->entries); ++j) {
+                t->entries[j].in_use = 0U;
+            }
+            return t;
+        }
+    }
+
+    return NULL;
+}
+
+int cap_table_init_for_process(kprocess_t* proc) {
+    if (!BHARAT_PTR_NON_NULL(proc)) {
+        return -1;
+    }
+
+    capability_table_t* t = cap_table_create();
+    if (!t) {
+        return -2;
+    }
+
+    proc->security_sandbox_ctx = t;
+    return 0;
+}
+
+int cap_table_grant(capability_table_t* table,
+                    cap_object_type_t type,
+                    uint64_t object_ref,
+                    uint32_t rights,
+                    uint32_t* out_cap_id) {
+    if (!BHARAT_PTR_NON_NULL(table) || type == CAP_OBJ_NONE) {
+        return -1;
+    }
+
+    if (!cap_rights_valid(type, rights) || rights == CAP_PERM_NONE) {
+        return -3;
+    }
+
+    for (size_t i = 0; i < BHARAT_ARRAY_SIZE(table->entries); ++i) {
+        capability_entry_t* e = &table->entries[i];
+        if (e->in_use == 0U) {
+            e->in_use = 1U;
+            e->id = table->next_id++;
+            e->type = type;
+            e->rights = rights;
+            e->object_ref = object_ref;
+            if (out_cap_id) {
+                *out_cap_id = e->id;
+            }
+            return 0;
+        }
+    }
+
+    return -2;
+}
+
+int cap_table_lookup(const capability_table_t* table,
+                     uint32_t cap_id,
+                     cap_object_type_t required_type,
+                     uint32_t required_rights,
+                     capability_entry_t* out_entry) {
+    if (!BHARAT_PTR_NON_NULL(table) || cap_id == 0U) {
+        return -1;
+    }
+
+    for (size_t i = 0; i < BHARAT_ARRAY_SIZE(table->entries); ++i) {
+        const capability_entry_t* e = &table->entries[i];
+        if (e->in_use != 0U && e->id == cap_id) {
+            if (required_type != CAP_OBJ_NONE && e->type != required_type) {
+                return -2;
+            }
+            if ((e->rights & required_rights) != required_rights) {
+                return -3;
+            }
+            if (out_entry) {
+                *out_entry = *e;
+            }
+            return 0;
+        }
+    }
+
+    return -4;
+}
+
+int cap_table_delegate(capability_table_t* src,
+                       capability_table_t* dst,
+                       uint32_t cap_id,
+                       uint32_t delegated_rights,
+                       uint32_t* out_new_cap_id) {
+    if (!BHARAT_PTR_NON_NULL(src) || !BHARAT_PTR_NON_NULL(dst) || cap_id == 0U) {
+        return -1;
+    }
+
+    capability_entry_t* src_entry = cap_find_entry(src, cap_id);
+    if (!src_entry) {
+        return -2;
+    }
+
+    if ((src_entry->rights & CAP_PERM_DELEGATE) == 0U) {
+        return -3;
+    }
+
+    if ((src_entry->rights & delegated_rights) != delegated_rights) {
+        return -4;
+    }
+
+    if (!cap_rights_valid(src_entry->type, delegated_rights) || delegated_rights == CAP_PERM_NONE) {
+        return -5;
+    }
+
+    return cap_table_grant(dst, src_entry->type, src_entry->object_ref, delegated_rights, out_new_cap_id);
+}

--- a/kernel/src/device/builtin_drivers.c
+++ b/kernel/src/device/builtin_drivers.c
@@ -1,0 +1,43 @@
+#include "device.h"
+
+#include <stddef.h>
+
+static int driver_probe_noop(void) {
+    return 0;
+}
+
+static void driver_irq_noop(uint32_t irq, void* ctx) {
+    (void)irq;
+    (void)ctx;
+}
+
+int device_register_builtin_drivers(void) {
+    static const device_driver_t drivers[] = {
+        {.name = "uart0", .class_id = DEVICE_CLASS_UART, .device_id = 0U, .probe = driver_probe_noop, .irq_handler = driver_irq_noop, .ctx = NULL},
+        {.name = "spi0", .class_id = DEVICE_CLASS_SPI, .device_id = 0U, .probe = driver_probe_noop, .irq_handler = driver_irq_noop, .ctx = NULL},
+        {.name = "i2c0", .class_id = DEVICE_CLASS_I2C, .device_id = 0U, .probe = driver_probe_noop, .irq_handler = driver_irq_noop, .ctx = NULL},
+        {.name = "sdmmc0", .class_id = DEVICE_CLASS_SDMMC, .device_id = 0U, .probe = driver_probe_noop, .irq_handler = driver_irq_noop, .ctx = NULL},
+        {.name = "eth0", .class_id = DEVICE_CLASS_ETHERNET, .device_id = 0U, .probe = driver_probe_noop, .irq_handler = driver_irq_noop, .ctx = NULL},
+    };
+
+    static const device_mmio_window_t windows[] = {
+        { .class_id = DEVICE_CLASS_ETHERNET, .device_id = 0U, .window_id = 0U, .phys_base = 0x40000000U, .virt_base = 0x8000000000U, .size_bytes = 0x10000U, .irq = 10U, .in_use = 1U },
+        { .class_id = DEVICE_CLASS_ETHERNET, .device_id = 0U, .window_id = 1U, .phys_base = 0x40010000U, .virt_base = 0x8000010000U, .size_bytes = 0x10000U, .irq = 10U, .in_use = 1U },
+        { .class_id = DEVICE_CLASS_ETHERNET, .device_id = 1U, .window_id = 0U, .phys_base = 0x40020000U, .virt_base = 0x8000020000U, .size_bytes = 0x10000U, .irq = 11U, .in_use = 1U },
+        { .class_id = DEVICE_CLASS_ETHERNET, .device_id = 1U, .window_id = 1U, .phys_base = 0x40030000U, .virt_base = 0x8000030000U, .size_bytes = 0x10000U, .irq = 11U, .in_use = 1U },
+    };
+
+    for (size_t i = 0; i < sizeof(drivers)/sizeof(drivers[0]); ++i) {
+        if (device_register_driver(&drivers[i]) != 0) {
+            return -1;
+        }
+    }
+
+    for (size_t i = 0; i < sizeof(windows)/sizeof(windows[0]); ++i) {
+        if (device_register_mmio_window(&windows[i]) != 0) {
+            return -2;
+        }
+    }
+
+    return 0;
+}

--- a/kernel/src/device/device_manager.c
+++ b/kernel/src/device/device_manager.c
@@ -1,0 +1,92 @@
+#include "device.h"
+#include "kernel_safety.h"
+
+#include <stddef.h>
+
+#define MAX_DEV_DRIVERS 32U
+#define MAX_MMIO_WINDOWS 64U
+
+static device_driver_t g_drivers[MAX_DEV_DRIVERS];
+static device_mmio_window_t g_windows[MAX_MMIO_WINDOWS];
+
+int device_framework_init(void) {
+    for (size_t i = 0; i < BHARAT_ARRAY_SIZE(g_drivers); ++i) {
+        g_drivers[i].name = NULL;
+        g_drivers[i].probe = NULL;
+        g_drivers[i].irq_handler = NULL;
+        g_drivers[i].ctx = NULL;
+        g_drivers[i].device_id = 0U;
+        g_drivers[i].class_id = DEVICE_CLASS_UART;
+    }
+
+    for (size_t i = 0; i < BHARAT_ARRAY_SIZE(g_windows); ++i) {
+        g_windows[i].in_use = 0U;
+    }
+
+    return 0;
+}
+
+int device_register_driver(const device_driver_t* driver) {
+    if (!driver || !driver->name) {
+        return -1;
+    }
+
+    for (size_t i = 0; i < BHARAT_ARRAY_SIZE(g_drivers); ++i) {
+        if (!g_drivers[i].name) {
+            g_drivers[i] = *driver;
+            if (g_drivers[i].probe) {
+                return g_drivers[i].probe();
+            }
+            return 0;
+        }
+    }
+
+    return -2;
+}
+
+int device_register_mmio_window(const device_mmio_window_t* window) {
+    if (!window || window->size_bytes == 0U) {
+        return -1;
+    }
+
+    for (size_t i = 0; i < BHARAT_ARRAY_SIZE(g_windows); ++i) {
+        if (g_windows[i].in_use == 0U) {
+            g_windows[i] = *window;
+            g_windows[i].in_use = 1U;
+            return 0;
+        }
+    }
+
+    return -2;
+}
+
+int device_lookup_mmio_window(device_class_t class_id,
+                              uint32_t device_id,
+                              uint32_t window_id,
+                              device_mmio_window_t* out_window) {
+    if (!out_window) {
+        return -1;
+    }
+
+    for (size_t i = 0; i < BHARAT_ARRAY_SIZE(g_windows); ++i) {
+        if (g_windows[i].in_use != 0U &&
+            g_windows[i].class_id == class_id &&
+            g_windows[i].device_id == device_id &&
+            g_windows[i].window_id == window_id) {
+            *out_window = g_windows[i];
+            return 0;
+        }
+    }
+
+    return -2;
+}
+
+int device_dispatch_irq(uint32_t irq) {
+    for (size_t i = 0; i < BHARAT_ARRAY_SIZE(g_drivers); ++i) {
+        if (g_drivers[i].name && g_drivers[i].irq_handler) {
+            g_drivers[i].irq_handler(irq, g_drivers[i].ctx);
+        }
+    }
+
+    return 0;
+}

--- a/kernel/src/hal/arm64/hal_cpu.c
+++ b/kernel/src/hal/arm64/hal_cpu.c
@@ -76,3 +76,21 @@ void hal_init(void) {
 void hal_tlb_flush(unsigned long long vaddr) {
     __asm__ volatile("tlbi vae1is, %0\n\tdsb sy\n\tisb" :: "r"(vaddr >> 12) : "memory");
 }
+
+
+int hal_interrupt_controller_init(void) {
+    // TODO: initialize GIC distributor/redistributor.
+    return 0;
+}
+
+int hal_interrupt_route(uint32_t irq, uint32_t target_core) {
+    (void)irq;
+    (void)target_core;
+    return 0;
+}
+
+int hal_timer_source_init(uint32_t tick_hz) {
+    (void)tick_hz;
+    // TODO: configure generic timer CNTP/CNTV periodic tick.
+    return 0;
+}

--- a/kernel/src/hal/interrupt_common.c
+++ b/kernel/src/hal/interrupt_common.c
@@ -1,0 +1,44 @@
+#include "hal/interrupt.h"
+#include "kernel_safety.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define HAL_MAX_IRQS 256U
+
+typedef struct {
+    hal_irq_handler_t handler;
+    void* ctx;
+} irq_slot_t;
+
+static irq_slot_t g_irq_slots[HAL_MAX_IRQS];
+
+int hal_interrupt_register(uint32_t irq, hal_irq_handler_t handler, void* ctx) {
+    if (irq >= HAL_MAX_IRQS || !handler) {
+        return -1;
+    }
+
+    g_irq_slots[irq].handler = handler;
+    g_irq_slots[irq].ctx = ctx;
+    return 0;
+}
+
+int hal_interrupt_unregister(uint32_t irq) {
+    if (irq >= HAL_MAX_IRQS) {
+        return -1;
+    }
+
+    g_irq_slots[irq].handler = NULL;
+    g_irq_slots[irq].ctx = NULL;
+    return 0;
+}
+
+void hal_interrupt_dispatch(uint32_t irq) {
+    if (irq >= HAL_MAX_IRQS) {
+        return;
+    }
+
+    if (g_irq_slots[irq].handler) {
+        g_irq_slots[irq].handler(g_irq_slots[irq].ctx);
+    }
+}

--- a/kernel/src/hal/riscv/hal_cpu.c
+++ b/kernel/src/hal/riscv/hal_cpu.c
@@ -1,8 +1,26 @@
 #include "hal/hal.h"
+#include "hal/riscv_bsp.h"
 
 #include "../../boot/riscv/sbi.h"
 
 // RISC-V Specific HAL Implementation (RV64 / Shakti)
+
+static uint64_t g_boot_hart_id;
+static uint64_t g_boot_fdt_ptr;
+
+void hal_riscv_set_boot_info(uint64_t hart_id, uint64_t fdt_ptr) {
+    g_boot_hart_id = hart_id;
+    g_boot_fdt_ptr = fdt_ptr;
+}
+
+uint64_t hal_riscv_boot_hart_id(void) {
+    return g_boot_hart_id;
+}
+
+uint64_t hal_riscv_boot_fdt_ptr(void) {
+    return g_boot_fdt_ptr;
+}
+
 
 void hal_serial_init(void) {
     // OpenSBI console is already available; no additional UART init required.
@@ -64,11 +82,46 @@ void hal_cpu_disable_interrupts(void) {
 }
 
 void hal_init(void) {
-    // Setup trap vectors (stvec) for Supervisor mode
-    // Setup SBI console if running in Supervisor mode, or physical UART if Machine mode
+    riscv_bsp_config_t cfg;
+
+    // Setup trap vectors (stvec) for Supervisor mode.
+    // Setup SBI console if running in Supervisor mode, or physical UART if Machine mode.
     hal_serial_init();
+
+#ifdef BHARAT_RISCV_SOC_PROFILE_STR
+    const char* profile = BHARAT_RISCV_SOC_PROFILE_STR;
+#else
+    const char* profile = "qemu-virt";
+#endif
+
+    if (hal_riscv_bsp_detect(profile, g_boot_fdt_ptr, &cfg) == 0) {
+        (void)hal_riscv_bsp_init(&cfg);
+    }
 }
 
 void hal_tlb_flush(unsigned long long vaddr) {
     __asm__ volatile("sfence.vma %0, x0" :: "r"(vaddr) : "memory");
+}
+
+
+int hal_interrupt_controller_init(void) {
+    // TODO: initialize PLIC/CLINT and per-hart interrupt enables.
+    return 0;
+}
+
+int hal_interrupt_route(uint32_t irq, uint32_t target_core) {
+    (void)irq;
+    (void)target_core;
+    // TODO: configure PLIC target context routing.
+    return 0;
+}
+
+int hal_timer_source_init(uint32_t tick_hz) {
+    if (tick_hz == 0U) {
+        return -1;
+    }
+
+    // Baseline periodic timer request via SBI TIME extension.
+    sbi_set_timer(1000000ULL / (uint64_t)tick_hz);
+    return 0;
 }

--- a/kernel/src/hal/riscv/shakti_bsp.c
+++ b/kernel/src/hal/riscv/shakti_bsp.c
@@ -1,0 +1,105 @@
+#include "hal/riscv_bsp.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+static riscv_bsp_config_t g_active_cfg;
+
+static int str_eq(const char* a, const char* b) {
+    if (!a || !b) {
+        return 0;
+    }
+
+    while (*a != '\0' && *b != '\0') {
+        if (*a != *b) {
+            return 0;
+        }
+        a++;
+        b++;
+    }
+
+    return (*a == '\0' && *b == '\0') ? 1 : 0;
+}
+
+static void cfg_clear(riscv_bsp_config_t* cfg) {
+    if (!cfg) {
+        return;
+    }
+
+    cfg->soc_profile = RISCV_SOC_QEMU_VIRT;
+    cfg->fdt_ptr = 0ULL;
+    cfg->uart_base = 0ULL;
+    cfg->plic_base = 0ULL;
+    cfg->clint_base = 0ULL;
+    cfg->dram_base = 0ULL;
+    cfg->dram_size = 0ULL;
+}
+
+int hal_riscv_bsp_detect(const char* profile, uint64_t fdt_ptr, riscv_bsp_config_t* out_cfg) {
+    if (!profile || !out_cfg) {
+        return -1;
+    }
+
+    cfg_clear(out_cfg);
+    out_cfg->fdt_ptr = fdt_ptr;
+
+    /*
+     * Baseline board descriptors for early boot.
+     * Runtime FDT parsing is planned to supersede these constants.
+     */
+    if (str_eq(profile, "shakti-e")) {
+        out_cfg->soc_profile = RISCV_SOC_SHAKTI_E;
+        out_cfg->uart_base = 0xF0000000ULL;
+        out_cfg->plic_base = 0x0C000000ULL;
+        out_cfg->clint_base = 0x02000000ULL;
+        out_cfg->dram_base = 0x80000000ULL;
+        out_cfg->dram_size = 0x10000000ULL; /* 256 MiB baseline */
+        return 0;
+    }
+
+    if (str_eq(profile, "shakti-c")) {
+        out_cfg->soc_profile = RISCV_SOC_SHAKTI_C;
+        out_cfg->uart_base = 0xE0001800ULL;
+        out_cfg->plic_base = 0x0C000000ULL;
+        out_cfg->clint_base = 0x02000000ULL;
+        out_cfg->dram_base = 0x80000000ULL;
+        out_cfg->dram_size = 0x40000000ULL; /* 1 GiB baseline */
+        return 0;
+    }
+
+    if (str_eq(profile, "shakti-i")) {
+        out_cfg->soc_profile = RISCV_SOC_SHAKTI_I;
+        out_cfg->uart_base = 0x20000000ULL;
+        out_cfg->plic_base = 0x0C000000ULL;
+        out_cfg->clint_base = 0x02000000ULL;
+        out_cfg->dram_base = 0x80000000ULL;
+        out_cfg->dram_size = 0x20000000ULL; /* 512 MiB baseline */
+        return 0;
+    }
+
+    /* Default QEMU virt profile used for current runtime CI. */
+    out_cfg->soc_profile = RISCV_SOC_QEMU_VIRT;
+    out_cfg->uart_base = 0x10000000ULL;
+    out_cfg->plic_base = 0x0C000000ULL;
+    out_cfg->clint_base = 0x02000000ULL;
+    out_cfg->dram_base = 0x80000000ULL;
+    out_cfg->dram_size = 0x08000000ULL; /* 128 MiB baseline */
+    return 0;
+}
+
+int hal_riscv_bsp_init(const riscv_bsp_config_t* cfg) {
+    if (!cfg) {
+        return -1;
+    }
+
+    if (cfg->uart_base == 0ULL || cfg->plic_base == 0ULL || cfg->clint_base == 0ULL) {
+        return -1;
+    }
+
+    g_active_cfg = *cfg;
+    return 0;
+}
+
+const riscv_bsp_config_t* hal_riscv_bsp_active(void) {
+    return &g_active_cfg;
+}

--- a/kernel/src/hal/timer_common.c
+++ b/kernel/src/hal/timer_common.c
@@ -1,0 +1,35 @@
+#include "hal/timer.h"
+#include "hal/hal.h"
+
+#include <stdint.h>
+
+static uint64_t g_ticks;
+static uint32_t g_tick_hz;
+
+int hal_timer_init(uint32_t tick_hz) {
+    if (tick_hz == 0U) {
+        return -1;
+    }
+
+    g_ticks = 0U;
+    g_tick_hz = tick_hz;
+    return hal_timer_source_init(tick_hz);
+}
+
+int hal_timer_set_periodic(uint32_t tick_hz) {
+    if (tick_hz == 0U) {
+        return -1;
+    }
+
+    g_tick_hz = tick_hz;
+    return hal_timer_source_init(tick_hz);
+}
+
+uint64_t hal_timer_monotonic_ticks(void) {
+    return g_ticks;
+}
+
+void hal_timer_tick(void) {
+    (void)g_tick_hz;
+    g_ticks++;
+}

--- a/kernel/src/hal/x86_64/hal_cpu.c
+++ b/kernel/src/hal/x86_64/hal_cpu.c
@@ -93,3 +93,22 @@ void hal_send_ipi_payload(uint32_t target_core, uint64_t payload) {
     (void)payload;
     // TODO: program local APIC/x2APIC ICR for inter-core notification.
 }
+
+
+int hal_interrupt_controller_init(void) {
+    // TODO: bring up local APIC/IOAPIC and enumerate IRQ routing.
+    return 0;
+}
+
+int hal_interrupt_route(uint32_t irq, uint32_t target_core) {
+    (void)irq;
+    (void)target_core;
+    // TODO: program IOAPIC redirection table.
+    return 0;
+}
+
+int hal_timer_source_init(uint32_t tick_hz) {
+    (void)tick_hz;
+    // TODO: configure APIC timer periodic mode.
+    return 0;
+}

--- a/kernel/src/ipc/endpoint_ipc.c
+++ b/kernel/src/ipc/endpoint_ipc.c
@@ -1,0 +1,133 @@
+#include "ipc_endpoint.h"
+#include "kernel_safety.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define MAX_ENDPOINTS 32U
+
+typedef struct {
+    uint8_t in_use;
+    ipc_message_t msg;
+    uint8_t has_msg;
+} ipc_endpoint_t;
+
+static ipc_endpoint_t g_endpoints[MAX_ENDPOINTS];
+
+static ipc_endpoint_t* endpoint_by_ref(uint64_t ref) {
+    if (ref >= BHARAT_ARRAY_SIZE(g_endpoints)) {
+        return NULL;
+    }
+    if (g_endpoints[ref].in_use == 0U) {
+        return NULL;
+    }
+    return &g_endpoints[ref];
+}
+
+int ipc_endpoint_create(capability_table_t* table, uint32_t* out_send_cap, uint32_t* out_recv_cap) {
+    if (!table || !out_send_cap || !out_recv_cap) {
+        return IPC_ERR_INVALID;
+    }
+
+    for (size_t i = 0; i < BHARAT_ARRAY_SIZE(g_endpoints); ++i) {
+        if (g_endpoints[i].in_use == 0U) {
+            g_endpoints[i].in_use = 1U;
+            g_endpoints[i].has_msg = 0U;
+            g_endpoints[i].msg.msg_len = 0U;
+
+            if (cap_table_grant(table, CAP_OBJ_ENDPOINT, i, CAP_PERM_SEND | CAP_PERM_DELEGATE, out_send_cap) != 0) {
+                g_endpoints[i].in_use = 0U;
+                return IPC_ERR_NO_SPACE;
+            }
+
+            if (cap_table_grant(table, CAP_OBJ_ENDPOINT, i, CAP_PERM_RECEIVE | CAP_PERM_DELEGATE, out_recv_cap) != 0) {
+                g_endpoints[i].in_use = 0U;
+                return IPC_ERR_NO_SPACE;
+            }
+
+            return IPC_OK;
+        }
+    }
+
+    return IPC_ERR_NO_SPACE;
+}
+
+int ipc_endpoint_send(capability_table_t* table, uint32_t send_cap, const void* payload, uint32_t payload_len) {
+    if (!table || !payload || payload_len == 0U) {
+        return IPC_ERR_INVALID;
+    }
+
+    capability_entry_t e = {0};
+    if (cap_table_lookup(table, send_cap, CAP_OBJ_ENDPOINT, CAP_PERM_SEND, &e) != 0) {
+        return IPC_ERR_PERM;
+    }
+
+    ipc_endpoint_t* ep = endpoint_by_ref(e.object_ref);
+    if (!ep) {
+        return IPC_ERR_INVALID;
+    }
+
+    if (payload_len > sizeof(ep->msg.payload)) {
+        return IPC_ERR_INVALID;
+    }
+
+    if (ep->has_msg != 0U) {
+        kthread_t* cur = sched_current_thread();
+        if (cur) {
+            cur->state = THREAD_STATE_BLOCKED;
+        }
+        return IPC_ERR_WOULD_BLOCK;
+    }
+
+    const uint8_t* src = (const uint8_t*)payload;
+    for (uint32_t i = 0; i < payload_len; ++i) {
+        ep->msg.payload[i] = src[i];
+    }
+    ep->msg.msg_len = payload_len;
+    ep->has_msg = 1U;
+    return IPC_OK;
+}
+
+int ipc_endpoint_receive(capability_table_t* table, uint32_t recv_cap, void* out_payload, uint32_t out_payload_capacity, uint32_t* out_received_len) {
+    if (!table || !out_payload || out_payload_capacity == 0U || !out_received_len) {
+        return IPC_ERR_INVALID;
+    }
+
+    capability_entry_t e = {0};
+    if (cap_table_lookup(table, recv_cap, CAP_OBJ_ENDPOINT, CAP_PERM_RECEIVE, &e) != 0) {
+        return IPC_ERR_PERM;
+    }
+
+    ipc_endpoint_t* ep = endpoint_by_ref(e.object_ref);
+    if (!ep) {
+        return IPC_ERR_INVALID;
+    }
+
+    if (ep->has_msg == 0U) {
+        kthread_t* cur = sched_current_thread();
+        if (cur) {
+            cur->state = THREAD_STATE_BLOCKED;
+        }
+        return IPC_ERR_WOULD_BLOCK;
+    }
+
+    if (out_payload_capacity < ep->msg.msg_len) {
+        return IPC_ERR_NO_SPACE;
+    }
+
+    uint8_t* dst = (uint8_t*)out_payload;
+    for (uint32_t i = 0; i < ep->msg.msg_len; ++i) {
+        dst[i] = ep->msg.payload[i];
+    }
+
+    *out_received_len = ep->msg.msg_len;
+    ep->msg.msg_len = 0U;
+    ep->has_msg = 0U;
+
+    kthread_t* cur = sched_current_thread();
+    if (cur && cur->state == THREAD_STATE_BLOCKED) {
+        cur->state = THREAD_STATE_READY;
+    }
+
+    return IPC_OK;
+}

--- a/kernel/src/ipc/multikernel.c
+++ b/kernel/src/ipc/multikernel.c
@@ -1,41 +1,51 @@
 #include "../../include/advanced/multikernel.h"
 #include "../../include/atomic.h"
 #include "../../include/hal/hal.h"
+#include "../../include/kernel_safety.h"
+#include "../../include/multicore.h"
 
 #include <stddef.h>
 #include <stdint.h>
 
-#define URPC_SUCCESS 0
-#define URPC_ERR_FULL -1
-#define URPC_ERR_EMPTY -2
-#define URPC_ERR_INVALID -3
-
 #define MK_MAX_CHANNELS 16U
 #define MK_MAX_PAYLOAD_WORDS 8U
 #define MK_MSG_TYPE_AI_SUGGESTION 1U
+#define MK_MAX_CORES 8U
+#define MK_DEFAULT_RING_CAPACITY 32U
 
 typedef struct {
-    urpc_msg_t backing_buffer[32];
+    urpc_msg_t backing_buffer[MK_DEFAULT_RING_CAPACITY];
     urpc_ring_t ring;
     mk_channel_t channel;
     uint8_t in_use;
 } mk_channel_slot_t;
 
 static mk_channel_slot_t g_channels[MK_MAX_CHANNELS];
+static mk_channel_t g_core_channel_matrix[MK_MAX_CORES][MK_MAX_CORES];
+static uint8_t g_core_channel_valid[MK_MAX_CORES][MK_MAX_CORES];
 
-void urpc_init_ring(urpc_ring_t* ring, urpc_msg_t* buffer_ptr, uint32_t ring_size) {
-    if (!ring || !buffer_ptr || ring_size == 0U) {
-        return;
+static int urpc_ring_config_valid(const urpc_ring_t* ring) {
+    return (ring != NULL && ring->buffer != NULL && ring->capacity >= 2U);
+}
+
+int urpc_init_ring(urpc_ring_t* ring, urpc_msg_t* buffer_ptr, uint32_t ring_size) {
+    if (!ring || !buffer_ptr || ring_size < 2U) {
+        return URPC_ERR_INVALID;
     }
 
     ring->buffer = buffer_ptr;
     ring->capacity = ring_size;
     ring->head = 0U;
     ring->tail = 0U;
+    return URPC_SUCCESS;
 }
 
-int urpc_send(urpc_ring_t* ring, urpc_msg_t* msg) {
-    if (!ring || !msg || !ring->buffer || ring->capacity == 0U) {
+int urpc_send(urpc_ring_t* ring, const urpc_msg_t* msg) {
+    if (!urpc_ring_config_valid(ring) || !msg) {
+        return URPC_ERR_INVALID;
+    }
+
+    if (msg->payload_size > sizeof(msg->payload_data)) {
         return URPC_ERR_INVALID;
     }
 
@@ -46,19 +56,19 @@ int urpc_send(urpc_ring_t* ring, urpc_msg_t* msg) {
         return URPC_ERR_FULL;
     }
 
-    if (msg->payload_size <= sizeof(uint64_t)) {
-        hal_send_ipi_payload(0U, msg->payload_data[0]);
-    }
-
     ring->buffer[head] = *msg;
     smp_mb();
     ring->head = next_head;
+
+    if (msg->payload_size <= sizeof(uint64_t)) {
+        hal_send_ipi_payload(0U, msg->payload_data[0]);
+    }
 
     return URPC_SUCCESS;
 }
 
 int urpc_receive(urpc_ring_t* ring, urpc_msg_t* out_msg) {
-    if (!ring || !out_msg || !ring->buffer || ring->capacity == 0U) {
+    if (!urpc_ring_config_valid(ring) || !out_msg) {
         return URPC_ERR_INVALID;
     }
 
@@ -74,17 +84,87 @@ int urpc_receive(urpc_ring_t* ring, urpc_msg_t* out_msg) {
     return URPC_SUCCESS;
 }
 
+int mk_boot_secondary_cores(uint32_t core_count) {
+    if (core_count > MK_MAX_CORES) {
+        return URPC_ERR_INVALID;
+    }
+
+    return multicore_boot_secondary_cores(core_count);
+}
+
+int mk_init_per_core_channels(uint32_t core_count, uint32_t ring_size) {
+    if (core_count == 0U || core_count > MK_MAX_CORES || ring_size < 2U || ring_size > MK_DEFAULT_RING_CAPACITY) {
+        return URPC_ERR_INVALID;
+    }
+
+    for (uint32_t s = 0; s < core_count; ++s) {
+        for (uint32_t r = 0; r < core_count; ++r) {
+            if (s == r) {
+                g_core_channel_valid[s][r] = 0U;
+                continue;
+            }
+
+            mk_channel_t* c = &g_core_channel_matrix[s][r];
+            mk_channel_slot_t* slot = NULL;
+            for (uint32_t i = 0; i < MK_MAX_CHANNELS; ++i) {
+                if (g_channels[i].in_use == 0U) {
+                    slot = &g_channels[i];
+                    slot->in_use = 1U;
+                    break;
+                }
+            }
+            if (!slot) {
+                return URPC_ERR_FULL;
+            }
+
+            if (urpc_init_ring(&slot->ring, slot->backing_buffer, ring_size) != URPC_SUCCESS) {
+                return URPC_ERR_INVALID;
+            }
+
+            slot->channel.sender_core_id = s;
+            slot->channel.receiver_core_id = r;
+            slot->channel.urpc_ring = &slot->ring;
+            slot->channel.ring_size = ring_size;
+
+            *c = slot->channel;
+            g_core_channel_valid[s][r] = 1U;
+        }
+    }
+
+    return URPC_SUCCESS;
+}
+
+int mk_get_channel(uint32_t sender_core, uint32_t receiver_core, mk_channel_t* out_channel) {
+    if (!out_channel || sender_core >= MK_MAX_CORES || receiver_core >= MK_MAX_CORES) {
+        return URPC_ERR_INVALID;
+    }
+
+    if (g_core_channel_valid[sender_core][receiver_core] == 0U) {
+        return URPC_ERR_NO_CHANNEL;
+    }
+
+    *out_channel = g_core_channel_matrix[sender_core][receiver_core];
+    return URPC_SUCCESS;
+}
+
 int mk_establish_channel(uint32_t target_core, mk_channel_t *out_channel) {
     if (!out_channel) {
         return URPC_ERR_INVALID;
     }
 
+    if (target_core < MK_MAX_CORES && g_core_channel_valid[0U][target_core] != 0U) {
+        *out_channel = g_core_channel_matrix[0U][target_core];
+        return URPC_SUCCESS;
+    }
+
     for (uint32_t i = 0; i < MK_MAX_CHANNELS; ++i) {
         if (g_channels[i].in_use == 0U) {
-            g_channels[i].in_use = 1U;
-            urpc_init_ring(&g_channels[i].ring, g_channels[i].backing_buffer,
-                           (uint32_t)(sizeof(g_channels[i].backing_buffer) / sizeof(g_channels[i].backing_buffer[0])));
+            if (urpc_init_ring(&g_channels[i].ring, g_channels[i].backing_buffer,
+                               (uint32_t)BHARAT_ARRAY_SIZE(g_channels[i].backing_buffer)) != URPC_SUCCESS) {
+                return URPC_ERR_INVALID;
+            }
 
+            g_channels[i].in_use = 1U;
             g_channels[i].channel.sender_core_id = 0U;
             g_channels[i].channel.receiver_core_id = target_core;
             g_channels[i].channel.urpc_ring = &g_channels[i].ring;
@@ -100,7 +180,11 @@ int mk_establish_channel(uint32_t target_core, mk_channel_t *out_channel) {
 
 int mk_send_message(mk_channel_t *channel, uint32_t msg_type, void *payload,
                     uint32_t size) {
-    if (!channel || !channel->urpc_ring || !payload) {
+    if (!channel || !channel->urpc_ring) {
+        return URPC_ERR_INVALID;
+    }
+
+    if (size > 0U && !payload) {
         return URPC_ERR_INVALID;
     }
 
@@ -117,9 +201,11 @@ int mk_send_message(mk_channel_t *channel, uint32_t msg_type, void *payload,
         msg.payload_size = MK_MAX_PAYLOAD_WORDS * sizeof(uint64_t);
     }
 
-    uint64_t *src = (uint64_t *)payload;
-    for (uint32_t i = 0; i < words; ++i) {
-        msg.payload_data[i] = src[i];
+    if (words > 0U) {
+        uint64_t *src = (uint64_t *)payload;
+        for (uint32_t i = 0; i < words; ++i) {
+            msg.payload_data[i] = src[i];
+        }
     }
 
     return urpc_send(channel->urpc_ring, &msg);
@@ -141,4 +227,51 @@ int mk_poll_messages(mk_channel_t *channel) {
     }
 
     return processed;
+}
+
+int mk_msg_pool_init(mk_msg_pool_t* pool, mk_message_slot_t* slots, uint32_t capacity) {
+    if (!pool || !slots || capacity == 0U) {
+        return URPC_ERR_INVALID;
+    }
+
+    pool->slots = slots;
+    pool->capacity = capacity;
+
+    for (uint32_t i = 0; i < capacity; ++i) {
+        pool->slots[i].in_use = 0U;
+        pool->slots[i].msg.msg_type = 0U;
+        pool->slots[i].msg.payload_size = 0U;
+    }
+
+    return URPC_SUCCESS;
+}
+
+urpc_msg_t* mk_msg_alloc(mk_msg_pool_t* pool) {
+    if (!pool || !pool->slots || pool->capacity == 0U) {
+        return NULL;
+    }
+
+    for (uint32_t i = 0; i < pool->capacity; ++i) {
+        if (pool->slots[i].in_use == 0U) {
+            pool->slots[i].in_use = 1U;
+            return &pool->slots[i].msg;
+        }
+    }
+
+    return NULL;
+}
+
+void mk_msg_free(mk_msg_pool_t* pool, urpc_msg_t* msg) {
+    if (!pool || !pool->slots || !msg) {
+        return;
+    }
+
+    for (uint32_t i = 0; i < pool->capacity; ++i) {
+        if (&pool->slots[i].msg == msg) {
+            pool->slots[i].in_use = 0U;
+            pool->slots[i].msg.msg_type = 0U;
+            pool->slots[i].msg.payload_size = 0U;
+            return;
+        }
+    }
 }

--- a/kernel/src/ipc/zero_copy_io.c
+++ b/kernel/src/ipc/zero_copy_io.c
@@ -1,6 +1,6 @@
 #include "../../include/io_subsys.h"
 #include "../../include/mm.h"
-#include <stddef.h>
+#include "../../include/device.h"
 
 /*
  * Implementation of Zero-Copy I/O Subsystem for OpenRAN User Plane.
@@ -15,27 +15,31 @@ int io_setup_zero_copy_nic_ring(uint32_t nic_device_id, zero_copy_nic_ring_t* ou
         return -2; // Unauthorized access
     }
 
-    // In a real implementation, we would query the PCIe device using nic_device_id
-    // to find the BAR (Base Address Register) for the RX and TX queues.
+    device_mmio_window_t rx_window = {0};
+    device_mmio_window_t tx_window = {0};
 
-    // Stub physical addresses for NIC hardware ring buffers
-    phys_addr_t rx_phys_base = 0x40000000;
-    phys_addr_t tx_phys_base = 0x40010000;
+    if (device_lookup_mmio_window(DEVICE_CLASS_ETHERNET, nic_device_id, 0U, &rx_window) != 0) {
+        return -3; // Unknown NIC RX window
+    }
 
-    // The kernel maps these physical addresses into the current task's virtual address space
-    // VMM needs an active address space context. We mock virtual addresses here.
-    virt_addr_t rx_virt_base = 0x8000000000;
-    virt_addr_t tx_virt_base = 0x8000010000;
+    if (device_lookup_mmio_window(DEVICE_CLASS_ETHERNET, nic_device_id, 1U, &tx_window) != 0) {
+        return -3; // Unknown NIC TX window
+    }
 
-    // Simulate mapping the physical NIC queues to user-space virtual memory
-    // vmm_map_device_mmio(rx_virt_base, rx_phys_base, cap, 0);
-    // vmm_map_device_mmio(tx_virt_base, tx_phys_base, cap, 0);
+    if (vmm_map_device_mmio(rx_window.virt_base, rx_window.phys_base, cap, 0) != 0) {
+        return -4;
+    }
+
+    if (vmm_map_device_mmio(tx_window.virt_base, tx_window.phys_base, cap, 0) != 0) {
+        vmm_unmap_page(rx_window.virt_base);
+        return -5;
+    }
 
     // Populate the output structure for the User Plane
-    out_ring->rx_ring_base = (void*)rx_virt_base;
-    out_ring->tx_ring_base = (void*)tx_virt_base;
-    out_ring->ring_size_bytes = 4096;
-    out_ring->msix_vector = 10; // Dummy interrupt vector for signaling
+    out_ring->rx_ring_base = (void*)rx_window.virt_base;
+    out_ring->tx_ring_base = (void*)tx_window.virt_base;
+    out_ring->ring_size_bytes = rx_window.size_bytes;
+    out_ring->msix_vector = rx_window.irq;
 
     return 0; // Success
 }

--- a/kernel/src/main.c
+++ b/kernel/src/main.c
@@ -3,9 +3,16 @@
 #include "mm.h"
 #include "advanced/multikernel.h"
 #include "advanced/ai_sched.h"
+#include "trap.h"
+#include "device.h"
+#include "numa.h"
 
 #include <stdint.h>
 #include <stddef.h>
+
+#if defined(__riscv)
+#include "hal/riscv_bsp.h"
+#endif
 
 #define KPRINT(s) hal_serial_write(s)
 #define CAP_RIGHT_IPC_ENDPOINT 0x1U
@@ -115,10 +122,16 @@ static void kernel_ai_governor_tick(void) {
 #if defined(__x86_64__)
 #include "boot/x86_64/multiboot2.h"
 void kernel_main(uint32_t magic, multiboot_information_t* mb_info) {
+#elif defined(__riscv)
+void kernel_main(uint64_t hart_id, uintptr_t fdt_ptr) {
 #else
 void kernel_main(void) {
 #endif
   const char *profile = kernel_boot_hw_profile();
+
+#if defined(__riscv)
+  hal_riscv_set_boot_info(hart_id, (uint64_t)fdt_ptr);
+#endif
 
   KPRINT("\nBharat-OS kernel boot\n");
   KPRINT("  [HAL] Initialising hardware...\n");
@@ -148,7 +161,44 @@ void kernel_main(void) {
   }
   KPRINT("BOOT: vmm initialized\n");
 
+  KPRINT("  [NUMA] Discovering topology\n");
+  if (numa_discover_topology() != 0) {
+    kernel_panic("numa topology discovery failed");
+  }
+
+  KPRINT("  [SMP] Booting secondary cores\n");
+  if (mk_boot_secondary_cores(2U) != 0) {
+    kernel_panic("secondary core boot failed");
+  }
+
+  KPRINT("  [SMP] Initializing per-core URPC channels\n");
+  if (mk_init_per_core_channels(2U, 32U) != 0) {
+    kernel_panic("per-core urpc channel init failed");
+  }
+
+  KPRINT("  [IRQ] Initializing interrupt controller\n");
+  if (hal_interrupt_controller_init() != 0) {
+    kernel_panic("interrupt controller initialization failed");
+  }
+
+  KPRINT("  [TMR] Initializing timer source\n");
+  if (hal_timer_init(100U) != 0) {
+    kernel_panic("timer initialization failed");
+  }
+
+  KPRINT("  [DEV] Initializing device framework\n");
+  if (device_framework_init() != 0 || device_register_builtin_drivers() != 0) {
+    kernel_panic("device framework initialization failed");
+  }
+
   kernel_boot_scheduler();
+
+  KPRINT("  [TRAP] Initializing syscall/trap gate...\n");
+  if (trap_init() != 0) {
+    kernel_panic("trap gate initialization failed");
+  }
+  KPRINT("  [TRAP] Ready.\n");
+
   kernel_ai_governor_init();
 
   KPRINT("  [CPU] Enabling interrupts...\n");
@@ -165,6 +215,8 @@ void kernel_main(void) {
 
   while (1) {
     kernel_ai_governor_tick();
+    hal_timer_tick();
+    sched_on_timer_tick();
     hal_cpu_halt();
   }
 }

--- a/kernel/src/mm/numa.c
+++ b/kernel/src/mm/numa.c
@@ -1,9 +1,60 @@
 #include "../../include/numa.h"
 
+#include <stddef.h>
+
+static numa_node_descriptor_t g_nodes[NUMA_MAX_NODES];
+static uint32_t g_active_nodes;
+
 int numa_discover_topology(void) {
+    // Baseline: single NUMA node until ACPI SRAT/FDT parsing lands.
+    g_nodes[0].node_id = 0U;
+    g_nodes[0].start_addr = 0U;
+    g_nodes[0].size_bytes = 0U;
+    g_nodes[0].cpu_count = 1U;
+    g_nodes[0].active = 1U;
+
+    for (uint32_t i = 1U; i < NUMA_MAX_NODES; ++i) {
+        g_nodes[i].active = 0U;
+    }
+
+    g_active_nodes = 1U;
     return 0;
 }
 
 memory_node_id_t numa_get_current_node(void) {
     return NUMA_NODE_LOCAL;
+}
+
+int numa_set_node_descriptor(memory_node_id_t node_id,
+                             uint64_t start_addr,
+                             uint64_t size_bytes,
+                             uint32_t cpu_count) {
+    if (node_id >= NUMA_MAX_NODES || cpu_count == 0U) {
+        return -1;
+    }
+
+    g_nodes[node_id].node_id = node_id;
+    g_nodes[node_id].start_addr = start_addr;
+    g_nodes[node_id].size_bytes = size_bytes;
+    g_nodes[node_id].cpu_count = cpu_count;
+    g_nodes[node_id].active = 1U;
+
+    if ((uint32_t)(node_id + 1U) > g_active_nodes) {
+        g_active_nodes = (uint32_t)(node_id + 1U);
+    }
+
+    return 0;
+}
+
+int numa_get_node_descriptor(memory_node_id_t node_id, numa_node_descriptor_t* out_desc) {
+    if (!out_desc || node_id >= NUMA_MAX_NODES || g_nodes[node_id].active == 0U) {
+        return -1;
+    }
+
+    *out_desc = g_nodes[node_id];
+    return 0;
+}
+
+uint32_t numa_active_node_count(void) {
+    return g_active_nodes;
 }

--- a/kernel/src/mm/pmm.c
+++ b/kernel/src/mm/pmm.c
@@ -156,6 +156,7 @@ static void mark_page_free(phys_addr_t phys) {
 }
 
 int mm_pmm_init(void* memory_map, uint32_t map_size) {
+    (void)map_size;
     if (!memory_map) return -1;
 
     phys_addr_t highest_addr = 0;

--- a/kernel/src/multicore.c
+++ b/kernel/src/multicore.c
@@ -1,0 +1,26 @@
+#include "multicore.h"
+
+#if defined(__riscv)
+#include "boot/riscv/sbi.h"
+#endif
+
+int multicore_boot_secondary_cores(uint32_t core_count) {
+    if (core_count <= 1U) {
+        return 0;
+    }
+
+#if defined(__riscv)
+    unsigned long hart_mask = 0UL;
+    for (uint32_t hart = 1U; hart < core_count; ++hart) {
+        hart_mask |= (1UL << hart);
+    }
+
+    if (hart_mask != 0UL) {
+        sbi_send_ipi(&hart_mask);
+    }
+#else
+    (void)core_count;
+#endif
+
+    return 0;
+}

--- a/kernel/src/sched_stub.c
+++ b/kernel/src/sched_stub.c
@@ -1,5 +1,260 @@
 #include "sched.h"
+#include "kernel_safety.h"
+#include "capability.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define SCHED_MAX_THREADS 64U
+#define SCHED_MAX_PROCESSES 32U
+#define SCHED_DEFAULT_SLICE_MS 10U
+
+typedef struct {
+    uint8_t in_use;
+    kthread_t thread;
+    cpu_context_t context;
+} thread_slot_t;
+
+typedef struct {
+    uint8_t in_use;
+    kprocess_t process;
+} process_slot_t;
+
+static thread_slot_t g_threads[SCHED_MAX_THREADS];
+static process_slot_t g_processes[SCHED_MAX_PROCESSES];
+
+static kthread_t* g_current;
+static sched_policy_t g_policy = SCHED_POLICY_ROUND_ROBIN;
+static uint64_t g_next_thread_id = 1U;
+static uint64_t g_next_process_id = 1U;
+
+void fv_secure_context_switch(void* next_thread_frame) __attribute__((weak));
+
+static thread_slot_t* sched_find_thread_slot_by_tid(uint64_t tid) {
+    for (size_t i = 0; i < BHARAT_ARRAY_SIZE(g_threads); ++i) {
+        if (g_threads[i].in_use != 0U && g_threads[i].thread.thread_id == tid) {
+            return &g_threads[i];
+        }
+    }
+    return NULL;
+}
+
+static thread_slot_t* sched_find_free_thread_slot(void) {
+    for (size_t i = 0; i < BHARAT_ARRAY_SIZE(g_threads); ++i) {
+        if (g_threads[i].in_use == 0U) {
+            return &g_threads[i];
+        }
+    }
+    return NULL;
+}
+
+static process_slot_t* sched_find_free_process_slot(void) {
+    for (size_t i = 0; i < BHARAT_ARRAY_SIZE(g_processes); ++i) {
+        if (g_processes[i].in_use == 0U) {
+            return &g_processes[i];
+        }
+    }
+    return NULL;
+}
+
+static kthread_t* sched_pick_next_ready(void) {
+    size_t start = 0U;
+    if (g_current) {
+        thread_slot_t* cur = sched_find_thread_slot_by_tid(g_current->thread_id);
+        if (cur) {
+            start = (size_t)(cur - &g_threads[0]) + 1U;
+        }
+    }
+
+    for (size_t attempt = 0U; attempt < BHARAT_ARRAY_SIZE(g_threads); ++attempt) {
+        size_t idx = (start + attempt) % BHARAT_ARRAY_SIZE(g_threads);
+        if (g_threads[idx].in_use != 0U && g_threads[idx].thread.state == THREAD_STATE_READY) {
+            return &g_threads[idx].thread;
+        }
+    }
+
+    return NULL;
+}
+
+static void sched_switch_to(kthread_t* next) {
+    if (!next) {
+        return;
+    }
+
+    if (g_current && g_current->state == THREAD_STATE_RUNNING) {
+        g_current->state = THREAD_STATE_READY;
+    }
+
+    next->state = THREAD_STATE_RUNNING;
+    g_current = next;
+
+    if (fv_secure_context_switch) {
+        fv_secure_context_switch(next->cpu_context);
+    }
+}
 
 void sched_init(void) {
-    // Phase-0 bootstrap scheduler stub.
+    for (size_t i = 0; i < BHARAT_ARRAY_SIZE(g_threads); ++i) {
+        g_threads[i].in_use = 0U;
+    }
+    for (size_t i = 0; i < BHARAT_ARRAY_SIZE(g_processes); ++i) {
+        g_processes[i].in_use = 0U;
+    }
+
+    g_current = NULL;
+    g_next_thread_id = 1U;
+    g_next_process_id = 1U;
+    g_policy = SCHED_POLICY_ROUND_ROBIN;
 }
+
+kprocess_t* process_create(const char* name) {
+    (void)name;
+
+    process_slot_t* slot = sched_find_free_process_slot();
+    if (!slot) {
+        return NULL;
+    }
+
+    slot->in_use = 1U;
+    slot->process.process_id = g_next_process_id++;
+    slot->process.addr_space = mm_create_address_space();
+    slot->process.main_thread = NULL;
+    slot->process.security_sandbox_ctx = NULL;
+
+    if (!slot->process.addr_space) {
+        slot->in_use = 0U;
+        return NULL;
+    }
+
+    if (cap_table_init_for_process(&slot->process) != 0) {
+        slot->in_use = 0U;
+        return NULL;
+    }
+
+    return &slot->process;
+}
+
+kthread_t* thread_create(kprocess_t* parent, void (*entry_point)(void)) {
+    if (!parent || !entry_point) {
+        return NULL;
+    }
+
+    thread_slot_t* slot = sched_find_free_thread_slot();
+    if (!slot) {
+        return NULL;
+    }
+
+    slot->in_use = 1U;
+    slot->thread.thread_id = g_next_thread_id++;
+    slot->thread.process_id = parent->process_id;
+    slot->thread.cpu_context = &slot->context;
+    slot->thread.kernel_stack = 0U;
+    slot->thread.state = THREAD_STATE_READY;
+    slot->thread.priority = 1U;
+    slot->thread.base_priority = 1U;
+    slot->thread.waiting_on_lock = NULL;
+    slot->thread.capability_list = NULL;
+    slot->thread.time_slice_ms = SCHED_DEFAULT_SLICE_MS;
+    slot->thread.cpu_time_consumed = 0U;
+
+    slot->context.pc = (uint64_t)(uintptr_t)entry_point;
+    slot->context.sp = 0U;
+
+    if (!parent->main_thread) {
+        parent->main_thread = &slot->thread;
+    }
+
+    return &slot->thread;
+}
+
+int thread_destroy(kthread_t* thread) {
+    if (!thread) {
+        return -1;
+    }
+
+    thread_slot_t* slot = sched_find_thread_slot_by_tid(thread->thread_id);
+    if (!slot) {
+        return -2;
+    }
+
+    slot->thread.state = THREAD_STATE_TERMINATED;
+    if (g_current == &slot->thread) {
+        g_current = NULL;
+    }
+    slot->in_use = 0U;
+    return 0;
+}
+
+void sched_yield(void) {
+    kthread_t* next = sched_pick_next_ready();
+    if (next) {
+        sched_switch_to(next);
+    }
+}
+
+void sched_on_timer_tick(void) {
+    if (g_current) {
+        g_current->cpu_time_consumed++;
+        if (g_current->cpu_time_consumed >= g_current->time_slice_ms) {
+            g_current->cpu_time_consumed = 0U;
+            sched_yield();
+        }
+        return;
+    }
+
+    sched_yield();
+}
+
+kthread_t* sched_current_thread(void) {
+    return g_current;
+}
+
+void sched_set_policy(sched_policy_t policy) {
+    g_policy = policy;
+    (void)g_policy; // current implementation keeps RR semantics for both profiles.
+}
+
+int sched_sys_thread_create(kprocess_t* parent, void (*entry_point)(void), uint64_t* out_tid) {
+    kthread_t* t = thread_create(parent, entry_point);
+    if (!t) {
+        return -1;
+    }
+
+    if (out_tid) {
+        *out_tid = t->thread_id;
+    }
+    return 0;
+}
+
+int sched_sys_thread_destroy(uint64_t tid) {
+    thread_slot_t* slot = sched_find_thread_slot_by_tid(tid);
+    if (!slot) {
+        return -1;
+    }
+
+    return thread_destroy(&slot->thread);
+}
+
+void sched_inherit_priority(kthread_t* thread, uint32_t new_priority) {
+    if (!thread) {
+        return;
+    }
+
+    if (new_priority > thread->priority) {
+        thread->priority = new_priority;
+    }
+}
+
+void sched_restore_priority(kthread_t* thread) {
+    if (!thread) {
+        return;
+    }
+
+    thread->priority = thread->base_priority;
+}
+
+#ifdef Profile_RTOS
+void sched_disable_tick_for_core(uint32_t core_id) {
+    (void)core_id;
+}
+#endif

--- a/kernel/src/stack_protector.c
+++ b/kernel/src/stack_protector.c
@@ -1,0 +1,8 @@
+#include "kernel.h"
+#include <stdint.h>
+
+uintptr_t __stack_chk_guard = 0x6A09E667F3BCC909ULL;
+
+void __stack_chk_fail(void) {
+    kernel_panic("stack protector check failed");
+}

--- a/kernel/src/trap/trap.c
+++ b/kernel/src/trap/trap.c
@@ -1,0 +1,158 @@
+#include "trap.h"
+#include "kernel.h"
+#include "mm.h"
+#include "hal/hal.h"
+#include "capability.h"
+#include "ipc_endpoint.h"
+#include "kernel_safety.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define TRAP_SUCCESS 0L
+#define TRAP_ERR_INVAL (-22L)
+#define TRAP_ERR_PERM (-1L)
+#define TRAP_ERR_NOSYS (-38L)
+
+#if defined(__x86_64__)
+#define TRAP_CAUSE_SYSCALL 0x80U
+#elif defined(__riscv)
+#define TRAP_CAUSE_SYSCALL 8U
+#else
+#define TRAP_CAUSE_SYSCALL 0xFFFFU
+#endif
+
+static kprocess_t g_syscall_proc;
+
+static capability_table_t* trap_current_cap_table(void) {
+    return (capability_table_t*)g_syscall_proc.security_sandbox_ctx;
+}
+
+static int trap_user_ptr_valid(uint64_t ptr) {
+    const uint64_t USER_MIN = 0x1000ULL;
+    const uint64_t USER_MAX = 0x00007FFFFFFFFFFFULL;
+    return BHARAT_RANGE_VALID(ptr, USER_MIN, USER_MAX);
+}
+
+int cap_invoke(uint64_t cap_id, uint64_t opcode, uint64_t arg0, uint64_t arg1) __attribute__((weak));
+int cap_invoke(uint64_t cap_id, uint64_t opcode, uint64_t arg0, uint64_t arg1) {
+    (void)cap_id;
+    (void)opcode;
+    (void)arg0;
+    (void)arg1;
+    return -1;
+}
+
+int trap_init(void) {
+    g_syscall_proc.process_id = 0U;
+    g_syscall_proc.addr_space = mm_create_address_space();
+    g_syscall_proc.main_thread = NULL;
+    g_syscall_proc.security_sandbox_ctx = NULL;
+
+    if (!g_syscall_proc.addr_space) {
+        return -1;
+    }
+
+    if (cap_table_init_for_process(&g_syscall_proc) != 0) {
+        return -1;
+    }
+
+    return 0;
+}
+
+long syscall_dispatch(syscall_id_t id,
+                      uint64_t arg0,
+                      uint64_t arg1,
+                      uint64_t arg2,
+                      uint64_t arg3,
+                      uint64_t arg4,
+                      uint64_t arg5) {
+    (void)arg4;
+    (void)arg5;
+
+    switch (id) {
+    case SYSCALL_NOP:
+        return TRAP_SUCCESS;
+    case SYSCALL_THREAD_CREATE: {
+        uint64_t* out_tid = (uint64_t*)(uintptr_t)arg1;
+        if (!trap_user_ptr_valid(arg1)) {
+            return TRAP_ERR_INVAL;
+        }
+        return (long)sched_sys_thread_create(&g_syscall_proc, (void (*)(void))(uintptr_t)arg0, out_tid);
+    }
+    case SYSCALL_THREAD_DESTROY:
+        return (long)sched_sys_thread_destroy(arg0);
+    case SYSCALL_SCHED_YIELD:
+        sched_yield();
+        return TRAP_SUCCESS;
+    case SYSCALL_VMM_MAP_PAGE:
+        return (long)vmm_map_page((virt_addr_t)arg0, (phys_addr_t)arg1, (uint32_t)arg2);
+    case SYSCALL_VMM_UNMAP_PAGE:
+        return (long)vmm_unmap_page((virt_addr_t)arg0);
+    case SYSCALL_CAPABILITY_INVOKE:
+        return (long)cap_invoke(arg0, arg1, arg2, arg3);
+    case SYSCALL_ENDPOINT_CREATE: {
+        capability_table_t* table = trap_current_cap_table();
+        uint32_t* out_send_cap = (uint32_t*)(uintptr_t)arg0;
+        uint32_t* out_recv_cap = (uint32_t*)(uintptr_t)arg1;
+        if (!trap_user_ptr_valid(arg0) || !trap_user_ptr_valid(arg1)) {
+            return TRAP_ERR_INVAL;
+        }
+        return (long)ipc_endpoint_create(table, out_send_cap, out_recv_cap);
+    }
+    case SYSCALL_ENDPOINT_SEND: {
+        capability_table_t* table = trap_current_cap_table();
+        if (!trap_user_ptr_valid(arg1)) {
+            return TRAP_ERR_INVAL;
+        }
+        return (long)ipc_endpoint_send(table, (uint32_t)arg0, (const void*)(uintptr_t)arg1, (uint32_t)arg2);
+    }
+    case SYSCALL_ENDPOINT_RECEIVE: {
+        capability_table_t* table = trap_current_cap_table();
+        uint32_t* out_len = (uint32_t*)(uintptr_t)arg3;
+        if (!trap_user_ptr_valid(arg1) || !trap_user_ptr_valid(arg3)) {
+            return TRAP_ERR_INVAL;
+        }
+        return (long)ipc_endpoint_receive(table, (uint32_t)arg0, (void*)(uintptr_t)arg1, (uint32_t)arg2, out_len);
+    }
+    case SYSCALL_CAPABILITY_DELEGATE: {
+        capability_table_t* table = trap_current_cap_table();
+        uint32_t* out_cap = (uint32_t*)(uintptr_t)arg2;
+        if (!trap_user_ptr_valid(arg2)) {
+            return TRAP_ERR_INVAL;
+        }
+        return (long)cap_table_delegate(table, table, (uint32_t)arg0, (uint32_t)arg1, out_cap);
+    }
+    default:
+        return TRAP_ERR_NOSYS;
+    }
+}
+
+long trap_handle(trap_frame_t* frame) {
+    if (!frame) {
+        return TRAP_ERR_INVAL;
+    }
+
+    if (frame->cause != TRAP_CAUSE_SYSCALL) {
+        return TRAP_ERR_NOSYS;
+    }
+
+    if (frame->from_user == 0U) {
+        return TRAP_ERR_PERM;
+    }
+
+    long rc = syscall_dispatch((syscall_id_t)frame->gpr[0],
+                               frame->gpr[1], frame->gpr[2], frame->gpr[3],
+                               frame->gpr[4], frame->gpr[5], frame->gpr[6]);
+    frame->gpr[0] = (uint64_t)rc;
+
+#if defined(__riscv)
+    frame->pc += 4U;
+#elif defined(__x86_64__)
+    frame->pc += 2U;
+#else
+    frame->pc += 4U;
+#endif
+
+    return rc;
+}

--- a/lib/include/ipc_user.h
+++ b/lib/include/ipc_user.h
@@ -1,0 +1,26 @@
+#ifndef BHARAT_USER_IPC_H
+#define BHARAT_USER_IPC_H
+
+#include <stdint.h>
+
+#include "unistd.h"
+
+enum {
+    BHARAT_SYS_ENDPOINT_CREATE = 7,
+    BHARAT_SYS_ENDPOINT_SEND = 8,
+    BHARAT_SYS_ENDPOINT_RECEIVE = 9,
+};
+
+static inline long ipc_endpoint_create(uint32_t* out_send_cap, uint32_t* out_recv_cap) {
+    return syscall(BHARAT_SYS_ENDPOINT_CREATE, out_send_cap, out_recv_cap);
+}
+
+static inline long ipc_endpoint_send(uint32_t send_cap, const void* payload, uint32_t len) {
+    return syscall(BHARAT_SYS_ENDPOINT_SEND, send_cap, payload, len);
+}
+
+static inline long ipc_endpoint_receive(uint32_t recv_cap, void* out_payload, uint32_t out_cap, uint32_t* out_len) {
+    return syscall(BHARAT_SYS_ENDPOINT_RECEIVE, recv_cap, out_payload, out_cap, out_len);
+}
+
+#endif // BHARAT_USER_IPC_H

--- a/lib/posix/include/sys/types.h
+++ b/lib/posix/include/sys/types.h
@@ -1,0 +1,35 @@
+#ifndef BHARAT_POSIX_SYS_TYPES_H
+#define BHARAT_POSIX_SYS_TYPES_H
+
+#include <stdint.h>
+
+/*
+ * Freestanding-friendly POSIX scalar type aliases.
+ * These guards avoid duplicate typedefs across libc/toolchain headers.
+ */
+#ifndef BHARAT_POSIX_SSIZE_T_DEFINED
+#define BHARAT_POSIX_SSIZE_T_DEFINED 1
+typedef intptr_t ssize_t;
+#endif
+
+#ifndef BHARAT_POSIX_PID_T_DEFINED
+#define BHARAT_POSIX_PID_T_DEFINED 1
+typedef int32_t pid_t;
+#endif
+
+#ifndef BHARAT_POSIX_OFF_T_DEFINED
+#define BHARAT_POSIX_OFF_T_DEFINED 1
+typedef int64_t off_t;
+#endif
+
+#ifndef BHARAT_POSIX_UID_T_DEFINED
+#define BHARAT_POSIX_UID_T_DEFINED 1
+typedef uint32_t uid_t;
+#endif
+
+#ifndef BHARAT_POSIX_GID_T_DEFINED
+#define BHARAT_POSIX_GID_T_DEFINED 1
+typedef uint32_t gid_t;
+#endif
+
+#endif /* BHARAT_POSIX_SYS_TYPES_H */

--- a/lib/posix/include/unistd.h
+++ b/lib/posix/include/unistd.h
@@ -8,36 +8,8 @@
  */
 
 #include <stddef.h>
-#include <stdint.h>
 
-/* Use conditional guards to prevent redefinition errors
- * when building with standard toolchains.
- */
-
-#ifndef _SSIZE_T_DEFINED_
-#define _SSIZE_T_DEFINED_
-typedef intptr_t ssize_t;
-#endif
-
-#ifndef _PID_T_DEFINED_
-#define _PID_T_DEFINED_
-typedef int32_t pid_t;
-#endif
-
-#ifndef _OFF_T_DEFINED_
-#define _OFF_T_DEFINED_
-typedef int64_t off_t;
-#endif
-
-#ifndef _UID_T_DEFINED_
-#define _UID_T_DEFINED_
-typedef uint32_t uid_t;
-#endif
-
-#ifndef _GID_T_DEFINED_
-#define _GID_T_DEFINED_
-typedef uint32_t gid_t;
-#endif
+#include <sys/types.h>
 
 // Standard File Descriptors
 #define STDIN_FILENO  0

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,3 +7,43 @@ add_executable(test_early_alloc test_early_alloc.c)
 target_include_directories(test_early_alloc PRIVATE ../kernel/include)
 
 add_test(NAME test_early_alloc COMMAND test_early_alloc)
+
+add_executable(test_urpc_ring test_urpc_ring.c ../kernel/src/ipc/multikernel.c)
+target_include_directories(test_urpc_ring PRIVATE ../kernel/include)
+add_test(NAME test_urpc_ring COMMAND test_urpc_ring)
+
+add_executable(test_scheduler test_scheduler.c ../kernel/src/sched_stub.c ../kernel/src/capability.c)
+target_include_directories(test_scheduler PRIVATE ../kernel/include)
+add_test(NAME test_scheduler COMMAND test_scheduler)
+
+add_executable(test_trap_syscall test_trap_syscall.c ../kernel/src/trap/trap.c ../kernel/src/sched_stub.c ../kernel/src/capability.c ../kernel/src/ipc/endpoint_ipc.c)
+target_include_directories(test_trap_syscall PRIVATE ../kernel/include)
+add_test(NAME test_trap_syscall COMMAND test_trap_syscall)
+
+add_executable(test_capability_ipc test_capability_ipc.c ../kernel/src/capability.c ../kernel/src/ipc/endpoint_ipc.c ../kernel/src/sched_stub.c)
+target_include_directories(test_capability_ipc PRIVATE ../kernel/include)
+add_test(NAME test_capability_ipc COMMAND test_capability_ipc)
+
+add_executable(test_device_framework test_device_framework.c ../kernel/src/device/device_manager.c ../kernel/src/device/builtin_drivers.c ../kernel/src/ipc/zero_copy_io.c ../kernel/src/capability.c ../kernel/src/sched_stub.c)
+target_include_directories(test_device_framework PRIVATE ../kernel/include)
+add_test(NAME test_device_framework COMMAND test_device_framework)
+
+add_executable(test_multikernel_topology test_multikernel_topology.c ../kernel/src/ipc/multikernel.c ../kernel/src/mm/numa.c)
+target_include_directories(test_multikernel_topology PRIVATE ../kernel/include)
+add_test(NAME test_multikernel_topology COMMAND test_multikernel_topology)
+
+add_executable(test_capability_misuse test_capability_misuse.c ../kernel/src/capability.c ../kernel/src/sched_stub.c)
+target_include_directories(test_capability_misuse PRIVATE ../kernel/include)
+add_test(NAME test_capability_misuse COMMAND test_capability_misuse)
+
+add_executable(test_memory_edgecases test_memory_edgecases.c ../kernel/src/mm/vmm.c ../kernel/src/capability.c ../kernel/src/sched_stub.c)
+target_include_directories(test_memory_edgecases PRIVATE ../kernel/include)
+add_test(NAME test_memory_edgecases COMMAND test_memory_edgecases)
+
+add_executable(test_tier_a_integration test_tier_a_integration.c ../kernel/src/trap/trap.c ../kernel/src/sched_stub.c ../kernel/src/capability.c ../kernel/src/ipc/endpoint_ipc.c)
+target_include_directories(test_tier_a_integration PRIVATE ../kernel/include)
+add_test(NAME test_tier_a_integration COMMAND test_tier_a_integration)
+
+add_executable(test_riscv_shakti_bsp test_riscv_shakti_bsp.c ../kernel/src/hal/riscv/shakti_bsp.c)
+target_include_directories(test_riscv_shakti_bsp PRIVATE ../kernel/include)
+add_test(NAME test_riscv_shakti_bsp COMMAND test_riscv_shakti_bsp)

--- a/tests/test_capability_ipc.c
+++ b/tests/test_capability_ipc.c
@@ -1,0 +1,53 @@
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include "../kernel/include/capability.h"
+#include "../kernel/include/ipc_endpoint.h"
+
+static address_space_t g_as = { .root_table = 0x1000U };
+
+address_space_t* mm_create_address_space(void) {
+    return &g_as;
+}
+
+phys_addr_t mm_alloc_page(uint32_t preferred_numa_node) {
+    (void)preferred_numa_node;
+    return 0;
+}
+
+void mm_free_page(phys_addr_t page) {
+    (void)page;
+}
+
+void entry_point(void) {}
+
+int main(void) {
+    sched_init();
+
+    kprocess_t* proc = process_create("ipc");
+    assert(proc != NULL);
+
+    capability_table_t* table = (capability_table_t*)proc->security_sandbox_ctx;
+    assert(table != NULL);
+
+    uint32_t send_cap = 0;
+    uint32_t recv_cap = 0;
+    assert(ipc_endpoint_create(table, &send_cap, &recv_cap) == IPC_OK);
+
+    const char* msg = "hello";
+    assert(ipc_endpoint_send(table, send_cap, msg, 5U) == IPC_OK);
+
+    char out[16] = {0};
+    uint32_t out_len = 0;
+    assert(ipc_endpoint_receive(table, recv_cap, out, sizeof(out), &out_len) == IPC_OK);
+    assert(out_len == 5U);
+    assert(out[0] == 'h' && out[4] == 'o');
+
+    // Delegation must only narrow rights.
+    uint32_t delegated = 0;
+    assert(cap_table_delegate(table, table, send_cap, CAP_PERM_SEND, &delegated) == 0);
+
+    printf("Capability/endpoint IPC tests passed.\n");
+    return 0;
+}

--- a/tests/test_capability_misuse.c
+++ b/tests/test_capability_misuse.c
@@ -1,0 +1,44 @@
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include "../kernel/include/capability.h"
+
+static address_space_t g_as = { .root_table = 0x1000U };
+
+address_space_t* mm_create_address_space(void) {
+    return &g_as;
+}
+
+phys_addr_t mm_alloc_page(uint32_t preferred_numa_node) {
+    (void)preferred_numa_node;
+    return 0;
+}
+
+void mm_free_page(phys_addr_t page) {
+    (void)page;
+}
+
+int main(void) {
+    sched_init();
+    kprocess_t* p = process_create("cap-misuse");
+    assert(p != NULL);
+
+    capability_table_t* t = (capability_table_t*)p->security_sandbox_ctx;
+    assert(t != NULL);
+
+    uint32_t cap = 0;
+
+    // Invalid rights for endpoint object should fail.
+    assert(cap_table_grant(t, CAP_OBJ_ENDPOINT, 1U, CAP_PERM_MAP, &cap) != 0);
+
+    // Valid grant succeeds.
+    assert(cap_table_grant(t, CAP_OBJ_ENDPOINT, 1U, CAP_PERM_SEND | CAP_PERM_DELEGATE, &cap) == 0);
+
+    // Delegating unsupported rights should fail.
+    uint32_t delegated = 0;
+    assert(cap_table_delegate(t, t, cap, CAP_PERM_MAP, &delegated) != 0);
+
+    printf("Capability misuse tests passed.\n");
+    return 0;
+}

--- a/tests/test_device_framework.c
+++ b/tests/test_device_framework.c
@@ -1,0 +1,56 @@
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include "../kernel/include/device.h"
+#include "../kernel/include/io_subsys.h"
+
+static address_space_t g_as = { .root_table = 0x1000U };
+
+address_space_t* mm_create_address_space(void) {
+    return &g_as;
+}
+
+phys_addr_t mm_alloc_page(uint32_t preferred_numa_node) {
+    (void)preferred_numa_node;
+    return 0;
+}
+
+void mm_free_page(phys_addr_t page) {
+    (void)page;
+}
+
+int vmm_map_device_mmio(virt_addr_t vaddr, phys_addr_t paddr, capability_t* cap, int is_npu) {
+    (void)vaddr;
+    (void)paddr;
+    (void)is_npu;
+    return (cap != NULL) ? 0 : -1;
+}
+
+int vmm_unmap_page(virt_addr_t vaddr) {
+    (void)vaddr;
+    return 0;
+}
+
+int main(void) {
+    assert(device_framework_init() == 0);
+    assert(device_register_builtin_drivers() == 0);
+
+    device_mmio_window_t rx = {0};
+    device_mmio_window_t tx = {0};
+    assert(device_lookup_mmio_window(DEVICE_CLASS_ETHERNET, 0U, 0U, &rx) == 0);
+    assert(device_lookup_mmio_window(DEVICE_CLASS_ETHERNET, 0U, 1U, &tx) == 0);
+    assert(rx.phys_base != 0U && tx.phys_base != 0U);
+
+    capability_t cap = {
+        .capability_id = 1U,
+        .target_object_id = 1U,
+        .rights_mask = CAP_RIGHT_NETWORK_IO,
+    };
+    zero_copy_nic_ring_t ring = {0};
+    assert(io_setup_zero_copy_nic_ring(0U, &ring, &cap) == 0);
+    assert(ring.rx_ring_base != NULL && ring.tx_ring_base != NULL);
+
+    printf("Device framework tests passed.\n");
+    return 0;
+}

--- a/tests/test_memory_edgecases.c
+++ b/tests/test_memory_edgecases.c
@@ -1,0 +1,32 @@
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include "../kernel/include/mm.h"
+
+phys_addr_t mm_alloc_page(uint32_t preferred_numa_node) {
+    (void)preferred_numa_node;
+    return 0;
+}
+
+void mm_free_page(phys_addr_t page) {
+    (void)page;
+}
+
+int mm_pmm_init(void* memory_map, uint32_t map_size) {
+    (void)memory_map;
+    (void)map_size;
+    return 0;
+}
+
+void mm_inc_page_ref(phys_addr_t page) { (void)page; }
+void hal_tlb_flush(unsigned long long vaddr) { (void)vaddr; }
+
+int main(void) {
+    // vmm wrappers should reject invalid inputs in baseline implementation
+    assert(vmm_map_page(0U, 0U, 0U) != 0);
+    assert(vmm_unmap_page(0U) != 0);
+
+    printf("Memory edge-case tests passed.\n");
+    return 0;
+}

--- a/tests/test_multikernel_topology.c
+++ b/tests/test_multikernel_topology.c
@@ -1,0 +1,68 @@
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include "../kernel/include/advanced/multikernel.h"
+#include "../kernel/include/numa.h"
+
+void hal_send_ipi_payload(uint32_t target_core, uint64_t payload) {
+    (void)target_core;
+    (void)payload;
+}
+
+int multicore_boot_secondary_cores(uint32_t core_count) {
+    return (core_count >= 1U) ? 0 : -1;
+}
+
+int main(void) {
+    assert(mk_boot_secondary_cores(2U) == URPC_SUCCESS);
+    assert(mk_init_per_core_channels(2U, 4U) == URPC_SUCCESS);
+
+    mk_channel_t c = {0};
+    assert(mk_get_channel(0U, 1U, &c) == URPC_SUCCESS);
+    assert(c.urpc_ring != NULL);
+
+    urpc_msg_t msg = {.msg_type = 1U, .payload_size = 8U, .payload_data = {42U}};
+    urpc_msg_t out = {0};
+
+    // Fill, drain, and wrap around
+    assert(urpc_send(c.urpc_ring, &msg) == URPC_SUCCESS);
+    assert(urpc_send(c.urpc_ring, &msg) == URPC_SUCCESS);
+    assert(urpc_send(c.urpc_ring, &msg) == URPC_SUCCESS);
+    assert(urpc_send(c.urpc_ring, &msg) == URPC_ERR_FULL);
+
+    assert(urpc_receive(c.urpc_ring, &out) == URPC_SUCCESS);
+    assert(urpc_receive(c.urpc_ring, &out) == URPC_SUCCESS);
+
+    assert(urpc_send(c.urpc_ring, &msg) == URPC_SUCCESS);
+    assert(urpc_send(c.urpc_ring, &msg) == URPC_SUCCESS);
+
+    int drained = 0;
+    while (urpc_receive(c.urpc_ring, &out) == URPC_SUCCESS) {
+        drained++;
+    }
+    assert(drained >= 3);
+
+    // Message pool allocator
+    mk_message_slot_t slots[2] = {0};
+    mk_msg_pool_t pool = {0};
+    assert(mk_msg_pool_init(&pool, slots, 2U) == URPC_SUCCESS);
+
+    urpc_msg_t* a = mk_msg_alloc(&pool);
+    urpc_msg_t* b = mk_msg_alloc(&pool);
+    urpc_msg_t* cmsg = mk_msg_alloc(&pool);
+    assert(a != NULL && b != NULL && cmsg == NULL);
+    mk_msg_free(&pool, a);
+    assert(mk_msg_alloc(&pool) != NULL);
+
+    // NUMA descriptors
+    assert(numa_discover_topology() == 0);
+    assert(numa_set_node_descriptor(1U, 0x100000000ULL, 0x20000000ULL, 4U) == 0);
+    numa_node_descriptor_t desc = {0};
+    assert(numa_get_node_descriptor(1U, &desc) == 0);
+    assert(desc.cpu_count == 4U);
+    assert(numa_active_node_count() >= 2U);
+
+    printf("Multikernel topology tests passed.\n");
+    return 0;
+}

--- a/tests/test_riscv_shakti_bsp.c
+++ b/tests/test_riscv_shakti_bsp.c
@@ -1,0 +1,34 @@
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include "../kernel/include/hal/riscv_bsp.h"
+
+static void assert_profile(const char* name,
+                           riscv_soc_profile_t profile,
+                           uint64_t expected_uart) {
+    riscv_bsp_config_t cfg;
+    assert(hal_riscv_bsp_detect(name, 0x88000000ULL, &cfg) == 0);
+    assert(cfg.soc_profile == profile);
+    assert(cfg.uart_base == expected_uart);
+    assert(cfg.plic_base != 0ULL);
+    assert(cfg.clint_base != 0ULL);
+}
+
+int main(void) {
+    assert_profile("shakti-e", RISCV_SOC_SHAKTI_E, 0xF0000000ULL);
+    assert_profile("shakti-c", RISCV_SOC_SHAKTI_C, 0xE0001800ULL);
+    assert_profile("shakti-i", RISCV_SOC_SHAKTI_I, 0x20000000ULL);
+    assert_profile("qemu-virt", RISCV_SOC_QEMU_VIRT, 0x10000000ULL);
+
+    riscv_bsp_config_t active;
+    assert(hal_riscv_bsp_detect("shakti-e", 0x81000000ULL, &active) == 0);
+    assert(hal_riscv_bsp_init(&active) == 0);
+
+    const riscv_bsp_config_t* got = hal_riscv_bsp_active();
+    assert(got->soc_profile == RISCV_SOC_SHAKTI_E);
+    assert(got->fdt_ptr == 0x81000000ULL);
+
+    printf("RISC-V Shakti BSP tests passed.\n");
+    return 0;
+}

--- a/tests/test_scheduler.c
+++ b/tests/test_scheduler.c
@@ -1,0 +1,57 @@
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include "../kernel/include/sched.h"
+
+static address_space_t g_as = { .root_table = 0x1000U };
+
+address_space_t* mm_create_address_space(void) {
+    return &g_as;
+}
+
+phys_addr_t mm_alloc_page(uint32_t preferred_numa_node) {
+    (void)preferred_numa_node;
+    return 0;
+}
+
+void mm_free_page(phys_addr_t page) {
+    (void)page;
+}
+
+void thread_a(void) {}
+void thread_b(void) {}
+
+int main(void) {
+    sched_init();
+
+    kprocess_t* p = process_create("init");
+    assert(p != NULL);
+
+    kthread_t* t1 = thread_create(p, thread_a);
+    kthread_t* t2 = thread_create(p, thread_b);
+    assert(t1 != NULL && t2 != NULL);
+
+    // First tick should dispatch first ready thread.
+    sched_on_timer_tick();
+    assert(sched_current_thread() != NULL);
+
+    // Force a yield and ensure scheduler can switch to another ready thread.
+    kthread_t* before = sched_current_thread();
+    sched_yield();
+    kthread_t* after = sched_current_thread();
+    assert(after != NULL);
+    assert(after != before);
+
+    // Syscall façade coverage
+    uint64_t tid = 0;
+    assert(sched_sys_thread_create(p, thread_a, &tid) == 0);
+    assert(tid != 0);
+    assert(sched_sys_thread_destroy(tid) == 0);
+
+    assert(thread_destroy(t1) == 0);
+    assert(thread_destroy(t2) == 0);
+
+    printf("Scheduler tests passed.\n");
+    return 0;
+}

--- a/tests/test_tier_a_integration.c
+++ b/tests/test_tier_a_integration.c
@@ -1,0 +1,78 @@
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include "../kernel/include/capability.h"
+#include "../kernel/include/ipc_endpoint.h"
+#include "../kernel/include/trap.h"
+
+static address_space_t g_as = { .root_table = 0x1000U };
+
+address_space_t* mm_create_address_space(void) {
+    return &g_as;
+}
+
+phys_addr_t mm_alloc_page(uint32_t preferred_numa_node) {
+    (void)preferred_numa_node;
+    return 0;
+}
+
+void mm_free_page(phys_addr_t page) {
+    (void)page;
+}
+
+int vmm_map_page(virt_addr_t vaddr, phys_addr_t paddr, uint32_t flags) {
+    (void)vaddr;
+    (void)paddr;
+    (void)flags;
+    return 0;
+}
+
+int vmm_unmap_page(virt_addr_t vaddr) {
+    (void)vaddr;
+    return 0;
+}
+
+void user_entry(void) {}
+
+int main(void) {
+    sched_init();
+    assert(trap_init() == 0);
+
+    uint64_t tid = 0;
+    assert(syscall_dispatch(SYSCALL_THREAD_CREATE,
+                            (uint64_t)(uintptr_t)user_entry,
+                            (uint64_t)(uintptr_t)&tid,
+                            0, 0, 0, 0) == 0);
+    assert(tid != 0);
+
+    uint32_t send_cap = 0;
+    uint32_t recv_cap = 0;
+    assert(syscall_dispatch(SYSCALL_ENDPOINT_CREATE,
+                            (uint64_t)(uintptr_t)&send_cap,
+                            (uint64_t)(uintptr_t)&recv_cap,
+                            0, 0, 0, 0) == 0);
+
+    const char payload[] = {'t', 'i', 'e', 'r', '-', 'a'};
+    assert(syscall_dispatch(SYSCALL_ENDPOINT_SEND,
+                            send_cap,
+                            (uint64_t)(uintptr_t)payload,
+                            sizeof(payload),
+                            0, 0, 0) == 0);
+
+    uint8_t out[16] = {0};
+    uint32_t out_len = 0;
+    assert(syscall_dispatch(SYSCALL_ENDPOINT_RECEIVE,
+                            recv_cap,
+                            (uint64_t)(uintptr_t)out,
+                            sizeof(out),
+                            (uint64_t)(uintptr_t)&out_len,
+                            0, 0) == 0);
+    assert(out_len == sizeof(payload));
+    assert(out[0] == 't' && out[5] == 'a');
+
+    assert(syscall_dispatch(SYSCALL_THREAD_DESTROY, tid, 0, 0, 0, 0, 0) == 0);
+
+    printf("Tier-A integration test passed.\n");
+    return 0;
+}

--- a/tests/test_trap_syscall.c
+++ b/tests/test_trap_syscall.c
@@ -1,0 +1,101 @@
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include "../kernel/include/trap.h"
+
+static address_space_t g_as = { .root_table = 0x1000U };
+
+address_space_t* mm_create_address_space(void) {
+    return &g_as;
+}
+
+phys_addr_t mm_alloc_page(uint32_t preferred_numa_node) {
+    (void)preferred_numa_node;
+    return 0;
+}
+
+void mm_free_page(phys_addr_t page) {
+    (void)page;
+}
+
+int vmm_map_page(virt_addr_t vaddr, phys_addr_t paddr, uint32_t flags) {
+    (void)vaddr;
+    (void)paddr;
+    (void)flags;
+    return 0;
+}
+
+int vmm_unmap_page(virt_addr_t vaddr) {
+    (void)vaddr;
+    return 0;
+}
+
+void user_entry(void) {}
+
+int main(void) {
+    sched_init();
+    assert(trap_init() == 0);
+
+    uint64_t tid = 0;
+    long rc = syscall_dispatch(SYSCALL_THREAD_CREATE,
+                               (uint64_t)(uintptr_t)user_entry,
+                               (uint64_t)(uintptr_t)&tid,
+                               0,0,0,0);
+    assert(rc == 0);
+    assert(tid != 0);
+
+    assert(syscall_dispatch(SYSCALL_THREAD_DESTROY, tid, 0,0,0,0,0) == 0);
+
+    // Invalid pointer should be rejected.
+    assert(syscall_dispatch(SYSCALL_THREAD_CREATE,
+                            (uint64_t)(uintptr_t)user_entry,
+                            0x10U,
+                            0,0,0,0) == -22);
+
+    uint32_t send_cap = 0;
+    uint32_t recv_cap = 0;
+    assert(syscall_dispatch(SYSCALL_ENDPOINT_CREATE,
+                            (uint64_t)(uintptr_t)&send_cap,
+                            (uint64_t)(uintptr_t)&recv_cap,
+                            0,0,0,0) == 0);
+
+    const char payload[] = {'o','k'};
+    assert(syscall_dispatch(SYSCALL_ENDPOINT_SEND,
+                            send_cap,
+                            (uint64_t)(uintptr_t)payload,
+                            2U,0,0,0) == 0);
+
+    uint8_t recv_buf[8] = {0};
+    uint32_t recv_len = 0;
+    assert(syscall_dispatch(SYSCALL_ENDPOINT_RECEIVE,
+                            recv_cap,
+                            (uint64_t)(uintptr_t)recv_buf,
+                            sizeof(recv_buf),
+                            (uint64_t)(uintptr_t)&recv_len,
+                            0,0) == 0);
+    assert(recv_len == 2U);
+    assert(recv_buf[0] == 'o' && recv_buf[1] == 'k');
+
+    trap_frame_t frame = {0};
+    frame.cause =
+#if defined(__x86_64__)
+      0x80U;
+#elif defined(__riscv)
+      8U;
+#else
+      0xFFFFU;
+#endif
+    frame.from_user = 1U;
+    frame.gpr[0] = SYSCALL_NOP;
+
+    assert(trap_handle(&frame) == 0);
+    assert(frame.gpr[0] == 0U);
+
+    frame.from_user = 0U;
+    frame.gpr[0] = SYSCALL_NOP;
+    assert(trap_handle(&frame) == -1);
+
+    printf("Trap/syscall gate tests passed.\n");
+    return 0;
+}

--- a/tests/test_urpc_ring.c
+++ b/tests/test_urpc_ring.c
@@ -1,0 +1,46 @@
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include "../kernel/include/advanced/multikernel.h"
+
+int multicore_boot_secondary_cores(uint32_t core_count) {
+    (void)core_count;
+    return 0;
+}
+
+void hal_send_ipi_payload(uint32_t target_core, uint64_t payload) {
+    (void)target_core;
+    (void)payload;
+}
+
+int main(void) {
+    urpc_msg_t buffer[2] = {0};
+    urpc_ring_t ring = {0};
+    urpc_msg_t msg = { .msg_type = 7U, .payload_size = 8U, .payload_data = {0xABCDU} };
+    urpc_msg_t out = {0};
+
+    assert(urpc_init_ring(NULL, buffer, 2U) == URPC_ERR_INVALID);
+    assert(urpc_init_ring(&ring, NULL, 2U) == URPC_ERR_INVALID);
+    assert(urpc_init_ring(&ring, buffer, 0U) == URPC_ERR_INVALID);
+    assert(urpc_init_ring(&ring, buffer, 1U) == URPC_ERR_INVALID);
+    assert(urpc_init_ring(&ring, buffer, 2U) == URPC_SUCCESS);
+
+    assert(urpc_receive(&ring, &out) == URPC_ERR_EMPTY);
+    assert(urpc_send(&ring, &msg) == URPC_SUCCESS);
+    assert(urpc_send(&ring, &msg) == URPC_ERR_FULL);
+
+    assert(urpc_receive(&ring, &out) == URPC_SUCCESS);
+    assert(out.msg_type == 7U);
+    assert(out.payload_size == 8U);
+    assert(out.payload_data[0] == 0xABCDU);
+
+    assert(urpc_receive(&ring, &out) == URPC_ERR_EMPTY);
+
+    ring.capacity = 0U;
+    assert(urpc_send(&ring, &msg) == URPC_ERR_INVALID);
+    assert(urpc_receive(&ring, &out) == URPC_ERR_INVALID);
+
+    printf("URPC ring tests passed.\n");
+    return 0;
+}


### PR DESCRIPTION
### Motivation

- Provide reproducible cross-arch build presets and a GitHub Actions CI job to build the kernel, run unit tests, and run an optional `clang-tidy` static-analysis pass. 
- Add a Shakti/OpenSBI-friendly RISC-V GCC toolchain flow and payload generation to support board-specific packaging and BSP bring-up. 
- Land an initial Tier-A kernel baseline: capability table, IPC endpoints, lockless URPC multikernel plumbing, basic scheduler, NUMA stubs, HAL hooks (interrupt/timer), device framework, and trap/syscall plumbing so host unit tests can exercise core paths. 
- Improve build hardening and developer ergonomics via `CMakePresets.json`, `BUILD.md` updates, and optional `BHARAT_ENABLE_CLANG_TIDY` integration.

### Description

- Add CI and tooling: new `/.clang-tidy`, `.github/workflows/kernel-ci.yml`, `CMakePresets.json`, and `cmake/toolchains/riscv64-elf-gcc.cmake`, plus `CMakeLists.txt` changes to expose `BHARAT_ENABLE_CLANG_TIDY`, hardening/ASLR options, and payload generation for RISC-V. 
- Implement HAL/board and platform baselines: RISC-V Shakti BSP (`hal/riscv/shakti_bsp.c` + header), HAL interrupt/timer stubs, x86_64/arm64 HAL extensions, and per-arch boot entry adjustments for OpenSBI args. 
- Add kernel subsystems and interfaces: capability management (`capability.h/.c`), device registry and built-in drivers, device MMIO window management, zero-copy NIC mapping integration, NUMA support and descriptors, multicore booting, multikernel URPC ring/channel and message-pool APIs, trap/syscall gate (`trap.h/.c`), scheduler stub (`sched.h` + `sched_stub.c`), stack protector, and many supporting headers. 
- Add tests and test harnesses: expanded `tests/CMakeLists.txt` and ~18 unit/integration tests under `tests/` (URPC ring, scheduler, trap/syscall, capability+IPC, device framework, multikernel topology, RISC-V BSP, Tier-A integration, etc.). 
- Update docs and build instructions: `BUILD.md` reflects CMake presets, Shakti/OpenSBI packaging, and toolchain notes; architecture docs added/extended to reflect capability/ipc, multiprocessor, scheduling, trap gates and threat model.

### Testing

- Built and exercised presets and CI flow via: `cmake --preset x86_64-elf-debug`, `cmake --build --preset build-x86_64-kernel`, `cmake --preset tests-host`, `cmake --build --preset build-tests`, and `ctest --preset run-tests`, with the test suite passing (unit/integration tests such as `test_urpc_ring`, `test_scheduler`, `test_trap_syscall`, `test_capability_ipc`, `test_device_framework`, `test_multikernel_topology`, `test_tier_a_integration` executed successfully). 
- Verified `clang-tidy` path by configuring and building with `cmake -S . -B build-tidy -DBHARAT_ENABLE_CLANG_TIDY=ON -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/x86_64-elf.cmake` and `cmake --build build-tidy --target kernel.elf`, which completed without blocking the CI flow. 
- Confirmed RISC-V Shakti payload build flows and packaging helpers by running `cmake --preset riscv64-shakti-e-gcc-debug` and `cmake --build --preset build-riscv64-shakti-e-gcc-kernel` to produce `kernel.payload.bin` when toolchain tools are available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac5090f0f0832089d534f2583e052f)