### PR TITLE
Fix CMake linker invocation for kernel builds and stabilize host test preset

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -72,7 +72,8 @@
       "generator": "Unix Makefiles",
       "binaryDir": "${sourceDir}/build-tests",
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Debug"
+        "CMAKE_BUILD_TYPE": "Debug",
+        "BHARAT_BUILD_AI_GOVERNOR": "OFF"
       }
     },
     {

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -3,22 +3,6 @@ project(BharatOS_Kernel C ASM)
 
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 
-# ── Linker selection (toolchain-provided linker preferred)
-# If the toolchain did not define CMAKE_LINKER, fallback to ld.lld.
-if(NOT CMAKE_LINKER)
-    find_program(LLD_LINKER NAMES ld.lld HINTS
-        "C:/Program Files/LLVM/bin"
-        "/usr/bin" "/usr/local/bin" "/opt/homebrew/bin"
-    )
-    if(NOT LLD_LINKER)
-        message(FATAL_ERROR "No linker configured and ld.lld not found (see BUILD.md)")
-    endif()
-    set(CMAKE_LINKER "${LLD_LINKER}")
-endif()
-
-set(CMAKE_C_LINK_EXECUTABLE   "<CMAKE_LINKER> <LINK_FLAGS> <OBJECTS> -o <TARGET>")
-set(CMAKE_ASM_LINK_EXECUTABLE "<CMAKE_LINKER> <LINK_FLAGS> <OBJECTS> -o <TARGET>")
-
 # ── Toolchain file provides all compiler/linker settings.
 # Pass -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/<arch>-elf.cmake at configure time.
 # See BUILD.md for exact commands for each platform.
@@ -153,14 +137,14 @@ if(BHARAT_KERNEL_ASLR)
         $<$<COMPILE_LANGUAGE:C>:-fpie>
     )
     target_link_options(kernel.elf PRIVATE
-        "--pie"
+        "LINKER:--pie"
     )
 else()
     target_compile_options(kernel.elf PRIVATE
         $<$<COMPILE_LANGUAGE:C>:-fno-pie>
     )
     target_link_options(kernel.elf PRIVATE
-        "--no-pie"
+        "LINKER:--no-pie"
     )
 endif()
 
@@ -169,8 +153,7 @@ if(ARCH STREQUAL "x86_64")
         $<$<COMPILE_LANGUAGE:C>:-mno-red-zone>
     )
     target_link_options(kernel.elf PRIVATE
-        "-m"
-        "elf_x86_64"
+        "LINKER:-m,elf_x86_64"
     )
 elseif(ARCH STREQUAL "riscv64")
     target_compile_options(kernel.elf PRIVATE
@@ -178,15 +161,15 @@ elseif(ARCH STREQUAL "riscv64")
     )
 endif()
 
-# ── Linker options (native ld.lld flags — we call ld.lld directly)
-# NOTE: LINKER: / -Wl, prefixes are for clang driver and DON'T work here.
-# Use native ld.lld flags directly: --nopie, -T, --build-id, --fatal-warnings
+# ── Linker options
+# Use LINKER: so CMake can translate options correctly when linking via the
+# compiler driver across clang/gcc and host/cross presets.
 target_link_options(kernel.elf PRIVATE
     "-nostdlib"
-    "--fatal-warnings"
-    "-T" "${LINKER_SCRIPT}"
-    "--build-id=none"
-    "--no-dynamic-linker"
+    "LINKER:--fatal-warnings"
+    "LINKER:-T,${LINKER_SCRIPT}"
+    "LINKER:--build-id=none"
+    "LINKER:--no-dynamic-linker"
 )
 
 

--- a/kernel/src/main.c
+++ b/kernel/src/main.c
@@ -110,13 +110,8 @@ static void kernel_phase2_hello_service_smoke(void) {
 }
 
 static void kernel_boot_scheduler(void) {
-  if (sched_init) {
-    sched_init();
-    KPRINT("  [SCHED] Scheduler initialized.\n");
-    return;
-  }
-
-  kernel_panic("scheduler init symbol missing");
+  sched_init();
+  KPRINT("  [SCHED] Scheduler initialized.\n");
 }
 
 static void kernel_ai_governor_init(void) {
@@ -173,7 +168,7 @@ void kernel_main(void) {
   KPRINT("\n");
   KPRINT("  ____  _                          _          ____   ____  \n");
   KPRINT(" | __ )| |__   __ _ _ __ __ _ _| |_       / ___| / ___| \n");
-  KPRINT(" |  _ \| '_ \\ / _` | '__/ _` | '__/ _` |_____| |  _  \\___ \\ \n");
+  KPRINT(" |  _ \\| '_ \\ / _` | '__/ _` | '__/ _` |_____| |  _  \\___ \\ \n");
   KPRINT(" | |_) | | | | (_| | | | (_| | | | (_| |_____| |_| |  ___) |\n");
   KPRINT(" |____/|_| |_|\\__,_|_|  \\__,_|_|  \\__,_|      \\____| |____/ \n");
   KPRINT("\nBharat-OS kernel boot (v3.2 bring-up)\n");

--- a/subsys/CMakeLists.txt
+++ b/subsys/CMakeLists.txt
@@ -18,6 +18,12 @@ set(AI_GOVERNOR_SOURCES
 add_library(subsys_manager STATIC ${SUBSYS_SOURCES})
 target_compile_options(subsys_manager PRIVATE -ffreestanding -nostdlib -Wall)
 
-add_executable(ai_governor ${AI_GOVERNOR_SOURCES})
+option(BHARAT_BUILD_AI_GOVERNOR "Build ai_governor user-space demo executable" ON)
+if(BHARAT_BUILD_AI_GOVERNOR)
+    add_executable(ai_governor ${AI_GOVERNOR_SOURCES})
+    target_include_directories(ai_governor PRIVATE
+        ${CMAKE_SOURCE_DIR}/kernel/include
+    )
+endif()
 # Might need host headers if it's considered user-space mock,
 # for now compiled natively or with suitable toolchain for user-space


### PR DESCRIPTION
### Motivation
- The build failed when the toolchain/compiler driver received raw native ld flags, and clang/gcc could not interpret options like `-m elf_x86_64` or `--no-pie`, causing kernel link errors.
- `kernel/src/main.c` produced warnings from an always-true function-pointer check and an incorrectly-escaped banner line that should be cleaned up.
- Host unit test configuration attempted to build a user-space `ai_governor` binary that pulled in kernel-only symbols, causing `build-tests` to fail.

### Description
- Stop overriding CMake link command templates in `kernel/CMakeLists.txt` and move linker arguments to driver-translatable form by using `LINKER:`-prefixed entries in `target_link_options`, while keeping `-nostdlib` as a driver-side flag.
- Convert `--pie/--no-pie`, linker script invocation, `--fatal-warnings`, `--build-id`, and the `-m elf_x86_64` target option to `LINKER:`-style entries so CMake can translate them correctly for clang/gcc and cross/host presets.
- Simplify `kernel_boot_scheduler()` to call `sched_init()` directly, removing the pointer-boolean check and eliminating the `-Waddress`/`-Wpointer-bool-conversion` warning in `kernel/src/main.c`.
- Fix the escaped backslash in the ASCII-art banner string in `kernel/src/main.c` to silence the unknown-escape-sequence warning.
- Add an option `BHARAT_BUILD_AI_GOVERNOR` to `subsys/CMakeLists.txt` and guard `ai_governor` behind it, and disable the target for the `tests-host` preset in `CMakePresets.json` to prevent host test builds from linking kernel-only symbols.

### Testing
- Ran `cmake --preset x86_64-elf-debug && cmake --build --preset build-x86_64-kernel` and the kernel target built successfully.
- Ran `cmake --preset tests-host && cmake --build --preset build-tests` and the tests/host build completed successfully with the subsystem manager target (the `ai_governor` executable is disabled for the preset).
- Both builds resolved the previous linker errors and compiler warnings described in the failure logs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac6bb73ca083208feda9576f049064)