### PR TITLE
docs: clarify VMM status as arch walkers present, pager path deferred

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Bharat-OS is a capability-oriented microkernel project with a multikernel direct
 | Area | Current status | Notes |
 | --- | --- | --- |
 | Capability model and IPC baseline | Implemented baseline | Capability tables, delegated rights checks, endpoint IPC + URPC scaffolding. |
-| Memory management | Partial baseline | PMM/buddy allocator and VMM mapping registry exist; full hardware page-table manager remains deferred. |
+| Memory management | Partial baseline | PMM/buddy allocator and arch-specific page-table walkers (x86_64/arm64/riscv) exist for map/unmap/query; robust page-fault resolution and user-space pager flow remain deferred. |
 | Scheduler and AI hook points | Implemented baseline | Timer-driven scheduler path with bounded AI suggestion ingestion/processing; full SMP runqueues/context switching remain deferred. |
 | Driver and HAL model | Implemented baseline | HAL contracts and driver framework scaffolding exist across x86_64, riscv64, arm64. |
 | Distributed/multikernel scale-out | Early baseline | Per-core URPC matrix and multicore bootstrap hooks exist; production-grade topology and transport tuning are deferred. |


### PR DESCRIPTION
### Motivation
- Correct README to reflect that the codebase already implements architecture-specific page-table walkers (x86_64/arm64/riscv) for mapping operations while the larger work of page-fault resolution and user-space pager flow is still outstanding.

### Description
- Replace a single line in `README.md` to state that the PMM/buddy allocator and arch-specific page-table walkers exist for `map`/`unmap`/`query`, and that robust page-fault handling and pager flow remain deferred.

### Testing
- Ran repository inspections and quick validations (`rg` searches for VMM-related symbols, viewed `kernel/src/mm/vmm.c` and `kernel/src/hal/*/vmm.c`, `nl`/`sed` to confirm code paths) and performed `git status`, `git add` and `git commit`; all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b53d9ec1288320b12c136f891b6b8d)