### PR TITLE
Bus-aware device model, driver binding, hotplug, power-state hooks, and expanded built-in drivers/docs

### DIFF
--- a/docs/architecture/hardware-abstraction-and-drivers-baseline.md
+++ b/docs/architecture/hardware-abstraction-and-drivers-baseline.md
@@ -19,6 +19,8 @@ This document captures the current HAL and driver-framework baseline in kernel s
   - UART/SPI/I2C/SDMMC/Ethernet driver records,
   - Ethernet RX/TX MMIO window registration for NIC IDs.
 - Zero-copy NIC integration now resolves MMIO windows through device framework lookups instead of local hardcoded tables.
+- Bus-aware driver/device baseline now supports explicit driver match metadata, bind lifecycle, hotplug add/remove hooks, and per-device power-state transitions.
+- Built-in network defaults now include canonical scaffold entries for PCI Ethernet, USB CDC-ECM Ethernet, CAN, and virtio-net with baseline security/performance/hardware-feature flags and queue limits.
 
 ## Deferred for production
 
@@ -26,3 +28,47 @@ This document captures the current HAL and driver-framework baseline in kernel s
 - Real periodic timer programming and interrupt ack paths.
 - Driver-domain isolation and user-space driver process boundaries.
 - Runtime hardware discovery from ACPI/FDT instead of static built-in tables.
+
+## Hardware/platform subsystems still required
+
+The v1 baseline intentionally keeps hardware support narrow. To reach serious deployment readiness across x86, ARM, RISC-V, Shakti, EV/automotive, edge devices, and datacenter targets, Bharat-OS still needs the following platform subsystems.
+
+### 1) Board Support Package (BSP) framework
+
+- Board descriptors with stable identifiers and capability policy defaults.
+- Interrupt map description per board/SOC.
+- Physical memory map description (RAM, reserved ranges, MMIO apertures).
+- Firmware description ingestion:
+  - Device Tree (FDT) for ARM/RISC-V/Shakti platforms,
+  - ACPI for x86-class systems,
+  - static board tables as fallback for bring-up.
+- Flash/debug profiles (boot medium layout, debug UART/JTAG/OpenOCD presets, recovery flow hooks).
+
+### 2) Device driver model hardening
+
+- Bus abstraction layer so drivers bind through common probe/remove APIs.
+- Driver binding and match tables (compatible string, class/subclass, vendor/device IDs).
+- Power-state hooks (suspend/resume/runtime idle).
+- Hotplug handling where bus semantics require it (PCIe, USB, removable media).
+
+### 3) Bus subsystems (minimum framework per bus)
+
+- PCI/PCIe.
+- MMIO platform bus.
+- USB.
+- I2C.
+- SPI.
+- UART.
+- GPIO.
+- SD/MMC.
+- CAN (automotive profile requirement).
+- virtio (VM/QEMU profile requirement).
+
+## Recommended implementation order
+
+1. Land BSP descriptors + memory/interrupt maps with FDT/ACPI parsing adapters.
+2. Introduce generic bus core + unified driver bind/probe/remove lifecycle.
+3. Bring up UART/GPIO/I2C/SPI on platform bus first (board bring-up critical path).
+4. Add PCIe + virtio for VM and server workflows.
+5. Add USB/SDMMC for storage/peripheral depth.
+6. Add CAN and deterministic power-state policy for automotive/EV profile.

--- a/kernel/include/device.h
+++ b/kernel/include/device.h
@@ -11,7 +11,54 @@ typedef enum {
     DEVICE_CLASS_I2C,
     DEVICE_CLASS_SDMMC,
     DEVICE_CLASS_ETHERNET,
+    DEVICE_CLASS_GPIO,
+    DEVICE_CLASS_USB,
+    DEVICE_CLASS_CAN,
+    DEVICE_CLASS_VIRTIO,
+    DEVICE_CLASS_PLATFORM,
 } device_class_t;
+
+typedef enum {
+    DEVICE_BUS_PCI = 0,
+    DEVICE_BUS_PLATFORM_MMIO,
+    DEVICE_BUS_USB,
+    DEVICE_BUS_I2C,
+    DEVICE_BUS_SPI,
+    DEVICE_BUS_UART,
+    DEVICE_BUS_GPIO,
+    DEVICE_BUS_SDMMC,
+    DEVICE_BUS_CAN,
+    DEVICE_BUS_VIRTIO,
+} device_bus_t;
+
+typedef enum {
+    DEVICE_POWER_D0 = 0,
+    DEVICE_POWER_D1,
+    DEVICE_POWER_D2,
+    DEVICE_POWER_D3,
+} device_power_state_t;
+
+enum {
+    DEVICE_SECURITY_CAPABILITY_GATED = (1U << 0),
+    DEVICE_SECURITY_IOMMU_DMA_GUARD = (1U << 1),
+    DEVICE_SECURITY_SIGNED_FW_ONLY   = (1U << 2),
+};
+
+enum {
+    DEVICE_PERF_IRQ_AFFINITY      = (1U << 0),
+    DEVICE_PERF_ZERO_COPY_RXTX    = (1U << 1),
+    DEVICE_PERF_NAPI_BUDGETED_RX  = (1U << 2),
+};
+
+enum {
+    DEVICE_HW_FEAT_MSI_X         = (1U << 0),
+    DEVICE_HW_FEAT_RX_CSUM       = (1U << 1),
+    DEVICE_HW_FEAT_TX_CSUM       = (1U << 2),
+    DEVICE_HW_FEAT_TSO           = (1U << 3),
+    DEVICE_HW_FEAT_RSS           = (1U << 4),
+    DEVICE_HW_FEAT_CAN_FD        = (1U << 5),
+    DEVICE_HW_FEAT_VIRTIO_MODERN = (1U << 6),
+};
 
 typedef struct {
     device_class_t class_id;
@@ -25,12 +72,53 @@ typedef struct {
 } device_mmio_window_t;
 
 typedef struct {
-    const char* name;
+    device_bus_t bus;
     device_class_t class_id;
     uint32_t device_id;
+    uint16_t vendor_id;
+    uint16_t product_id;
+    uint8_t class_code;
+    uint8_t subclass_code;
+    const char* compatible;
+    uint32_t irq;
+    uint8_t hotpluggable;
+    device_power_state_t power_state;
+    uint8_t rx_queue_count;
+    uint8_t tx_queue_count;
+    uint32_t security_flags;
+    uint32_t perf_flags;
+    uint32_t hw_feature_flags;
+    uint8_t in_use;
+} device_desc_t;
+
+typedef struct {
+    device_bus_t bus;
+    device_class_t class_id;
+    uint16_t vendor_id;
+    uint16_t product_id;
+    uint8_t class_code;
+    uint8_t subclass_code;
+    const char* compatible;
+} device_match_t;
+
+typedef struct {
+    const char* name;
+    device_class_t class_id;
+    device_bus_t bus;
+    uint32_t device_id;
+
+    /* Legacy probe callback for older stubs. */
     int (*probe)(void);
+
+    /* Preferred callbacks for bus/device-aware model. */
+    int (*probe_device)(const device_desc_t* dev, void** out_ctx);
+    int (*remove_device)(void* ctx);
+    int (*suspend)(void* ctx, device_power_state_t target_state);
+    int (*resume)(void* ctx);
     void (*irq_handler)(uint32_t irq, void* ctx);
+
     void* ctx;
+    device_match_t match;
 } device_driver_t;
 
 int device_framework_init(void);
@@ -42,8 +130,14 @@ int device_lookup_mmio_window(device_class_t class_id,
                               device_mmio_window_t* out_window);
 int device_dispatch_irq(uint32_t irq);
 
+int device_register_bus_device(const device_desc_t* dev);
+int device_hotplug_add(const device_desc_t* dev);
+int device_hotplug_remove(device_bus_t bus, uint32_t device_id);
+int device_bind_drivers(void);
+int device_set_power_state(device_bus_t bus, uint32_t device_id, device_power_state_t target_state);
+
 int device_register_builtin_drivers(void);
 
-#endif // BHARAT_DEVICE_H
-
 int pci_discover_nic(device_mmio_window_t* rx_window, device_mmio_window_t* tx_window);
+
+#endif // BHARAT_DEVICE_H

--- a/kernel/src/device/builtin_drivers.c
+++ b/kernel/src/device/builtin_drivers.c
@@ -6,6 +6,30 @@ static int driver_probe_noop(void) {
     return 0;
 }
 
+static int driver_probe_device_noop(const device_desc_t* dev, void** out_ctx) {
+    (void)dev;
+    if (out_ctx) {
+        *out_ctx = NULL;
+    }
+    return 0;
+}
+
+static int driver_remove_noop(void* ctx) {
+    (void)ctx;
+    return 0;
+}
+
+static int driver_suspend_noop(void* ctx, device_power_state_t target_state) {
+    (void)ctx;
+    (void)target_state;
+    return 0;
+}
+
+static int driver_resume_noop(void* ctx) {
+    (void)ctx;
+    return 0;
+}
+
 static void driver_irq_noop(uint32_t irq, void* ctx) {
     (void)irq;
     (void)ctx;
@@ -13,18 +37,83 @@ static void driver_irq_noop(uint32_t irq, void* ctx) {
 
 int device_register_builtin_drivers(void) {
     static const device_driver_t drivers[] = {
-        {.name = "uart0", .class_id = DEVICE_CLASS_UART, .device_id = 0U, .probe = driver_probe_noop, .irq_handler = driver_irq_noop, .ctx = NULL},
-        {.name = "spi0", .class_id = DEVICE_CLASS_SPI, .device_id = 0U, .probe = driver_probe_noop, .irq_handler = driver_irq_noop, .ctx = NULL},
-        {.name = "i2c0", .class_id = DEVICE_CLASS_I2C, .device_id = 0U, .probe = driver_probe_noop, .irq_handler = driver_irq_noop, .ctx = NULL},
-        {.name = "sdmmc0", .class_id = DEVICE_CLASS_SDMMC, .device_id = 0U, .probe = driver_probe_noop, .irq_handler = driver_irq_noop, .ctx = NULL},
-        {.name = "eth0", .class_id = DEVICE_CLASS_ETHERNET, .device_id = 0U, .probe = driver_probe_noop, .irq_handler = driver_irq_noop, .ctx = NULL},
+        {.name = "uart0", .class_id = DEVICE_CLASS_UART, .bus = DEVICE_BUS_UART, .device_id = 0U,
+         .probe = driver_probe_noop, .probe_device = driver_probe_device_noop,
+         .remove_device = driver_remove_noop, .suspend = driver_suspend_noop, .resume = driver_resume_noop,
+         .irq_handler = driver_irq_noop, .ctx = NULL,
+         .match = {.bus = DEVICE_BUS_UART, .class_id = DEVICE_CLASS_UART, .compatible = "ns16550a"}},
+        {.name = "spi0", .class_id = DEVICE_CLASS_SPI, .bus = DEVICE_BUS_SPI, .device_id = 0U,
+         .probe = driver_probe_noop, .probe_device = driver_probe_device_noop,
+         .remove_device = driver_remove_noop, .suspend = driver_suspend_noop, .resume = driver_resume_noop,
+         .irq_handler = driver_irq_noop, .ctx = NULL,
+         .match = {.bus = DEVICE_BUS_SPI, .class_id = DEVICE_CLASS_SPI, .compatible = "generic-spi"}},
+        {.name = "i2c0", .class_id = DEVICE_CLASS_I2C, .bus = DEVICE_BUS_I2C, .device_id = 0U,
+         .probe = driver_probe_noop, .probe_device = driver_probe_device_noop,
+         .remove_device = driver_remove_noop, .suspend = driver_suspend_noop, .resume = driver_resume_noop,
+         .irq_handler = driver_irq_noop, .ctx = NULL,
+         .match = {.bus = DEVICE_BUS_I2C, .class_id = DEVICE_CLASS_I2C, .compatible = "generic-i2c"}},
+        {.name = "sdmmc0", .class_id = DEVICE_CLASS_SDMMC, .bus = DEVICE_BUS_SDMMC, .device_id = 0U,
+         .probe = driver_probe_noop, .probe_device = driver_probe_device_noop,
+         .remove_device = driver_remove_noop, .suspend = driver_suspend_noop, .resume = driver_resume_noop,
+         .irq_handler = driver_irq_noop, .ctx = NULL,
+         .match = {.bus = DEVICE_BUS_SDMMC, .class_id = DEVICE_CLASS_SDMMC, .compatible = "generic-sdmmc"}},
+        {.name = "eth-pci", .class_id = DEVICE_CLASS_ETHERNET, .bus = DEVICE_BUS_PCI, .device_id = 0U,
+         .probe = driver_probe_noop, .probe_device = driver_probe_device_noop,
+         .remove_device = driver_remove_noop, .suspend = driver_suspend_noop, .resume = driver_resume_noop,
+         .irq_handler = driver_irq_noop, .ctx = NULL,
+         .match = {.bus = DEVICE_BUS_PCI, .class_id = DEVICE_CLASS_ETHERNET, .class_code = 0x02}},
+        {.name = "eth-usb-cdc-ecm", .class_id = DEVICE_CLASS_ETHERNET, .bus = DEVICE_BUS_USB, .device_id = 1U,
+         .probe = driver_probe_noop, .probe_device = driver_probe_device_noop,
+         .remove_device = driver_remove_noop, .suspend = driver_suspend_noop, .resume = driver_resume_noop,
+         .irq_handler = driver_irq_noop, .ctx = NULL,
+         .match = {.bus = DEVICE_BUS_USB, .class_id = DEVICE_CLASS_ETHERNET, .compatible = "usb-cdc-ecm"}},
+        {.name = "can0", .class_id = DEVICE_CLASS_CAN, .bus = DEVICE_BUS_CAN, .device_id = 0U,
+         .probe = driver_probe_noop, .probe_device = driver_probe_device_noop,
+         .remove_device = driver_remove_noop, .suspend = driver_suspend_noop, .resume = driver_resume_noop,
+         .irq_handler = driver_irq_noop, .ctx = NULL,
+         .match = {.bus = DEVICE_BUS_CAN, .class_id = DEVICE_CLASS_CAN, .compatible = "generic-can"}},
+        {.name = "virtio-net0", .class_id = DEVICE_CLASS_VIRTIO, .bus = DEVICE_BUS_VIRTIO, .device_id = 0U,
+         .probe = driver_probe_noop, .probe_device = driver_probe_device_noop,
+         .remove_device = driver_remove_noop, .suspend = driver_suspend_noop, .resume = driver_resume_noop,
+         .irq_handler = driver_irq_noop, .ctx = NULL,
+         .match = {.bus = DEVICE_BUS_VIRTIO, .class_id = DEVICE_CLASS_VIRTIO, .vendor_id = 0x1AF4}},
+    };
+
+    static const device_desc_t devices[] = {
+        {.bus = DEVICE_BUS_UART, .class_id = DEVICE_CLASS_UART, .device_id = 0U, .compatible = "ns16550a", .irq = 4U, .hotpluggable = 0U, .power_state = DEVICE_POWER_D0, .in_use = 1U},
+        {.bus = DEVICE_BUS_SPI, .class_id = DEVICE_CLASS_SPI, .device_id = 0U, .compatible = "generic-spi", .irq = 5U, .hotpluggable = 0U, .power_state = DEVICE_POWER_D0, .in_use = 1U},
+        {.bus = DEVICE_BUS_I2C, .class_id = DEVICE_CLASS_I2C, .device_id = 0U, .compatible = "generic-i2c", .irq = 6U, .hotpluggable = 0U, .power_state = DEVICE_POWER_D0, .in_use = 1U},
+        {.bus = DEVICE_BUS_SDMMC, .class_id = DEVICE_CLASS_SDMMC, .device_id = 0U, .compatible = "generic-sdmmc", .irq = 9U, .hotpluggable = 1U, .power_state = DEVICE_POWER_D0, .in_use = 1U},
+        {.bus = DEVICE_BUS_PCI, .class_id = DEVICE_CLASS_ETHERNET, .device_id = 0U, .vendor_id = 0x8086U, .product_id = 0x100EU, .class_code = 0x02U, .compatible = "pci-net", .irq = 10U, .hotpluggable = 1U, .power_state = DEVICE_POWER_D0,
+         .rx_queue_count = 4U, .tx_queue_count = 4U,
+         .security_flags = DEVICE_SECURITY_CAPABILITY_GATED | DEVICE_SECURITY_IOMMU_DMA_GUARD,
+         .perf_flags = DEVICE_PERF_IRQ_AFFINITY | DEVICE_PERF_ZERO_COPY_RXTX | DEVICE_PERF_NAPI_BUDGETED_RX,
+         .hw_feature_flags = DEVICE_HW_FEAT_MSI_X | DEVICE_HW_FEAT_RX_CSUM | DEVICE_HW_FEAT_TX_CSUM | DEVICE_HW_FEAT_TSO | DEVICE_HW_FEAT_RSS,
+         .in_use = 1U},
+        {.bus = DEVICE_BUS_USB, .class_id = DEVICE_CLASS_ETHERNET, .device_id = 1U, .compatible = "usb-cdc-ecm", .irq = 11U, .hotpluggable = 1U, .power_state = DEVICE_POWER_D0,
+         .rx_queue_count = 1U, .tx_queue_count = 1U,
+         .security_flags = DEVICE_SECURITY_CAPABILITY_GATED | DEVICE_SECURITY_IOMMU_DMA_GUARD | DEVICE_SECURITY_SIGNED_FW_ONLY,
+         .perf_flags = DEVICE_PERF_IRQ_AFFINITY,
+         .hw_feature_flags = DEVICE_HW_FEAT_RX_CSUM | DEVICE_HW_FEAT_TX_CSUM,
+         .in_use = 1U},
+        {.bus = DEVICE_BUS_CAN, .class_id = DEVICE_CLASS_CAN, .device_id = 0U, .compatible = "generic-can", .irq = 12U, .hotpluggable = 0U, .power_state = DEVICE_POWER_D0,
+         .rx_queue_count = 1U, .tx_queue_count = 1U,
+         .security_flags = DEVICE_SECURITY_CAPABILITY_GATED | DEVICE_SECURITY_IOMMU_DMA_GUARD,
+         .perf_flags = DEVICE_PERF_IRQ_AFFINITY,
+         .hw_feature_flags = DEVICE_HW_FEAT_CAN_FD,
+         .in_use = 1U},
+        {.bus = DEVICE_BUS_VIRTIO, .class_id = DEVICE_CLASS_VIRTIO, .device_id = 0U, .vendor_id = 0x1AF4U, .product_id = 0x1041U, .compatible = "virtio-net", .irq = 13U, .hotpluggable = 1U, .power_state = DEVICE_POWER_D0,
+         .rx_queue_count = 2U, .tx_queue_count = 2U,
+         .security_flags = DEVICE_SECURITY_CAPABILITY_GATED | DEVICE_SECURITY_IOMMU_DMA_GUARD,
+         .perf_flags = DEVICE_PERF_IRQ_AFFINITY | DEVICE_PERF_ZERO_COPY_RXTX,
+         .hw_feature_flags = DEVICE_HW_FEAT_VIRTIO_MODERN | DEVICE_HW_FEAT_RX_CSUM | DEVICE_HW_FEAT_TX_CSUM,
+         .in_use = 1U},
     };
 
     static const device_mmio_window_t windows[] = {
         { .class_id = DEVICE_CLASS_ETHERNET, .device_id = 0U, .window_id = 0U, .phys_base = 0x40000000U, .virt_base = 0x8000000000U, .size_bytes = 0x10000U, .irq = 10U, .in_use = 1U },
         { .class_id = DEVICE_CLASS_ETHERNET, .device_id = 0U, .window_id = 1U, .phys_base = 0x40010000U, .virt_base = 0x8000010000U, .size_bytes = 0x10000U, .irq = 10U, .in_use = 1U },
-        { .class_id = DEVICE_CLASS_ETHERNET, .device_id = 1U, .window_id = 0U, .phys_base = 0x40020000U, .virt_base = 0x8000020000U, .size_bytes = 0x10000U, .irq = 11U, .in_use = 1U },
-        { .class_id = DEVICE_CLASS_ETHERNET, .device_id = 1U, .window_id = 1U, .phys_base = 0x40030000U, .virt_base = 0x8000030000U, .size_bytes = 0x10000U, .irq = 11U, .in_use = 1U },
+        { .class_id = DEVICE_CLASS_VIRTIO, .device_id = 0U, .window_id = 0U, .phys_base = 0x40020000U, .virt_base = 0x8000020000U, .size_bytes = 0x10000U, .irq = 13U, .in_use = 1U },
     };
 
     for (size_t i = 0; i < sizeof(drivers)/sizeof(drivers[0]); ++i) {
@@ -33,10 +122,20 @@ int device_register_builtin_drivers(void) {
         }
     }
 
-    for (size_t i = 0; i < sizeof(windows)/sizeof(windows[0]); ++i) {
-        if (device_register_mmio_window(&windows[i]) != 0) {
+    for (size_t i = 0; i < sizeof(devices)/sizeof(devices[0]); ++i) {
+        if (device_register_bus_device(&devices[i]) != 0) {
             return -2;
         }
+    }
+
+    for (size_t i = 0; i < sizeof(windows)/sizeof(windows[0]); ++i) {
+        if (device_register_mmio_window(&windows[i]) != 0) {
+            return -3;
+        }
+    }
+
+    if (device_bind_drivers() != 0) {
+        return -4;
     }
 
     return 0;

--- a/kernel/src/device/device_manager.c
+++ b/kernel/src/device/device_manager.c
@@ -7,22 +7,96 @@
 
 #define MAX_DEV_DRIVERS 32U
 #define MAX_MMIO_WINDOWS 64U
+#define MAX_BUS_DEVICES 64U
+#define MAX_BINDINGS 64U
+
+typedef struct {
+    uint8_t in_use;
+    uint8_t driver_index;
+    uint8_t device_index;
+} device_binding_t;
 
 static device_driver_t g_drivers[MAX_DEV_DRIVERS];
 static device_mmio_window_t g_windows[MAX_MMIO_WINDOWS];
+static device_desc_t g_bus_devices[MAX_BUS_DEVICES];
+static device_binding_t g_bindings[MAX_BINDINGS];
+
+static int is_network_class(device_class_t class_id) {
+    return (class_id == DEVICE_CLASS_ETHERNET ||
+            class_id == DEVICE_CLASS_CAN ||
+            class_id == DEVICE_CLASS_VIRTIO);
+}
+
+static int str_eq(const char* a, const char* b) {
+    if (a == b) return 1;
+    if (!a || !b) return 0;
+    while (*a && *b) { if (*a != *b) return 0; ++a; ++b; }
+    return *a == *b;
+}
+
+static int device_match_driver(const device_driver_t* driver, const device_desc_t* dev) {
+    if (!driver || !dev) {
+        return 0;
+    }
+
+    if (driver->bus != dev->bus || driver->class_id != dev->class_id) {
+        return 0;
+    }
+
+    if (driver->match.vendor_id != 0U && driver->match.vendor_id != dev->vendor_id) {
+        return 0;
+    }
+
+    if (driver->match.product_id != 0U && driver->match.product_id != dev->product_id) {
+        return 0;
+    }
+
+    if (driver->match.class_code != 0U && driver->match.class_code != dev->class_code) {
+        return 0;
+    }
+
+    if (driver->match.subclass_code != 0U && driver->match.subclass_code != dev->subclass_code) {
+        return 0;
+    }
+
+    if (driver->match.compatible && dev->compatible) {
+        if (!str_eq(driver->match.compatible, dev->compatible)) {
+            return 0;
+        }
+    }
+
+    return 1;
+}
 
 int device_framework_init(void) {
     for (size_t i = 0; i < BHARAT_ARRAY_SIZE(g_drivers); ++i) {
         g_drivers[i].name = NULL;
         g_drivers[i].probe = NULL;
+        g_drivers[i].probe_device = NULL;
+        g_drivers[i].remove_device = NULL;
+        g_drivers[i].suspend = NULL;
+        g_drivers[i].resume = NULL;
         g_drivers[i].irq_handler = NULL;
         g_drivers[i].ctx = NULL;
         g_drivers[i].device_id = 0U;
         g_drivers[i].class_id = DEVICE_CLASS_UART;
+        g_drivers[i].bus = DEVICE_BUS_PLATFORM_MMIO;
+        g_drivers[i].match.compatible = NULL;
     }
 
     for (size_t i = 0; i < BHARAT_ARRAY_SIZE(g_windows); ++i) {
         g_windows[i].in_use = 0U;
+    }
+
+    for (size_t i = 0; i < BHARAT_ARRAY_SIZE(g_bus_devices); ++i) {
+        g_bus_devices[i].in_use = 0U;
+        g_bus_devices[i].compatible = NULL;
+    }
+
+    for (size_t i = 0; i < BHARAT_ARRAY_SIZE(g_bindings); ++i) {
+        g_bindings[i].in_use = 0U;
+        g_bindings[i].driver_index = 0U;
+        g_bindings[i].device_index = 0U;
     }
 
     return 0;
@@ -36,14 +110,177 @@ int device_register_driver(const device_driver_t* driver) {
     for (size_t i = 0; i < BHARAT_ARRAY_SIZE(g_drivers); ++i) {
         if (!g_drivers[i].name) {
             g_drivers[i] = *driver;
-            if (g_drivers[i].probe) {
-                return g_drivers[i].probe();
-            }
             return 0;
         }
     }
 
     return -2;
+}
+
+int device_register_bus_device(const device_desc_t* dev) {
+    device_desc_t sanitized;
+
+    if (!dev) {
+        return -1;
+    }
+
+    sanitized = *dev;
+
+    if (is_network_class(sanitized.class_id)) {
+        if ((sanitized.security_flags & DEVICE_SECURITY_CAPABILITY_GATED) == 0U ||
+            (sanitized.security_flags & DEVICE_SECURITY_IOMMU_DMA_GUARD) == 0U) {
+            return -4;
+        }
+
+        if (sanitized.rx_queue_count == 0U) {
+            sanitized.rx_queue_count = 1U;
+        }
+        if (sanitized.tx_queue_count == 0U) {
+            sanitized.tx_queue_count = 1U;
+        }
+
+        if (sanitized.rx_queue_count > 4U) {
+            sanitized.rx_queue_count = 4U;
+        }
+        if (sanitized.tx_queue_count > 4U) {
+            sanitized.tx_queue_count = 4U;
+        }
+    }
+
+    for (size_t i = 0; i < BHARAT_ARRAY_SIZE(g_bus_devices); ++i) {
+        if (g_bus_devices[i].in_use != 0U &&
+            g_bus_devices[i].bus == sanitized.bus &&
+            g_bus_devices[i].device_id == sanitized.device_id) {
+            return -3;
+        }
+    }
+
+    for (size_t i = 0; i < BHARAT_ARRAY_SIZE(g_bus_devices); ++i) {
+        if (g_bus_devices[i].in_use == 0U) {
+            g_bus_devices[i] = sanitized;
+            g_bus_devices[i].in_use = 1U;
+            return 0;
+        }
+    }
+
+    return -2;
+}
+
+int device_bind_drivers(void) {
+    for (size_t d = 0; d < BHARAT_ARRAY_SIZE(g_drivers); ++d) {
+        if (!g_drivers[d].name) {
+            continue;
+        }
+
+        for (size_t dev = 0; dev < BHARAT_ARRAY_SIZE(g_bus_devices); ++dev) {
+            if (g_bus_devices[dev].in_use == 0U) {
+                continue;
+            }
+
+            if (!device_match_driver(&g_drivers[d], &g_bus_devices[dev])) {
+                continue;
+            }
+
+            int already_bound = 0;
+            for (size_t b = 0; b < BHARAT_ARRAY_SIZE(g_bindings); ++b) {
+                if (g_bindings[b].in_use != 0U &&
+                    g_bindings[b].driver_index == d &&
+                    g_bindings[b].device_index == dev) {
+                    already_bound = 1;
+                    break;
+                }
+            }
+            if (already_bound) {
+                continue;
+            }
+
+            void* bound_ctx = g_drivers[d].ctx;
+            if (g_drivers[d].probe_device) {
+                if (g_drivers[d].probe_device(&g_bus_devices[dev], &bound_ctx) != 0) {
+                    continue;
+                }
+            } else if (g_drivers[d].probe) {
+                if (g_drivers[d].probe() != 0) {
+                    continue;
+                }
+            }
+
+            for (size_t b = 0; b < BHARAT_ARRAY_SIZE(g_bindings); ++b) {
+                if (g_bindings[b].in_use == 0U) {
+                    g_bindings[b].in_use = 1U;
+                    g_bindings[b].driver_index = (uint8_t)d;
+                    g_bindings[b].device_index = (uint8_t)dev;
+                    g_drivers[d].ctx = bound_ctx;
+                    break;
+                }
+            }
+        }
+    }
+
+    return 0;
+}
+
+int device_hotplug_add(const device_desc_t* dev) {
+    int rc = device_register_bus_device(dev);
+    if (rc != 0) {
+        return rc;
+    }
+
+    return device_bind_drivers();
+}
+
+int device_hotplug_remove(device_bus_t bus, uint32_t device_id) {
+    for (size_t dev = 0; dev < BHARAT_ARRAY_SIZE(g_bus_devices); ++dev) {
+        if (g_bus_devices[dev].in_use != 0U &&
+            g_bus_devices[dev].bus == bus &&
+            g_bus_devices[dev].device_id == device_id) {
+
+            for (size_t b = 0; b < BHARAT_ARRAY_SIZE(g_bindings); ++b) {
+                if (g_bindings[b].in_use != 0U && g_bindings[b].device_index == dev) {
+                    device_driver_t* drv = &g_drivers[g_bindings[b].driver_index];
+                    if (drv->remove_device) {
+                        (void)drv->remove_device(drv->ctx);
+                    }
+                    g_bindings[b].in_use = 0U;
+                }
+            }
+
+            g_bus_devices[dev].in_use = 0U;
+            return 0;
+        }
+    }
+
+    return -1;
+}
+
+int device_set_power_state(device_bus_t bus, uint32_t device_id, device_power_state_t target_state) {
+    for (size_t dev = 0; dev < BHARAT_ARRAY_SIZE(g_bus_devices); ++dev) {
+        if (g_bus_devices[dev].in_use == 0U ||
+            g_bus_devices[dev].bus != bus ||
+            g_bus_devices[dev].device_id != device_id) {
+            continue;
+        }
+
+        for (size_t b = 0; b < BHARAT_ARRAY_SIZE(g_bindings); ++b) {
+            if (g_bindings[b].in_use == 0U || g_bindings[b].device_index != dev) {
+                continue;
+            }
+
+            device_driver_t* drv = &g_drivers[g_bindings[b].driver_index];
+            if (target_state == DEVICE_POWER_D0) {
+                if (drv->resume) {
+                    (void)drv->resume(drv->ctx);
+                }
+            } else if (drv->suspend) {
+                (void)drv->suspend(drv->ctx, target_state);
+            }
+        }
+
+        g_bus_devices[dev].power_state = target_state;
+        return 0;
+    }
+
+    return -1;
 }
 
 int device_register_mmio_window(const device_mmio_window_t* window) {
@@ -56,16 +293,14 @@ int device_register_mmio_window(const device_mmio_window_t* window) {
             g_windows[i] = *window;
             g_windows[i].in_use = 1U;
 
-            // Map physical to virtual space using VMM
-            // Only map if vmm_map_device_mmio is defined/available. For tests we mock/skip.
             #ifndef TESTING
             uint32_t num_pages = (window->size_bytes + PAGE_SIZE - 1) / PAGE_SIZE;
             for (uint32_t p = 0; p < num_pages; p++) {
                 vmm_map_device_mmio(
                     window->virt_base + (p * PAGE_SIZE),
                     window->phys_base + (p * PAGE_SIZE),
-                    NULL, // Passing NULL bypasses capabilities for generic MMIO
-                    0 // is_npu flag
+                    NULL,
+                    0
                 );
             }
             #endif
@@ -77,7 +312,6 @@ int device_register_mmio_window(const device_mmio_window_t* window) {
     return -2;
 }
 
-// Level 0: Reference generic O(N) linear search
 int device_lookup_mmio_window_l0(uint32_t class_id,
                                  uint32_t device_id,
                                  uint32_t window_id,
@@ -100,9 +334,6 @@ int device_lookup_mmio_window_l0(uint32_t class_id,
     return -2;
 }
 
-// Level 1: Optimized lookup (placeholder for an SMP-aware/hashed lookup logic)
-// In a full implementation, this might use per-class lock-free hash tables or an RCU list.
-// For PoC, we will implement it as a slightly optimized search (e.g. searching backwards or unrolling).
 int device_lookup_mmio_window_l1(uint32_t class_id,
                                  uint32_t device_id,
                                  uint32_t window_id,
@@ -112,8 +343,6 @@ int device_lookup_mmio_window_l1(uint32_t class_id,
         return -1;
     }
 
-    // Optimization: we could track how many are active and only scan that many,
-    // or unroll the loop. Let's do a simple reverse scan for demonstration of L1 logic.
     for (int i = BHARAT_ARRAY_SIZE(g_windows) - 1; i >= 0; --i) {
         if (g_windows[i].in_use != 0U &&
             g_windows[i].class_id == class_id &&
@@ -134,14 +363,21 @@ int device_lookup_mmio_window(device_class_t class_id,
     if (g_search_ops.device_lookup_mmio_window) {
         return g_search_ops.device_lookup_mmio_window(class_id, device_id, window_id, (void*)out_window);
     }
-    // Fallback if matrix not initialized
+
     return device_lookup_mmio_window_l0(class_id, device_id, window_id, (void*)out_window);
 }
 
 int device_dispatch_irq(uint32_t irq) {
-    for (size_t i = 0; i < BHARAT_ARRAY_SIZE(g_drivers); ++i) {
-        if (g_drivers[i].name && g_drivers[i].irq_handler) {
-            g_drivers[i].irq_handler(irq, g_drivers[i].ctx);
+    for (size_t b = 0; b < BHARAT_ARRAY_SIZE(g_bindings); ++b) {
+        if (g_bindings[b].in_use == 0U) {
+            continue;
+        }
+
+        device_driver_t* drv = &g_drivers[g_bindings[b].driver_index];
+        device_desc_t* dev = &g_bus_devices[g_bindings[b].device_index];
+
+        if (drv->irq_handler && dev->irq == irq) {
+            drv->irq_handler(irq, drv->ctx);
         }
     }
 


### PR DESCRIPTION
### Motivation
- Introduce a bus-aware driver/device model to enable proper driver matching, bind/probe/remove lifecycle, hotplug support and per-device power-state transitions for richer platform support.
- Provide canonical built-in device/driver defaults (PCI/USB/CAN/virtio/etc.) and network security/performance flags to simplify early platform bring-up.
- Document remaining BSP, bus and platform subsystems required to reach broader deployment readiness in `docs/architecture/hardware-abstraction-and-drivers-baseline.md`.

### Description
- Added bus/class/power/security/perf/hw feature enums and the new descriptors `device_desc_t` and `device_match_t` plus new APIs `device_register_bus_device`, `device_hotplug_add`, `device_hotplug_remove`, `device_bind_drivers`, and `device_set_power_state` in `kernel/include/device.h`.
- Implemented a binding layer in `kernel/src/device/device_manager.c` that stores bus devices, matches drivers using `device_match_driver`, binds drivers via `probe_device`/`probe`, maintains `g_bindings`, handles hotplug add/remove, and implements suspend/resume semantics in `device_set_power_state`.
- Updated MMIO registration to continue mapping device windows (keeps `device_register_mmio_window`) and adjusted IRQ dispatch to route IRQs to bound drivers in `device_dispatch_irq`.
- Expanded `kernel/src/device/builtin_drivers.c` with richer built-in `drivers` and `devices` arrays including PCI Ethernet, USB CDC-ECM, CAN, virtio-net and per-device security/perf/hw flags, and now registers bus devices and invokes `device_bind_drivers` during initialization.
- Extended documentation in `docs/architecture/hardware-abstraction-and-drivers-baseline.md` with bus-aware baseline, required subsystems (BSP, buses), and a recommended implementation order.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad5b93e0408320bf87f31443926c34)