### PR TITLE
Fix IPC endpoint wake-up logic via proper wait queues

### DIFF
--- a/docs/IPC_ARCHITECTURE.md
+++ b/docs/IPC_ARCHITECTURE.md
@@ -1,0 +1,46 @@
+# Bharat-OS IPC Architecture
+
+This document describes the design and guarantees of the Inter-Process Communication (IPC) subsystem in Bharat-OS.
+
+## Endpoint Model
+Bharat-OS utilizes capability-protected synchronous and asynchronous endpoints for secure messaging. Endpoints (`ipc_endpoint_t`) act as rendezvous points or bounded buffers for transferring messages between isolated execution contexts (processes or threads).
+
+Every endpoint maintains:
+- A message buffer.
+- `senders` wait queue: Threads waiting to send a message when the buffer is full.
+- `receivers` wait queue: Threads waiting to receive a message when the buffer is empty.
+
+Access to endpoints is strongly regulated via capabilities (`send_cap` and `recv_cap`), ensuring only authorized participants can exchange data.
+
+## Sync vs Async Semantics
+### Synchronous IPC
+The core `ipc_endpoint_send` and `ipc_endpoint_receive` operations are fully synchronous:
+- **Send**: If an endpoint buffer is occupied, the sender enqueues itself onto the `senders` wait queue and blocks.
+- **Receive**: If an endpoint buffer is empty, the receiver enqueues itself onto the `receivers` wait queue and blocks.
+
+### Asynchronous IPC
+For lockless, high-throughput applications, Bharat-OS also supports asynchronous IPC via a dedicated ring buffer (URPC) system (`lib/urpc/`), which operates independently of synchronous endpoint wait queues.
+
+## Wait Queues and Wake-up Rules
+To prevent spurious wakeups and guarantee starvation-free operations, blocked IPC operations are strictly coordinated through explicit wait queues (`wait_queue_t`).
+
+- When a thread blocks on an IPC operation, it explicitly queues itself onto the endpoint's wait queue and calls the scheduler to transition its state to `THREAD_STATE_BLOCKED`.
+- When an operation succeeds (a sender fills the buffer or a receiver consumes the buffer):
+  - A successful `send` dequeues **exactly one** receiver from the `receivers` queue and explicitly wakes it using `sched_wakeup()`.
+  - A successful `receive` dequeues **exactly one** sender from the `senders` queue and wakes it using `sched_wakeup()`.
+
+This ensures FIFO fairness among waiters and prevents thundering herd problems.
+
+## Scheduler Interaction
+The IPC subsystem relies entirely on the kernel scheduler (`sched.h`) for state transitions. IPC code does **not** manipulate `THREAD_STATE_READY` directly. All state management and queueing is delegated to:
+- `sched_wait_queue_enqueue`
+- `sched_wait_queue_dequeue`
+- `sched_wakeup`
+
+This isolates the IPC code from internal scheduler data structures and runqueues.
+
+## SMP / Multicore Notes
+Wait queues and state transitions are architecture-independent. While the current stub implements a simplified queuing mechanism, full SMP deployments must protect endpoint state modifications (message copying and wait-queue manipulation) using a spinlock or equivalent synchronization primitive to avoid race conditions. Currently, the kernel relies on higher-level generic locks.
+
+## Guarantees Across Profiles / Personalities
+Because IPC blocking and wake-up logic delegates entirely to the core scheduler, IPC behaves consistently across all supported CPU architectures (x86_64, ARM64, RISC-V) and subsystem personalities (Linux, Android). No architecture-specific hacks or global states (like `g_current`) are directly used within the wake-up logic.

--- a/kernel/include/sched.h
+++ b/kernel/include/sched.h
@@ -57,6 +57,11 @@ typedef struct {
     uint32_t throttled;
 } sched_core_t;
 
+typedef struct {
+    kthread_t* head;
+    kthread_t* tail;
+} wait_queue_t;
+
 struct kthread {
     uint64_t thread_id;
     uint64_t process_id;
@@ -89,6 +94,9 @@ struct kthread {
     uint64_t wake_deadline_ms;
     uint32_t bound_core_id;
     uint32_t affinity_mask;
+
+    // Next thread in a wait queue
+    kthread_t* next_waiter;
 };
 
 typedef struct {
@@ -111,6 +119,14 @@ kprocess_t* process_create(const char* name);
 int process_destroy(kprocess_t* process);
 kthread_t* thread_create(kprocess_t* parent, void (*entry_point)(void));
 int thread_destroy(kthread_t* thread);
+
+// Wait Queues
+void sched_wait_queue_init(wait_queue_t* queue);
+void sched_wait_queue_enqueue(wait_queue_t* queue, kthread_t* thread);
+kthread_t* sched_wait_queue_dequeue(wait_queue_t* queue);
+
+// Wait Queue State
+void sched_block(void);
 
 // Context Switching
 void sched_yield(void);

--- a/kernel/src/ai_sched.c
+++ b/kernel/src/ai_sched.c
@@ -117,13 +117,8 @@ void ai_sched_collect_sample(ai_sched_context_t* ctx,
         // g_silicon_* metrics represent (IPC * 100).
         // e.g. 200 = 2.0 instructions per cycle, 10 = 0.1 instructions per cycle.
 
-        extern uint32_t g_silicon_alu_ipc;
-        extern uint32_t g_silicon_mem_ipc;
-
         uint32_t active_ipc_x100;
 
-        extern uint32_t g_silicon_alu_ipc;
-        extern uint32_t g_silicon_mem_ipc;
         if (ctx->predicted_complexity == 2U) { // High complexity / memory-bound
             active_ipc_x100 = g_silicon_mem_ipc;
         } else if (ctx->predicted_complexity == 1U) { // Medium
@@ -186,8 +181,6 @@ int ai_heuristic_config_store(const ai_heuristic_config_t* cfg) {
 }
 
 // Hypothetical boot-time calibration
-uint32_t g_silicon_alu_ipc = 0;
-uint32_t g_silicon_mem_ipc = 0;
 
 // Ensure the chasing array avoids global optimization
 static volatile uint32_t g_chase[4096];

--- a/kernel/src/ipc/endpoint_ipc.c
+++ b/kernel/src/ipc/endpoint_ipc.c
@@ -10,6 +10,8 @@ typedef struct {
     uint8_t in_use;
     ipc_message_t msg;
     uint8_t has_msg;
+    wait_queue_t senders;
+    wait_queue_t receivers;
 } ipc_endpoint_t;
 
 static ipc_endpoint_t g_endpoints[MAX_ENDPOINTS];
@@ -34,6 +36,8 @@ int ipc_endpoint_create(capability_table_t* table, uint32_t* out_send_cap, uint3
             g_endpoints[i].in_use = 1U;
             g_endpoints[i].has_msg = 0U;
             g_endpoints[i].msg.msg_len = 0U;
+            sched_wait_queue_init(&g_endpoints[i].senders);
+            sched_wait_queue_init(&g_endpoints[i].receivers);
 
             if (cap_table_grant(table, CAP_OBJ_ENDPOINT, i, CAP_PERM_SEND | CAP_PERM_DELEGATE, out_send_cap) != 0) {
                 g_endpoints[i].in_use = 0U;
@@ -74,7 +78,8 @@ int ipc_endpoint_send(capability_table_t* table, uint32_t send_cap, const void* 
     if (ep->has_msg != 0U) {
         kthread_t* cur = sched_current_thread();
         if (cur) {
-            cur->state = THREAD_STATE_BLOCKED;
+            sched_wait_queue_enqueue(&ep->senders, cur);
+            sched_block();
         }
         return IPC_ERR_WOULD_BLOCK;
     }
@@ -85,6 +90,12 @@ int ipc_endpoint_send(capability_table_t* table, uint32_t send_cap, const void* 
     }
     ep->msg.msg_len = payload_len;
     ep->has_msg = 1U;
+
+    kthread_t* recv = sched_wait_queue_dequeue(&ep->receivers);
+    if (recv) {
+        sched_wakeup(recv);
+    }
+
     return IPC_OK;
 }
 
@@ -106,7 +117,8 @@ int ipc_endpoint_receive(capability_table_t* table, uint32_t recv_cap, void* out
     if (ep->has_msg == 0U) {
         kthread_t* cur = sched_current_thread();
         if (cur) {
-            cur->state = THREAD_STATE_BLOCKED;
+            sched_wait_queue_enqueue(&ep->receivers, cur);
+            sched_block();
         }
         return IPC_ERR_WOULD_BLOCK;
     }
@@ -124,9 +136,9 @@ int ipc_endpoint_receive(capability_table_t* table, uint32_t recv_cap, void* out
     ep->msg.msg_len = 0U;
     ep->has_msg = 0U;
 
-    kthread_t* cur = sched_current_thread();
-    if (cur && cur->state == THREAD_STATE_BLOCKED) {
-        cur->state = THREAD_STATE_READY;
+    kthread_t* sender = sched_wait_queue_dequeue(&ep->senders);
+    if (sender) {
+        sched_wakeup(sender);
     }
 
     return IPC_OK;

--- a/kernel/src/sched.c
+++ b/kernel/src/sched.c
@@ -546,6 +546,52 @@ static void sched_switch_to(kthread_t *next, uint32_t core_id) {
   }
 }
 
+void sched_wait_queue_init(wait_queue_t* queue) {
+  if (queue) {
+    queue->head = NULL;
+    queue->tail = NULL;
+  }
+}
+
+void sched_wait_queue_enqueue(wait_queue_t* queue, kthread_t* thread) {
+  if (!queue || !thread) {
+    return;
+  }
+
+  thread->next_waiter = NULL;
+
+  if (!queue->tail) {
+    queue->head = thread;
+    queue->tail = thread;
+  } else {
+    queue->tail->next_waiter = thread;
+    queue->tail = thread;
+  }
+}
+
+kthread_t* sched_wait_queue_dequeue(wait_queue_t* queue) {
+  if (!queue || !queue->head) {
+    return NULL;
+  }
+
+  kthread_t* thread = queue->head;
+
+  queue->head = thread->next_waiter;
+  if (!queue->head) {
+    queue->tail = NULL;
+  }
+
+  thread->next_waiter = NULL;
+  return thread;
+}
+
+void sched_block(void) {
+  kthread_t *current = sched_current_thread();
+  if (current) {
+    current->state = THREAD_STATE_BLOCKED;
+  }
+}
+
 void sched_reschedule(void) {
   uint32_t core = sched_clamp_core(hal_cpu_get_id());
   sched_process_pending_ai_suggestions();

--- a/kernel/src/sched_stub.c
+++ b/kernel/src/sched_stub.c
@@ -46,7 +46,6 @@ static suggestion_queue_t g_pending_suggestions;
 
 static kcache_t* thread_cache = NULL;
 
-
 void fv_secure_context_switch(void* next_thread_frame) __attribute__((weak));
 
 uint32_t numa_active_node_count(void) __attribute__((weak));
@@ -202,6 +201,51 @@ void sched_init(void) {
     g_pending_suggestions.tail = 0U;
 }
 
+void sched_wait_queue_init(wait_queue_t* queue) {
+    if (queue) {
+        queue->head = NULL;
+        queue->tail = NULL;
+    }
+}
+
+void sched_wait_queue_enqueue(wait_queue_t* queue, kthread_t* thread) {
+    if (!queue || !thread) {
+        return;
+    }
+
+    thread->next_waiter = NULL;
+
+    if (!queue->tail) {
+        queue->head = thread;
+        queue->tail = thread;
+    } else {
+        queue->tail->next_waiter = thread;
+        queue->tail = thread;
+    }
+}
+
+kthread_t* sched_wait_queue_dequeue(wait_queue_t* queue) {
+    if (!queue || !queue->head) {
+        return NULL;
+    }
+
+    kthread_t* thread = queue->head;
+
+    queue->head = thread->next_waiter;
+    if (!queue->head) {
+        queue->tail = NULL;
+    }
+
+    thread->next_waiter = NULL;
+    return thread;
+}
+
+void sched_block(void) {
+    if (g_current) {
+        g_current->state = THREAD_STATE_BLOCKED;
+    }
+}
+
 kprocess_t* process_create(const char* name) {
     (void)name;
 
@@ -298,7 +342,7 @@ void sched_wakeup(kthread_t* thread) {
         return;
     }
 
-    if (thread->state == THREAD_STATE_SLEEPING) {
+    if (thread->state == THREAD_STATE_SLEEPING || thread->state == THREAD_STATE_BLOCKED) {
         thread->state = THREAD_STATE_READY;
         thread->wake_deadline_ms = 0U;
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -142,6 +142,54 @@ add_executable(test_ipc_fuzz test_ipc_fuzz.c benchmark_stubs.c
 target_include_directories(test_ipc_fuzz PRIVATE ../kernel/include)
 add_test(NAME test_ipc_fuzz COMMAND test_ipc_fuzz)
 
+add_executable(test_ipc_sync_sender_wakeup test_ipc_sync_sender_wakeup.c benchmark_stubs.c
+    ../kernel/src/sched.c
+    ../kernel/src/ai_sched.c
+    ../kernel/src/capability.c
+    ../kernel/src/ipc/endpoint_ipc.c
+    ../kernel/src/algo_matrix.c
+    ../kernel/src/device/device_manager.c
+    ../kernel/src/mm/numa.c
+)
+target_include_directories(test_ipc_sync_sender_wakeup PRIVATE ../kernel/include)
+add_test(NAME test_ipc_sync_sender_wakeup COMMAND test_ipc_sync_sender_wakeup)
+
+add_executable(test_ipc_sync_receiver_wakeup test_ipc_sync_receiver_wakeup.c benchmark_stubs.c
+    ../kernel/src/sched.c
+    ../kernel/src/ai_sched.c
+    ../kernel/src/capability.c
+    ../kernel/src/ipc/endpoint_ipc.c
+    ../kernel/src/algo_matrix.c
+    ../kernel/src/device/device_manager.c
+    ../kernel/src/mm/numa.c
+)
+target_include_directories(test_ipc_sync_receiver_wakeup PRIVATE ../kernel/include)
+add_test(NAME test_ipc_sync_receiver_wakeup COMMAND test_ipc_sync_receiver_wakeup)
+
+add_executable(test_ipc_multiple_waiters_fifo test_ipc_multiple_waiters_fifo.c benchmark_stubs.c
+    ../kernel/src/sched.c
+    ../kernel/src/ai_sched.c
+    ../kernel/src/capability.c
+    ../kernel/src/ipc/endpoint_ipc.c
+    ../kernel/src/algo_matrix.c
+    ../kernel/src/device/device_manager.c
+    ../kernel/src/mm/numa.c
+)
+target_include_directories(test_ipc_multiple_waiters_fifo PRIVATE ../kernel/include)
+add_test(NAME test_ipc_multiple_waiters_fifo COMMAND test_ipc_multiple_waiters_fifo)
+
+add_executable(test_ipc_no_spurious_self_wakeup test_ipc_no_spurious_self_wakeup.c benchmark_stubs.c
+    ../kernel/src/sched.c
+    ../kernel/src/ai_sched.c
+    ../kernel/src/capability.c
+    ../kernel/src/ipc/endpoint_ipc.c
+    ../kernel/src/algo_matrix.c
+    ../kernel/src/device/device_manager.c
+    ../kernel/src/mm/numa.c
+)
+target_include_directories(test_ipc_no_spurious_self_wakeup PRIVATE ../kernel/include)
+add_test(NAME test_ipc_no_spurious_self_wakeup COMMAND test_ipc_no_spurious_self_wakeup)
+
 add_executable(test_security_isolation test_security_isolation.c benchmark_stubs.c
     ../kernel/src/sched.c
     ../kernel/src/ai_sched.c

--- a/tests/benchmark_stubs.c
+++ b/tests/benchmark_stubs.c
@@ -78,6 +78,11 @@ int __attribute__((weak)) hal_vmm_get_mapping(phys_addr_t root_table, virt_addr_
     (void)root_table; (void)vaddr; (void)paddr; (void)flags;
     return -1;
 }
+
+int __attribute__((weak)) vmm_map_device_mmio(virt_addr_t vaddr, phys_addr_t paddr, capability_t *cap, int rw) {
+    (void)vaddr; (void)paddr; (void)cap; (void)rw;
+    return -1;
+}
 int __attribute__((weak)) hal_vmm_update_mapping(phys_addr_t root_table, virt_addr_t vaddr, phys_addr_t paddr, uint32_t flags) {
     (void)root_table; (void)vaddr; (void)paddr; (void)flags;
     return -1;

--- a/tests/test_ipc_multiple_waiters_fifo.c
+++ b/tests/test_ipc_multiple_waiters_fifo.c
@@ -1,0 +1,83 @@
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include "ipc_endpoint.h"
+#include "capability.h"
+#include "sched.h"
+#include <stdlib.h>
+#include "../kernel/include/slab.h"
+
+// Mock dependencies
+void ipc_async_check_timeouts(uint64_t current_ticks) { (void)current_ticks; }
+static address_space_t g_as = { .root_table = 0x1000U };
+address_space_t* mm_create_address_space(void) { return &g_as; }
+phys_addr_t mm_alloc_page(uint32_t preferred_numa_node) { (void)preferred_numa_node; return 0; }
+void mm_free_page(phys_addr_t page) { (void)page; }
+phys_addr_t pmm_alloc_pages_colored(int order, uint32_t preferred_numa_node, uint32_t flags, mm_color_config_t *color_config) { return 0; }
+phys_addr_t mm_alloc_pages_order(int order, uint32_t preferred_numa_node, uint32_t flags) { return 0; }
+void tlb_shootdown(virt_addr_t vaddr) { (void)vaddr; }
+
+
+static void dummy_entry(void) {}
+
+void test_ipc_multiple_waiters_fifo(void) {
+    sched_init();
+
+    kprocess_t* proc = process_create("test_fifo");
+    assert(proc != NULL);
+
+    capability_table_t* table = (capability_table_t*)proc->security_sandbox_ctx;
+    assert(table != NULL);
+
+    uint32_t send_cap, recv_cap;
+    assert(ipc_endpoint_create(table, &send_cap, &recv_cap) == IPC_OK);
+
+    kthread_t* r1 = thread_create(proc, dummy_entry);
+    kthread_t* r2 = thread_create(proc, dummy_entry);
+    kthread_t* r3 = thread_create(proc, dummy_entry);
+    kthread_t* sender = thread_create(proc, dummy_entry);
+
+    // Get all receivers blocked
+    char buf[16];
+    uint32_t len;
+
+    while (sched_current_thread() != r1) { sched_yield(); }
+    assert(ipc_endpoint_receive(table, recv_cap, buf, sizeof(buf), &len) == IPC_ERR_WOULD_BLOCK);
+    assert(r1->state == THREAD_STATE_BLOCKED);
+
+    while (sched_current_thread() != r2) { sched_yield(); }
+    assert(ipc_endpoint_receive(table, recv_cap, buf, sizeof(buf), &len) == IPC_ERR_WOULD_BLOCK);
+    assert(r2->state == THREAD_STATE_BLOCKED);
+
+    while (sched_current_thread() != r3) { sched_yield(); }
+    assert(ipc_endpoint_receive(table, recv_cap, buf, sizeof(buf), &len) == IPC_ERR_WOULD_BLOCK);
+    assert(r3->state == THREAD_STATE_BLOCKED);
+
+    // Switch to sender, and send one message
+    while (sched_current_thread() != sender) { sched_yield(); }
+    assert(ipc_endpoint_send(table, send_cap, "msg", 4) == IPC_OK);
+
+    // Check that exactly the FIRST blocked thread (r1) was woken
+    assert(r1->state == THREAD_STATE_READY);
+    assert(r2->state == THREAD_STATE_BLOCKED);
+    assert(r3->state == THREAD_STATE_BLOCKED);
+
+    // Wait, the buffer is full now because the receiver was only woken up and didn't consume the message yet.
+    // If we send again, it should return IPC_ERR_WOULD_BLOCK since buffer size is 1.
+    // So let's consume the message with r1 first, which should be able to run and empty the buffer.
+    while (sched_current_thread() != r1) { sched_yield(); }
+    assert(ipc_endpoint_receive(table, recv_cap, buf, sizeof(buf), &len) == IPC_OK);
+
+    // Now send the second message
+    while (sched_current_thread() != sender) { sched_yield(); }
+    assert(ipc_endpoint_send(table, send_cap, "msg", 4) == IPC_OK);
+    assert(r2->state == THREAD_STATE_READY);
+    assert(r3->state == THREAD_STATE_BLOCKED);
+
+    printf("test_ipc_multiple_waiters_fifo passed\n");
+}
+
+int main(void) {
+    test_ipc_multiple_waiters_fifo();
+    return 0;
+}

--- a/tests/test_ipc_no_spurious_self_wakeup.c
+++ b/tests/test_ipc_no_spurious_self_wakeup.c
@@ -1,0 +1,60 @@
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include "ipc_endpoint.h"
+#include "capability.h"
+#include "sched.h"
+#include <stdlib.h>
+#include "../kernel/include/slab.h"
+
+// Mock dependencies
+void ipc_async_check_timeouts(uint64_t current_ticks) { (void)current_ticks; }
+static address_space_t g_as = { .root_table = 0x1000U };
+address_space_t* mm_create_address_space(void) { return &g_as; }
+phys_addr_t mm_alloc_page(uint32_t preferred_numa_node) { (void)preferred_numa_node; return 0; }
+void mm_free_page(phys_addr_t page) { (void)page; }
+phys_addr_t pmm_alloc_pages_colored(int order, uint32_t preferred_numa_node, uint32_t flags, mm_color_config_t *color_config) { return 0; }
+phys_addr_t mm_alloc_pages_order(int order, uint32_t preferred_numa_node, uint32_t flags) { return 0; }
+void tlb_shootdown(virt_addr_t vaddr) { (void)vaddr; }
+
+
+static void dummy_entry(void) {}
+
+void test_ipc_no_spurious_self_wakeup(void) {
+    sched_init();
+
+    kprocess_t* proc = process_create("test_spurious");
+    assert(proc != NULL);
+
+    capability_table_t* table = (capability_table_t*)proc->security_sandbox_ctx;
+    assert(table != NULL);
+
+    uint32_t send_cap, recv_cap;
+    assert(ipc_endpoint_create(table, &send_cap, &recv_cap) == IPC_OK);
+
+    kthread_t* self = thread_create(proc, dummy_entry);
+
+    while (sched_current_thread() != self) {
+        sched_yield();
+    }
+    assert(sched_current_thread() == self);
+
+    // Initial state: buffer is empty. We attempt to send to ourselves
+    // Buffer has size 1, so the first send works.
+    assert(ipc_endpoint_send(table, send_cap, "msg", 4) == IPC_OK);
+
+    // Now buffer is full. If we attempt to send again, we should block,
+    // but the bug previously was waking up "current thread", so let's verify
+    // that our state genuinely stays blocked, and no subsequent operation spuriously wakes us.
+    assert(ipc_endpoint_send(table, send_cap, "msg2", 5) == IPC_ERR_WOULD_BLOCK);
+    assert(self->state == THREAD_STATE_BLOCKED);
+
+    // The thread is genuinely blocked and wouldn't be able to run.
+
+    printf("test_ipc_no_spurious_self_wakeup passed\n");
+}
+
+int main(void) {
+    test_ipc_no_spurious_self_wakeup();
+    return 0;
+}

--- a/tests/test_ipc_sync_receiver_wakeup.c
+++ b/tests/test_ipc_sync_receiver_wakeup.c
@@ -1,0 +1,69 @@
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include "ipc_endpoint.h"
+#include "capability.h"
+#include "sched.h"
+#include <stdlib.h>
+#include "../kernel/include/slab.h"
+
+// Mock dependencies
+void ipc_async_check_timeouts(uint64_t current_ticks) { (void)current_ticks; }
+static address_space_t g_as = { .root_table = 0x1000U };
+address_space_t* mm_create_address_space(void) { return &g_as; }
+phys_addr_t mm_alloc_page(uint32_t preferred_numa_node) { (void)preferred_numa_node; return 0; }
+void mm_free_page(phys_addr_t page) { (void)page; }
+phys_addr_t pmm_alloc_pages_colored(int order, uint32_t preferred_numa_node, uint32_t flags, mm_color_config_t *color_config) { return 0; }
+phys_addr_t mm_alloc_pages_order(int order, uint32_t preferred_numa_node, uint32_t flags) { return 0; }
+void tlb_shootdown(virt_addr_t vaddr) { (void)vaddr; }
+
+
+static void dummy_entry(void) {}
+
+void test_ipc_sync_receiver_wakeup(void) {
+    sched_init();
+
+    kprocess_t* proc = process_create("test_receiver");
+    assert(proc != NULL);
+
+    capability_table_t* table = (capability_table_t*)proc->security_sandbox_ctx;
+    assert(table != NULL);
+
+    uint32_t send_cap, recv_cap;
+    assert(ipc_endpoint_create(table, &send_cap, &recv_cap) == IPC_OK);
+
+    kthread_t* t_receiver = thread_create(proc, dummy_entry);
+    kthread_t* t_sender = thread_create(proc, dummy_entry);
+
+    // Initial state: buffer is empty.
+    // Switch to receiver. Attempting to receive should block it.
+    while (sched_current_thread() != t_receiver) {
+        sched_yield();
+    }
+    assert(sched_current_thread() == t_receiver);
+
+    char buf[16];
+    uint32_t len = 0;
+    assert(ipc_endpoint_receive(table, recv_cap, buf, sizeof(buf), &len) == IPC_ERR_WOULD_BLOCK);
+    assert(t_receiver->state == THREAD_STATE_BLOCKED);
+
+    // Switch to sender.
+    // Since receiver is blocked, yielding will switch to the next ready thread (sender).
+    while (sched_current_thread() != t_sender) {
+        sched_yield();
+    }
+    assert(sched_current_thread() == t_sender);
+
+    const char* msg = "msg";
+    assert(ipc_endpoint_send(table, send_cap, msg, 4) == IPC_OK);
+
+    // Now t_receiver should be READY.
+    assert(t_receiver->state == THREAD_STATE_READY);
+
+    printf("test_ipc_sync_receiver_wakeup passed\n");
+}
+
+int main(void) {
+    test_ipc_sync_receiver_wakeup();
+    return 0;
+}

--- a/tests/test_ipc_sync_sender_wakeup.c
+++ b/tests/test_ipc_sync_sender_wakeup.c
@@ -1,0 +1,81 @@
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include "ipc_endpoint.h"
+#include "capability.h"
+#include "sched.h"
+#include <stdlib.h>
+#include "../kernel/include/slab.h"
+
+// Mock dependencies
+void ipc_async_check_timeouts(uint64_t current_ticks) { (void)current_ticks; }
+static address_space_t g_as = { .root_table = 0x1000U };
+address_space_t* mm_create_address_space(void) { return &g_as; }
+phys_addr_t mm_alloc_page(uint32_t preferred_numa_node) { (void)preferred_numa_node; return 0; }
+void mm_free_page(phys_addr_t page) { (void)page; }
+phys_addr_t pmm_alloc_pages_colored(int order, uint32_t preferred_numa_node, uint32_t flags, mm_color_config_t *color_config) { return 0; }
+phys_addr_t mm_alloc_pages_order(int order, uint32_t preferred_numa_node, uint32_t flags) { return 0; }
+void tlb_shootdown(virt_addr_t vaddr) { (void)vaddr; }
+
+
+static void dummy_entry(void) {}
+
+void test_ipc_sync_sender_wakeup(void) {
+    sched_init();
+
+    kprocess_t* proc = process_create("test_sender");
+    assert(proc != NULL);
+
+    capability_table_t* table = (capability_table_t*)proc->security_sandbox_ctx;
+    assert(table != NULL);
+
+    uint32_t send_cap, recv_cap;
+    assert(ipc_endpoint_create(table, &send_cap, &recv_cap) == IPC_OK);
+
+    kthread_t* t_sender1 = thread_create(proc, dummy_entry);
+    kthread_t* t_sender2 = thread_create(proc, dummy_entry);
+    kthread_t* t_receiver = thread_create(proc, dummy_entry);
+
+    // Initial state: sender1 fills the endpoint buffer.
+    // To pretend t_sender1 is running:
+    while (sched_current_thread() != t_sender1) {
+        sched_yield();
+    }
+    assert(sched_current_thread() == t_sender1);
+
+    const char* msg1 = "msg1";
+    assert(ipc_endpoint_send(table, send_cap, msg1, 5) == IPC_OK);
+
+    // Switch to sender2. Attempting to send should block it.
+    while (sched_current_thread() != t_sender2) {
+        sched_yield();
+    }
+    assert(sched_current_thread() == t_sender2);
+
+    const char* msg2 = "msg2";
+    assert(ipc_endpoint_send(table, send_cap, msg2, 5) == IPC_ERR_WOULD_BLOCK);
+    assert(t_sender2->state == THREAD_STATE_BLOCKED);
+
+    // Switch to receiver. Receiver receives first message.
+    // Since sender2 is blocked, it won't be scheduled, we must run yield until receiver is active.
+    while (sched_current_thread() != t_receiver) {
+        sched_yield();
+    }
+    assert(sched_current_thread() == t_receiver);
+
+    char buf[16];
+    uint32_t len = 0;
+    assert(ipc_endpoint_receive(table, recv_cap, buf, sizeof(buf), &len) == IPC_OK);
+    assert(len == 5);
+    assert(strcmp(buf, "msg1") == 0);
+
+    // Now t_sender2 should be READY.
+    assert(t_sender2->state == THREAD_STATE_READY);
+
+    printf("test_ipc_sync_sender_wakeup passed\n");
+}
+
+int main(void) {
+    test_ipc_sync_sender_wakeup();
+    return 0;
+}


### PR DESCRIPTION
This PR addresses the reported IPC wake-up logic bug.

Previously, `ipc_endpoint_receive` (and its counterpart) relied on the `sched_current_thread()` function to identify and wake up the blocking sender thread, which inherently fails because `g_current` changes once the sender is descheduled. Furthermore, state transitions (`cur->state = THREAD_STATE_BLOCKED`) were open-coded in IPC functions instead of being correctly mediated by the scheduler.

**Changes made:**
1.  **Wait Queues:** Introduced explicit `wait_queue_t` data structures to `ipc_endpoint_t` for `senders` and `receivers`.
2.  **Zero-Allocation Enqueue:** Added an intrusive `next_waiter` pointer to `struct kthread`, allowing `sched_wait_queue_enqueue` to add threads directly into wait queues without volatile `kmalloc` logic, satisfying safety requirements for kernel state transitions.
3.  **Scheduler Integration:** Created a new scheduler helper `sched_block()` that delegates setting `THREAD_STATE_BLOCKED` to the scheduler, moving away from manipulating it directly inside IPC functions. `sched_wakeup()` is correctly utilized to awaken dequeued peers.
4.  **Documentation:** Created `docs/IPC_ARCHITECTURE.md` to document the endpoint model, sync semantics, and scheduler interaction explicitly as requested.
5.  **Test Suite:** Added 4 specific tests to robustly verify synchronization wakeups across edge cases, multiple-waiter FIFO ordering, and spurious self-wakeups. These tests successfully pass.

---
*PR created automatically by Jules for task [9259190735466441778](https://jules.google.com/task/9259190735466441778) started by @divyang4481*