### PR TITLE
Add profile scaffolding for mobile, datacenter, and network_appliance

### DIFF
--- a/docs/profile_priorities_and_kernel_changes.md
+++ b/docs/profile_priorities_and_kernel_changes.md
@@ -1,0 +1,187 @@
+# Profile-first roadmap: kernel/core impact and subsystem deltas
+
+This document maps each hardware/deployment profile to:
+
+1. What to build first.
+2. Core-kernel changes needed.
+3. Subsystems that require extensions or refactors.
+
+## Cross-profile kernel baseline (do once)
+
+Before tuning per profile, the core kernel should expose stable contracts for:
+
+- **Boot policy selection** (security/perf/timer/SMP toggles).
+- **Scheduler classes** (deterministic RT, fair, throughput).
+- **IPC primitives** (endpoint, shared-memory, async message path).
+- **Memory classes** (static pools, pageable heaps, NUMA domains).
+- **Device model** (driver probe + policy hooks).
+- **Observability hooks** (tracepoints, counters, crash logs).
+
+These are the profile control points that avoid code forks.
+
+---
+
+## RTOS / safety profile
+
+### Build first
+- interrupt/timer
+- deterministic scheduler
+- lightweight IPC
+- static memory pools
+- watchdog
+- CAN/UART/SPI/I2C
+- fast boot
+- health monitor
+
+### Core kernel changes
+- Add strict preemption controls and bounded critical sections in scheduler core.
+- Prefer static allocation paths; avoid runtime heap dependency in early/critical paths.
+- Enforce synchronous fault containment (panic domain + watchdog-safe reset path).
+- Reduce boot variance by disabling optional non-critical bring-up (e.g., delayed services).
+
+### Subsystems needing changes
+- **HAL**: interrupt latency accounting, periodic timer precision, watchdog feed semantics.
+- **MM**: fixed-size memory pools and deterministic alloc/free timing.
+- **IPC**: bounded-copy endpoint path with timeout guarantees.
+- **Drivers**: deterministic init ordering for safety buses (CAN/SPI/I2C/UART).
+- **Health**: liveness checks tied to watchdog window.
+
+---
+
+## Edge / IoT profile
+
+### Build first
+- lightweight VFS
+- network stack
+- secure boot hooks
+- OTA/update subsystem
+- framebuffer/simple UI
+- shared memory IPC
+- power management
+
+### Core kernel changes
+- Keep small memory footprint with configurable VFS + networking feature slices.
+- Introduce secure update and rollback control points into boot chain.
+- Add low-power idle states and wake policy integration into scheduler/timer.
+
+### Subsystems needing changes
+- **VFS**: compact inode/path cache policies and read-mostly optimizations.
+- **Net**: small-footprint TCP/UDP path with predictable buffer limits.
+- **Security**: measured boot + update signature verification plumbing.
+- **Power**: tick suppression and peripheral autosuspend.
+
+---
+
+## Desktop / laptop profile
+
+### Build first
+- full VFS
+- ELF loader
+- Linux personality baseline
+- tty/pty
+- input
+- framebuffer + display stack
+- audio later
+- network
+- storage
+- power/thermal
+
+### Core kernel changes
+- Expand process/fd/memory semantics for POSIX/Linux compatibility layers.
+- Grow driver model toward interactive devices and storage hierarchy.
+- Add robust user-session I/O pathways (tty/input/display).
+
+### Subsystems needing changes
+- **Process/Trap**: richer syscall surface and signal-compatible semantics.
+- **VFS**: full pathname/permission/link semantics.
+- **Display/Input**: compositor-friendly framebuffer handoff and event routing.
+- **Storage/Net**: desktop-class buffering and fault tolerance.
+
+---
+
+## Mobile / Android profile
+
+### Build first
+- Linux-like process/fd/memory substrate
+- Binder-oriented IPC hooks
+- ashmem/shared memory
+- service manager
+- power management
+- input/display pipeline
+- security hooks
+- app/runtime spawning hooks
+
+### Core kernel changes
+- Add Binder/ashmem integration points into IPC + memory subsystems.
+- Strengthen per-app isolation and credential transitions.
+- Optimize suspend/resume and foreground/background scheduling policy.
+
+### Subsystems needing changes
+- **IPC**: Binder transaction model and object reference lifecycle hooks.
+- **MM**: ashmem-like shared regions and reclaim policy coordination.
+- **Security**: mandatory hooks for app sandbox + service mediation.
+- **Lifecycle**: app spawn/zygote-like runtime interfaces.
+
+---
+
+## Datacenter / server profile
+
+### Build first
+- NUMA-aware memory
+- scalable scheduler
+- high-performance network
+- block I/O
+- observability
+- namespaces/cgroups later
+- strong crash recovery
+- virtio + VM support
+
+### Core kernel changes
+- Make scheduler topology-aware and scalable to high core counts.
+- Expand NUMA placement/migration policy in allocator and VM mappings.
+- Prioritize crash consistency and restart/recovery strategy.
+
+### Subsystems needing changes
+- **MM/NUMA**: locality-aware allocations, migration telemetry.
+- **Scheduler**: per-core run queues, load balancing heuristics.
+- **Net/Block**: high-throughput queueing, multiqueue IO paths.
+- **Observability**: structured metrics + trace export.
+- **Virtualization**: virtio and VM lifecycle hooks.
+
+---
+
+## Network appliance profile
+
+### Build first
+- packet path
+- NIC drivers
+- flow tables
+- lightweight control plane IPC
+- watchdog/failover
+- secure boot
+- traffic shaping/QoS hooks
+
+### Core kernel changes
+- Introduce fastpath bypass where safe (minimal scheduler/allocator overhead).
+- Support flow-table acceleration hooks and deterministic control-plane messaging.
+- Implement failover-aware health and restart orchestration.
+
+### Subsystems needing changes
+- **Net**: fast ingress/egress, zero-copy rings where possible.
+- **Drivers**: NIC offload capability abstraction.
+- **IPC**: low-latency control channel for routing/policy updates.
+- **QoS**: classifier + shaper hooks tied to scheduler/network queues.
+- **Security/HA**: secure boot attestation + crash/failover policy.
+
+---
+
+## Immediate implementation status in this repo
+
+Current repository changes focus on **profile plumbing** in core kernel:
+
+- Build system accepts and routes `mobile`, `datacenter`, and `network_appliance` boot profiles.
+- Boot profile detection string support is added in kernel main.
+- Boot policy defaults are added for these profiles (timer/SMP/security/perf knobs).
+- New per-profile init stubs are added so each profile has a concrete source target.
+
+This establishes the foundation for next patches that implement deeper subsystem behavior.

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -62,8 +62,8 @@ endif()
 
 string(TOLOWER "${BHARAT_BOOT_HW_PROFILE}" KERNEL_PROFILE_LOWER)
 
-if(NOT KERNEL_PROFILE_LOWER MATCHES "^(generic|desktop|server|vm|laptop|edge|rtos)$")
-    message(FATAL_ERROR "Invalid BHARAT_BOOT_HW_PROFILE='${KERNEL_PROFILE_LOWER}'. Allowed: generic, desktop, server, vm, laptop, edge, rtos")
+if(NOT KERNEL_PROFILE_LOWER MATCHES "^(generic|desktop|server|vm|laptop|edge|rtos|mobile|datacenter|network_appliance)$")
+    message(FATAL_ERROR "Invalid BHARAT_BOOT_HW_PROFILE='${KERNEL_PROFILE_LOWER}'. Allowed: generic, desktop, server, vm, laptop, edge, rtos, mobile, datacenter, network_appliance")
 endif()
 
 add_compile_definitions(BHARAT_BOOT_HW_PROFILE_${KERNEL_PROFILE_LOWER}=1)

--- a/kernel/include/profile.h
+++ b/kernel/include/profile.h
@@ -2,37 +2,41 @@
 #define BHARAT_PROFILE_H
 
 /*
- * Bharat-OS Profile Management
- * Defines feature toggles and compilation options based on the
- * target personality layer or deployment environment.
+ * Bharat-OS profile selection and lightweight feature switches.
  *
- * Target profiles can be:
- * - PROFILE_OPENRAN: Hard real-time scheduling, zero-copy networking.
- * - PROFILE_AUTOMOBILE / PROFILE_DRONE: Safety critical, formal verification, RTOS defense.
- * - PROFILE_MOBILE: Aggressive CoW, AI power governors.
- * - PROFILE_DATACENTER: NUMA aware, high-throughput.
+ * This header intentionally keeps profile decisions build-time and small.
+ * Runtime policy knobs are represented by bharat_boot_active_policy().
  */
 
-// Example definition, this should be set by the build system (e.g., CMake)
-// #define CONFIG_PROFILE_MOBILE 1
+void profile_init(void);
 
 #if defined(CONFIG_PROFILE_OPENRAN)
-    #define FEATURE_HARD_REAL_TIME 1
-    #define FEATURE_ZERO_COPY_NET 1
+#define FEATURE_HARD_REAL_TIME 1
+#define FEATURE_ZERO_COPY_NET 1
 #endif
 
 #if defined(CONFIG_PROFILE_AUTOMOBILE) || defined(CONFIG_PROFILE_DRONE)
-    #define Profile_RTOS 1
-    #define FEATURE_SAFETY_CRITICAL 1
+#define Profile_RTOS 1
+#define FEATURE_SAFETY_CRITICAL 1
 #endif
 
 #if defined(CONFIG_PROFILE_MOBILE)
-    #define FEATURE_AGGRESSIVE_COW 1
-    #define FEATURE_AI_POWER_GOV 1
+#define FEATURE_AGGRESSIVE_COW 1
+#define FEATURE_AI_POWER_GOV 1
+#define FEATURE_BINDER_IPC_HOOKS 1
+#define FEATURE_SERVICE_MANAGER_HOOKS 1
 #endif
 
 #if defined(CONFIG_PROFILE_DATACENTER)
-    #define FEATURE_NUMA_AWARE 1
+#define FEATURE_NUMA_AWARE 1
+#define FEATURE_SCALABLE_SCHEDULER 1
+#define FEATURE_OBSERVABILITY_PIPELINE 1
+#endif
+
+#if defined(CONFIG_PROFILE_NETWORK_APPLIANCE)
+#define FEATURE_PACKET_FASTPATH 1
+#define FEATURE_FLOW_TABLE_ACCEL 1
+#define FEATURE_QOS_HOOKS 1
 #endif
 
 typedef enum {
@@ -41,7 +45,6 @@ typedef enum {
     PROFILE_TIER_C
 } SystemProfile;
 
-// Mock function to get system profile
 static inline SystemProfile get_system_profile(void) {
 #if defined(Profile_RTOS)
     return PROFILE_TIER_A;
@@ -52,4 +55,4 @@ static inline SystemProfile get_system_profile(void) {
 #endif
 }
 
-#endif // BHARAT_PROFILE_H
+#endif /* BHARAT_PROFILE_H */

--- a/kernel/src/main.c
+++ b/kernel/src/main.c
@@ -52,6 +52,12 @@ static const char *kernel_boot_hw_profile(void) {
   return "vm";
 #elif defined(BHARAT_BOOT_HW_PROFILE_laptop)
   return "laptop";
+#elif defined(BHARAT_BOOT_HW_PROFILE_mobile)
+  return "mobile";
+#elif defined(BHARAT_BOOT_HW_PROFILE_datacenter)
+  return "datacenter";
+#elif defined(BHARAT_BOOT_HW_PROFILE_network_appliance)
+  return "network_appliance";
 #else
   return "generic";
 #endif
@@ -190,6 +196,9 @@ void kernel_main(void) {
     KPRINT("  [HAL] Initialising hardware on BSP...\n");
     hal_init();
     KPRINT("  [HAL] Ready.\n");
+
+    KPRINT("  [PROFILE] Applying hardware profile hooks...\n");
+    profile_init();
 
     KPRINT("  [SEC] Running secure-boot verification...\n");
     if (bharat_secure_boot_verify_early() != 0) {

--- a/kernel/src/profile/datacenter/profile.c
+++ b/kernel/src/profile/datacenter/profile.c
@@ -1,0 +1,7 @@
+#include "profile.h"
+
+void profile_init(void) {
+    /* DATACENTER: prioritize NUMA-aware memory, scalable scheduling,
+     * high-performance networking, block I/O, and crash recovery paths.
+     */
+}

--- a/kernel/src/profile/mobile/profile.c
+++ b/kernel/src/profile/mobile/profile.c
@@ -1,0 +1,7 @@
+#include "profile.h"
+
+void profile_init(void) {
+    /* MOBILE: prioritize Linux-like process/fd/memory substrate, Binder hooks,
+     * ashmem/shared memory, service manager, and aggressive power management.
+     */
+}

--- a/kernel/src/profile/network_appliance/profile.c
+++ b/kernel/src/profile/network_appliance/profile.c
@@ -1,0 +1,7 @@
+#include "profile.h"
+
+void profile_init(void) {
+    /* NETWORK APPLIANCE: prioritize packet path, NIC drivers, flow tables,
+     * lightweight control-plane IPC, and watchdog/failover.
+     */
+}

--- a/kernel/src/security/secure_boot.c
+++ b/kernel/src/security/secure_boot.c
@@ -16,6 +16,27 @@ static const bharat_boot_policy_t g_boot_policy = {
     .smp_target_cores = 2U,
     .enable_zswap = 1U,
     .enable_ai_governor = 0U,
+#elif defined(BHARAT_BOOT_HW_PROFILE_mobile)
+    .security_level = BHARAT_BOOT_SECURITY_ENFORCED,
+    .perf_mode = BHARAT_BOOT_PERF_BALANCED,
+    .timer_tick_hz = 250U,
+    .smp_target_cores = 4U,
+    .enable_zswap = 1U,
+    .enable_ai_governor = 1U,
+#elif defined(BHARAT_BOOT_HW_PROFILE_datacenter)
+    .security_level = BHARAT_BOOT_SECURITY_MEASURED,
+    .perf_mode = BHARAT_BOOT_PERF_FAST,
+    .timer_tick_hz = 250U,
+    .smp_target_cores = 8U,
+    .enable_zswap = 1U,
+    .enable_ai_governor = 1U,
+#elif defined(BHARAT_BOOT_HW_PROFILE_network_appliance)
+    .security_level = BHARAT_BOOT_SECURITY_ENFORCED,
+    .perf_mode = BHARAT_BOOT_PERF_FAST,
+    .timer_tick_hz = 1000U,
+    .smp_target_cores = 4U,
+    .enable_zswap = 0U,
+    .enable_ai_governor = 0U,
 #elif defined(BHARAT_PROFILE_DRONE) || defined(BHARAT_PROFILE_ROBOT) || \
       defined(BHARAT_PROFILE_AUTOMOTIVE_ECU) || defined(BHARAT_PROFILE_AUTOMOTIVE_INFOTAINMENT)
     .security_level = BHARAT_BOOT_SECURITY_ENFORCED,


### PR DESCRIPTION
### Motivation
- Provide boot-time plumbing and a roadmap so the kernel can be configured and initialized for `mobile`, `datacenter`, and `network_appliance` hardware profiles. 
- Surface a consistent hook point to run lightweight, profile-specific kernel initialization early on the BSP and capture profile-specific boot policy defaults.

### Description
- Extend kernel configuration validation in `kernel/CMakeLists.txt` to accept `mobile`, `datacenter`, and `network_appliance` and export `BHARAT_BOOT_HW_PROFILE_<name>` compile defines. 
- Add a shared profile API in `kernel/include/profile.h` with small per-profile feature macros and a `profile_init()` declaration. 
- Wire profile reporting into the boot path in `kernel/src/main.c` and call `profile_init()` during BSP bring-up so profile hooks run early. 
- Add boot policy defaults for the three new profiles in `kernel/src/security/secure_boot.c` (timer tick, SMP target cores, zswap and AI-governor flags, security/perf modes). 
- Add scaffold source files for each profile at `kernel/src/profile/{mobile,datacenter,network_appliance}/profile.c` and a new documentation roadmap at `docs/profile_priorities_and_kernel_changes.md` describing priorities and subsystem impacts.

### Testing
- Ran configuration: `cmake -S . -B build-check -DBHARAT_BOOT_HW_PROFILE=mobile` and `cmake -S . -B build-check -DBHARAT_BOOT_HW_PROFILE=network_appliance` which completed successfully (configuration/generation returned 0). 
- Ran build: `cmake --build build-check -j2` which failed with an existing, pre-existing compilation error (`duplicate member 'personality'` in `kernel/include/sched.h`) surfaced by `subsys/src/manager.c` and not introduced by this change; configuration and profile plumbing changes themselves did not cause the failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad589a73808320ad726f543444f8a5)