### PR TITLE
ci: pin GitHub Action runner to ubuntu-22.04 to fix missing frama-c / alt-ergo apt packages

### DIFF
--- a/.github/workflows/kernel-ci.yml
+++ b/.github/workflows/kernel-ci.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   kernel-and-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies


### PR DESCRIPTION
The `kernel-ci` GitHub action started failing because `ubuntu-latest` was updated to Ubuntu 24.04, and the `frama-c` and `alt-ergo` packages are not available in the default `apt` repositories for Ubuntu 24.04. This PR pins the runner version to `ubuntu-22.04` to resolve the dependency issues and ensure the formal verification step can run successfully.

---
*PR created automatically by Jules for task [11014637218032707427](https://jules.google.com/task/11014637218032707427) started by @divyang4481*