### PR TITLE
Implement True Timer and Interrupt Controllers in HAL

### DIFF
--- a/kernel/src/hal/arm64/hal_cpu.c
+++ b/kernel/src/hal/arm64/hal_cpu.c
@@ -200,6 +200,8 @@ int hal_interrupt_route(uint32_t irq, uint32_t target_core) {
     return 0;
 }
 
+static uint64_t g_timer_interval;
+
 int hal_timer_source_init(uint32_t tick_hz) {
     if (tick_hz == 0U) return -1;
 
@@ -208,13 +210,13 @@ int hal_timer_source_init(uint32_t tick_hz) {
 
     if (freq == 0) return -1;
 
-    uint64_t ticks_per_period = freq / tick_hz;
+    g_timer_interval = freq / tick_hz;
 
     // Set timer value
-    __asm__ volatile("msr cntp_tval_el0, %0" : : "r"(ticks_per_period));
+    __asm__ volatile("msr cntp_tval_el0, %0" : : "r"(g_timer_interval));
 
     // Enable timer and unmask interrupt
-    // cntp_ctl_el0: bit 0 = ENABLE, bit 1 = IMASK
+    // cntp_ctl_el0: bit 0 = ENABLE, bit 1 = IMASK (0 means unmasked)
     uint64_t ctl = 1;
     __asm__ volatile("msr cntp_ctl_el0, %0" : : "r"(ctl));
 
@@ -222,6 +224,13 @@ int hal_timer_source_init(uint32_t tick_hz) {
     hal_interrupt_route(30, 0);
 
     return 0;
+}
+
+void hal_timer_isr(void) {
+    // Acknowledge and re-arm timer (cntp_tval_el0 is a countdown timer, writing to it re-arms it and clears the interrupt condition)
+    __asm__ volatile("msr cntp_tval_el0, %0" : : "r"(g_timer_interval));
+
+    hal_timer_tick();
 }
 
 uint32_t hal_cpu_get_id(void) {

--- a/kernel/src/hal/riscv/hal_cpu.c
+++ b/kernel/src/hal/riscv/hal_cpu.c
@@ -216,10 +216,20 @@ int hal_interrupt_route(uint32_t irq, uint32_t target_core) {
     return 0;
 }
 
+static uint64_t g_timer_interval;
+
 int hal_timer_source_init(uint32_t tick_hz) {
     if (tick_hz == 0U) {
         return -1;
     }
+
+    // Assuming a timebase frequency of 10MHz (e.g. QEMU Virt and Shakti default)
+    uint64_t timebase_freq = 10000000ULL;
+    g_timer_interval = timebase_freq / (uint64_t)tick_hz;
+
+    uint64_t current_time;
+    __asm__ volatile("csrr %0, time" : "=r"(current_time));
+    sbi_set_timer(current_time + g_timer_interval);
 
     // Enable Supervisor Timer Interrupt (STIE) in sie CSR
 #ifdef CONFIG_RISCV_M_MODE
@@ -228,9 +238,17 @@ int hal_timer_source_init(uint32_t tick_hz) {
     __asm__ volatile("csrs sie, %0" : : "r"(32)); // STIE is bit 5
 #endif
 
-    // Baseline periodic timer request via SBI TIME extension.
-    sbi_set_timer(1000000ULL / (uint64_t)tick_hz);
     return 0;
+}
+
+void hal_timer_isr(void) {
+    uint64_t current_time;
+    __asm__ volatile("csrr %0, time" : "=r"(current_time));
+
+    // Set next timer interrupt
+    sbi_set_timer(current_time + g_timer_interval);
+
+    hal_timer_tick();
 }
 
 uint32_t hal_cpu_get_id(void) {

--- a/kernel/src/hal/timer_common.c
+++ b/kernel/src/hal/timer_common.c
@@ -1,5 +1,6 @@
 #include "hal/timer.h"
 #include "hal/hal.h"
+#include "sched.h"
 
 #include <stdint.h>
 
@@ -32,4 +33,5 @@ uint64_t hal_timer_monotonic_ticks(void) {
 void hal_timer_tick(void) {
     (void)g_tick_hz;
     g_ticks++;
+    sched_on_timer_tick();
 }

--- a/kernel/src/hal/x86_64/hal_cpu.c
+++ b/kernel/src/hal/x86_64/hal_cpu.c
@@ -220,15 +220,13 @@ static void default_isr(void) {
     __asm__ volatile("iretq");
 }
 
-static void default_timer_isr(void) {
+void default_timer_isr(void) {
     // Ack APIC EOI
     volatile uint32_t *apic_eoi = (volatile uint32_t *)0xFEE000B0;
     *apic_eoi = 0;
 
     // Call generic timer tick
     hal_timer_tick();
-
-    __asm__ volatile("iretq");
 }
 
 

--- a/kernel/src/main.c
+++ b/kernel/src/main.c
@@ -259,8 +259,6 @@ void kernel_main(void) {
     while (1) {
       kernel_ai_publish_telemetry();
       kernel_ai_governor_tick();
-      hal_timer_tick();
-      sched_on_timer_tick();
       hal_cpu_halt();
     }
   } else {

--- a/kernel/src/trap/trap.c
+++ b/kernel/src/trap/trap.c
@@ -16,10 +16,13 @@
 
 #if defined(__x86_64__)
 #define TRAP_CAUSE_SYSCALL 0x80U
+#define TRAP_CAUSE_TIMER_INT 32U
 #elif defined(__riscv)
 #define TRAP_CAUSE_SYSCALL 8U
+#define TRAP_CAUSE_TIMER_INT 0x8000000000000005ULL // Supervisor timer interrupt
 #else
 #define TRAP_CAUSE_SYSCALL 0xFFFFU
+#define TRAP_CAUSE_TIMER_INT 30U // Generic timer PPI on ARM
 #endif
 
 static kprocess_t g_syscall_proc;
@@ -131,6 +134,20 @@ long syscall_dispatch(syscall_id_t id,
 long trap_handle(trap_frame_t* frame) {
     if (!frame) {
         return TRAP_ERR_INVAL;
+    }
+
+    if (frame->cause == TRAP_CAUSE_TIMER_INT) {
+#if defined(__x86_64__)
+        void default_timer_isr(void);
+        default_timer_isr();
+#elif defined(__riscv)
+        void hal_timer_isr(void);
+        hal_timer_isr();
+#else
+        void hal_timer_isr(void);
+        hal_timer_isr();
+#endif
+        return 0;
     }
 
     if (frame->cause != TRAP_CAUSE_SYSCALL) {


### PR DESCRIPTION
Completed the hardware timer implementations for x86_64 (APIC timer), RISC-V (SBI Timer), and ARM64 (Generic Timer). The system now correctly relies on timer interrupts for kernel preemptions instead of manual polling in the idle loop, effectively removing the reliance on the CPU halting loop for driving system progression. The core `hal_timer_tick()` was updated to internally drive `sched_on_timer_tick()` to encapsulate scheduler operations cleanly inside the HAL timer interrupt routines.

---
*PR created automatically by Jules for task [17673591978389104457](https://jules.google.com/task/17673591978389104457) started by @divyang4481*