### PR TITLE
Add SHAKTI integration plan, workflow wrappers, and compat shim skeleton

### DIFF
--- a/compat/shakti_sdk/bsp_shim/board_compat.c
+++ b/compat/shakti_sdk/bsp_shim/board_compat.c
@@ -1,0 +1,5 @@
+#include "shakti_board_compat.h"
+
+shakti_compat_board_t shakti_compat_current_board(void) {
+    return SHAKTI_COMPAT_BOARD_UNKNOWN;
+}

--- a/compat/shakti_sdk/include/shakti_board_compat.h
+++ b/compat/shakti_sdk/include/shakti_board_compat.h
@@ -1,0 +1,25 @@
+#ifndef BHARAT_COMPAT_SHAKTI_BOARD_COMPAT_H
+#define BHARAT_COMPAT_SHAKTI_BOARD_COMPAT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Compatibility identifiers for SHAKTI-style board selection.
+ * Internal Bharat-OS code should continue using Bharat-native board/profile APIs.
+ */
+typedef enum {
+    SHAKTI_COMPAT_BOARD_UNKNOWN = 0,
+    SHAKTI_COMPAT_BOARD_E,
+    SHAKTI_COMPAT_BOARD_C,
+    SHAKTI_COMPAT_BOARD_I,
+} shakti_compat_board_t;
+
+shakti_compat_board_t shakti_compat_current_board(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -17,6 +17,7 @@ This folder captures the current architectural baseline for Bharat-OS.
 - [`kernel-functionality-tiers-v1.md`](kernel-functionality-tiers-v1.md)
 - [`boot-flow-x86_64.md`](boot-flow-x86_64.md)
 - [`boot-flow-riscv64.md`](boot-flow-riscv64.md)
+- [`SHAKTI_BHARAT_OS_IMPLEMENTATION_PLAN.md`](SHAKTI_BHARAT_OS_IMPLEMENTATION_PLAN.md)
 
 ### Core kernel architecture
 

--- a/docs/architecture/SHAKTI_BHARAT_OS_IMPLEMENTATION_PLAN.md
+++ b/docs/architecture/SHAKTI_BHARAT_OS_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,248 @@
+# SHAKTI Integration Plan for Bharat-OS
+
+This document defines a **clean-integration plan** for SHAKTI support in Bharat-OS without contaminating architecture-neutral kernel surfaces.
+
+## Goals
+
+Bharat-OS must:
+
+1. Boot natively on SHAKTI targets with SHAKTI-style bring-up and debug flows.
+2. Reuse SHAKTI-SDK developer expectations (board selection, build/debug/upload habits) with minimal app changes.
+3. Keep x86_64, arm64, and generic riscv64 clean and unaffected.
+
+## Non-goals and guardrails
+
+Do **not**:
+
+- hardcode SHAKTI board maps into scheduler/mm/ipc.
+- couple capability or IPC model to BSP conventions.
+- spread board `#ifdef` logic through generic HAL layers.
+- mirror SHAKTI-SDK repository layout inside core kernel paths.
+
+Core invariants that must remain stable:
+
+- capability ABI and rights checks;
+- synchronous IPC and URPC semantics;
+- scheduler contracts;
+- VMM/PMM object model;
+- personality-neutral syscall/kernel contract.
+
+## Layered seam (required)
+
+```text
+Bharat-OS Core
+  -> architecture-neutral kernel primitives
+  -> architecture-specific HAL
+  -> SHAKTI platform backend
+  -> optional SHAKTI-SDK compatibility shim
+```
+
+SHAKTI support belongs in HAL/platform/backends, not in core kernel semantics.
+
+## Repository shape and ownership
+
+Recommended structure:
+
+```text
+kernel/
+  arch/
+    riscv64/
+      core/
+      generic/
+      shakti/
+        boot/
+        trap/
+        timer/
+        irq/
+        mm/
+        smp/
+drivers/
+  interrupt/
+    plic_shakti.c
+    clint_shakti.c
+  serial/
+    uart_shakti.c
+platform/
+  shakti/
+    boards/
+    common/
+compat/
+  shakti_sdk/
+    include/
+    bsp_shim/
+    make/
+```
+
+Existing Bharat-OS directories already align with this split (`kernel/src/hal`, `drivers/`, `tools/boards/`, `docs/`). Implementation should preserve that separation.
+
+## Platform contract (Phase 0)
+
+Introduce/standardize a platform contract used by generic RISC-V code:
+
+- early console init/write;
+- timer init/program/ack;
+- irq init/mask/unmask/eoi;
+- board memory map discovery;
+- boot info parsing;
+- hart startup hooks;
+- MMIO reservation;
+- reset/poweroff/panic hooks.
+
+Suggested config flags:
+
+- `CONFIG_ARCH_RISCV64`
+- `CONFIG_PLATFORM_SHAKTI`
+- `CONFIG_SHAKTI_BOARD_ARTIX7_35T`
+- `CONFIG_SHAKTI_BOARD_ARTIX7_100T`
+- `CONFIG_SHAKTI_SDK_COMPAT`
+- `CONFIG_SHAKTI_SPI_BOOT`
+- `CONFIG_SHAKTI_DEBUG_BOOT`
+
+## Native SHAKTI bring-up backend (Phase 1)
+
+### 1) Entry split
+
+Two-stage boot entry:
+
+- **Stage A (SHAKTI stub):** reset entry, stack, `.bss`, temporary traps, early UART, board discovery, boot metadata.
+- **Stage B (generic kernel entry):** consume `bharat_boot_info`, continue generic bootstrap without board constants.
+
+### 2) Board manifest system
+
+Create canonical `bharat_board_desc` for SHAKTI boards with:
+
+- board/SoC ID, hart count, ISA details;
+- ROM/RAM ranges;
+- UART/CLINT/PLIC base + IRQ/clock metadata;
+- SPI/QSPI/I2C/GPIO/PWM capability flags;
+- flash layout offsets and boot/debug mode flags.
+
+### 3) Early console and panic path
+
+Must provide panic-safe, heap-independent UART output:
+
+- `early_putc`, `early_puts`;
+- fatal trap/panic dump path;
+- optional post-init ring buffer.
+
+### 4) Trap/CLINT/PLIC
+
+Implement SHAKTI backend handlers for:
+
+- early trap vector setup;
+- interrupt/exception split and cause decode;
+- CLINT timer + software interrupts;
+- PLIC priority/enable/claim/complete.
+
+Generic callers should use neutral APIs (for example `platform_irq_init()` and `platform_timer_program()`).
+
+### 5) Memory/bootstrap and linker layout
+
+Implement board-manifest-driven memory init:
+
+- bootstrap bump allocator;
+- PMM seeding from descriptor;
+- reserved regions (ROM, flash staging, MMIO, stacks, vectors).
+
+Provide linker classes for:
+
+- SRAM/BRAM minimal modes;
+- DDR-backed modes;
+- SPI-uploaded image format.
+
+## SHAKTI-style workflow compatibility (Phase 2)
+
+To minimize migration friction, Bharat-OS should expose workflow-compatible wrappers:
+
+- `tools/shakti/list-targets`
+- `tools/shakti/build`
+- `tools/shakti/upload`
+- `tools/shakti/debug`
+
+These wrappers should map to existing Bharat build/upload/debug machinery rather than forking architecture.
+
+## SHAKTI-SDK compatibility shim (Phase 3)
+
+Create optional shim under `compat/shakti_sdk/` with familiar BSP-like names at boundary, while internal kernel/driver APIs remain Bharat-native.
+
+Initial shim surface:
+
+- UART/GPIO/SPI/I2C/timer/IRQ headers;
+- thin wrapper C files in `bsp_shim/`;
+- explicit scope statement: low-change for simple examples, moderate changes for BSP-internal-heavy apps.
+
+## Firmware personality mode
+
+Add/maintain lightweight profile for bare-metal-style SHAKTI use:
+
+- no heavy POSIX stack;
+- static-memory-capable mode;
+- direct timer/irq/device access with minimal services.
+
+## Device roadmap
+
+Wave 1:
+
+- UART, CLINT, PLIC, SPI/QSPI, GPIO, basic I2C, timer services, flash R/W/E.
+
+Wave 2:
+
+- PWM, watchdog, RTC, XADC, Ethernet-lite, pinmux.
+
+## Multi-architecture safety rules
+
+- Keep `riscv64/generic` distinct from `riscv64/shakti`.
+- Never add SHAKTI conditionals into x86_64/arm64 paths.
+- Keep personalities platform-neutral.
+
+## Validation plan
+
+### Bring-up matrix
+
+Per board/target:
+
+- debug boot;
+- SPI boot;
+- UART and panic path;
+- timer tick and IRQ delivery;
+- memory init sanity;
+- scheduler/context-switch smoke.
+
+### Compatibility matrix
+
+Port SHAKTI-style demos:
+
+- UART hello;
+- timer interrupt;
+- GPIO demo;
+- SPI flash read;
+- I2C sensor stub;
+- benchmark sample.
+
+### Regression matrix
+
+Run Bharat tests for:
+
+- x86_64;
+- arm64;
+- generic riscv64;
+- riscv64 + SHAKTI backend.
+
+## Milestones
+
+1. **Board brings up**: early UART, traps, CLINT/PLIC, scheduler init logs.
+2. **Image lifecycle works**: build/upload/boot with debug and SPI flows.
+3. **SDK seam exists**: compat headers/wrappers + first migrated examples.
+4. **Kernel stays clean**: no SHAKTI leakage into core APIs; cross-arch green.
+5. **Ecosystem credibility**: docs, board matrix, porting guide, known limits.
+
+## Recommended implementation order
+
+1. Board descriptors + early UART
+2. Trap + CLINT + PLIC
+3. Boot info handoff + linker layouts
+4. Flash/debug workflow
+5. Minimal firmware profile
+6. Compatibility shim
+7. Example migration
+8. Broader device drivers and tuning

--- a/docs/boards/shakti/README.md
+++ b/docs/boards/shakti/README.md
@@ -1,0 +1,27 @@
+# SHAKTI Board Support Notes
+
+This folder tracks SHAKTI board-specific support status for Bharat-OS.
+
+## Planned boards
+
+- `artix7_35t`
+- `artix7_100t`
+- `nexys_video`
+
+## Expected artifacts per board
+
+- board manifest/descriptor;
+- linker profile(s);
+- OpenOCD config;
+- GDB init script;
+- upload/flash helper wiring;
+- bring-up checklist results.
+
+## Status convention
+
+- `planned`
+- `in-progress`
+- `booting`
+- `validated`
+
+Keep board-specific constants isolated to platform/backend layers; do not place board maps into scheduler/mm/ipc/core capability code.

--- a/tools/shakti/README.md
+++ b/tools/shakti/README.md
@@ -1,0 +1,10 @@
+# SHAKTI Workflow Wrappers
+
+These scripts provide SHAKTI-style entry points while reusing Bharat-OS build and board metadata.
+
+- `list-targets` — lists `shakti-*` entries from `tools/boards/boards.json`.
+- `build` — wraps `tools/build.sh` for riscv64 SHAKTI board targets.
+- `upload` — placeholder upload wrapper using existing flash helper fallback.
+- `debug` — OpenOCD/GDB convenience wrapper (expects board cfg under `platform/shakti/boards/<target>/openocd.cfg`).
+
+They are intentionally thin wrappers so that architecture and kernel internals remain platform-neutral.

--- a/tools/shakti/build
+++ b/tools/shakti/build
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<USAGE
+Usage: $0 --target <shakti-board> [--run] [--clean]
+
+Examples:
+  $0 --target shakti-e
+  $0 --target shakti-c --clean
+USAGE
+}
+
+TARGET=""
+RUN=""
+CLEAN=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --target) TARGET="${2:-}"; shift 2 ;;
+    --run) RUN="--run"; shift ;;
+    --clean) CLEAN="--clean"; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown arg: $1"; usage; exit 2 ;;
+  esac
+done
+
+if [[ -z "$TARGET" ]]; then
+  echo "Missing --target" >&2
+  usage
+  exit 2
+fi
+
+if [[ ! "$TARGET" =~ ^shakti- ]]; then
+  echo "Target must be a shakti-* board (got: $TARGET)" >&2
+  exit 2
+fi
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+exec "$ROOT_DIR/tools/build.sh" riscv64 "${RUN}" "${CLEAN}" --board "$TARGET"

--- a/tools/shakti/debug
+++ b/tools/shakti/debug
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<USAGE
+Usage: $0 --target <shakti-board> [--elf <path>]
+
+Starts OpenOCD if board config exists and prints a matching GDB command.
+USAGE
+}
+
+TARGET=""
+ELF=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --target) TARGET="${2:-}"; shift 2 ;;
+    --elf) ELF="${2:-}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown arg: $1"; usage; exit 2 ;;
+  esac
+done
+
+[[ -n "$TARGET" ]] || { usage; exit 2; }
+[[ "$TARGET" =~ ^shakti- ]] || { echo "--target must be shakti-*" >&2; exit 2; }
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CFG="$ROOT_DIR/platform/shakti/boards/${TARGET}/openocd.cfg"
+
+if [[ -f "$CFG" ]]; then
+  echo "Starting OpenOCD with $CFG"
+  openocd -f "$CFG"
+else
+  echo "No board OpenOCD config found at $CFG"
+  if [[ -n "$ELF" ]]; then
+    echo "Suggested: riscv64-unknown-elf-gdb $ELF -ex 'target extended-remote :3333'"
+  else
+    echo "Suggested: provide --elf and use riscv64-unknown-elf-gdb"
+  fi
+  exit 1
+fi

--- a/tools/shakti/list-targets
+++ b/tools/shakti/list-targets
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BOARDS_JSON="$ROOT_DIR/tools/boards/boards.json"
+
+python3 - "$BOARDS_JSON" <<'PY'
+import json,sys
+p=sys.argv[1]
+with open(p,'r',encoding='utf-8') as f:
+    data=json.load(f)
+boards=data.get('boards',{})
+for name,b in sorted(boards.items()):
+    if str(name).startswith('shakti-'):
+        print(f"{name}\tarch={b.get('arch','?')}\ttoolchain={b.get('default_toolchain','?')}")
+PY

--- a/tools/shakti/upload
+++ b/tools/shakti/upload
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<USAGE
+Usage: $0 --target <shakti-board> --image <path/to/kernel.elf>
+USAGE
+}
+
+TARGET=""
+IMAGE=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --target) TARGET="${2:-}"; shift 2 ;;
+    --image) IMAGE="${2:-}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown arg: $1"; usage; exit 2 ;;
+  esac
+done
+
+[[ -n "$TARGET" && -n "$IMAGE" ]] || { usage; exit 2; }
+[[ "$TARGET" =~ ^shakti- ]] || { echo "--target must be shakti-*" >&2; exit 2; }
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+FLASH_SCRIPT="$ROOT_DIR/tools/boards/qemu-virt-riscv64/flash.sh"
+
+if [[ ! -f "$IMAGE" ]]; then
+  echo "Image not found: $IMAGE" >&2
+  exit 2
+fi
+
+if [[ -x "$FLASH_SCRIPT" ]]; then
+  "$FLASH_SCRIPT" "$IMAGE"
+  echo "[shakti/upload] Used fallback flash script: tools/boards/qemu-virt-riscv64/flash.sh"
+else
+  echo "No upload helper available for $TARGET yet." >&2
+  exit 1
+fi


### PR DESCRIPTION
### Motivation
- Provide a disciplined, non-invasive path to support SHAKTI targets while preserving Bharat-OS core invariants and multi-architecture cleanliness.
- Offer repo-level guidance, board tracking, and lightweight developer workflow compatibility so SHAKTI bring-up and SDK-style flows can be integrated without contaminating kernel internals.

### Description
- Add a repo-ready integration spec at `docs/architecture/SHAKTI_BHARAT_OS_IMPLEMENTATION_PLAN.md` that details layering, guardrails, phased milestones, board-manifest expectations, and validation matrices.
- Add board scaffolding at `docs/boards/shakti/README.md` and link the plan from `docs/architecture/README.md` so SHAKTI bring-up appears in the recommended architecture reading flow.
- Add thin SHAKTI workflow wrapper scripts under `tools/shakti/`: `list-targets`, `build`, `upload`, `debug`, plus `tools/shakti/README.md` to expose SHAKTI-style `list/build/upload/debug` entry points while reusing existing build/board metadata.
- Add an initial SHAKTI-SDK compatibility shim skeleton in `compat/shakti_sdk/` with `include/shakti_board_compat.h` and a minimal `bsp_shim/board_compat.c` stub to provide a future BSP-facing boundary without changing kernel APIs.

### Testing
- Verified shell syntax for the new scripts with `bash -n tools/shakti/list-targets tools/shakti/build tools/shakti/upload tools/shakti/debug` and it succeeded.
- Ran `tools/shakti/list-targets` and confirmed it enumerates `shakti-*` boards from `tools/boards/boards.json` (printed `shakti-c` and `shakti-e`).
- Called the wrapper help flows (`tools/shakti/build --help`, `tools/shakti/upload --help`, `tools/shakti/debug --help`) and they produced their expected usage output.
- Compiled the shim stub with `cc -Icompat/shakti_sdk/include -c compat/shakti_sdk/bsp_shim/board_compat.c` to validate header/implementation wiring and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b05ec4a74c8320b0a40d8c754aeca3)