### PR TITLE
Program PMC using IA32_PERF_GLOBAL_CTRL and rdpmc

### DIFF
--- a/kernel/src/hal/x86_64/hal_cpu.c
+++ b/kernel/src/hal/x86_64/hal_cpu.c
@@ -7,6 +7,8 @@
 
 #define COM1_PORT 0x3F8
 
+static void hal_cpu_pmc_init(void);
+
 static inline uint8_t x86_inb(uint16_t port) {
     uint8_t value;
     __asm__ volatile("inb %1, %0" : "=a"(value) : "Nd"(port));
@@ -15,6 +17,18 @@ static inline uint8_t x86_inb(uint16_t port) {
 
 static inline void x86_outb(uint16_t port, uint8_t value) {
     __asm__ volatile("outb %0, %1" : : "a"(value), "Nd"(port));
+}
+
+static inline void x86_wrmsr(uint32_t msr, uint64_t value) {
+    uint32_t low = (uint32_t)value;
+    uint32_t high = (uint32_t)(value >> 32);
+    __asm__ volatile("wrmsr" : : "c"(msr), "a"(low), "d"(high));
+}
+
+static inline uint64_t x86_rdpmc(uint32_t counter) {
+    uint32_t low, high;
+    __asm__ volatile("rdpmc" : "=a"(low), "=d"(high) : "c"(counter));
+    return ((uint64_t)high << 32) | low;
 }
 
 void hal_serial_init(void) {
@@ -345,6 +359,9 @@ void hal_init(void) {
     // Timer vector 32
     idt_set_descriptor(32, isr32, 0x8E);
 
+    // Initialize Performance Monitoring Counters
+    hal_cpu_pmc_init();
+
     // Syscall vector 0x80 (128) -> from user (DPL=3 -> 0xEE)
     idt_set_descriptor(128, isr128, 0xEE);
 
@@ -433,6 +450,20 @@ uint32_t hal_cpu_get_id(void) {
 
 #define SCHED_MAX_THREADS 64U
 
+#define MSR_IA32_PERFEVTSEL1      0x187
+#define MSR_IA32_PERF_GLOBAL_CTRL 0x38F
+#define ARCH_EVENT_INST_RETIRED   0xC0
+
+static void hal_cpu_pmc_init(void) {
+    // Program PMC1 to count Instructions Retired (Event 0xC0, Umask 0x00)
+    // Bit 16: USR, Bit 17: OS, Bit 22: EN
+    uint64_t evtsel = ARCH_EVENT_INST_RETIRED | (1ULL << 16) | (1ULL << 17) | (1ULL << 22);
+    x86_wrmsr(MSR_IA32_PERFEVTSEL1, evtsel);
+
+    // Enable PMC1 in GLOBAL_CTRL (Bit 1)
+    x86_wrmsr(MSR_IA32_PERF_GLOBAL_CTRL, (1ULL << 1));
+}
+
 typedef struct {
     uint64_t last_cycles;
     uint64_t last_instr;
@@ -456,18 +487,17 @@ int ai_sched_arch_sample_pmc(uint32_t thread_id, ai_pmc_sample_t* out_sample) {
     __asm__ volatile("rdtsc" : "=a"(low), "=d"(high));
     cycles = ((uint64_t)high << 32) | low;
 
-    uint64_t cycles_delta = cycles - g_pmc_state[thread_id].last_cycles;
+    uint64_t instr = x86_rdpmc(1);
 
-    // TODO: Program IA32_PERF_GLOBAL_CTRL and use rdpmc(1)
-    uint64_t instr_delta = cycles_delta / 2;
+    uint64_t cycles_delta = cycles - g_pmc_state[thread_id].last_cycles;
+    uint64_t instr_delta = instr - g_pmc_state[thread_id].last_instr;
 
     out_sample->available = 1U;
     out_sample->cycles_delta = cycles_delta;
     out_sample->instructions_delta = instr_delta;
 
     g_pmc_state[thread_id].last_cycles = cycles;
-    // We mock instructions here
-    g_pmc_state[thread_id].last_instr += instr_delta;
+    g_pmc_state[thread_id].last_instr = instr;
 
     return 0;
 }


### PR DESCRIPTION
Implemented hardware Performance Monitoring Counter (PMC) sampling for retired instructions on x86_64. This replaces the previous mock implementation (cycles/2) with accurate hardware-level telemetry.

Key highlights:
- Defined architectural MSRs: IA32_PERFEVTSEL1 (0x187) and IA32_PERF_GLOBAL_CTRL (0x38F).
- Implemented `x86_wrmsr` and `x86_rdpmc` in-line assembly helpers.
- Configured PMC1 to track event 0xC0 (Instructions Retired) during HAL initialization.
- Refactored `ai_sched_arch_sample_pmc` to calculate deltas using real counter values.
- Verified build and passed all host-level tests.

---
*PR created automatically by Jules for task [16248465521968652716](https://jules.google.com/task/16248465521968652716) started by @divyang4481*