### PR TITLE
docs: add device profiles and AI scheduler architecture guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,44 @@ graph TD
 * **Multi-Architecture HAL:** Native support for `x86_64`, `ARMv8`, and notably **Shakti RISC-V**, ensuring performance on local semiconductor innovations.
 * **Distributed IPC:** A capability-based IPC model that treats local and remote system calls through a unified messaging interface.
 
+### Current v1 Architecture Highlights
+
+| Feature | Summary |
+| --- | --- |
+| Verification-first microkernel | Ring-0 keeps only boot flow, memory mapping, capability tables, IPC and scheduling scaffolding; most services run in isolated user-space domains. |
+| Capability-based security model | No global ACL/root model in kernel. Object access is capability-mediated (`invoke`, `grant`, `revoke`, `retype`) with zero-trust isolation. |
+| Flexible memory model | Kernel only maps/unmaps physical pages while policy lives in user space: Bharat-RT favors static/no-paging determinism; Bharat-Cloud favors demand paging, NUMA-awareness, and a path toward distributed shared memory. |
+| Synchronous + asynchronous IPC | Fast register-based synchronous endpoint IPC for low latency plus lockless ring-buffer URPC for cross-core multikernel messaging. |
+| User-space driver model | Drivers remain unprivileged. Capabilities gate MMIO/IRQ access and IOMMU policy hardens DMA boundaries; drivers are restartable via IPC boundaries. |
+| Modular scheduler with AI hooks | Tick-driven scheduler collects telemetry and applies AI hints through an architecture-neutral plugin contract (ADR-008), with deterministic fallbacks when PMCs are unavailable. |
+
+### Device Profiles & Use-cases
+
+Bharat-OS is intentionally profile-driven instead of forcing one heavyweight image on every board.
+
+- **Mobile & embedded:** revocable capabilities for sensor isolation, user-space driver recovery, and Bharat-RT static allocation for deterministic latency.
+- **Edge & IoT gateways:** small attack surface, real-time tuning, and hot-swappable network/USB drivers.
+- **Robotics & UAVs:** mixed-criticality partitioning, dedicated-core workflows, and low-latency URPC messaging between control/perception tasks.
+- **Network appliances:** isolated user-space drivers plus fast-path packet processing and restart without whole-system panic.
+- **Datacenter/cloud:** multikernel-friendly scaling on many-core/NUMA systems with demand paging and policy-driven AI scheduling.
+- **Display strategy by device class:** explicit tiers for headless systems, serial/text console, framebuffer-first embedded UI, and full compositor desktop where hardware supports it.
+
+---
+
+## 🧭 Roadmap (Condensed)
+
+- **Phase 1 (kernel spine):** boot stability, scheduler/memory correctness, timer+interrupts, SMP bring-up, tracing/observability.
+- **Phase 2 (device specialization):** edge/robotics/drone service packs, power management, secure update chain, sensor+actuator frameworks.
+- **Phase 3 (cloud/appliance):** NUMA/resource isolation, high-speed networking/storage, accelerator orchestration, virtualization hooks.
+- **Phase 4 (UX surfaces):** framebuffer and embedded UI first, richer compositor/desktop layers later.
+
+### AI Features & Roadmap
+
+- Current kernel scheduler tracks thread telemetry (`cycles`, `instructions`, `CPI`) and accepts AI suggestions through a bounded, testable path.
+- Architecture-specific PMCs can be sampled when available; deterministic approximations are used otherwise.
+- ADR-008 defines the plugin boundary so scheduler core remains portable while profile/architecture overrides evolve.
+- Near-term extensions include user-space AI governors, profile-aware scheduling heuristics, and accelerator-aware placement for edge/cloud workloads.
+
 ---
 
 ## 🧠 AI-Driven Resource Management
@@ -120,9 +158,10 @@ The kernel is optimized for various form factors and architectures:
 
 ## Research & References
 
-Bharat-OS draws inspiration from and builds upon research in AI-driven systems and microkernel architectures:
+Bharat-OS draws inspiration from and builds upon research in AI-driven systems and microkernel architectures.
 
-* **AI-Driven Scheduling**: Inspired by "DeepRM: RL-based Resource Management" (Mao et al.) and research on using Reinforcement Learning for OS process scheduling.
-* **Microkernel Design**: Built on principles from the L4 microkernel family and the seL4 formal verification project.
-* **Capability-based Security**: References the KeyKOS and EROS systems for fine-grained access control.
-* **Heterogeneous Computing**: Architecture influenced by the Barrelfish multikernel approach for modern, diverse hardware.
+### Research Inspirations
+
+- **Barrelfish multikernel model:** treats a machine as a distributed system of cores coordinated by explicit message passing; this directly informs Bharat-OS URPC and cross-core service decomposition.
+- **seL4 capability model and verification-first design:** capability invocation as the primary authority path and a small trusted kernel base inform Bharat-OS object-capability isolation goals.
+- **AI scheduling research:** workload-aware scheduling literature (including RL-driven resource managers) informs the long-term AI-governor and scheduler policy roadmap.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -38,6 +38,8 @@ This folder captures the current architectural baseline for Bharat-OS.
 
 - [`personality-layer.md`](personality-layer.md)
 - [`gui-strategy.md`](gui-strategy.md)
+- [`device-profiles.md`](device-profiles.md)
+- [`ai-scheduler-overview.md`](ai-scheduler-overview.md)
 
 ## Scope note
 

--- a/docs/architecture/ai-scheduler-overview.md
+++ b/docs/architecture/ai-scheduler-overview.md
@@ -1,0 +1,52 @@
+# AI Scheduler Overview
+
+This document explains Bharat-OS's current AI-guided scheduling path and how it stays portable across architectures.
+
+## Goals
+
+- preserve deterministic core scheduler behavior
+- enrich scheduling with bounded AI suggestions
+- keep architecture-specific telemetry optional and pluggable
+
+## Current components
+
+- Kernel scheduler telemetry and prediction logic: `kernel/src/ai_sched.c`
+- Architecture-neutral scheduler contract: `kernel/include/advanced/ai_sched.h`
+- User-space governor seed implementation: `subsys/src/ai_governor.c`
+- Plugin contract ADR: `docs/decisions/ADR-008-ai-scheduler-plugin-contract.md`
+
+## Telemetry model
+
+Per-thread telemetry maintained by the scheduler includes:
+
+- total cycle estimates
+- instruction count estimates
+- CPI-style derived metrics
+- complexity prediction context
+
+When architecture PMCs are available, profile/arch hooks can sample hardware counters. When PMCs are unavailable, the scheduler uses deterministic approximations from timeslice usage, run-queue context, and switch behavior.
+
+## Plugin architecture (ADR-008)
+
+The scheduler core depends only on arch-neutral helper APIs and bounded callbacks. Architecture/profile plugins can provide:
+
+- PMC sampling overrides
+- scaling-factor policies by profile (`RTOS`, `EDGE`, `DESKTOP`)
+- optional heuristics for migration/priority/throttle suggestions
+
+This keeps the main scheduler path testable and portable while allowing architecture-specific optimization.
+
+## Execution flow summary
+
+1. Timer tick enters scheduler path.
+2. Telemetry update runs for active threads.
+3. Pending AI suggestions are processed with bounded queue logic.
+4. Scheduler applies accepted actions (migrate, reprioritize, throttle).
+5. Dispatch selects next runnable thread.
+
+## Planned extensions
+
+- user-space AI governor policies feeding scheduler hints
+- profile-tuned heuristics for mobile/edge/cloud tiers
+- accelerator-aware placement (NPU/GPU/DSP workloads)
+- stronger power/thermal coordination hooks

--- a/docs/architecture/capability-model.md
+++ b/docs/architecture/capability-model.md
@@ -19,3 +19,6 @@ A capability is an unforgeable, kernel-managed token that pairs an object refere
 
 - **Zero-Trust**: No ambient authority.
 - **Verifiability**: The flow of authority can be graph-analyzed at compile time to mathematically prove isolation between critical domains (e.g., separating networking stacks from AI cryptographic enclaves).
+
+
+> Reference: seL4 capability systems define a capability as an immutable reference paired with rights, where capability invocation is the authority path that enables least-privilege control.

--- a/docs/architecture/device-profiles.md
+++ b/docs/architecture/device-profiles.md
@@ -1,0 +1,75 @@
+# Device Profiles and Subsystem Matrix
+
+This document summarizes how Bharat-OS maps a common microkernel core to different device categories and deployment profiles.
+
+## Profile model
+
+Bharat-OS keeps the kernel core small and portable, then composes profile-specific capability packs in user space.
+
+### Shared kernel core (all profiles)
+
+- boot and platform initialization
+- scheduler and timer/interrupt framework
+- memory map/unmap primitives
+- capability/object/IPC substrate
+- SMP bring-up and per-core scaffolding
+- driver and syscall boundary primitives
+- observability, tracing, and crash hooks
+
+## Bharat-RT vs Bharat-Cloud
+
+| Area | Bharat-RT | Bharat-Cloud |
+| --- | --- | --- |
+| Memory policy | static allocation; paging disabled for deterministic bounds | demand paging with user-space pagers |
+| Scheduling target | bounded latency and low jitter | throughput, fairness, and core utilization |
+| Core topology | dedicated cores for mixed-criticality partitions | many-core and NUMA-aware placement |
+| IPC emphasis | low-latency synchronous endpoint paths | lockless URPC for cross-core/service scaling |
+| Typical devices | embedded/mobile/robotics/UAV | server, appliance, cloud, AI clusters |
+
+## Device categories and subsystem emphasis
+
+### Mobile and embedded
+
+- capability-gated sensor/peripheral access
+- user-space driver restartability for resilience
+- power/thermal tuning and suspend/resume hooks
+- framebuffer-first UX for low-cost panels; compositor optional
+
+### Edge and IoT gateways
+
+- minimal attack surface with service sandboxing
+- watchdog/recovery and secure OTA paths
+- industrial networking and telemetry-first operations
+- headless-first, with optional local framebuffer dashboard
+
+### Robotics and autonomous systems
+
+- mixed-criticality partitioning via capabilities
+- static-allocation real-time profile support
+- dedicated-core pipelines (sensor fusion, planning, control)
+- deterministic IPC across tasks and cores
+
+### Drones and UAVs
+
+- flight-control determinism and failsafe state machines
+- tight power/thermal budgets and telemetry prioritization
+- strict isolation between flight-critical and auxiliary services
+- low-overhead cross-core messaging for sensor/navigation workloads
+
+### Network appliances
+
+- user-space network drivers with isolation boundaries
+- fast-path packet processing and QoS shaping hooks
+- service restartability without full-kernel panic
+- control-plane hardening via capability-mediated access
+
+### Datacenter and cloud
+
+- multikernel scaling across many-core hosts
+- NUMA-aware memory and scheduling policy
+- accelerator-aware placement and service partitioning
+- distributed-memory roadmap including CXL-oriented design paths
+
+## Multikernel and research alignment
+
+Bharat-OS adopts a multikernel direction inspired by Barrelfish: treat cores as cooperative nodes using explicit message passing instead of shared-kernel lock contention. This aligns with the architecture goal of predictable scaling as core counts and heterogeneity rise.

--- a/docs/architecture/ipc-model.md
+++ b/docs/architecture/ipc-model.md
@@ -5,6 +5,8 @@
 Because Bharat-OS is a microkernel, almost all OS services (file systems, networking, drivers) run in isolated user-space domains. Thus, IPC performance is the most critical bottleneck.
 
 We utilize two distinct IPC models to serve both deterministic bounds (Bharat-RT) and massive scalability (Bharat-Cloud).
+The cross-core URPC path follows the multikernel principle popularized by Barrelfish: the machine is treated as a network of independent cores coordinated through explicit message passing rather than shared-kernel locks.
+
 
 ```mermaid
 flowchart LR

--- a/docs/architecture/scheduler-and-threading.md
+++ b/docs/architecture/scheduler-and-threading.md
@@ -65,6 +65,8 @@ The AI telemetry path is intentionally pluggable:
 
 This keeps scheduler mechanism portable across `x86_64`, `riscv64`, and `arm64` while allowing architecture-specific acceleration.
 
+This pluggable design is formalized by ADR-008 (`docs/decisions/ADR-008-ai-scheduler-plugin-contract.md`), which keeps scheduler mechanism portable and testable while permitting architecture/profile overrides.
+
 ## Deferred for production
 
 - Real per-core run queues and SMP load balancing.


### PR DESCRIPTION
### Motivation

- Clarify Bharat-OS design principles and surface architecture choices (verification-first microkernel, capability model, flexible memory profiles, URPC multikernel path, and user-space drivers) so contributors understand intended trade-offs. 
- Make device-oriented guidance explicit so subsystem priorities and UI/display tiers are aligned with device classes (mobile, edge, robotics, drones, network appliances, datacenter, desktop). 
- Document the AI scheduler work and ADR-008 plugin contract so telemetry, PMC fallbacks, and planned AI/governor extensions are discoverable and reviewable. 

### Description

- Added a new overview table and sections in `README.md` describing Current v1 Architecture Highlights, Device Profiles & Use-cases, a condensed Roadmap, and an AI Features & Roadmap subsection. 
- Created `docs/architecture/device-profiles.md` to map Bharat-RT vs Bharat-Cloud and to summarize subsystem emphasis across device categories. 
- Created `docs/architecture/ai-scheduler-overview.md` documenting scheduler telemetry, components (`kernel/src/ai_sched.c`, `kernel/include/advanced/ai_sched.h`, `subsys/src/ai_governor.c`), ADR-008 plugin semantics, execution flow, and planned extensions. 
- Updated architecture index and references by editing `docs/architecture/README.md`, and added contextual citations in `docs/architecture/ipc-model.md`, `docs/architecture/capability-model.md`, and `docs/architecture/scheduler-and-threading.md` to reference Barrelfish, seL4, and ADR-008 respectively. 

### Testing

- Ran `git diff --check` to validate no whitespace or diff issues and it reported no problems. 
- Verified presence of the new/updated documentation entries using `rg -n "device-profiles|ai-scheduler-overview|ADR-008|Research Inspirations|Device Profiles & Use-cases|AI Features & Roadmap"` across `README.md` and `docs/architecture` which returned the expected matches.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acf72fea708320be16e86305e71918)