### PR TITLE
docs: Refactor build instructions and add environment preparation script

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -26,55 +26,11 @@ flowchart TD
 
 ---
 
-## Prerequisites
+## Prerequisites & Environment Preparation
 
-| Tool        | Version | Purpose                          |
-| ----------- | ------- | -------------------------------- |
-| CMake       | ≥ 3.20  | Build system generator           |
-| Clang + LLD | ≥ 16    | C compiler + linker (bare-metal) |
-| Ninja       | any     | Fast build backend               |
-| QEMU        | any     | Hardware emulator for testing    |
+Before building Bharat-OS, you need to set up your development environment. We support Windows, WSL, Linux, macOS, and BSD. We also provide a complete setup script for **Coding Agent Environments** (e.g., Jules, Codex).
 
-### Install on Windows (PowerShell as Administrator)
-
-```powershell
-winget install -e --id Kitware.CMake
-winget install -e --id LLVM.LLVM
-winget install -e --id Ninja-build.Ninja
-winget install -e --id SoftwareFreedomConservancy.QEMU
-```
-
-> Restart your terminal after installation so tools appear in `PATH`.
-
-### Install on Ubuntu / Debian / WSL
-
-```bash
-sudo apt update
-sudo apt install -y cmake ninja-build clang lld qemu-system-x86 qemu-system-misc
-```
-
-### Install on Arch Linux
-
-```bash
-sudo pacman -S cmake ninja clang lld qemu-desktop
-```
-
-### Install on macOS (Homebrew)
-
-```bash
-brew install cmake ninja llvm qemu
-export PATH="$(brew --prefix llvm)/bin:$PATH"   # add to ~/.zshrc
-```
-
-### Install on FreeBSD / NetBSD / OpenBSD
-
-```bash
-# FreeBSD
-pkg install cmake ninja llvm qemu-system-x86_64
-
-# OpenBSD
-pkg_add cmake ninja llvm qemu
-```
+Please see the comprehensive **[Environment Preparation Guide](docs/ENV_PREP.md)** to install all necessary tools (`cmake`, `clang`, `lld`, `qemu`, `gcc`, `python3`, etc.) for your specific platform.
 
 ---
 
@@ -93,116 +49,19 @@ cmake/toolchains/
 
 ---
 
-## Building (All Platforms)
+## Architecture-Specific Build Guides
 
-### Option A — Convenience scripts (Recommended)
+Bharat-OS supports multiple architectures, each with specific build flows, run commands, and testing procedures.
 
-**Linux / macOS / WSL / BSD (bash)**
+For detailed instructions on how to build, run in QEMU, run SDK builds, and execute tests for a specific architecture, please refer to the corresponding guide:
 
-```bash
-chmod +x tools/build.sh
-
-# Build x86_64
-./tools/build.sh x86_64
-
-# Build and boot in QEMU
-./tools/build.sh x86_64 --run
-
-# Clean build + QEMU
-./tools/build.sh x86_64 --clean --run
-
-# Build RISC-V 64-bit
-./tools/build.sh riscv64
-
-# Build ARM64 (compile-only scaffold)
-./tools/build.sh arm64
-
-# Override boot knobs
-./tools/build.sh x86_64 --boot-gui=OFF --hw=vm
-
-# Run RISC-V with specific QEMU machine (e.g., sifive_u)
-./tools/build.sh riscv64 --machine=sifive_u --run
-
-# Build RISC-V GCC OpenSBI payload
-./tools/build.sh riscv64 --payload
-
-# Run with GDB debug server enabled
-./tools/build.sh x86_64 --run --debug
-```
-
-**Windows (PowerShell 5+ or pwsh)**
-
-```powershell
-# Build x86_64
-.\tools\build.ps1
-
-# Build and boot in QEMU
-.\tools\build.ps1 -Arch x86_64 -Run
-
-# Clean build + QEMU
-.\tools\build.ps1 -Arch x86_64 -Clean -Run
-
-# Build RISC-V 64-bit
-.\tools\build.ps1 -Arch riscv64
-
-# Build ARM64 (compile-only scaffold)
-.\tools\build.ps1 -Arch arm64
-
-# Override boot knobs
-.\tools\build.ps1 -Arch x86_64 -BootGui OFF -HardwareProfile vm
-
-# Run RISC-V with specific QEMU machine
-.\tools\build.ps1 -Arch riscv64 -Machine sifive_u -Run
-
-# Build RISC-V GCC OpenSBI payload
-.\tools\build.ps1 -Arch riscv64 -Payload
-
-# Run with GDB debug server enabled
-.\tools\build.ps1 -Arch x86_64 -Run -DebugQemu
-```
+- **[Building for x86_64](docs/BUILD_X86_64.md)**
+- **[Building for RISC-V 64-bit](docs/BUILD_RISCV64.md)**
+- **[Building for ARM64](docs/BUILD_ARM64.md)**
 
 ---
 
-
-### Windows 11 + WSL validation flow (recommended)
-
-Use this sequence to verify both scripts on a Windows 11 Pro workstation:
-
-1. **Native PowerShell check (host Windows)**
-
-```powershell
-# from repo root
-.\tools\build.ps1 -Arch x86_64 -Clean
-.\tools\build.ps1 -Arch riscv64 -Clean
-.\tools\build.ps1 -Arch arm64 -Clean
-```
-
-2. **WSL bash check (inside Ubuntu/WSL)**
-
-```bash
-# from repo root
-./tools/build.sh x86_64 --clean
-./tools/build.sh riscv64 --clean
-./tools/build.sh arm64 --clean
-```
-
-3. **Runtime smoke check in QEMU**
-
-```powershell
-.\tools\build.ps1 -Arch x86_64 -Run
-.\tools\build.ps1 -Arch riscv64 -Run
-.\tools\build.ps1 -Arch arm64 -Run
-```
-
-```bash
-./tools/build.sh x86_64 --run
-./tools/build.sh riscv64 --run
-./tools/build.sh arm64 --run
-```
-
-> On Windows, `tools/build.ps1` expects QEMU at `C:\Program Files\qemu\` and auto-adds `C:\Program Files\LLVM\bin` to `PATH`.
-
----
+## Testing & SDK Development
 
 ### Validating Host-Side Tests (Windows & WSL/Linux)
 
@@ -240,9 +99,17 @@ ctest -R test_integration_core_subsys -V
 ctest -R test_profile_edge -V
 ```
 
+### SDK Development (Planned)
+
+Support for building a standalone SDK for the target architectures, including headers and pre-compiled libraries for user-space development, is currently planned.
+
+This will enable developers to link their C/C++ applications directly against the Bharat-OS POSIX compat layer or native capability interfaces, packaging their applications into a payload alongside the core kernel.
+
+Future updates to the architecture guides will detail SDK packaging commands, test payloads, and user-space compilation instructions.
+
 ---
 
-### Option C — CMake Presets (cross-arch)
+### CMake Presets (cross-arch)
 
 The repository includes `CMakePresets.json` for cross compilation and tests:
 
@@ -278,53 +145,6 @@ ctest --preset run-tests -R test_integration_core_subsys
 ctest --preset run-tests -R test_profile_edge
 ```
 
-### Option B — Raw CMake commands
-
-Same commands work on every platform:
-
-```bash
-# x86_64
-cmake -S . -B build/x86_64 \
-      -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/x86_64-elf.cmake \
-      -G Ninja
-
-cmake --build build/x86_64 --target kernel.elf
-
-# RISC-V 64-bit
-cmake -S . -B build/riscv64 \
-      -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/riscv64-elf.cmake \
-      -G Ninja
-
-cmake --build build/riscv64 --target kernel.elf
-```
-
-On **Windows**, use the same commands from PowerShell — CMake finds Clang automatically from `C:\Program Files\LLVM\bin`. If Clang is not on `PATH`, pass the compiler explicitly:
-
-```powershell
-cmake -S . -B build/x86_64 `
-      -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/x86_64-elf.cmake `
-      -DCMAKE_C_COMPILER="C:/Program Files/LLVM/bin/clang.exe" `
-      -G Ninja
-```
-
----
-
-## Running in QEMU
-
-```bash
-# x86_64 — serial output to terminal
-qemu-system-x86_64 -kernel build/x86_64/kernel.elf \
-    -m 256M -nographic -serial mon:stdio -no-reboot
-
-# RISC-V 64-bit
-qemu-system-riscv64 -machine virt \
-    -kernel build/riscv64/kernel.elf \
-    -m 256M -nographic -serial mon:stdio -no-reboot
-```
-
-> Press **Ctrl+A then X** to quit QEMU.
-
----
 
 ## Build Output
 
@@ -371,36 +191,6 @@ To run the AI governor in user space during development or testing:
 ---
 
 
-## Shakti toolchain and OpenSBI packaging
-
-For Shakti boards, install the Shakti RISC-V toolchain (recommended prebuilt installer) and expose binaries in `PATH`:
-
-```bash
-# example: toolchain paths from shakti-tools installer
-export PATH=$PATH:/opt/shakti/riscv64/bin:/opt/shakti/riscv64/riscv64-unknown-elf/bin
-which riscv64-unknown-elf-gcc
-which riscv64-unknown-elf-objcopy
-```
-
-Build Bharat-OS payload artifacts for OpenSBI:
-
-```bash
-cmake --preset riscv64-shakti-e-gcc-debug
-cmake --build --preset build-riscv64-shakti-e-gcc-kernel
-# outputs kernel.elf + kernel.payload.bin
-```
-
-Package with OpenSBI (example):
-
-```bash
-# in opensbi checkout
-make PLATFORM=generic FW_PAYLOAD_PATH=/workspace/Bharat-OS/build-riscv64-shakti-e-gcc/kernel/kernel.elf
-# or use payload.bin in board-specific flash/image pipeline
-```
-
-At runtime OpenSBI passes `(hartid, fdt_ptr)` to Bharat-OS `_start` / `kernel_main` on RISC-V.
-
----
 
 ## Troubleshooting
 

--- a/docs/BUILD_ARM64.md
+++ b/docs/BUILD_ARM64.md
@@ -1,0 +1,99 @@
+# Building for ARM64
+
+The `arm64` architecture is currently a **Cross-compile validated (runtime pending)** target for Bharat-OS. It uses a bare-metal toolchain based on `aarch64-elf-clang` and `aarch64-elf-lld`. This document outlines how to build and validate the ARM64 compile process.
+
+## Prerequisites
+
+Before starting, ensure your environment is configured according to the [Environment Preparation Guide](ENV_PREP.md).
+
+## Build Options
+
+The build system offers multiple paths for configuring and building the kernel. The options below are supported across Linux, Windows, macOS, WSL, and BSD.
+
+### Using Convenience Scripts (Recommended)
+
+**Linux / macOS / WSL / BSD:**
+
+```bash
+chmod +x tools/build.sh
+
+# Build the kernel
+./tools/build.sh arm64
+
+# Clean and rebuild the kernel
+./tools/build.sh arm64 --clean
+
+# Build and attempt to boot in QEMU (Runtime pending)
+./tools/build.sh arm64 --run
+```
+
+**Windows (PowerShell):**
+
+```powershell
+# Build the kernel
+.\tools\build.ps1 -Arch arm64
+
+# Clean and rebuild the kernel
+.\tools\build.ps1 -Arch arm64 -Clean
+
+# Build and attempt to boot in QEMU (Runtime pending)
+.\tools\build.ps1 -Arch arm64 -Run
+```
+
+### Using CMake Presets
+
+You can use standard CMake presets for compiling the kernel and executing tests.
+
+```bash
+# Configure and build the kernel
+cmake --preset arm64-elf-debug
+cmake --build --preset build-arm64-kernel
+```
+
+### Using Raw CMake Commands
+
+For granular control, you can manually configure and build using CMake:
+
+```bash
+cmake -S . -B build/arm64 \
+      -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/arm64-elf.cmake \
+      -G Ninja
+
+cmake --build build/arm64 --target kernel.elf
+```
+
+## Running the Kernel in QEMU
+
+While runtime execution is currently pending full validation on `arm64`, you can still test the generated ELF file in QEMU for bootloader and early initialization issues.
+
+```bash
+# Serial output to terminal
+qemu-system-aarch64 -machine virt -cpu cortex-a57 \
+    -kernel build/arm64/kernel.elf \
+    -m 256M -nographic -serial mon:stdio -no-reboot
+```
+
+> **Note:** To exit QEMU, press `Ctrl+A` followed by `X`. To use a separate QEMU window, remove `-nographic` and use `-serial stdio`.
+
+## Testing
+
+Host-side testing functions identically for ARM64 code pathways. These tests run on your local machine and bypass QEMU entirely.
+
+**Building and running host-side tests:**
+
+```bash
+# Configure and build the host-side test suite
+cmake --preset tests-host
+cmake --build --preset build-tests
+
+# Run all tests natively
+ctest --preset run-tests
+```
+
+### Target-Specific Testing
+
+Target-specific tests are currently under development. To validate architecture-specific bindings, rely on the runtime execution tests via QEMU using the `--run` parameter during the build process.
+
+## SDK Development (Planned)
+
+Support for building a standalone SDK for the `arm64` architecture, including headers and pre-compiled libraries for user-space development, is planned. Future updates will detail SDK packaging commands and integration with external user-space projects.

--- a/docs/BUILD_RISCV64.md
+++ b/docs/BUILD_RISCV64.md
@@ -1,0 +1,136 @@
+# Building for RISC-V 64-bit
+
+The `riscv64` architecture is currently a **Cross-compile validated** target for Bharat-OS. It uses an LLVM/Clang and LLD toolchain. Additionally, an optional GCC flow is provided for packaging OpenSBI firmware for Shakti RISC-V boards. This document outlines how to build, test, and run the RISC-V 64-bit target.
+
+## Prerequisites
+
+Before starting, ensure your environment is configured according to the [Environment Preparation Guide](ENV_PREP.md).
+
+If you are targeting Shakti boards, you will need the optional Shakti RISC-V toolchain. See the [Shakti RISC-V Toolchain (Optional)](ENV_PREP.md#shakti-risc-v-toolchain-optional) section for installation instructions.
+
+## Build Options
+
+The build system offers multiple paths for configuring and building the kernel. The options below are supported across Linux, Windows, macOS, WSL, and BSD.
+
+### Using Convenience Scripts (Recommended)
+
+**Linux / macOS / WSL / BSD:**
+
+```bash
+chmod +x tools/build.sh
+
+# Build the kernel
+./tools/build.sh riscv64
+
+# Clean and rebuild the kernel
+./tools/build.sh riscv64 --clean
+
+# Build and boot directly in QEMU
+./tools/build.sh riscv64 --run
+
+# Run with a specific QEMU machine (e.g., sifive_u)
+./tools/build.sh riscv64 --machine=sifive_u --run
+
+# Build RISC-V GCC OpenSBI payload
+./tools/build.sh riscv64 --payload
+```
+
+**Windows (PowerShell):**
+
+```powershell
+# Build the kernel
+.\tools\build.ps1 -Arch riscv64
+
+# Clean and rebuild the kernel
+.\tools\build.ps1 -Arch riscv64 -Clean
+
+# Build and boot directly in QEMU
+.\tools\build.ps1 -Arch riscv64 -Run
+
+# Run with a specific QEMU machine (e.g., sifive_u)
+.\tools\build.ps1 -Arch riscv64 -Machine sifive_u -Run
+
+# Build RISC-V GCC OpenSBI payload
+.\tools\build.ps1 -Arch riscv64 -Payload
+```
+
+### Using CMake Presets
+
+You can use standard CMake presets for compiling the kernel and executing tests. This is particularly useful for configuring Shakti-specific builds.
+
+```bash
+# Configure and build the default kernel
+cmake --preset riscv64-elf-debug
+cmake --build --preset build-riscv64-kernel
+
+# Configure and build Shakti-focused profiles (Clang/LLD)
+cmake --preset riscv64-shakti-e-debug && cmake --build --preset build-riscv64-shakti-e-kernel
+cmake --preset riscv64-shakti-c-debug && cmake --build --preset build-riscv64-shakti-c-kernel
+cmake --preset riscv64-shakti-i-debug && cmake --build --preset build-riscv64-shakti-i-kernel
+
+# Configure and build Shakti/OpenSBI-friendly GCC presets (Produces payload.bin)
+cmake --preset riscv64-elf-gcc-debug && cmake --build --preset build-riscv64-gcc-kernel
+cmake --preset riscv64-shakti-e-gcc-debug && cmake --build --preset build-riscv64-shakti-e-gcc-kernel
+```
+
+### Using Raw CMake Commands
+
+For granular control, you can manually configure and build using CMake:
+
+```bash
+cmake -S . -B build/riscv64 \
+      -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/riscv64-elf.cmake \
+      -G Ninja
+
+cmake --build build/riscv64 --target kernel.elf
+```
+
+## Running the Kernel in QEMU
+
+If you are not using the `--run` flag with the build scripts, you can run the generated ELF file directly in QEMU.
+
+```bash
+# Serial output to terminal
+qemu-system-riscv64 -machine virt \
+    -kernel build/riscv64/kernel.elf \
+    -m 256M -nographic -serial mon:stdio -no-reboot
+```
+
+> **Note:** To exit QEMU, press `Ctrl+A` followed by `X`. To use a separate QEMU window, remove `-nographic` and use `-serial stdio`.
+
+## OpenSBI Packaging (Shakti Boards)
+
+To package the `payload.bin` output for OpenSBI:
+
+1. Build the payload artifacts using the GCC presets or the `--payload` flag with the build script. This will output `kernel.elf` and `kernel.payload.bin`.
+2. Package the payload with OpenSBI (replace `/workspace/Bharat-OS` with the path to your Bharat-OS repository):
+
+```bash
+# In your OpenSBI checkout
+make PLATFORM=generic FW_PAYLOAD_PATH=/workspace/Bharat-OS/build-riscv64-shakti-e-gcc/kernel/kernel.elf
+```
+
+At runtime, OpenSBI will pass the `(hartid, fdt_ptr)` to the Bharat-OS `_start` / `kernel_main` entry points.
+
+## Testing
+
+Host-side testing works similarly across architectures, running natively on your machine to validate the core logic, profile integration, and system behaviors.
+
+**Building and running host-side tests:**
+
+```bash
+# Configure and build the host-side test suite
+cmake --preset tests-host
+cmake --build --preset build-tests
+
+# Run all tests natively
+ctest --preset run-tests
+```
+
+### Target-Specific Testing
+
+Target-specific tests are currently under development. To validate architecture-specific bindings, rely on the runtime execution tests via QEMU using the `--run` parameter during the build process.
+
+## SDK Development (Planned)
+
+Support for building a standalone SDK for the `riscv64` architecture, including headers and pre-compiled libraries for user-space development, is planned. Future updates will detail SDK packaging commands and integration with external user-space projects.

--- a/docs/BUILD_X86_64.md
+++ b/docs/BUILD_X86_64.md
@@ -1,0 +1,117 @@
+# Building for x86_64
+
+The `x86_64` architecture is currently an **Active** target for Bharat-OS. It uses a bare-metal toolchain based on `x86_64-elf-clang` and `x86_64-elf-lld`. This document outlines how to build, test, and run the x86_64 target.
+
+## Prerequisites
+
+Before starting, ensure your environment is configured according to the [Environment Preparation Guide](ENV_PREP.md).
+
+## Build Options
+
+The build system offers multiple paths for configuring and building the kernel. The options below are supported across Linux, Windows, macOS, WSL, and BSD.
+
+### Using Convenience Scripts (Recommended)
+
+**Linux / macOS / WSL / BSD:**
+
+```bash
+chmod +x tools/build.sh
+
+# Build the kernel
+./tools/build.sh x86_64
+
+# Clean and rebuild the kernel
+./tools/build.sh x86_64 --clean
+
+# Build and boot directly in QEMU
+./tools/build.sh x86_64 --run
+
+# Run with GDB debug server enabled
+./tools/build.sh x86_64 --run --debug
+
+# Override boot knobs (e.g., disable GUI, use VM profile)
+./tools/build.sh x86_64 --boot-gui=OFF --hw=vm
+```
+
+**Windows (PowerShell):**
+
+```powershell
+# Build the kernel
+.\tools\build.ps1 -Arch x86_64
+
+# Clean and rebuild the kernel
+.\tools\build.ps1 -Arch x86_64 -Clean
+
+# Build and boot directly in QEMU
+.\tools\build.ps1 -Arch x86_64 -Run
+
+# Run with GDB debug server enabled
+.\tools\build.ps1 -Arch x86_64 -Run -DebugQemu
+
+# Override boot knobs
+.\tools\build.ps1 -Arch x86_64 -BootGui OFF -HardwareProfile vm
+```
+
+### Using CMake Presets
+
+You can use standard CMake presets for compiling the kernel and executing tests.
+
+```bash
+# Configure and build the kernel
+cmake --preset x86_64-elf-debug
+cmake --build --preset build-x86_64-kernel
+```
+
+### Using Raw CMake Commands
+
+For granular control, you can manually configure and build using CMake:
+
+```bash
+cmake -S . -B build/x86_64 \
+      -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/x86_64-elf.cmake \
+      -G Ninja
+
+cmake --build build/x86_64 --target kernel.elf
+```
+
+## Running the Kernel in QEMU
+
+If you are not using the `--run` flag with the build scripts, you can run the generated ELF file directly in QEMU.
+
+```bash
+# Serial output to terminal
+qemu-system-x86_64 -kernel build/x86_64/kernel.elf \
+    -m 256M -nographic -serial mon:stdio -no-reboot
+```
+
+> **Note:** To exit QEMU, press `Ctrl+A` followed by `X`. To use a separate QEMU window, remove `-nographic` and use `-serial stdio`.
+
+## Testing
+
+Bharat-OS includes host-side tests for core kernel logic, integration behavior, and hardware profiles. These tests execute natively on your host machine (Windows or Linux) bypassing the need for QEMU, making them extremely fast and useful for continuous integration.
+
+**Building and running host-side tests:**
+
+```bash
+# Configure and build the host-side test suite
+cmake --preset tests-host
+cmake --build --preset build-tests
+
+# Run all tests natively
+ctest --preset run-tests
+
+# Run specifically the full integration subsystem tests
+cd build-tests
+ctest -R test_integration_core_subsys -V
+
+# Run specifically the edge/embedded profile tests
+ctest -R test_profile_edge -V
+```
+
+### Target-Specific Testing
+
+Target-specific tests are currently under development. To validate architecture-specific bindings, rely on the runtime execution tests via QEMU using the `--run` parameter during the build process.
+
+## SDK Development (Planned)
+
+Support for building a standalone SDK for the `x86_64` architecture, including headers and pre-compiled libraries for user-space development, is planned. Future updates will detail SDK packaging commands and integration with external user-space projects.

--- a/docs/ENV_PREP.md
+++ b/docs/ENV_PREP.md
@@ -1,0 +1,140 @@
+# Environment Preparation
+
+This guide covers how to set up your development environment for building Bharat-OS across various platforms.
+
+Bharat-OS primarily uses **LLVM/Clang** + **LLD** for cross-architecture reproducibility, with an optional **riscv64-unknown-elf-gcc** flow for Shakti/OpenSBI firmware packaging. The build scripts work on Windows, WSL, Linux, macOS, and BSD.
+
+## Prerequisites
+
+| Tool | Version | Purpose |
+| --- | --- | --- |
+| CMake | ≥ 3.20 | Build system generator |
+| Clang + LLD | ≥ 16 | C compiler + linker (bare-metal) |
+| Ninja | any | Fast build backend |
+| QEMU | any | Hardware emulator for testing |
+| Python | ≥ 3.x | Build scripts, utilities |
+| GDB | any | Debugger |
+| GCC / Binutils | any | Optional toolchain (RISC-V/OpenSBI, tests) |
+
+---
+
+## Coding Agent Environment (Jules, Codex, etc.)
+
+For coding agents and automated CI/CD environments, you can use the following script to install all necessary tools on a Debian/Ubuntu-based system (like WSL or a Linux container):
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+export DEBIAN_FRONTEND=noninteractive
+
+sudo apt-get update
+sudo apt-get install -y \
+  git bash curl wget ca-certificates \
+  make cmake ninja-build pkg-config \
+  clang lld llvm gcc g++ binutils nasm \
+  gdb gdb-multiarch \
+  python3 python3-pip \
+  qemu-system-x86 qemu-system-arm qemu-system-misc \
+  ovmf mtools dosfstools xorriso \
+  grub-pc-bin grub-efi-amd64-bin
+
+cmake --version
+ninja --version
+clang --version
+ld.lld --version
+python3 --version
+qemu-system-x86_64 --version
+qemu-system-aarch64 --version || true
+qemu-system-riscv64 --version || true
+```
+
+---
+
+## Platform-Specific Setup
+
+### Windows 11 + WSL (Recommended Flow)
+
+The recommended setup for Windows users is to install tools natively for PowerShell, and also set up a WSL environment for Linux-based testing.
+
+**1. Install on Windows (PowerShell as Administrator)**
+
+```powershell
+winget install -e --id Kitware.CMake
+winget install -e --id LLVM.LLVM
+winget install -e --id Ninja-build.Ninja
+winget install -e --id SoftwareFreedomConservancy.QEMU
+winget install -e --id Python.Python.3.11
+```
+
+> **Note:** Restart your terminal after installation so tools appear in `PATH`. On Windows, `tools/build.ps1` expects QEMU at `C:\Program Files\qemu\` and auto-adds `C:\Program Files\LLVM\bin` to `PATH`.
+
+**2. Install on WSL (Ubuntu/Debian inside Windows)**
+
+Open your WSL terminal and run:
+
+```bash
+sudo apt update
+sudo apt install -y cmake ninja-build clang lld qemu-system-x86 qemu-system-misc \
+  python3 gcc g++ binutils nasm gdb gdb-multiarch ovmf mtools dosfstools xorriso \
+  grub-pc-bin grub-efi-amd64-bin
+```
+
+### Ubuntu / Debian (Native)
+
+```bash
+sudo apt update
+sudo apt install -y cmake ninja-build clang lld qemu-system-x86 qemu-system-misc \
+  python3 gcc g++ binutils nasm gdb gdb-multiarch ovmf mtools dosfstools xorriso \
+  grub-pc-bin grub-efi-amd64-bin
+```
+
+### Arch Linux
+
+```bash
+sudo pacman -S cmake ninja clang lld qemu-desktop python gcc binutils nasm gdb \
+  mtools dosfstools xorriso grub
+```
+
+### macOS (Homebrew)
+
+```bash
+brew install cmake ninja llvm qemu python gcc binutils nasm gdb mtools dosfstools xorriso
+export PATH="$(brew --prefix llvm)/bin:$PATH"   # add to ~/.zshrc
+```
+
+### FreeBSD / NetBSD / OpenBSD
+
+**FreeBSD:**
+```bash
+pkg install cmake ninja llvm qemu-system-x86_64 python gcc binutils nasm gdb
+```
+
+**OpenBSD:**
+```bash
+pkg_add cmake ninja llvm qemu python gcc binutils nasm gdb
+```
+
+---
+
+## Shakti RISC-V Toolchain (Optional)
+
+For Shakti boards, install the Shakti RISC-V toolchain (recommended prebuilt installer) and expose binaries in `PATH`:
+
+```bash
+# example: toolchain paths from shakti-tools installer
+export PATH=$PATH:/opt/shakti/riscv64/bin:/opt/shakti/riscv64/riscv64-unknown-elf/bin
+which riscv64-unknown-elf-gcc
+which riscv64-unknown-elf-objcopy
+```
+
+---
+
+## Next Steps
+
+Once your environment is set up, proceed to the architecture-specific build guides:
+
+- [Building for x86_64](BUILD_X86_64.md)
+- [Building for RISC-V 64-bit](BUILD_RISCV64.md)
+- [Building for ARM64](BUILD_ARM64.md)
+- [General Build Overview](../BUILD.md)


### PR DESCRIPTION
Refactored the documentation to split large build instructions into architecture-specific files and an environment preparation guide. Included the requested bash script for setting up coding agent environments, and expanded the package prerequisites to match the script's needs (adding gcc, python3, gdb, grub, etc).

---
*PR created automatically by Jules for task [16319955019712123030](https://jules.google.com/task/16319955019712123030) started by @divyang4481*