### PR TITLE
Enhance Architecture Docs and Build Tools

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -2,6 +2,28 @@
 
 Bharat-OS primarily uses **LLVM/Clang** + **LLD** for cross-arch reproducibility, with an optional **riscv64-unknown-elf-gcc** flow for Shakti/OpenSBI firmware packaging. Build scripts work identically on Windows, WSL, Linux, macOS, and BSD.
 
+```mermaid
+flowchart TD
+    subgraph BuildSystem["Build System"]
+        A[Source Code] -->|CMake| B(Build Generator)
+    end
+
+    subgraph Toolchains["Cross-Platform Toolchains"]
+        B -->|x86_64-elf.cmake| X86[LLVM/Clang x86_64]
+        B -->|riscv64-elf.cmake| RV[LLVM/Clang riscv64]
+        B -.->|riscv64-elf-gcc.cmake| RVGCC[GCC riscv64 - Optional Payload]
+        B -->|arm64-elf.cmake| ARM[LLVM/Clang arm64]
+    end
+
+    subgraph Output["Output Artifacts"]
+        X86 --> O1[kernel.elf]
+        X86 --> O4[kernel32.elf Multiboot]
+        RV --> O2[kernel.elf]
+        RVGCC -.-> O5[payload.bin for OpenSBI]
+        ARM --> O3[kernel.elf]
+    end
+```
+
 ---
 
 ## Prerequisites
@@ -97,6 +119,15 @@ chmod +x tools/build.sh
 
 # Override boot knobs
 ./tools/build.sh x86_64 --boot-gui=OFF --hw=vm
+
+# Run RISC-V with specific QEMU machine (e.g., sifive_u)
+./tools/build.sh riscv64 --machine=sifive_u --run
+
+# Build RISC-V GCC OpenSBI payload
+./tools/build.sh riscv64 --payload
+
+# Run with GDB debug server enabled
+./tools/build.sh x86_64 --run --debug
 ```
 
 **Windows (PowerShell 5+ or pwsh)**
@@ -119,6 +150,15 @@ chmod +x tools/build.sh
 
 # Override boot knobs
 .\tools\build.ps1 -Arch x86_64 -BootGui OFF -HardwareProfile vm
+
+# Run RISC-V with specific QEMU machine
+.\tools\build.ps1 -Arch riscv64 -Machine sifive_u -Run
+
+# Build RISC-V GCC OpenSBI payload
+.\tools\build.ps1 -Arch riscv64 -Payload
+
+# Run with GDB debug server enabled
+.\tools\build.ps1 -Arch x86_64 -Run -DebugQemu
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -39,25 +39,31 @@ For architecture details, see [`docs/architecture/README.md`](docs/architecture/
 
 ## Architecture Design (v1 Blueprint)
 
-```text
-┌──────────────────────────────────────────────────────────────────┐
-│                      User Space / Services                       │
-│  Drivers  |  Filesystems  |  Network Stack  |  Runtime Services │
-└───────────────▲────────────────────────▲─────────────────────────┘
-                │ Capability-guarded IPC │
-┌───────────────┴────────────────────────┴─────────────────────────┐
-│                    Microkernel (Trusted Core)                    │
-│  Scheduling  |  IPC Routing  |  Capability Checks  |  VM/PMM API │
-└───────────────▲────────────────────────▲─────────────────────────┘
-                │ HAL interfaces         │
-┌───────────────┴────────────────────────┴─────────────────────────┐
-│                              HAL                                 │
-│       Interrupts  |  Timer  |  MMU  |  Device/Platform Glue     │
-└───────────────▲────────────────────────▲─────────────────────────┘
-                │                        │
-         ┌──────┴──────┐          ┌──────┴──────┐
-         │   x86_64    │          │   riscv64   │  (+ arm64 planned)
-         └─────────────┘          └─────────────┘
+```mermaid
+flowchart TD
+    subgraph Userspace["User Space / Services"]
+        direction LR
+        D[Drivers] --- F[Filesystems] --- N[Network Stack] --- R[Runtime Services]
+    end
+
+    subgraph Microkernel["Microkernel (Trusted Core)"]
+        direction LR
+        S[Scheduling] --- I[IPC Routing] --- C[Capability Checks] --- V[VM/PMM API]
+    end
+
+    subgraph HAL["Hardware Abstraction Layer (HAL)"]
+        direction LR
+        Int[Interrupts] --- T[Timer] --- M[MMU] --- Plat[Device/Platform Glue]
+    end
+
+    subgraph Hardware["Hardware Platforms"]
+        direction LR
+        X86[x86_64] --- RISCV[riscv64] -.-> ARM[arm64 planned]
+    end
+
+    Userspace <-->|Capability-guarded IPC| Microkernel
+    Microkernel <-->|HAL interfaces| HAL
+    HAL <--> Hardware
 ```
 
 Design principles represented above:

--- a/docs/architecture/boot-flow-riscv64.md
+++ b/docs/architecture/boot-flow-riscv64.md
@@ -6,6 +6,28 @@ Unlike x86, RISC-V enforces strict privilege levels (M-Mode, S-Mode, U-Mode). Th
 
 ## Sequence
 
+```mermaid
+sequenceDiagram
+    participant Hardware as BootROM (M-Mode)
+    participant SBI as SBI Firmware (M-Mode)
+    participant Stub as Assembly Stub (_start) (S-Mode)
+    participant Kernel as Microkernel (kernel_main)
+    participant User as Root User Task
+
+    Hardware->>SBI: Bring up HART, init RAM
+    SBI->>SBI: Setup trap delegation
+    SBI->>SBI: Discover hardware (DeviceTree)
+    SBI->>SBI: Load kernel binary
+    SBI->>Stub: mret (Drop to S-Mode)
+    Stub->>Stub: Setup supervisor stack (sp)
+    Stub->>Kernel: Call kernel_main(hartid, dtb_ptr)
+    Kernel->>Kernel: Parse FDT/DTB
+    Kernel->>Kernel: Init PMM and VMM (satp for Sv39/48)
+    Kernel->>Kernel: Configure trap vectors (stvec)
+    Kernel->>Kernel: Wake secondary HARTs (sbi_send_ipi)
+    Kernel->>User: Handover capabilities & Start
+```
+
 1. **Hardware / BootROM (M-Mode)**: Initial silicon brings up the primary HART (Hardware Thread), initializes RAM, and jumps to the SBI firmware.
 2. **SBI Firmware (OpenSBI / RustSBI) (M-Mode)**:
    - Sets up trap delegation so traps pass immediately down to the OS.

--- a/docs/architecture/boot-flow-x86_64.md
+++ b/docs/architecture/boot-flow-x86_64.md
@@ -6,6 +6,28 @@ The x86_64 architecture is highly legacy-encumbered. Bharat-OS targets modern UE
 
 ## Sequence
 
+```mermaid
+sequenceDiagram
+    participant UEFI as UEFI Firmware
+    participant Bootloader as Bootloader (GRUB2/Limine)
+    participant Stub as Assembly Stub (_start)
+    participant Kernel as Microkernel (kernel_main)
+    participant User as Root User Task (init)
+
+    UEFI->>Bootloader: Load from ESP
+    Bootloader->>Bootloader: Setup basic 64-bit page table
+    Bootloader->>Bootloader: Collect Memory Map & Framebuffer
+    Bootloader->>Stub: Jump to _start (with Multiboot2 magic)
+    Stub->>Stub: Setup initial kernel stack
+    Stub->>Kernel: Call kernel_main(magic, info_ptr)
+    Kernel->>Kernel: Parse Multiboot2 tags (Physical Memory)
+    Kernel->>Kernel: pmm_init() (Physical Memory Manager)
+    Kernel->>Kernel: idt_init() (Interrupts)
+    Kernel->>Kernel: vmm_init() (Virtual Memory Manager)
+    Kernel->>User: Handover capabilities & Start
+    User->>User: Spawn Personality Servers & Drivers
+```
+
 1. **UEFI Firmware**: Initializes the hardware, maps standard ACPI tables, and loads the bootloader from the ESP (EFI System Partition).
 2. **Bootloader (GRUB2/Limine)**:
    - Reads the ELF64 Bharat-OS kernel binary.

--- a/docs/architecture/ipc-model.md
+++ b/docs/architecture/ipc-model.md
@@ -6,6 +6,30 @@ Because Bharat-OS is a microkernel, almost all OS services (file systems, networ
 
 We utilize two distinct IPC models to serve both deterministic bounds (Bharat-RT) and massive scalability (Bharat-Cloud).
 
+```mermaid
+flowchart LR
+    subgraph Userspace["User Space"]
+        Client[Client Task]
+        Server[Server Task]
+    end
+
+    subgraph Kernel["Microkernel"]
+        Endpoint[IPC Endpoint]
+    end
+
+    subgraph MultiCore["Multikernel Architecture (Cross-Core)"]
+        CoreA[Core A]
+        CoreB[Core B]
+        RingBuffer[(Shared Ring Buffer)]
+    end
+
+    Client -- "1. Sync Send (Registers)" --> Endpoint
+    Endpoint -- "2. Sync Receive" --> Server
+
+    CoreA -- "Lockless URPC" --> RingBuffer
+    RingBuffer -- "Lockless URPC" --> CoreB
+```
+
 ## 1. Synchronous Endpoint IPC (The Microkernel Standard)
 
 Fast, blocking, unbuffered message passing used for capability delegation and strict procedural calls.

--- a/docs/architecture/scheduler-and-threading.md
+++ b/docs/architecture/scheduler-and-threading.md
@@ -2,6 +2,31 @@
 
 This document captures the current baseline implementation for scheduler/threading in the kernel.
 
+```mermaid
+flowchart TD
+    subgraph ThreadLifecycle["Thread Lifecycle"]
+        direction LR
+        Create[thread_create] --> Ready[Ready Queue]
+        Ready --> Running[Running]
+        Running --> Blocked[Blocked/Sleep]
+        Blocked --> Ready
+        Running --> Destroy[thread_destroy]
+    end
+
+    subgraph SchedulerTick["Scheduler Tick (sched_on_timer_tick)"]
+        Tick[Timer Tick] --> Telemetry[Update Telemetry]
+        Telemetry --> AI[Process AI Suggestions]
+        AI --> Dispatch[Context Switch]
+        Dispatch --> Running
+    end
+
+    subgraph AIActions["AI Scheduler Actions"]
+        AI --> Migrate[Migrate Task]
+        AI --> Priority[Adjust Priority]
+        AI --> Throttle[Throttle Core]
+    end
+```
+
 ## Implemented in this baseline
 
 - Static in-kernel process/thread registries.

--- a/docs/decisions/ADR-002-capability-model.md
+++ b/docs/decisions/ADR-002-capability-model.md
@@ -13,6 +13,26 @@ Traditional operating systems rely on Access Control Lists (ACLs) checking User 
 We adopted a pure **Capability-Based Object Model**.
 A capability is an unforgeable token (managed entirely in kernel memory so user-space cannot tamper with it) that acts as both a pointer to an object and a set of permission rights (Read/Write/Grant).
 
+```mermaid
+flowchart TD
+    subgraph Userspace["User Space Process (CSpace)"]
+        Cap1[Capability A (Read/Write)]
+        Cap2[Capability B (Grant)]
+    end
+
+    subgraph Kernel["Microkernel Memory"]
+        Obj1[(Kernel Object X)]
+        Obj2[(Kernel Object Y)]
+    end
+
+    Cap1 -->|Verified Reference| Obj1
+    Cap2 -->|Verified Reference| Obj2
+
+    %% Tampering attempt fails
+    Tamper[Malicious Code] -.->|Invalid direct memory access| Obj1
+    style Tamper fill:#f9f,stroke:#333,stroke-width:2px
+```
+
 If a thread does not possess a capability (in its Capability Space, or CSpace) pointing to an object, that object does not functionally exist to the thread.
 
 ## Consequences

--- a/docs/decisions/ADR-005-ml-stays-out-of-ring-0.md
+++ b/docs/decisions/ADR-005-ml-stays-out-of-ring-0.md
@@ -16,6 +16,26 @@ While the OS supports AI-aware tuning, we architecturally enforce a strict separ
 - **Mechanism (Ring-0)**: The microkernel exports rich hardware telemetry, performance counters, and bounded policy tuning hooks (e.g., setting a CPU timeslice coefficient or page eviction threshold).
 - **Policy (Ring-3 User-Space)**: ML heuristic daemons (RL agents) run as unprivileged tasks in user-space. They observe the telemetry and invoke capabilities to adjust the bounded tuning hooks.
 
+```mermaid
+flowchart TD
+    subgraph Userspace["Ring-3 User-Space (Policy)"]
+        AI[AI Governor Daemon]
+        Model[ML/Heuristic Model]
+        AI <--> Model
+    end
+
+    subgraph Kernel["Ring-0 Microkernel (Mechanism)"]
+        Sched[Scheduler & Dispatcher]
+        Tele[Hardware Telemetry/PMCs]
+        Hooks[Bounded Tuning Hooks]
+    end
+
+    Tele -- "1. Export Telemetry (URPC/Shared Mem)" --> AI
+    AI -- "2. Evaluate & Decide" --> AI
+    AI -- "3. Adjust Hooks (Capability IPC)" --> Hooks
+    Hooks --> Sched
+```
+
 ## Consequences
 
 ### Positive

--- a/kernel/include/advanced/ai_sched.h
+++ b/kernel/include/advanced/ai_sched.h
@@ -57,8 +57,8 @@ typedef struct {
 
     uint64_t total_cycles;
     uint64_t total_instructions;
-    float current_cpi;
-    float historical_cpi_window[10];
+    uint32_t current_cpi;
+    uint32_t historical_cpi_window[10];
     uint32_t window_index;
     uint32_t predicted_complexity;
 } ai_sched_context_t;

--- a/kernel/linker_arm64.ld
+++ b/kernel/linker_arm64.ld
@@ -33,6 +33,9 @@ SECTIONS
         bss_end = .;
     }
 
+    . = ALIGN(4096);
+    _end = .;
+
     /DISCARD/ :
     {
         *(.comment)

--- a/kernel/linker_riscv64.ld
+++ b/kernel/linker_riscv64.ld
@@ -33,6 +33,9 @@ SECTIONS
         bss_end = .;
     }
 
+    . = ALIGN(4096);
+    _end = .;
+
     /DISCARD/ :
     {
         *(.comment)

--- a/kernel/src/ai_sched.c
+++ b/kernel/src/ai_sched.c
@@ -38,7 +38,11 @@ void ai_sched_update_telemetry(ai_sched_context_t* ctx, uint64_t cycles_delta, u
     ctx->total_instructions += inst_delta;
 
     if (inst_delta != 0U) {
-        ctx->current_cpi = (float)cycles_delta / (float)inst_delta;
+        // Use integer arithmetic (CPI * 100) instead of floats for bare-metal portability
+        // to avoid soft-float libgcc dependencies.
+        ctx->current_cpi = (uint32_t)((cycles_delta * 100U) / inst_delta);
+    } else {
+        ctx->current_cpi = 0;
     }
 
     ctx->historical_cpi_window[ctx->window_index % 10U] = ctx->current_cpi;
@@ -53,15 +57,15 @@ void ai_sched_predict_and_scale(ai_sched_context_t* ctx) {
         return;
     }
 
-    float cpi_sum = 0.0f;
+    uint32_t cpi_sum = 0;
     for (uint32_t i = 0; i < 10U; ++i) {
         cpi_sum += ctx->historical_cpi_window[i];
     }
 
-    float cpi_avg = cpi_sum / 10.0f;
-    if (cpi_avg > 2.0f) {
+    uint32_t cpi_avg = cpi_sum / 10U;
+    if (cpi_avg > 200U) {
         ctx->predicted_complexity = 2U;
-    } else if (cpi_avg > 1.0f) {
+    } else if (cpi_avg > 100U) {
         ctx->predicted_complexity = 1U;
     } else {
         ctx->predicted_complexity = 0U;

--- a/tools/build.ps1
+++ b/tools/build.ps1
@@ -19,6 +19,9 @@ param(
     [string]$Arch = "x86_64",
     [switch]$Clean = $false,
     [switch]$Run = $false,
+    [switch]$DebugQemu = $false,
+    [switch]$Payload = $false,
+    [string]$Machine = "virt",
     [ValidateSet("ON", "OFF")][string]$BootGui = "ON",
     [ValidateSet("generic", "desktop", "server", "vm", "laptop")][string]$HardwareProfile = "generic"
 )
@@ -28,8 +31,16 @@ $ErrorActionPreference = "Stop"
 
 $Root = Split-Path -Parent $PSScriptRoot
 $BuildDir = "$Root\build\$Arch"
+if ($Payload -and $Arch -eq "riscv64") {
+    $BuildDir = "$Root\build\$Arch-gcc"
+}
+
 $OutELF = "$BuildDir\kernel.elf"
+
 $Toolchain = "$Root\cmake\toolchains\$Arch-elf.cmake"
+if ($Payload -and $Arch -eq "riscv64") {
+    $Toolchain = "$Root\cmake\toolchains\riscv64-elf-gcc.cmake"
+}
 
 # ── Ensure LLVM tools are on PATH ─────────────────────────────────────────
 $llvmBin = "C:\Program Files\LLVM\bin"
@@ -73,8 +84,13 @@ if (-not (Test-Path "$BuildDir\CMakeCache.txt")) {
 
 # ── Build ──────────────────────────────────────────────────────────────────
 inf "Building kernel.elf"
-& cmake --build $BuildDir --target kernel.elf
-if ($LASTEXITCODE -ne 0) { fail "Build failed" }
+if ($Payload -and $Arch -eq "riscv64") {
+    & cmake --build $BuildDir --target kernel.payload.bin
+    if ($LASTEXITCODE -ne 0) { fail "Build failed (payload)" }
+} else {
+    & cmake --build $BuildDir --target kernel.elf
+    if ($LASTEXITCODE -ne 0) { fail "Build failed" }
+}
 
 # ── Convert to 32-bit ELF for x86_64 (Requirement for Multiboot) ──────────
 $KernelBinary = $OutELF
@@ -86,8 +102,14 @@ if ($Arch -eq "x86_64") {
     $KernelBinary = $OutELF32
 }
 
-$sizeKB = [math]::Round((Get-Item $OutELF).Length / 1KB, 1)
-ok "kernel.elf -> $OutELF  ($sizeKB KB)"
+if ($Payload -and $Arch -eq "riscv64") {
+    $sizeKB = [math]::Round((Get-Item "$BuildDir\payload.bin").Length / 1KB, 1)
+    ok "payload.bin -> $BuildDir\payload.bin  ($sizeKB KB)"
+} else {
+    $sizeKB = [math]::Round((Get-Item $OutELF).Length / 1KB, 1)
+    ok "kernel.elf -> $OutELF  ($sizeKB KB)"
+}
+
 if ($Arch -eq "x86_64") { ok "kernel32.elf -> $OutELF32" }
 
 # ── QEMU ──────────────────────────────────────────────────────────────────
@@ -103,10 +125,24 @@ if ($Run) {
     ok "Booting in QEMU (press Ctrl+A then X to quit)..."
     Write-Host ""
 
-    $qemuArgs = switch ($Arch) {
-        "x86_64" { @("-kernel", $KernelBinary, "-m", "256M", "-nographic", "-serial", "mon:stdio", "-no-reboot") }
-        "riscv64" { @("-machine", "virt", "-kernel", $OutELF, "-m", "256M", "-nographic", "-serial", "mon:stdio", "-no-reboot") }
-        "arm64" { @("-machine", "virt", "-cpu", "cortex-a53", "-kernel", $OutELF, "-m", "256M", "-nographic", "-serial", "mon:stdio", "-no-reboot") }
+    $qemuArgs = @()
+
+    if ($Arch -eq "x86_64") {
+        $qemuArgs += @("-kernel", $KernelBinary, "-m", "256M", "-nographic", "-serial", "mon:stdio", "-no-reboot")
+    } elseif ($Arch -eq "riscv64") {
+        if ($Payload) {
+            $qemuArgs += @("-machine", $Machine, "-bios", "$BuildDir\payload.bin", "-m", "256M", "-nographic", "-serial", "mon:stdio", "-no-reboot")
+        } else {
+            $qemuArgs += @("-machine", $Machine, "-kernel", $OutELF, "-m", "256M", "-nographic", "-serial", "mon:stdio", "-no-reboot")
+        }
+    } elseif ($Arch -eq "arm64") {
+        $qemuArgs += @("-machine", $Machine, "-cpu", "cortex-a53", "-kernel", $OutELF, "-m", "256M", "-nographic", "-serial", "mon:stdio", "-no-reboot")
     }
+
+    if ($DebugQemu) {
+        inf "GDB Server enabled on tcp::1234. Waiting for debugger..."
+        $qemuArgs += @("-s", "-S")
+    }
+
     & $qemuExe @qemuArgs
 }

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -9,19 +9,30 @@ if [ $# -ge 1 ]; then shift; SHIFT_DONE=true; fi
 
 CLEAN=false
 RUN=false
+DEBUG=false
+PAYLOAD=false
 BOOT_GUI="ON"
 BOOT_HW="generic"
+MACHINE="virt"
 for arg in "$@"; do
     case "$arg" in
         --clean) CLEAN=true ;;
         --run)   RUN=true   ;;
+        --debug) DEBUG=true ;;
+        --payload) PAYLOAD=true ;;
         --boot-gui=*) BOOT_GUI="${arg#*=}" ;;
         --hw=*) BOOT_HW="${arg#*=}" ;;
+        --machine=*) MACHINE="${arg#*=}" ;;
     esac
 done
 
 BHARAT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 BUILD_DIR="${BHARAT_ROOT}/build/${ARCH}"
+
+if [ "${PAYLOAD}" = "true" ] && [ "${ARCH}" = "riscv64" ]; then
+    BUILD_DIR="${BHARAT_ROOT}/build/${ARCH}-gcc"
+fi
+
 OUT_ELF="${BUILD_DIR}/kernel.elf"
 
 SAF="\033[38;2;255;153;51m"
@@ -38,7 +49,13 @@ echo ""
 
 case "${ARCH}" in
     x86_64)  TOOLCHAIN="cmake/toolchains/x86_64-elf.cmake" ;;
-    riscv64) TOOLCHAIN="cmake/toolchains/riscv64-elf.cmake" ;;
+    riscv64)
+        if [ "${PAYLOAD}" = "true" ]; then
+            TOOLCHAIN="cmake/toolchains/riscv64-elf-gcc.cmake"
+        else
+            TOOLCHAIN="cmake/toolchains/riscv64-elf.cmake"
+        fi
+        ;;
     arm64)   TOOLCHAIN="cmake/toolchains/arm64-elf.cmake" ;;
 esac
 
@@ -57,12 +74,23 @@ cmake -S "${BHARAT_ROOT}/kernel" \
       --no-warn-unused-cli
 
 inf "Building kernel.elf"
-cmake --build "${BUILD_DIR}" --target kernel.elf
-
-SIZE=$(du -sh "${OUT_ELF}" 2>/dev/null | cut -f1)
-ok "kernel.elf → ${OUT_ELF}  (${SIZE})"
+if [ "${PAYLOAD}" = "true" ] && [ "${ARCH}" = "riscv64" ]; then
+    cmake --build "${BUILD_DIR}" --target kernel.payload.bin
+    SIZE=$(du -sh "${BUILD_DIR}/payload.bin" 2>/dev/null | cut -f1)
+    ok "payload.bin → ${BUILD_DIR}/payload.bin  (${SIZE})"
+else
+    cmake --build "${BUILD_DIR}" --target kernel.elf
+    SIZE=$(du -sh "${OUT_ELF}" 2>/dev/null | cut -f1)
+    ok "kernel.elf → ${OUT_ELF}  (${SIZE})"
+fi
 
 if [ "${RUN}" = "true" ]; then
+    DEBUG_ARGS=()
+    if [ "${DEBUG}" = "true" ]; then
+        inf "GDB Server enabled on tcp::1234. Waiting for debugger..."
+        DEBUG_ARGS=("-s" "-S")
+    fi
+
     echo ""
     ok "Booting in QEMU (press Ctrl+A then X to quit)..."
     echo ""
@@ -89,34 +117,52 @@ EOF2
                     -nographic \
                     -serial mon:stdio \
                     -no-reboot \
-                    -boot d
+                    -boot d \
+                    "${DEBUG_ARGS[@]}"
             else
                 qemu-system-x86_64 \
                     -kernel "${OUT_ELF}" \
                     -m 256M \
                     -nographic \
                     -serial mon:stdio \
-                    -no-reboot
+                    -no-reboot \
+                    "${DEBUG_ARGS[@]}"
             fi
             ;;
         riscv64)
-            qemu-system-riscv64 \
-                -machine virt \
-                -kernel "${OUT_ELF}" \
-                -m 256M \
-                -nographic \
-                -serial mon:stdio \
-                -no-reboot
+            if [ "${PAYLOAD}" = "true" ]; then
+                # Example: payload.bin run flow, requires fw_payload integration generally,
+                # but we'll try to boot it as a bios/kernel depending on QEMU capability.
+                # For generic virt, QEMU can take kernel or bios.
+                qemu-system-riscv64 \
+                    -machine "${MACHINE}" \
+                    -bios "${BUILD_DIR}/payload.bin" \
+                    -m 256M \
+                    -nographic \
+                    -serial mon:stdio \
+                    -no-reboot \
+                    "${DEBUG_ARGS[@]}"
+            else
+                qemu-system-riscv64 \
+                    -machine "${MACHINE}" \
+                    -kernel "${OUT_ELF}" \
+                    -m 256M \
+                    -nographic \
+                    -serial mon:stdio \
+                    -no-reboot \
+                    "${DEBUG_ARGS[@]}"
+            fi
             ;;
         arm64)
             qemu-system-aarch64 \
-                -machine virt \
+                -machine "${MACHINE}" \
                 -cpu cortex-a53 \
                 -kernel "${OUT_ELF}" \
                 -m 256M \
                 -nographic \
                 -serial mon:stdio \
-                -no-reboot
+                -no-reboot \
+                "${DEBUG_ARGS[@]}"
             ;;
     esac
 fi


### PR DESCRIPTION
This PR enhances the documentation to use Mermaid diagrams for easier architecture comprehension. It also significantly updates the build script capability, adding debugging, specific hardware emulation, and optional OpenSBI payload compilation for RISC-V targets. Bare-metal float logic in `ai_sched.c` was fixed to ensure cross-compilation works seamlessly without relying on `libgcc` soft-float routines.

---
*PR created automatically by Jules for task [12565677134047251705](https://jules.google.com/task/12565677134047251705) started by @divyang4481*