### PR TITLE
🧪 [test] add error path test for vmm_map_device_mmio

### DIFF
--- a/tests/test_memory_edgecases.c
+++ b/tests/test_memory_edgecases.c
@@ -48,6 +48,29 @@ int main(void) {
     // Unmap the valid page
     //assert(vmm_unmap_page(0x1000U) == 0);
 
+    // Test vmm_map_device_mmio error paths and success paths
+    capability_t cap_npu = { .rights_mask = CAP_RIGHT_DEVICE_NPU };
+    capability_t cap_gpu = { .rights_mask = CAP_RIGHT_DEVICE_GPU };
+    capability_t cap_none = { .rights_mask = CAP_RIGHT_READ };
+
+    // 1. NULL capability should be denied (-3)
+    assert(vmm_map_device_mmio(0x3000U, 0x4000U, NULL, 1) == -3);
+
+    // 2. NPU request with GPU-only capability should be denied (-3)
+    assert(vmm_map_device_mmio(0x3000U, 0x4000U, &cap_gpu, 1) == -3);
+
+    // 3. GPU request with NPU-only capability should be denied (-3)
+    assert(vmm_map_device_mmio(0x3000U, 0x4000U, &cap_npu, 0) == -3);
+
+    // 4. NPU request with no device rights should be denied (-3)
+    assert(vmm_map_device_mmio(0x3000U, 0x4000U, &cap_none, 1) == -3);
+
+    // 5. Valid NPU request with NPU capability should succeed (0)
+    assert(vmm_map_device_mmio(0x3000U, 0x4000U, &cap_npu, 1) == 0);
+
+    // 6. Valid GPU request with GPU capability should succeed (0)
+    assert(vmm_map_device_mmio(0x4000U, 0x5000U, &cap_gpu, 0) == 0);
+
     printf("Memory edge-case tests passed.\n");
     return 0;
 }


### PR DESCRIPTION
🎯 **What:** The testing gap in `vmm_map_device_mmio` within `kernel/src/mm/vmm.c` was addressed by adding specific error path and success path tests for capability rights checks.
📊 **Coverage:** The following scenarios are now explicitly tested in `tests/test_memory_edgecases.c`:
- `NULL` capability returns `-3` (ERR_CAP_DENIED).
- NPU request with only GPU rights returns `-3`.
- GPU request with only NPU rights returns `-3`.
- Requests with no device-specific rights return `-3`.
- Valid requests with correct NPU/GPU rights return `0`.
✨ **Result:** Increased test reliability for security-critical memory mapping by ensuring device-specific capability rights are strictly enforced and correctly handled.

---
*PR created automatically by Jules for task [15631580371465257916](https://jules.google.com/task/15631580371465257916) started by @divyang4481*