### PR TITLE
build(cmake): default BHARAT_BOOT_HW_PROFILE to generic when unset

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,11 @@ set(BHARAT_ACCELERATOR_CLASSES "" CACHE STRING "Target accelerator classes as a 
 # Platform Firmware
 set(BHARAT_PLATFORM_FIRMWARE "" CACHE STRING "Target platform firmware (e.g., ACPI, FDT)")
 
+# Boot Hardware Profile
+set(BHARAT_BOOT_HW_PROFILE "generic" CACHE STRING "Boot hardware profile (generic, desktop, server, vm, laptop, edge, rtos)")
+set_property(CACHE BHARAT_BOOT_HW_PROFILE PROPERTY STRINGS generic desktop server vm laptop edge rtos)
+
+
 # For backward compatibility with existing CMake scripts (like tests, toolchains)
 if(BHARAT_ARCH_FAMILY STREQUAL "X86" AND BHARAT_ARCH_BITS STREQUAL "64")
     set(ARCH "x86_64")

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -38,12 +38,10 @@ configure_file(
 )
 
 option(BHARAT_BOOT_GUI "Enable boot-time GUI handoff metadata" ON)
-if(BHARAT_BOOT_HW_PROFILE STREQUAL "")
-    set(BHARAT_BOOT_HW_PROFILE "generic")
-endif()
 
-set(BHARAT_BOOT_HW_PROFILE "${BHARAT_BOOT_HW_PROFILE}" CACHE STRING "Boot hardware profile (generic, desktop, server, vm, laptop, edge, rtos)")
-set_property(CACHE BHARAT_BOOT_HW_PROFILE PROPERTY STRINGS generic desktop server vm laptop edge rtos)
+if(NOT DEFINED BHARAT_BOOT_HW_PROFILE OR "${BHARAT_BOOT_HW_PROFILE}" STREQUAL "")
+    message(FATAL_ERROR "BHARAT_BOOT_HW_PROFILE must not be empty")
+endif()
 
 if(BHARAT_BOOT_GUI)
     add_compile_definitions(BHARAT_BOOT_GUI=1)


### PR DESCRIPTION
Fixes CI configure failure for x86_64 debug preset where `BHARAT_BOOT_HW_PROFILE` evaluated to empty.

Moves the default fallback declaration to the root `CMakeLists.txt` to establish clear configuration ownership and ensure downstream build scripts see a stable cache value.

Removes conditional defaulting from `kernel/CMakeLists.txt` and replaces it with a strict validation check.

---
*PR created automatically by Jules for task [1193986373467919697](https://jules.google.com/task/1193986373467919697) started by @divyang4481*