### PR TITLE
Add VFS core, read-only S3-style blob backend, unit test, and Phase 1 storage milestone

### DIFF
--- a/docs/architecture/storage-and-sandbox-strategy.md
+++ b/docs/architecture/storage-and-sandbox-strategy.md
@@ -109,12 +109,29 @@ Recommended defaults:
 
 ## Suggested implementation milestones
 
+### Phase 1 (must ship first): block + POSIX filesystem baseline
+
 1. Extend VFS metadata to identify backend type (filesystem, block, blob).
-2. Add filesystem driver capability registry.
-3. Introduce sandbox filesystem policies with path-prefix rules.
-4. Implement mount namespace + mount option enforcement.
-5. Expand POSIX layer with `openat`/`statat` and errno parity tests.
-6. Add blob mount prototype with immutable object reads.
+2. Implement block-device plumbing (virtio-blk/NVMe path) with basic buffering/cache management.
+3. Ship one stable POSIX-style filesystem driver first (ext2/ext4-like or FAT-like), including mount handling.
+4. Expand POSIX layer with `openat*`/`stat*`, `read/write`, `renameat2`, link semantics, and errno parity tests.
+5. Validate desktop and edge root-FS boot/profile flows on this baseline.
+
+This phase is the minimum viable storage stack. Without a mature block path, cache behavior, and mount semantics, higher-level storage backends cannot be made reliable.
+
+### Phase 2: blob/object backend on top of VFS
+
+6. Implement `VFS_BACKEND_BLOB` as a separate mount backend (not as a replacement for block filesystems).
+7. Use namespace paths such as `/blob/remote/<provider>/<bucket>/<key>` and expose immutable read descriptors first.
+8. Stage writes via temporary objects plus commit/rename flow, but keep initial release read-mostly to reduce risk.
+9. Start with S3-compatible providers via userspace service + capability-guarded IPC (MinIO first target, then Ceph RGW/OpenIO compatibility).
+
+### Phase 3 (deferred/experimental): advanced distributed and CoW filesystems
+
+10. Keep BFS/DFS in experimental scope until Phase 1 + Phase 2 are complete and production-tested.
+11. Only then scope CoW snapshots/dedup/encryption trees and distributed replication/RDMA coordination.
+
+Rationale: BFS/DFS are multi-year efforts and should not block a bootable, testable system with a working root filesystem and pragmatic object-storage story.
 
 ## Success metrics
 

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -150,6 +150,8 @@ set(KERNEL_SRCS
     src/hal/interrupt_common.c
     src/trap/trap.c
     src/multicore.c
+    src/fs/vfs.c
+    src/fs/blob_backend.c
 )
 
 # ── Kernel ELF ──────────────────────────────────────────────────────────────

--- a/kernel/include/fs/blob_backend.h
+++ b/kernel/include/fs/blob_backend.h
@@ -1,0 +1,17 @@
+#ifndef BHARAT_BLOB_BACKEND_H
+#define BHARAT_BLOB_BACKEND_H
+
+#include "fs/vfs.h"
+
+#include <stddef.h>
+
+// Register a basic immutable S3-style blob driver descriptor in the VFS registry.
+int blob_backend_register_s3_driver(void);
+
+// Create a read-only in-memory blob node for initial immutable object read support.
+int blob_backend_init_immutable_node(vfs_node_t *node,
+                                     const char *name,
+                                     const void *data,
+                                     size_t size);
+
+#endif // BHARAT_BLOB_BACKEND_H

--- a/kernel/include/fs/vfs.h
+++ b/kernel/include/fs/vfs.h
@@ -12,6 +12,10 @@
 
 typedef struct vfs_node vfs_node_t;
 
+#define VFS_OPEN_READ  0x1
+#define VFS_OPEN_WRITE 0x2
+#define VFS_OPEN_RDWR  (VFS_OPEN_READ | VFS_OPEN_WRITE)
+
 // Backing storage class for a node/mount
 typedef enum {
     VFS_BACKEND_FILESYSTEM = 0,
@@ -83,5 +87,9 @@ int vfs_register_driver(const vfs_driver_info_t* info);
 
 // Lookup a registered driver descriptor by name.
 const vfs_driver_info_t* vfs_get_driver(const char* name);
+
+#ifdef TESTING
+void vfs_test_reset_state(void);
+#endif
 
 #endif // BHARAT_VFS_H

--- a/kernel/src/fs/blob_backend.c
+++ b/kernel/src/fs/blob_backend.c
@@ -1,0 +1,110 @@
+#include "fs/blob_backend.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define BLOB_S3_DRIVER_NAME "s3-compatible"
+
+typedef struct {
+    const uint8_t *data;
+    size_t size;
+} blob_immutable_object_t;
+
+static int blob_read(vfs_node_t *node, uint64_t offset, void *buffer, size_t size) {
+    blob_immutable_object_t *obj;
+    size_t i;
+
+    if (!node || !buffer || !node->fs_data) {
+        return -1;
+    }
+
+    obj = (blob_immutable_object_t *)node->fs_data;
+    if (offset >= obj->size) {
+        return 0;
+    }
+
+    if (size > obj->size - (size_t)offset) {
+        size = obj->size - (size_t)offset;
+    }
+
+    for (i = 0; i < size; ++i) {
+        ((uint8_t *)buffer)[i] = obj->data[(size_t)offset + i];
+    }
+
+    return (int)size;
+}
+
+static int blob_write(vfs_node_t *node, uint64_t offset, const void *buffer, size_t size) {
+    (void)node;
+    (void)offset;
+    (void)buffer;
+    (void)size;
+    return -1;
+}
+
+static vfs_operations_t g_blob_ops = {
+    .read = blob_read,
+    .write = blob_write,
+    .open = NULL,
+    .close = NULL,
+    .readdir = NULL,
+    .finddir = NULL,
+    .ioctl = NULL,
+};
+
+static blob_immutable_object_t g_blob_objects[8];
+static size_t g_blob_object_count = 0;
+
+static void copy_name(char *dst, const char *src, size_t dst_size) {
+    size_t i = 0;
+    if (!dst || dst_size == 0) {
+        return;
+    }
+    if (!src) {
+        dst[0] = '\0';
+        return;
+    }
+    while (i + 1 < dst_size && src[i] != '\0') {
+        dst[i] = src[i];
+        i++;
+    }
+    dst[i] = '\0';
+}
+
+int blob_backend_register_s3_driver(void) {
+    vfs_driver_info_t info;
+
+    info.name = BLOB_S3_DRIVER_NAME;
+    info.backend_type = VFS_BACKEND_BLOB;
+    info.features.supports_journaling = 0;
+    info.features.supports_snapshots = 0;
+    info.features.supports_xattrs = 1;
+    info.features.supports_acls = 1;
+    info.features.supports_posix_hardlinks = 0;
+    info.features.supports_sparse_files = 0;
+    info.features.supports_mmap = 0;
+
+    return vfs_register_driver(&info);
+}
+
+int blob_backend_init_immutable_node(vfs_node_t *node,
+                                     const char *name,
+                                     const void *data,
+                                     size_t size) {
+    blob_immutable_object_t *obj;
+
+    if (!node || !data || size == 0 || g_blob_object_count >= 8) {
+        return -1;
+    }
+
+    obj = &g_blob_objects[g_blob_object_count++];
+    obj->data = (const uint8_t *)data;
+    obj->size = size;
+
+    copy_name(node->name, name, sizeof(node->name));
+    node->backend_type = VFS_BACKEND_BLOB;
+    node->size = size;
+    node->ops = &g_blob_ops;
+    node->fs_data = obj;
+    return 0;
+}

--- a/kernel/src/fs/vfs.c
+++ b/kernel/src/fs/vfs.c
@@ -1,0 +1,277 @@
+#include "fs/vfs.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define VFS_MAX_DRIVERS 16
+#define VFS_MAX_MOUNTS 16
+#define VFS_MAX_OPEN_FILES 64
+
+#ifndef VFS_OPEN_READ
+#define VFS_OPEN_READ 0x1
+#endif
+#ifndef VFS_OPEN_WRITE
+#define VFS_OPEN_WRITE 0x2
+#endif
+
+typedef struct {
+    char target_path[256];
+    vfs_node_t *root;
+} vfs_mount_entry_t;
+
+typedef struct {
+    int in_use;
+    int flags;
+    uint64_t offset;
+    vfs_node_t *node;
+} vfs_fd_entry_t;
+
+vfs_node_t *vfs_root = NULL;
+
+static vfs_driver_info_t g_driver_registry[VFS_MAX_DRIVERS];
+static size_t g_driver_count = 0;
+
+static vfs_mount_entry_t g_mounts[VFS_MAX_MOUNTS];
+static size_t g_mount_count = 0;
+
+static vfs_fd_entry_t g_open_files[VFS_MAX_OPEN_FILES];
+
+static size_t vfs_strnlen(const char *s, size_t max_len) {
+    size_t i = 0;
+    if (!s) {
+        return 0;
+    }
+    while (i < max_len && s[i] != '\0') {
+        i++;
+    }
+    return i;
+}
+
+static int vfs_streq(const char *a, const char *b) {
+    size_t i = 0;
+    if (!a || !b) {
+        return 0;
+    }
+    while (a[i] != '\0' && b[i] != '\0') {
+        if (a[i] != b[i]) {
+            return 0;
+        }
+        i++;
+    }
+    return a[i] == b[i];
+}
+
+static void vfs_strcpy(char *dst, const char *src, size_t dst_size) {
+    size_t i = 0;
+    if (!dst || dst_size == 0) {
+        return;
+    }
+    if (!src) {
+        dst[0] = '\0';
+        return;
+    }
+    while (i + 1 < dst_size && src[i] != '\0') {
+        dst[i] = src[i];
+        i++;
+    }
+    dst[i] = '\0';
+}
+
+static int path_prefix_match(const char *path, const char *prefix) {
+    size_t i = 0;
+
+    if (!path || !prefix) {
+        return 0;
+    }
+
+    while (prefix[i] != '\0' && path[i] != '\0') {
+        if (prefix[i] != path[i]) {
+            return 0;
+        }
+        i++;
+    }
+
+    if (prefix[i] != '\0') {
+        return 0;
+    }
+
+    return (path[i] == '\0' || path[i] == '/');
+}
+
+static vfs_node_t *vfs_resolve_path(const char *path) {
+    size_t best_len = 0;
+    vfs_node_t *best_node = NULL;
+    size_t i = 0;
+
+    if (!path) {
+        return NULL;
+    }
+
+    for (i = 0; i < g_mount_count; ++i) {
+        const char *mount_path = g_mounts[i].target_path;
+        if (!path_prefix_match(path, mount_path)) {
+            continue;
+        }
+
+        size_t mount_len = vfs_strnlen(mount_path, sizeof(g_mounts[i].target_path));
+        if (mount_len >= best_len) {
+            best_len = mount_len;
+            best_node = g_mounts[i].root;
+        }
+    }
+
+    if (!best_node && vfs_root) {
+        best_node = vfs_root;
+    }
+
+    return best_node;
+}
+
+int vfs_register_driver(const vfs_driver_info_t *info) {
+    if (!info || !info->name || info->name[0] == '\0') {
+        return -1;
+    }
+
+    if (g_driver_count >= VFS_MAX_DRIVERS) {
+        return -1;
+    }
+
+    g_driver_registry[g_driver_count] = *info;
+    g_driver_count++;
+    return 0;
+}
+
+const vfs_driver_info_t *vfs_get_driver(const char *name) {
+    size_t i;
+    if (!name) {
+        return NULL;
+    }
+
+    for (i = 0; i < g_driver_count; ++i) {
+        if (vfs_streq(g_driver_registry[i].name, name)) {
+            return &g_driver_registry[i];
+        }
+    }
+
+    return NULL;
+}
+
+int vfs_mount(const char *target_path, vfs_node_t *fs_root) {
+    if (!target_path || !fs_root) {
+        return -1;
+    }
+
+    if (g_mount_count >= VFS_MAX_MOUNTS) {
+        return -1;
+    }
+
+    if (target_path[0] != '/') {
+        return -1;
+    }
+
+    vfs_strcpy(g_mounts[g_mount_count].target_path, target_path, sizeof(g_mounts[g_mount_count].target_path));
+    g_mounts[g_mount_count].root = fs_root;
+
+    if (vfs_streq(target_path, "/")) {
+        vfs_root = fs_root;
+    }
+
+    g_mount_count++;
+    return 0;
+}
+
+int vfs_open(const char *path, int flags) {
+    size_t i;
+    vfs_node_t *node = vfs_resolve_path(path);
+
+    if (!node) {
+        return -1;
+    }
+
+    if (node->backend_type == VFS_BACKEND_BLOB && (flags & VFS_OPEN_WRITE)) {
+        return -1;
+    }
+
+    if (node->ops && node->ops->open) {
+        if (node->ops->open(node, flags) != 0) {
+            return -1;
+        }
+    }
+
+    for (i = 0; i < VFS_MAX_OPEN_FILES; ++i) {
+        if (!g_open_files[i].in_use) {
+            g_open_files[i].in_use = 1;
+            g_open_files[i].flags = flags;
+            g_open_files[i].offset = 0;
+            g_open_files[i].node = node;
+            return (int)i;
+        }
+    }
+
+    return -1;
+}
+
+int vfs_read(int fd, void *buffer, size_t size) {
+    int bytes;
+    vfs_fd_entry_t *entry;
+
+    if (fd < 0 || fd >= (int)VFS_MAX_OPEN_FILES) {
+        return -1;
+    }
+
+    entry = &g_open_files[fd];
+    if (!entry->in_use || !entry->node || !entry->node->ops || !entry->node->ops->read) {
+        return -1;
+    }
+
+    bytes = entry->node->ops->read(entry->node, entry->offset, buffer, size);
+    if (bytes > 0) {
+        entry->offset += (uint64_t)bytes;
+    }
+    return bytes;
+}
+
+int vfs_write(int fd, const void *buffer, size_t size) {
+    int bytes;
+    vfs_fd_entry_t *entry;
+
+    if (fd < 0 || fd >= (int)VFS_MAX_OPEN_FILES) {
+        return -1;
+    }
+
+    entry = &g_open_files[fd];
+    if (!entry->in_use || !entry->node || !entry->node->ops || !entry->node->ops->write) {
+        return -1;
+    }
+
+    if ((entry->flags & VFS_OPEN_WRITE) == 0) {
+        return -1;
+    }
+
+    if (entry->node->backend_type == VFS_BACKEND_BLOB) {
+        return -1;
+    }
+
+    bytes = entry->node->ops->write(entry->node, entry->offset, buffer, size);
+    if (bytes > 0) {
+        entry->offset += (uint64_t)bytes;
+    }
+    return bytes;
+}
+
+#ifdef TESTING
+void vfs_test_reset_state(void) {
+    size_t i;
+
+    vfs_root = NULL;
+    g_driver_count = 0;
+    g_mount_count = 0;
+
+    for (i = 0; i < VFS_MAX_OPEN_FILES; ++i) {
+        g_open_files[i].in_use = 0;
+        g_open_files[i].flags = 0;
+        g_open_files[i].offset = 0;
+        g_open_files[i].node = NULL;
+    }
+}
+#endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -125,3 +125,9 @@ add_executable(test_bench_sched test_bench_sched.c benchmark_stubs.c
 target_include_directories(test_bench_sched PRIVATE ${CMAKE_SOURCE_DIR}/../kernel/include)
 target_compile_definitions(test_bench_sched PRIVATE TESTING=1)
 add_test(NAME test_bench_sched COMMAND test_bench_sched)
+
+
+add_executable(test_vfs_storage test_vfs_storage.c ../kernel/src/fs/vfs.c ../kernel/src/fs/blob_backend.c)
+target_include_directories(test_vfs_storage PRIVATE ../kernel/include)
+target_compile_definitions(test_vfs_storage PRIVATE TESTING=1)
+add_test(NAME test_vfs_storage COMMAND test_vfs_storage)

--- a/tests/test_vfs_storage.c
+++ b/tests/test_vfs_storage.c
@@ -1,0 +1,78 @@
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "fs/blob_backend.h"
+#include "fs/vfs.h"
+
+static int mem_read(vfs_node_t *node, uint64_t offset, void *buffer, size_t size) {
+    const char *src = (const char *)node->fs_data;
+    size_t len = strlen(src);
+    if (offset >= len) {
+        return 0;
+    }
+    if (size > len - (size_t)offset) {
+        size = len - (size_t)offset;
+    }
+    memcpy(buffer, src + offset, size);
+    return (int)size;
+}
+
+static int mem_write(vfs_node_t *node, uint64_t offset, const void *buffer, size_t size) {
+    char *dst = (char *)node->fs_data;
+    memcpy(dst + offset, buffer, size);
+    return (int)size;
+}
+
+int main(void) {
+    vfs_node_t fs_root = {0};
+    vfs_node_t blob_node = {0};
+    vfs_operations_t fs_ops = {
+        .read = mem_read,
+        .write = mem_write,
+        .open = NULL,
+        .close = NULL,
+        .readdir = NULL,
+        .finddir = NULL,
+        .ioctl = NULL,
+    };
+    char fs_data[64] = "hello-kernel-vfs";
+    char read_buf[64] = {0};
+    static const char blob_data[] = "immutable-object";
+    int fd;
+
+    vfs_test_reset_state();
+
+    fs_root.backend_type = VFS_BACKEND_FILESYSTEM;
+    fs_root.ops = &fs_ops;
+    fs_root.fs_data = fs_data;
+
+    assert(vfs_mount("/", &fs_root) == 0);
+
+    assert(blob_backend_register_s3_driver() == 0);
+    assert(vfs_get_driver("s3-compatible") != NULL);
+
+    assert(blob_backend_init_immutable_node(&blob_node,
+                                            "remote/minio/bucket/key",
+                                            blob_data,
+                                            sizeof(blob_data) - 1) == 0);
+
+    assert(vfs_mount("/blob/remote/minio/bucket/key", &blob_node) == 0);
+
+    fd = vfs_open("/", VFS_OPEN_READ | VFS_OPEN_WRITE);
+    assert(fd >= 0);
+    assert(vfs_read(fd, read_buf, 5) == 5);
+    assert(memcmp(read_buf, "hello", 5) == 0);
+
+    fd = vfs_open("/blob/remote/minio/bucket/key", VFS_OPEN_READ);
+    assert(fd >= 0);
+    memset(read_buf, 0, sizeof(read_buf));
+    assert(vfs_read(fd, read_buf, sizeof(blob_data) - 1) == (int)(sizeof(blob_data) - 1));
+    assert(memcmp(read_buf, blob_data, sizeof(blob_data) - 1) == 0);
+
+    fd = vfs_open("/blob/remote/minio/bucket/key", VFS_OPEN_WRITE);
+    assert(fd < 0);
+
+    puts("test_vfs_storage: PASS");
+    return 0;
+}


### PR DESCRIPTION
### Motivation

- Introduce a minimal, testable VFS layer and an immutable blob backend to provide a baseline storage stack for higher-level filesystems and object storage integration.
- Document a concrete Phase 1 milestone in storage planning so a bootable POSIX root plus block/cache plumbing can be prioritized before experimental DFS/CoW efforts.

### Description

- Add a lightweight VFS implementation with path resolution, mount registry, driver registry, and simple open/read/write semantics in `kernel/src/fs/vfs.c` and API in `kernel/include/fs/vfs.h`, including `vfs_mount`, `vfs_open`, `vfs_read`, `vfs_write`, `vfs_register_driver`, and `vfs_get_driver`, plus `VFS_OPEN_*` flags and a `TESTING` reset helper `vfs_test_reset_state`.
- Implement a basic read-only S3-compatible blob backend in `kernel/src/fs/blob_backend.c` with registration (`blob_backend_register_s3_driver`) and in-memory immutable object creation (`blob_backend_init_immutable_node`) and wire it into the VFS via `vfs_operations_t` hooks.
- Expose new headers `kernel/include/fs/blob_backend.h` and update `kernel/CMakeLists.txt` to compile and link the new VFS and blob backend sources into the kernel build.
- Add a unit test `tests/test_vfs_storage.c` and register it in `tests/CMakeLists.txt` as `test_vfs_storage`, which exercises mounting, driver registration, read access to filesystem and blob mounts, and write-rejection for blob mounts.
- Update storage architecture docs `docs/architecture/storage-and-sandbox-strategy.md` to add a "Phase 1 (must ship first): block + POSIX filesystem baseline" section and reorganize the storage rollout milestones.

### Testing

- Added and executed the unit test `test_vfs_storage` (built with `TESTING=1`) which mounts an in-memory filesystem root and an immutable blob node, verifies reads from both mounts and that write attempts to blob mounts are rejected; the test passed.
- Existing CTest entries were updated to include `test_vfs_storage` and the test binary was built as part of the test suite successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad47ed2ef083208be822c5660f6f65)