### PR TITLE
VFS: Implement capability-native, hardware-agnostic storage spine

### DIFF
--- a/docs/architecture/vfs-storage-architecture.md
+++ b/docs/architecture/vfs-storage-architecture.md
@@ -1,0 +1,85 @@
+# Bharat-OS VFS & Storage Architecture
+
+## 1. Goals
+- **Hardware-Neutral:** Abstract the complexities of storage hardware (NVMe, virtio, eMMC) behind generic block and object interfaces.
+- **Personality-Neutral:** The core kernel VFS exposes capability-based, generic object operations. POSIX (Linux), Android, and Windows NT semantics are layered on top via personality adapters.
+- **Profile-Driven:** Allow compile-time and boot-time composition. RTOS profiles can use lightweight RAM-backed filesystems, while Datacenter profiles utilize async NVMe queues and remote object storage.
+- **Capability-Native:** Eliminate global root/ACL concepts in the kernel. Mounts, file handles, and namespaces are governed exclusively by capabilities.
+
+## 2. Non-Goals
+- Implementing a monolithic Linux VFS clone inside the kernel.
+- Hardcoding POSIX-specific behaviors (e.g., specific `errno` values or Linux-specific path resolution quirks) into the core path traversal logic.
+- Building complex filesystems (like Btrfs or ZFS) before a stable, baseline POSIX and block IO path is proven.
+
+## 3. The 5-Layer Storage Stack
+The storage architecture in Bharat-OS is explicitly divided into 5 distinct layers:
+
+### Layer 0: Hardware & HAL
+Architecture-specific bus, interrupt, and DMA management.
+*Examples: PCI-e initialization, arm64 MMIO routing, DMA memory mapping.*
+
+### Layer 1: Device Class Drivers
+Drivers that talk to specific storage hardware but implement a standard interface.
+*Examples: NVMe driver, virtio-blk driver, eMMC driver, remote blob gateway.*
+
+### Layer 2: Generic Block / Object Interfaces
+The unified contract for asynchronous and synchronous I/O.
+- **Block:** Request queues, elevator algorithms, flush/barrier/FUA semantics.
+- **Object:** Put/Get semantics, URI routing, immutable read/staged write flows.
+
+### Layer 3: Cache & FS Core (VFS Spine)
+The capability-aware, neutral storage spine.
+- Page Cache integration and writeback buffering.
+- Generic inode/vnode objects (`vfs_node_t`).
+- Mount tree (`vfs_mount_t`) and namespaces (`vfs_namespace_t`).
+- Capability validation (path rights, storage-class rights).
+
+### Layer 4: Personality Shims
+Subsystems that translate the neutral VFS spine into ABIs expected by user applications.
+- **Linux:** Maps generic open/read/write/rename to POSIX `openat`, `renameat2`, `stat`, and `errno`.
+- **Android:** Adds Binder-mediated content providers and strict app sandboxing.
+- **Windows:** Translates to NT-style handles, case rules, and reparse points.
+
+## 4. Core Structures & Capability Model
+
+Bharat-OS utilizes capabilities to manage authority across the entire stack.
+
+- **`vfs_node_t`**: Represents a canonical storage object (file, directory, block device). It does *not* grant access; it contains an object ID and provenance metadata linking it to the capability system.
+- **`vfs_mount_t`**: Represents a mounted filesystem instance. It carries a **mount capability** that dictates namespace visibility, path-rooted rights (R/W/X), and storage-class rights (e.g., whether this mount allows block access or only blob access).
+- **`vfs_file_t`**: An open file description/handle. It holds a **live capability handle** that enforces specific rights (read, write, append) negotiated at open time, preventing ambient privilege escalation.
+- **`vfs_namespace_t`**: A per-process or per-sandbox view of the mount graph, filtered by the capabilities assigned to the sandbox.
+
+## 5. Profile Model
+
+Subsystem features are activated based on the deployment profile:
+- **RT/Safety Profile:** tmpfs/ramfs priority, deterministic allocation, minimal writeback buffering.
+- **Edge/Mobile Profile:** Local filesystem priority, wear-aware block policies, per-app sandboxing namespaces.
+- **Datacenter Profile:** Deep page caching, async block queues (virtio/NVMe), and remote blob storage integration.
+
+## 6. Block vs. Blob Backends
+
+- **Block Backends:** Utilize `block_device_t` and `block_request_t` for queue-based I/O. Supports hints like `sync`, `direct`, `buffered`, and `polling`.
+- **Blob Backends:** Utilize `object_store_t` for URI-based addressing (e.g., `/blob/remote/bucket/key`). Designed for immutable reads and staged, transactional writes.
+
+## 7. Phased Roadmap
+
+### Phase 1: Block + Baseline POSIX (Current Focus)
+- Implement Layer 2 generic block queues (`block.h`, `block.c`).
+- Implement Layer 3 capability-aware mounts, namespaces, and file handles.
+- Provide a stable, basic POSIX-style filesystem driver (e.g., ext2-like or FAT-like) over virtio-blk/NVMe.
+- Add personality shims for standard POSIX file operations (`openat`, `stat`, `renameat2`, symlinks/hardlinks) mapping to the neutral core.
+
+### Phase 2: Blob / Object Backend
+- Introduce `VFS_BACKEND_BLOB` as a formal mount backend.
+- Expose immutable read descriptors for remote URI paths.
+- Implement staged writes via temp objects and atomic commit flows.
+
+### Phase 3: Advanced Features (Deferred)
+- Copy-on-Write (CoW) snapshots, deduplication, and encryption trees.
+- Distributed replication and persistent memory (Optane) semantics.
+- Complex caching algorithms and ML-driven I/O prediction.
+
+## 8. Testing Strategy
+- **Unit Tests:** Verify capability token validation on mounts and file descriptors without hardware drivers.
+- **Integration Tests:** Mount a virtual ram-backed block device, create namespaces, and verify path resolution boundaries.
+- **POSIX Conformance:** Run standard POSIX filesystem test suites against the Linux personality shim to ensure correct `errno` mapping and `openat`/`renameat2` semantics.

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -169,6 +169,12 @@ set(KERNEL_SRCS
     src/trap/trap.c
     src/multicore.c
     src/fs/vfs.c
+    src/fs/mount.c
+    src/fs/file.c
+    src/fs/namespace.c
+    src/fs/path.c
+    src/fs/block.c
+    src/fs/object_store.c
     src/fs/blob_backend.c
     src/apps/hello_world.c
     src/apps/kernel_tester.c

--- a/kernel/include/fs/block.h
+++ b/kernel/include/fs/block.h
@@ -1,0 +1,71 @@
+#ifndef BHARAT_FS_BLOCK_H
+#define BHARAT_FS_BLOCK_H
+
+#include <stdint.h>
+#include <stddef.h>
+#include "advanced/formal_verif.h"
+
+/*
+ * Generic block layer abstractions.
+ * Provides a unified contract for asynchronous and synchronous I/O
+ * (e.g., NVMe, virtio-blk, MMC, RAM disks).
+ */
+
+typedef enum {
+    BLOCK_HINT_SYNC,
+    BLOCK_HINT_DIRECT,
+    BLOCK_HINT_BUFFERED,
+    BLOCK_HINT_POLLING
+} block_io_hint_t;
+
+typedef enum {
+    BLOCK_REQ_READ,
+    BLOCK_REQ_WRITE,
+    BLOCK_REQ_FLUSH,
+    BLOCK_REQ_DISCARD
+} block_req_type_t;
+
+// Asynchronous block request structure
+typedef struct block_request {
+    block_req_type_t type;
+    uint64_t sector_offset;
+    uint32_t sector_count;
+    void* buffer;           // Buffer for read/write
+
+    // Hint for elevator/scheduler policies
+    block_io_hint_t hint;
+
+    // Capability gating access to this block operation
+    capability_t* cap;
+
+    // Completion callback (for async operations)
+    void (*complete)(struct block_request* req, int status);
+
+    // Status and next pointer for request queueing
+    int status;
+    struct block_request* next;
+} block_request_t;
+
+// A block device registered with the generic block layer
+typedef struct block_device {
+    char name[32];
+    uint32_t sector_size;
+    uint64_t total_sectors;
+
+    // Device specific data (e.g. nvme namespace, virtio handle)
+    void* driver_data;
+
+    // Operations implemented by the underlying driver
+    int (*submit_request)(struct block_device* dev, block_request_t* req);
+    int (*flush)(struct block_device* dev);
+    int (*get_info)(struct block_device* dev, void* info_out);
+
+} block_device_t;
+
+// Register a block device with the generic block layer
+int block_device_register(block_device_t* dev, capability_t* cap);
+
+// Allocate and submit a request to a block device
+int block_request_submit(block_device_t* dev, block_request_t* req, capability_t* cap);
+
+#endif // BHARAT_FS_BLOCK_H

--- a/kernel/include/fs/file.h
+++ b/kernel/include/fs/file.h
@@ -1,0 +1,35 @@
+#ifndef BHARAT_FS_FILE_H
+#define BHARAT_FS_FILE_H
+
+#include "fs/vfs.h"
+#include "advanced/formal_verif.h"
+
+/*
+ * vfs_file_t: Represents an open file description/handle.
+ * Governs negotiated read/write rights using a capability-based live token
+ * to prevent ambient privilege escalation.
+ */
+typedef struct vfs_file {
+    int in_use;
+    int flags;          // O_RDONLY, O_WRONLY, O_RDWR, etc.
+    uint64_t offset;    // Current seek offset
+
+    // The canonical node this file points to
+    vfs_node_t* node;
+
+    // Live capability token governing this open handle's specific rights
+    capability_t handle_cap;
+
+} vfs_file_t;
+
+// Capability-checked file operations (neutral semantics, not POSIX)
+int vfs_open_file(const char* path, int flags, capability_t* caller_cap, int* out_fd);
+int vfs_read_file(int fd, void* buffer, size_t size, capability_t* caller_cap);
+int vfs_write_file(int fd, const void* buffer, size_t size, capability_t* caller_cap);
+int vfs_close_file(int fd, capability_t* caller_cap);
+
+#ifdef TESTING
+void vfs_file_test_reset_state(void);
+#endif
+
+#endif // BHARAT_FS_FILE_H

--- a/kernel/include/fs/mount.h
+++ b/kernel/include/fs/mount.h
@@ -1,0 +1,34 @@
+#ifndef BHARAT_FS_MOUNT_H
+#define BHARAT_FS_MOUNT_H
+
+#include "fs/vfs.h"
+#include "advanced/formal_verif.h"
+
+/*
+ * vfs_mount_t: Represents a mounted filesystem instance.
+ * Governs namespace visibility, path-rooted rights, and storage-class rights
+ * via a mount capability token.
+ */
+typedef struct vfs_mount {
+    char target_path[256];      // The point in the VFS tree where this is mounted
+    vfs_node_t* root_node;      // The root node of the mounted filesystem
+    const vfs_driver_info_t* driver; // The driver backing this mount
+
+    // Mount-specific capability token (restricts path, class, TTL)
+    capability_t mount_cap;
+
+    // References to next mount in system list or namespace mount graph
+    struct vfs_mount* next;
+} vfs_mount_t;
+
+// Capability-checked mount request
+int vfs_mount_fs(const char* target_path, vfs_node_t* fs_root, capability_t* caller_cap);
+
+// Resolve a path using mount capabilities
+vfs_node_t* vfs_resolve_mount_path(const char* path, capability_t* caller_cap);
+
+#ifdef TESTING
+void vfs_mount_test_reset_state(void);
+#endif
+
+#endif // BHARAT_FS_MOUNT_H

--- a/kernel/include/fs/namespace.h
+++ b/kernel/include/fs/namespace.h
@@ -1,0 +1,30 @@
+#ifndef BHARAT_FS_NAMESPACE_H
+#define BHARAT_FS_NAMESPACE_H
+
+#include "fs/vfs.h"
+#include "fs/mount.h"
+#include "advanced/formal_verif.h"
+
+/*
+ * vfs_namespace_t: A per-process or per-sandbox view of the mount graph.
+ * Provides a subset of available mounts based on the sandbox capabilities.
+ */
+typedef struct vfs_namespace {
+    // The sandbox capabilities mapping to visible mounts and allowed paths
+    capability_t sandbox_cap;
+
+    // The list of mounts specifically visible to this namespace
+    vfs_mount_t* mounts;
+    uint32_t mount_count;
+
+    // A reference back to a parent namespace if derived (or NULL)
+    struct vfs_namespace* parent;
+} vfs_namespace_t;
+
+// Create a new, derived namespace restricted by capabilities
+int vfs_namespace_create(vfs_namespace_t* parent, vfs_namespace_t** out_namespace, capability_t* cap);
+
+// Look up a node within a given namespace
+vfs_node_t* vfs_namespace_lookup(vfs_namespace_t* ns, const char* path, capability_t* caller_cap);
+
+#endif // BHARAT_FS_NAMESPACE_H

--- a/kernel/include/fs/object_store.h
+++ b/kernel/include/fs/object_store.h
@@ -1,0 +1,39 @@
+#ifndef BHARAT_FS_OBJECT_STORE_H
+#define BHARAT_FS_OBJECT_STORE_H
+
+#include "fs/vfs.h"
+#include "advanced/formal_verif.h"
+
+/*
+ * Blob/object storage interfaces.
+ * Utilizes URI-based addressing (e.g., /blob/remote/bucket/key)
+ * Designed for immutable reads and staged, transactional writes.
+ */
+
+// Represents an object stored in a blob backend
+typedef struct object_store {
+    char uri[256];
+    uint64_t size;
+    uint32_t flags; // E.g., read-only, staged
+
+    // Content hash/ETag for data integrity checks
+    char etag[64];
+
+    // Read an object (potentially streaming or chunked)
+    int (*get_object)(struct object_store* obj, void* buffer, size_t size, uint64_t offset, capability_t* cap);
+
+    // Staged write for an object (atomic commit flows)
+    int (*put_object)(struct object_store* obj, const void* buffer, size_t size, uint64_t offset, capability_t* cap);
+
+    // Commit a staged object to its permanent URI
+    int (*commit_object)(struct object_store* temp_obj, const char* final_uri, capability_t* cap);
+
+} object_store_t;
+
+// Register a blob backend/gateway
+int object_store_register(object_store_t* store, capability_t* cap);
+
+// Look up a blob object by URI
+int object_store_lookup(const char* uri, object_store_t** out_store, capability_t* cap);
+
+#endif // BHARAT_FS_OBJECT_STORE_H

--- a/kernel/include/fs/path.h
+++ b/kernel/include/fs/path.h
@@ -1,0 +1,37 @@
+#ifndef BHARAT_FS_PATH_H
+#define BHARAT_FS_PATH_H
+
+#include "fs/vfs.h"
+#include "advanced/formal_verif.h"
+
+/*
+ * Path resolution structures and rights definition.
+ * Used for capability checks across paths.
+ */
+
+// Basic path-rooted rights (similar to Unix modes, but distinct from ambient ACLs)
+#define PATH_RIGHT_READ      CAP_RIGHT_READ
+#define PATH_RIGHT_WRITE     CAP_RIGHT_WRITE
+#define PATH_RIGHT_EXECUTE   CAP_RIGHT_EXECUTE
+#define PATH_RIGHT_CREATE    (1 << 3)
+#define PATH_RIGHT_DELETE    (1 << 4)
+
+// Storage class right definitions (what backends can be used)
+typedef enum {
+    STORAGE_CLASS_FILESYSTEM = 1,
+    STORAGE_CLASS_BLOCK      = 2,
+    STORAGE_CLASS_BLOB       = 4,
+    STORAGE_CLASS_TMPFS      = 8
+} storage_class_rights_t;
+
+// Contains the allowed prefix path and rights for a capability token
+typedef struct path_rights {
+    char allowed_prefix[256];
+    uint32_t rights;
+    storage_class_rights_t allowed_classes;
+} path_rights_t;
+
+// Validates whether the given capability has the required rights for a path
+int vfs_validate_path_rights(const char* path, uint32_t required_rights, capability_t* cap);
+
+#endif // BHARAT_FS_PATH_H

--- a/kernel/include/fs/vfs.h
+++ b/kernel/include/fs/vfs.h
@@ -3,15 +3,16 @@
 
 #include <stdint.h>
 #include <stddef.h>
+#include "advanced/formal_verif.h" // For capability_t
 
 /*
  * Bharat-OS Virtual File System (VFS)
- * Provides a unified namespace for disparate file systems (ext4, BFS, FAT32)
- * and pseudo-devices (/dev, /proc).
+ * Provides a unified, personality-neutral namespace for storage objects.
+ * Features capability-based security, profile-driven backends, and
+ * abstraction over block, blob, and filesystem resources.
  */
 
-typedef struct vfs_node vfs_node_t;
-
+// Basic neutral flags
 #define VFS_OPEN_READ  0x1
 #define VFS_OPEN_WRITE 0x2
 #define VFS_OPEN_RDWR  (VFS_OPEN_READ | VFS_OPEN_WRITE)
@@ -24,7 +25,7 @@ typedef enum {
     VFS_BACKEND_PSEUDO
 } vfs_backend_type_t;
 
-// Mount feature capabilities for FS and storage providers
+// Mount feature capabilities (Feature set, NOT security tokens)
 typedef struct {
     uint32_t supports_journaling;
     uint32_t supports_snapshots;
@@ -42,51 +43,57 @@ typedef struct {
     vfs_feature_caps_t features;
 } vfs_driver_info_t;
 
+typedef struct vfs_node vfs_node_t;
+typedef struct vfs_mount vfs_mount_t;
+typedef struct vfs_file vfs_file_t;
 
-// File operations function pointers (Linux inode_operations style)
+// Personality-neutral file operations
 typedef struct {
-    int (*read)(vfs_node_t* node, uint64_t offset, void* buffer, size_t size);
-    int (*write)(vfs_node_t* node, uint64_t offset, const void* buffer, size_t size);
-    int (*open)(vfs_node_t* node, int flags);
-    int (*close)(vfs_node_t* node);
-    struct dirent* (*readdir)(vfs_node_t* node, uint32_t index);
+    int (*read)(vfs_file_t* file, uint64_t offset, void* buffer, size_t size);
+    int (*write)(vfs_file_t* file, uint64_t offset, const void* buffer, size_t size);
+    int (*open)(vfs_node_t* node, vfs_file_t* file, int flags);
+    int (*close)(vfs_file_t* file);
+    struct dirent* (*readdir)(vfs_file_t* file, uint32_t index);
     vfs_node_t* (*finddir)(vfs_node_t* node, const char* name);
-    int (*ioctl)(vfs_node_t* node, int request, void* arg);
+    int (*ioctl)(vfs_file_t* file, int request, void* arg);
+    int (*stat)(vfs_node_t* node, void* stat_buf); // Generic stat-like structure
 } vfs_operations_t;
 
+/*
+ * vfs_node_t: The canonical storage object.
+ * Represents a file, directory, or device. Does NOT contain ambient
+ * permissions, but rather links to the capability system via provenance.
+ */
 struct vfs_node {
     char name[256];
     uint32_t flags; // Type (file, dir, block device, pipe)
-    uint32_t permissions; // Capability-based security ACLs
-    uint32_t uid;
-    uint32_t gid;
+
+    // Ownership/Security Metadata
+    // The canonical object ID to which capabilities grant access
+    uint32_t object_id;
+    // Link to capability provenance/derivation tree
+    capability_t* provenance_cap;
+
     uint64_t size; // File size in bytes
     uint64_t inode; // FS specific inode number
-    vfs_backend_type_t backend_type; // Filesystem, block, blob, pseudo
+    vfs_backend_type_t backend_type;
     
-    // Function table routing calls to the specific file system implementation
     vfs_operations_t* ops;
-    
-    // Pointer to specific FS data (e.g., ext4_inode, bfs_node)
     void* fs_data;
 };
 
-// Global VFS Root mounting point
+// Global VFS Root mounting point (Legacy fallback or root namespace reference)
 extern vfs_node_t* vfs_root;
-
-// Mount a specific filesystem driver to a path in the VFS tree
-int vfs_mount(const char* target_path, vfs_node_t* fs_root);
-
-// Standard open/read/write wrappers abstracting away the vfs lookup
-int vfs_open(const char* path, int flags);
-int vfs_read(int fd, void* buffer, size_t size);
-int vfs_write(int fd, const void* buffer, size_t size);
 
 // Register a filesystem/storage driver with the VFS core.
 int vfs_register_driver(const vfs_driver_info_t* info);
 
 // Lookup a registered driver descriptor by name.
 const vfs_driver_info_t* vfs_get_driver(const char* name);
+
+// Path utilities
+int vfs_path_prefix_match(const char *path, const char *prefix);
+size_t vfs_strnlen(const char *s, size_t max_len);
 
 #ifdef TESTING
 void vfs_test_reset_state(void);

--- a/kernel/src/fs/blob_backend.c
+++ b/kernel/src/fs/blob_backend.c
@@ -10,15 +10,17 @@ typedef struct {
     size_t size;
 } blob_immutable_object_t;
 
-static int blob_read(vfs_node_t *node, uint64_t offset, void *buffer, size_t size) {
+#include "fs/file.h"
+
+static int blob_read(vfs_file_t *file, uint64_t offset, void *buffer, size_t size) {
     blob_immutable_object_t *obj;
     size_t i;
 
-    if (!node || !buffer || !node->fs_data) {
+    if (!file || !file->node || !buffer || !file->node->fs_data) {
         return -1;
     }
 
-    obj = (blob_immutable_object_t *)node->fs_data;
+    obj = (blob_immutable_object_t *)file->node->fs_data;
     if (offset >= obj->size) {
         return 0;
     }
@@ -34,8 +36,8 @@ static int blob_read(vfs_node_t *node, uint64_t offset, void *buffer, size_t siz
     return (int)size;
 }
 
-static int blob_write(vfs_node_t *node, uint64_t offset, const void *buffer, size_t size) {
-    (void)node;
+static int blob_write(vfs_file_t *file, uint64_t offset, const void *buffer, size_t size) {
+    (void)file;
     (void)offset;
     (void)buffer;
     (void)size;

--- a/kernel/src/fs/block.c
+++ b/kernel/src/fs/block.c
@@ -1,0 +1,32 @@
+#include "fs/block.h"
+
+#define MAX_BLOCK_DEVICES 8
+
+static block_device_t* g_block_devices[MAX_BLOCK_DEVICES];
+static size_t g_block_device_count = 0;
+
+int block_device_register(block_device_t* dev, capability_t* cap) {
+    if (!dev || !dev->submit_request || !cap) {
+        return -1;
+    }
+
+    // TODO: Verify capability allows block device registration
+
+    if (g_block_device_count >= MAX_BLOCK_DEVICES) {
+        return -1;
+    }
+
+    g_block_devices[g_block_device_count++] = dev;
+    return 0;
+}
+
+int block_request_submit(block_device_t* dev, block_request_t* req, capability_t* cap) {
+    if (!dev || !req || !dev->submit_request || !cap) {
+        return -1;
+    }
+
+    // TODO: Verify capability matches device
+
+    // Enqueue request or submit to underlying driver
+    return dev->submit_request(dev, req);
+}

--- a/kernel/src/fs/file.c
+++ b/kernel/src/fs/file.c
@@ -1,0 +1,138 @@
+#include "fs/file.h"
+#include "fs/mount.h"
+
+#define VFS_MAX_OPEN_FILES 64
+
+static vfs_file_t g_open_files[VFS_MAX_OPEN_FILES];
+
+int vfs_open_file(const char* path, int flags, capability_t* caller_cap, int* out_fd) {
+    size_t i;
+    vfs_node_t *node;
+
+    if (!path || !caller_cap || !out_fd) {
+        return -1;
+    }
+
+    node = vfs_resolve_mount_path(path, caller_cap);
+
+    if (!node) {
+        return -1;
+    }
+
+    if (node->backend_type == VFS_BACKEND_BLOB && (flags & VFS_OPEN_WRITE)) {
+        return -1;
+    }
+
+    for (i = 0; i < VFS_MAX_OPEN_FILES; ++i) {
+        if (!g_open_files[i].in_use) {
+
+            g_open_files[i].in_use = 1;
+            g_open_files[i].flags = flags;
+            g_open_files[i].offset = 0;
+            g_open_files[i].node = node;
+
+            // Allow underlying implementation to populate/reject handle
+            if (node->ops && node->ops->open) {
+                if (node->ops->open(node, &g_open_files[i], flags) != 0) {
+                    g_open_files[i].in_use = 0;
+                    g_open_files[i].node = NULL;
+                    return -1;
+                }
+            }
+
+            // TODO: Generate handle_cap based on path/node cap and flags
+
+            *out_fd = (int)i;
+            return 0;
+        }
+    }
+
+    return -1;
+}
+
+int vfs_read_file(int fd, void* buffer, size_t size, capability_t* caller_cap) {
+    int bytes;
+    vfs_file_t *entry;
+
+    if (fd < 0 || fd >= (int)VFS_MAX_OPEN_FILES || !caller_cap) {
+        return -1;
+    }
+
+    entry = &g_open_files[fd];
+    if (!entry->in_use || !entry->node || !entry->node->ops || !entry->node->ops->read) {
+        return -1;
+    }
+
+    // TODO: Verify caller_cap matches entry->handle_cap rights
+
+    bytes = entry->node->ops->read(entry, entry->offset, buffer, size);
+    if (bytes > 0) {
+        entry->offset += (uint64_t)bytes;
+    }
+    return bytes;
+}
+
+int vfs_write_file(int fd, const void* buffer, size_t size, capability_t* caller_cap) {
+    int bytes;
+    vfs_file_t *entry;
+
+    if (fd < 0 || fd >= (int)VFS_MAX_OPEN_FILES || !caller_cap) {
+        return -1;
+    }
+
+    entry = &g_open_files[fd];
+    if (!entry->in_use || !entry->node || !entry->node->ops || !entry->node->ops->write) {
+        return -1;
+    }
+
+    if ((entry->flags & VFS_OPEN_WRITE) == 0) {
+        return -1;
+    }
+
+    if (entry->node->backend_type == VFS_BACKEND_BLOB) {
+        return -1;
+    }
+
+    // TODO: Verify caller_cap matches entry->handle_cap rights
+
+    bytes = entry->node->ops->write(entry, entry->offset, buffer, size);
+    if (bytes > 0) {
+        entry->offset += (uint64_t)bytes;
+    }
+    return bytes;
+}
+
+int vfs_close_file(int fd, capability_t* caller_cap) {
+    vfs_file_t *entry;
+
+    if (fd < 0 || fd >= (int)VFS_MAX_OPEN_FILES || !caller_cap) {
+        return -1;
+    }
+
+    entry = &g_open_files[fd];
+    if (!entry->in_use) {
+        return -1;
+    }
+
+    // TODO: Verify caller_cap
+
+    if (entry->node && entry->node->ops && entry->node->ops->close) {
+        entry->node->ops->close(entry);
+    }
+
+    entry->in_use = 0;
+    entry->node = NULL;
+    return 0;
+}
+
+#ifdef TESTING
+void vfs_file_test_reset_state(void) {
+    size_t i;
+    for (i = 0; i < VFS_MAX_OPEN_FILES; ++i) {
+        g_open_files[i].in_use = 0;
+        g_open_files[i].flags = 0;
+        g_open_files[i].offset = 0;
+        g_open_files[i].node = NULL;
+    }
+}
+#endif

--- a/kernel/src/fs/mount.c
+++ b/kernel/src/fs/mount.c
@@ -1,0 +1,88 @@
+#include "fs/mount.h"
+
+#define VFS_MAX_MOUNTS 16
+
+static vfs_mount_t g_mounts[VFS_MAX_MOUNTS];
+static size_t g_mount_count = 0;
+
+static void vfs_strcpy(char *dst, const char *src, size_t dst_size) {
+    size_t i = 0;
+    if (!dst || dst_size == 0) {
+        return;
+    }
+    if (!src) {
+        dst[0] = '\0';
+        return;
+    }
+    while (i + 1 < dst_size && src[i] != '\0') {
+        dst[i] = src[i];
+        i++;
+    }
+    dst[i] = '\0';
+}
+
+int vfs_mount_fs(const char* target_path, vfs_node_t* fs_root, capability_t* caller_cap) {
+    if (!target_path || !fs_root || !caller_cap) {
+        return -1;
+    }
+
+    // TODO: Verify caller_cap allows mounting at target_path
+
+    if (g_mount_count >= VFS_MAX_MOUNTS) {
+        return -1;
+    }
+
+    if (target_path[0] != '/') {
+        return -1;
+    }
+
+    vfs_strcpy(g_mounts[g_mount_count].target_path, target_path, sizeof(g_mounts[g_mount_count].target_path));
+    g_mounts[g_mount_count].root_node = fs_root;
+
+    if (vfs_path_prefix_match(target_path, "/")) {
+        vfs_root = fs_root;
+    }
+
+    g_mount_count++;
+    return 0;
+}
+
+vfs_node_t* vfs_resolve_mount_path(const char* path, capability_t* caller_cap) {
+    size_t best_len = 0;
+    vfs_node_t *best_node = NULL;
+    size_t i = 0;
+
+    if (!path || !caller_cap) {
+        return NULL;
+    }
+
+    // TODO: Filter visible mounts based on caller_cap
+    for (i = 0; i < g_mount_count; ++i) {
+        const char *mount_path = g_mounts[i].target_path;
+        if (!vfs_path_prefix_match(path, mount_path)) {
+            continue;
+        }
+
+        size_t mount_len = 0;
+        while(mount_path[mount_len] != '\0' && mount_len < sizeof(g_mounts[i].target_path)) {
+            mount_len++;
+        }
+
+        if (mount_len >= best_len) {
+            best_len = mount_len;
+            best_node = g_mounts[i].root_node;
+        }
+    }
+
+    if (!best_node && vfs_root) {
+        best_node = vfs_root;
+    }
+
+    return best_node;
+}
+
+#ifdef TESTING
+void vfs_mount_test_reset_state(void) {
+    g_mount_count = 0;
+}
+#endif

--- a/kernel/src/fs/namespace.c
+++ b/kernel/src/fs/namespace.c
@@ -1,0 +1,24 @@
+#include "fs/namespace.h"
+
+int vfs_namespace_create(vfs_namespace_t* parent, vfs_namespace_t** out_namespace, capability_t* cap) {
+    if (!out_namespace || !cap) {
+        return -1;
+    }
+
+    // TODO: Verify cap allows namespace derivation from parent
+
+    // In a full implementation, allocate and derive a restricted view
+    // from the parent namespace.
+    *out_namespace = NULL;
+
+    return -1; // Unimplemented
+}
+
+vfs_node_t* vfs_namespace_lookup(vfs_namespace_t* ns, const char* path, capability_t* caller_cap) {
+    if (!ns || !path || !caller_cap) {
+        return NULL;
+    }
+
+    // TODO: Resolve path relative to the specific namespace's mount list
+    return NULL; // Unimplemented
+}

--- a/kernel/src/fs/object_store.c
+++ b/kernel/src/fs/object_store.c
@@ -1,0 +1,50 @@
+#include "fs/object_store.h"
+
+#define MAX_OBJECT_STORES 4
+
+static object_store_t* g_object_stores[MAX_OBJECT_STORES];
+static size_t g_object_store_count = 0;
+
+int object_store_register(object_store_t* store, capability_t* cap) {
+    if (!store || !cap) {
+        return -1;
+    }
+
+    if (g_object_store_count >= MAX_OBJECT_STORES) {
+        return -1;
+    }
+
+    g_object_stores[g_object_store_count++] = store;
+    return 0;
+}
+
+int object_store_lookup(const char* uri, object_store_t** out_store, capability_t* cap) {
+    if (!uri || !out_store || !cap) {
+        return -1;
+    }
+
+    // TODO: Verify capability allows store access
+
+    // Iterate through stores, returning match based on URI prefix
+    for (size_t i = 0; i < g_object_store_count; i++) {
+        const char *store_uri = g_object_stores[i]->uri;
+        size_t j = 0;
+        int match = 1;
+
+        while (store_uri[j] != '\0' && uri[j] != '\0') {
+            if (store_uri[j] != uri[j]) {
+                match = 0;
+                break;
+            }
+            j++;
+        }
+
+        if (match && store_uri[j] == '\0' && (uri[j] == '\0' || uri[j] == '/')) {
+            *out_store = g_object_stores[i];
+            return 0;
+        }
+    }
+
+    *out_store = NULL;
+    return -1;
+}

--- a/kernel/src/fs/path.c
+++ b/kernel/src/fs/path.c
@@ -1,0 +1,14 @@
+#include "fs/path.h"
+
+int vfs_validate_path_rights(const char* path, uint32_t required_rights, capability_t* cap) {
+    if (!path || !cap) {
+        return -1;
+    }
+
+    // In a complete implementation, we would extract the path prefix
+    // from the capability and confirm the target path falls beneath it.
+    // Also verifying that the storage class is valid.
+
+    // Stub implementation denies all access
+    return -1;
+}

--- a/kernel/src/fs/vfs.c
+++ b/kernel/src/fs/vfs.c
@@ -4,39 +4,13 @@
 #include <stdint.h>
 
 #define VFS_MAX_DRIVERS 16
-#define VFS_MAX_MOUNTS 16
-#define VFS_MAX_OPEN_FILES 64
-
-#ifndef VFS_OPEN_READ
-#define VFS_OPEN_READ 0x1
-#endif
-#ifndef VFS_OPEN_WRITE
-#define VFS_OPEN_WRITE 0x2
-#endif
-
-typedef struct {
-    char target_path[256];
-    vfs_node_t *root;
-} vfs_mount_entry_t;
-
-typedef struct {
-    int in_use;
-    int flags;
-    uint64_t offset;
-    vfs_node_t *node;
-} vfs_fd_entry_t;
 
 vfs_node_t *vfs_root = NULL;
 
 static vfs_driver_info_t g_driver_registry[VFS_MAX_DRIVERS];
 static size_t g_driver_count = 0;
 
-static vfs_mount_entry_t g_mounts[VFS_MAX_MOUNTS];
-static size_t g_mount_count = 0;
-
-static vfs_fd_entry_t g_open_files[VFS_MAX_OPEN_FILES];
-
-static size_t vfs_strnlen(const char *s, size_t max_len) {
+size_t vfs_strnlen(const char *s, size_t max_len) {
     size_t i = 0;
     if (!s) {
         return 0;
@@ -47,37 +21,7 @@ static size_t vfs_strnlen(const char *s, size_t max_len) {
     return i;
 }
 
-static int vfs_streq(const char *a, const char *b) {
-    size_t i = 0;
-    if (!a || !b) {
-        return 0;
-    }
-    while (a[i] != '\0' && b[i] != '\0') {
-        if (a[i] != b[i]) {
-            return 0;
-        }
-        i++;
-    }
-    return a[i] == b[i];
-}
-
-static void vfs_strcpy(char *dst, const char *src, size_t dst_size) {
-    size_t i = 0;
-    if (!dst || dst_size == 0) {
-        return;
-    }
-    if (!src) {
-        dst[0] = '\0';
-        return;
-    }
-    while (i + 1 < dst_size && src[i] != '\0') {
-        dst[i] = src[i];
-        i++;
-    }
-    dst[i] = '\0';
-}
-
-static int path_prefix_match(const char *path, const char *prefix) {
+int vfs_path_prefix_match(const char *path, const char *prefix) {
     size_t i = 0;
 
     if (!path || !prefix) {
@@ -98,33 +42,18 @@ static int path_prefix_match(const char *path, const char *prefix) {
     return (path[i] == '\0' || path[i] == '/');
 }
 
-static vfs_node_t *vfs_resolve_path(const char *path) {
-    size_t best_len = 0;
-    vfs_node_t *best_node = NULL;
+static int vfs_streq(const char *a, const char *b) {
     size_t i = 0;
-
-    if (!path) {
-        return NULL;
+    if (!a || !b) {
+        return 0;
     }
-
-    for (i = 0; i < g_mount_count; ++i) {
-        const char *mount_path = g_mounts[i].target_path;
-        if (!path_prefix_match(path, mount_path)) {
-            continue;
+    while (a[i] != '\0' && b[i] != '\0') {
+        if (a[i] != b[i]) {
+            return 0;
         }
-
-        size_t mount_len = vfs_strnlen(mount_path, sizeof(g_mounts[i].target_path));
-        if (mount_len >= best_len) {
-            best_len = mount_len;
-            best_node = g_mounts[i].root;
-        }
+        i++;
     }
-
-    if (!best_node && vfs_root) {
-        best_node = vfs_root;
-    }
-
-    return best_node;
+    return a[i] == b[i];
 }
 
 int vfs_register_driver(const vfs_driver_info_t *info) {
@@ -156,122 +85,14 @@ const vfs_driver_info_t *vfs_get_driver(const char *name) {
     return NULL;
 }
 
-int vfs_mount(const char *target_path, vfs_node_t *fs_root) {
-    if (!target_path || !fs_root) {
-        return -1;
-    }
-
-    if (g_mount_count >= VFS_MAX_MOUNTS) {
-        return -1;
-    }
-
-    if (target_path[0] != '/') {
-        return -1;
-    }
-
-    vfs_strcpy(g_mounts[g_mount_count].target_path, target_path, sizeof(g_mounts[g_mount_count].target_path));
-    g_mounts[g_mount_count].root = fs_root;
-
-    if (vfs_streq(target_path, "/")) {
-        vfs_root = fs_root;
-    }
-
-    g_mount_count++;
-    return 0;
-}
-
-int vfs_open(const char *path, int flags) {
-    size_t i;
-    vfs_node_t *node = vfs_resolve_path(path);
-
-    if (!node) {
-        return -1;
-    }
-
-    if (node->backend_type == VFS_BACKEND_BLOB && (flags & VFS_OPEN_WRITE)) {
-        return -1;
-    }
-
-    if (node->ops && node->ops->open) {
-        if (node->ops->open(node, flags) != 0) {
-            return -1;
-        }
-    }
-
-    for (i = 0; i < VFS_MAX_OPEN_FILES; ++i) {
-        if (!g_open_files[i].in_use) {
-            g_open_files[i].in_use = 1;
-            g_open_files[i].flags = flags;
-            g_open_files[i].offset = 0;
-            g_open_files[i].node = node;
-            return (int)i;
-        }
-    }
-
-    return -1;
-}
-
-int vfs_read(int fd, void *buffer, size_t size) {
-    int bytes;
-    vfs_fd_entry_t *entry;
-
-    if (fd < 0 || fd >= (int)VFS_MAX_OPEN_FILES) {
-        return -1;
-    }
-
-    entry = &g_open_files[fd];
-    if (!entry->in_use || !entry->node || !entry->node->ops || !entry->node->ops->read) {
-        return -1;
-    }
-
-    bytes = entry->node->ops->read(entry->node, entry->offset, buffer, size);
-    if (bytes > 0) {
-        entry->offset += (uint64_t)bytes;
-    }
-    return bytes;
-}
-
-int vfs_write(int fd, const void *buffer, size_t size) {
-    int bytes;
-    vfs_fd_entry_t *entry;
-
-    if (fd < 0 || fd >= (int)VFS_MAX_OPEN_FILES) {
-        return -1;
-    }
-
-    entry = &g_open_files[fd];
-    if (!entry->in_use || !entry->node || !entry->node->ops || !entry->node->ops->write) {
-        return -1;
-    }
-
-    if ((entry->flags & VFS_OPEN_WRITE) == 0) {
-        return -1;
-    }
-
-    if (entry->node->backend_type == VFS_BACKEND_BLOB) {
-        return -1;
-    }
-
-    bytes = entry->node->ops->write(entry->node, entry->offset, buffer, size);
-    if (bytes > 0) {
-        entry->offset += (uint64_t)bytes;
-    }
-    return bytes;
-}
-
 #ifdef TESTING
-void vfs_test_reset_state(void) {
-    size_t i;
+#include "fs/mount.h"
+#include "fs/file.h"
 
+void vfs_test_reset_state(void) {
     vfs_root = NULL;
     g_driver_count = 0;
-    g_mount_count = 0;
-
-    for (i = 0; i < VFS_MAX_OPEN_FILES; ++i) {
-        g_open_files[i].in_use = 0;
-        g_open_files[i].flags = 0;
-        g_open_files[i].offset = 0;
-        g_open_files[i].node = NULL;
-    }
+    vfs_mount_test_reset_state();
+    vfs_file_test_reset_state();
 }
 #endif


### PR DESCRIPTION
Implement the core structural foundation for the new Bharat-OS VFS and storage stack. This aligns with the microkernel, capability-first, and profile-driven architectural vision. Instead of a monolithic POSIX clone, this PR sets up a 5-layer generic storage spine, upon which personality shims (Linux, Android, Windows) can project their own semantics.
- Architecture document explaining goals, capability flow, and milestones.
- Core header definitions (vfs_node_t, vfs_mount_t, vfs_file_t, block_device_t, object_store_t) linking object structures to their provenance or capability rights.
- Build-safe C source stubs laying the groundwork for future POSIX/NVMe implementation phases.

---
*PR created automatically by Jules for task [10421435333420638871](https://jules.google.com/task/10421435333420638871) started by @divyang4481*