### PR TITLE
Optimize kernel context switching and subsystem CPU affinity handling

### DIFF
--- a/docs/reviews/context-switching-hw-optimization-review.md
+++ b/docs/reviews/context-switching-hw-optimization-review.md
@@ -1,0 +1,33 @@
+# Context Switching Review: Kernel + Subsystem
+
+## Scope
+- Kernel scheduler context-switch path (`sched.c`) and architecture-facing selection hooks.
+- Subsystem CPU allocation model (`subsys/src/*.c`).
+
+## Findings (Gaps)
+1. **L1 scheduler path claimed bitmap optimization but still performed full linear scans.**
+   - Existing code comments mentioned `__builtin_clz`-style bitmask selection, but implementation still iterated all priorities.
+2. **Redundant context-switch churn when scheduler re-selected the currently running thread.**
+   - This inflated software switch counters and wasted preemption path work.
+3. **No hardware-informed dynamic slice adaptation in runtime path.**
+   - Telemetry was collected but not used to tune slice length.
+4. **Subsystem CPU masks were not normalized against platform-supported core range.**
+   - A subsystem could carry an all-zero or out-of-range mask until runtime use.
+
+## Improvement Plan
+1. Add and maintain a per-core active-priority bitmask in runqueue state.
+2. Use highest-set-bit selection (`clz`) in L1 pick-next path for O(1) priority discovery.
+3. Avoid no-op switch accounting when next == current.
+4. Feed AI complexity telemetry back into bounded time-slice tuning.
+5. Normalize subsystem CPU masks at creation/start so execution domains always map to valid cores.
+
+## Implemented in this change
+- Added `active_priority_mask` maintenance on enqueue/dequeue and used it in L1 scheduler selection.
+- Added self-switch fast path in `sched_switch_to`.
+- Added bounded dynamic time-slice shaping based on predicted complexity.
+- Added subsystem CPU mask normalization helper and enforcement at subsystem creation/start.
+
+## Next candidates (not yet implemented)
+- Save/restore SIMD/FPU/vector context lazily by arch (x86 XSAVE/XRSTOR, ARM64 FP/SIMD, RISC-V V extension).
+- Add explicit CPU count query in HAL (instead of fixed max assumption in multiple modules).
+- Introduce per-core runqueue locking + remote wakeups/IPI balancing for true SMP concurrency.

--- a/kernel/src/sched.c
+++ b/kernel/src/sched.c
@@ -48,6 +48,7 @@ typedef struct {
     kthread_t* idle_thread;
     list_head_t ready_queue[MAX_PRIORITY_LEVELS];
     uint32_t active_weight;
+    uint32_t active_priority_mask;
     uint64_t total_ticks;
     uint32_t throttled;
 } core_runqueue_t;
@@ -157,6 +158,7 @@ void sched_init(void) {
             list_init(&g_runqueues[i].ready_queue[p]);
         }
         g_runqueues[i].active_weight = 0U;
+        g_runqueues[i].active_priority_mask = 0U;
         g_runqueues[i].total_ticks = 0U;
         g_runqueues[i].throttled = 0U;
     }
@@ -318,6 +320,24 @@ static uint32_t sched_run_queue_depth(uint32_t core_id) {
     return count;
 }
 
+static uint32_t sched_clamp_time_slice(uint64_t time_slice_ms) {
+    if (time_slice_ms < 2U) {
+        return 2U;
+    }
+    if (time_slice_ms > 20U) {
+        return 20U;
+    }
+    return (uint32_t)time_slice_ms;
+}
+
+static int sched_highest_active_priority(uint32_t core_id) {
+    uint32_t mask = g_runqueues[core_id].active_priority_mask;
+    if (mask == 0U) {
+        return -1;
+    }
+    return (int)(31U - (uint32_t)__builtin_clz(mask));
+}
+
 static void sched_update_telemetry(kthread_t* thread) {
     if (!thread || !thread->ai_sched_ctx) return;
     uint32_t core_id = hal_cpu_get_id();
@@ -326,6 +346,21 @@ static void sched_update_telemetry(kthread_t* thread) {
                             thread->cpu_time_consumed,
                             sched_run_queue_depth(core_id),
                             (uint32_t)thread->context_switch_count);
+
+    if (thread->state == THREAD_STATE_RUNNING) {
+        switch (thread->ai_sched_ctx->predicted_complexity) {
+            case 2U:
+                thread->time_slice_ms = sched_clamp_time_slice(thread->time_slice_ms + 1U);
+                break;
+            case 0U:
+                if (thread->time_slice_ms > 2U) {
+                    thread->time_slice_ms = sched_clamp_time_slice(thread->time_slice_ms - 1U);
+                }
+                break;
+            default:
+                break;
+        }
+    }
 }
 
 // Level 0: Reference generic O(N) iterative run-queue lookup
@@ -347,18 +382,28 @@ kthread_t* sched_pick_next_ready_l0(uint32_t core_id) {
 // int p = 31 - __builtin_clz(runqueue->active_priority_mask);
 // For this PoC, we will implement a slightly optimized loop or simulation.
 kthread_t* sched_pick_next_ready_l1(uint32_t core_id) {
-    // A full L1 would maintain a bitmap, but we'll optimize by quickly scanning
-    // or batching for SMP. In real life, `active_weight` or a `bitmap` would be checked.
-    for (int p = MAX_PRIORITY_LEVELS - 1; p >= 0; --p) {
-        if (!list_empty(&g_runqueues[core_id].ready_queue[p])) {
-            list_head_t* node = g_runqueues[core_id].ready_queue[p].next;
-            thread_slot_t* slot = list_entry(node, thread_slot_t, list_node);
-            list_del(node); // Dequeue
-            list_init(node);
-            return &slot->thread;
+    while (1) {
+        int p = sched_highest_active_priority(core_id);
+        if (p < 0) {
+            return g_runqueues[core_id].idle_thread;
         }
+
+        list_head_t* queue = &g_runqueues[core_id].ready_queue[(uint32_t)p];
+        if (list_empty(queue)) {
+            g_runqueues[core_id].active_priority_mask &= ~(1U << (uint32_t)p);
+            continue;
+        }
+
+        list_head_t* node = queue->next;
+        thread_slot_t* slot = list_entry(node, thread_slot_t, list_node);
+        list_del(node);
+        list_init(node);
+
+        if (list_empty(queue)) {
+            g_runqueues[core_id].active_priority_mask &= ~(1U << (uint32_t)p);
+        }
+        return &slot->thread;
     }
-    return g_runqueues[core_id].idle_thread;
 }
 
 kthread_t* sched_pick_next_ready(uint32_t core_id) {
@@ -375,6 +420,7 @@ void sched_enqueue_task_l0(kthread_t* thread, uint32_t core_id) {
     thread_slot_t* slot = sched_find_thread_slot_by_tid(thread->thread_id);
     if (slot && thread->priority < MAX_PRIORITY_LEVELS) {
         list_add(&slot->list_node, &g_runqueues[core_id].ready_queue[thread->priority]);
+        g_runqueues[core_id].active_priority_mask |= (1U << thread->priority);
     }
 }
 
@@ -383,9 +429,8 @@ void sched_enqueue_task_l1(kthread_t* thread, uint32_t core_id) {
     if (!thread) return;
     thread_slot_t* slot = sched_find_thread_slot_by_tid(thread->thread_id);
     if (slot && thread->priority < MAX_PRIORITY_LEVELS) {
-        // use list_add as list_add_tail is not present, we will adjust
         list_add(&slot->list_node, &g_runqueues[core_id].ready_queue[thread->priority]);
-        // Here we would also update the bitmask: `g_runqueues[core_id].active_mask |= (1 << thread->priority);`
+        g_runqueues[core_id].active_priority_mask |= (1U << thread->priority);
     }
 }
 
@@ -399,27 +444,29 @@ void sched_enqueue_task(kthread_t* thread, uint32_t core_id) {
 
 // Level 0 Dequeue
 void sched_dequeue_task_l0(kthread_t* thread, uint32_t core_id) {
-    (void)core_id;
     if (!thread) return;
     thread_slot_t* slot = sched_find_thread_slot_by_tid(thread->thread_id);
     if (slot && !list_empty(&slot->list_node)) {
+        uint32_t priority = thread->priority;
         list_del(&slot->list_node);
         list_init(&slot->list_node);
+        if (priority < MAX_PRIORITY_LEVELS && list_empty(&g_runqueues[core_id].ready_queue[priority])) {
+            g_runqueues[core_id].active_priority_mask &= ~(1U << priority);
+        }
     }
 }
 
 // Level 1 Dequeue (e.g. updating the active bitmap)
 void sched_dequeue_task_l1(kthread_t* thread, uint32_t core_id) {
-    (void)core_id;
     if (!thread) return;
     thread_slot_t* slot = sched_find_thread_slot_by_tid(thread->thread_id);
     if (slot && !list_empty(&slot->list_node)) {
+        uint32_t priority = thread->priority;
         list_del(&slot->list_node);
         list_init(&slot->list_node);
-        // Here we would update the bitmask if the queue is empty:
-        // if (list_empty(&g_runqueues[core_id].ready_queue[thread->priority])) {
-        //     g_runqueues[core_id].active_mask &= ~(1 << thread->priority);
-        // }
+        if (priority < MAX_PRIORITY_LEVELS && list_empty(&g_runqueues[core_id].ready_queue[priority])) {
+            g_runqueues[core_id].active_priority_mask &= ~(1U << priority);
+        }
     }
 }
 
@@ -435,6 +482,10 @@ static void sched_switch_to(kthread_t* next, uint32_t core_id) {
     if (!next) return;
 
     kthread_t* current = g_runqueues[core_id].current_thread;
+    if (current == next) {
+        current->state = THREAD_STATE_RUNNING;
+        return;
+    }
     if (current && current->state == THREAD_STATE_RUNNING && current != g_runqueues[core_id].idle_thread) {
         current->state = THREAD_STATE_READY;
         sched_enqueue_task(current, core_id);

--- a/subsys/src/manager.c
+++ b/subsys/src/manager.c
@@ -2,6 +2,24 @@
 #include "linux_compat.h"
 #include "win_compat.h"
 
+#ifndef MAX_SUPPORTED_CORES
+#define MAX_SUPPORTED_CORES 8U
+#endif
+
+static uint32_t subsys_effective_cpu_mask(uint32_t requested_mask) {
+    uint32_t allowed_mask = 0U;
+    for (uint32_t i = 0; i < MAX_SUPPORTED_CORES && i < 32U; ++i) {
+        allowed_mask |= (1U << i);
+    }
+
+    uint32_t effective = requested_mask & allowed_mask;
+    if (effective == 0U) {
+        effective = 0x1U;
+    }
+
+    return effective;
+}
+
 static uint32_t next_subsys_id = 1;
 
 int subsys_create(subsys_type_t type, subsys_exec_mode_t mode, subsys_instance_t* out_instance) {
@@ -11,7 +29,7 @@ int subsys_create(subsys_type_t type, subsys_exec_mode_t mode, subsys_instance_t
     out_instance->type = type;
     out_instance->exec_mode = mode;
     out_instance->memory_limit_mb = 0;
-    out_instance->cpu_core_allocation_mask = 0;
+    out_instance->cpu_core_allocation_mask = subsys_effective_cpu_mask(0U);
     out_instance->is_running = 0;
 
     switch (type) {
@@ -31,6 +49,10 @@ int subsys_load_env(subsys_instance_t* instance, const char* root_path) {
 
 int subsys_start(subsys_instance_t* instance) {
     if (!instance) return -1;
+
+    instance->cpu_core_allocation_mask =
+        subsys_effective_cpu_mask(instance->cpu_core_allocation_mask);
+
     instance->is_running = 1;
     return 0;
 }


### PR DESCRIPTION
### Motivation
- Close gaps where the scheduler L1 path referenced a bitmap but still did linear scans, causing unnecessary overhead. 
- Reduce context-switch churn when the scheduler re-selects the running thread and improve responsiveness by using telemetry. 
- Ensure subsystem CPU allocation masks are normalized to platform-supported cores so subsystems always get a valid, non-zero CPU mask.

### Description
- Add a per-core `active_priority_mask` to the runqueue and maintain it in enqueue/dequeue paths to support O(1) highest-priority discovery via `__builtin_clz` in the L1 pick-next path (`sched_pick_next_ready_l1`).
- Implement `sched_highest_active_priority` and replace the previous linear scan in the L1 path with a mask-driven loop that trims empty buckets and returns the highest active priority in O(1) amortized time.
- Add a self-switch fast path in `sched_switch_to` to skip redundant work when `next == current`.
- Wire AI telemetry into bounded time-slice shaping by adding `sched_clamp_time_slice` and adjusting `thread->time_slice_ms` in `sched_update_telemetry` based on `ai_sched_ctx->predicted_complexity`.
- Initialize `active_priority_mask` in `sched_init` and keep it coherent on enqueue/dequeue for both L0 and L1 implementations.
- Add `subsys_effective_cpu_mask` helper and normalize `cpu_core_allocation_mask` at subsystem creation and start in `subsys/src/manager.c` to enforce valid CPU affinity defaults.
- Add a review note at `docs/reviews/context-switching-hw-optimization-review.md` documenting the gaps found, the improvement plan, implemented items, and next candidates for further hardware-aware work.

### Testing
- Successfully compiled the modified scheduler unit translation with `cc -std=c11 -Ikernel/include -Iinclude -Isubsys/include -c kernel/src/sched.c -o /tmp/sched.o` (succeeded).
- Successfully compiled the modified subsystem manager with `cc -std=c11 -Ikernel/include -Iinclude -Isubsys/include -c subsys/src/manager.c -o /tmp/manager.o` (succeeded).
- Attempted full project configure with `cmake -S . -B build` which failed due to environment configuration: `BHARAT_BOOT_HW_PROFILE` is not set in this environment (expected failure unrelated to the changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad12c9108c83208ae31786b922d398)