### PR TITLE
Introduce memory subsystem API headers, HAL MMU/IOMMU/TLB interfaces, and memory gap closure plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ Bharat-OS is a capability-oriented microkernel project with a multikernel direct
 | Area | Current status | Notes |
 | --- | --- | --- |
 | Capability model and IPC baseline | Implemented baseline | Capability tables, delegated rights checks, endpoint IPC + URPC scaffolding. |
-| Memory management | Partial baseline | PMM/buddy allocator and arch-specific page-table walkers (x86_64/arm64/riscv) exist for map/unmap/query; robust page-fault resolution and user-space pager flow remain deferred. |
+| Memory management | Partial baseline | PMM/buddy allocator and software mapping registry are in place; production-grade hardware page-table lifecycle, SMP-safe TLB discipline, demand paging/COW, NUMA policy, and DMA/IOMMU mapping lifecycle remain in progress. |
 | Scheduler and AI hook points | Implemented baseline | Timer-driven scheduler path with bounded AI suggestion ingestion/processing; full SMP runqueues/context switching remain deferred. |
 | Driver and HAL model | Implemented baseline | HAL contracts and driver framework scaffolding exist across x86_64, riscv64, arm64. |
 | Distributed/multikernel scale-out | Early baseline | Per-core URPC matrix and multicore bootstrap hooks exist; production-grade topology and transport tuning are deferred. |
 
-For architecture-level details and deferred boundaries, see `docs/architecture/` and ADRs in `docs/decisions/`.
+For architecture-level details and deferred boundaries, see `docs/architecture/` and ADRs in `docs/decisions/`. For the step-by-step closure plan, see `docs/architecture/memory-gap-closure-plan.md`.
 
 ## Device Profiles & Use-cases
 

--- a/docs/architecture/memory-gap-closure-plan.md
+++ b/docs/architecture/memory-gap-closure-plan.md
@@ -1,0 +1,175 @@
+# Memory Gap Closure Plan (PMM → VM → MMU → Pager → DMA)
+
+This document converts the current memory-management gap assessment into an implementation backlog that can be executed incrementally.
+
+## 1) Current-state rewrite (authoritative)
+
+## Implementation progress snapshot
+
+- ✅ Phase 0 (API surface bootstrap) started: memory and HAL contract headers landed under `kernel/include/mm/` and `kernel/include/hal/` to provide stable interfaces for PMM/VM object/aspace/fault/DMA and page-table/TLB/IOMMU work.
+
+Bharat-OS has a credible baseline for physical memory management (PMM/buddy allocator) and software-visible mapping bookkeeping (VMM registry). However, a production-grade, architecture-complete virtual memory stack is still in progress:
+
+- hardware page-table lifecycle and permission correctness are not fully mature across all targets,
+- SMP-safe TLB invalidation discipline is incomplete,
+- demand paging, COW, and pager integration are partial/deferred,
+- NUMA/topology policy is early,
+- DMA/IOMMU-aware mapping lifecycle is not yet end-to-end.
+
+## 2) Layered target architecture (must keep boundaries strict)
+
+To avoid coupling and architecture leakage, implement and enforce these layers:
+
+1. **PMM layer** (`pmm/`): frame discovery, zones, buddy/contiguous alloc, refcounts, pinned/reserved classes.
+2. **VM Object layer** (`vm/objects/`): anonymous/file/shared/device/DMA objects + COW semantics.
+3. **Address-space layer** (`vm/aspace/`): region reservations, overlap checks, attach/detach object mappings.
+4. **Hardware page-table layer** (`hal/mmu/arch/*`): map/unmap/protect/query + page-table page lifecycle + TLB rules.
+5. **Fault/Pager layer** (`vm/fault/`): lazy allocation, COW break, stack growth, page-in/out policy.
+6. **DMA/IOMMU layer** (`dma/`, `iommu/`): pinning, IOVA domains, cache sync, device-visible mappings.
+
+## 3) Profile guarantees (explicit, non-negotiable)
+
+Define and enforce profile-specific guarantees in build/config and docs:
+
+- `PROFILE_MMU_FULL`: full VM + demand paging + COW + shared memory + pager hooks.
+- `PROFILE_MMU_LITE`: static/eager mappings with limited isolation and no mandatory demand paging.
+- `PROFILE_MPU_ONLY`: region isolation semantics only; no sparse paged VM promises.
+
+> Rule: MPU-only and MMU paths must not share fake "compatibility" semantics.
+
+## 4) Cross-architecture acceptance criteria
+
+Every architecture backend (`x86_64`, `arm64`, `riscv64`) must satisfy:
+
+- create/destroy address-space root,
+- map/unmap/protect/query range,
+- encode permissions and cache attributes correctly,
+- local + remote TLB invalidation contract,
+- kernel/user split invariants,
+- page-table teardown with no leaks.
+
+### x86_64 specifics
+
+- 4-level required, 5-level abstraction-ready.
+- 4 KiB + 2 MiB mappings required, 1 GiB optional.
+- NX/U/S/W/Global/PAT handling and PCID-aware switching.
+
+### arm64 specifics
+
+- stage-1 descriptor correctness for configured VA/granule.
+- MAIR + shareability + device memory attributes.
+- break-before-make remap path.
+- ASID-aware context switching.
+
+### riscv64 specifics
+
+- Sv39 required, Sv48 abstraction-ready.
+- V/R/W/X/U/G/A/D handling with hardware capability checks.
+- `satp` switching + `sfence.vma` local/remote discipline.
+
+## 5) Implementation backlog (execute in order)
+
+## Phase 0 — Contract and layout cleanup
+
+- [ ] Create/normalize directory boundaries: `pmm/`, `vm/objects/`, `vm/aspace/`, `vm/fault/`, `dma/`, `iommu/`, `hal/mmu/`.
+- [x] Add public headers:
+  - [ ] `include/mm/pmm.h`
+  - [ ] `include/mm/vm_object.h`
+  - [ ] `include/mm/aspace.h`
+  - [ ] `include/mm/fault.h`
+  - [ ] `include/mm/dma.h`
+  - [ ] `include/hal/hal_pt.h`
+  - [ ] `include/hal/hal_tlb.h`
+  - [ ] `include/hal/hal_iommu.h`
+- [ ] Define stable API contracts and ownership rules between layers.
+
+## Phase 1 — PMM hardening
+
+- [ ] Normalize firmware/bootloader memory map ingestion.
+- [ ] Add page metadata (`page_frame_t`) with refcount, flags, owner class.
+- [ ] Add DMA-capable zones and low-memory constraints.
+- [ ] Add contiguous allocation + pin/unpin hooks.
+- [ ] Add optional NUMA node tagging in metadata.
+- [ ] Add PMM invariants tests (allocation/free/refcount/leak checks).
+
+## Phase 2 — Hardware page-table manager completion
+
+- [ ] Implement architecture-neutral page-table API (`hal_pt_*`).
+- [ ] Complete runtime map/unmap/protect/query flows for each arch.
+- [ ] Implement split/merge support for large pages.
+- [ ] Implement local + remote TLB shootdown APIs (`hal_tlb_*`).
+- [ ] Implement safe teardown path with accounting.
+- [ ] Add arch MMU conformance tests (permissions, faults, teardown).
+
+## Phase 3 — Address spaces and VM objects
+
+- [ ] Introduce `address_space_t` per process/container.
+- [ ] Implement region tree/interval map with overlap protection.
+- [ ] Introduce `vm_object_t` kinds: anon/shared/file/device/dma.
+- [ ] Add region attach/detach and inheritance semantics.
+- [ ] Wire authoritative VA→region→object lookup path.
+- [ ] Add clone/fork scaffolding for later COW.
+
+## Phase 4 — Fault engine and demand paging
+
+- [ ] Implement fault decoder: not-present vs permission vs access type.
+- [ ] Implement zero-fill-on-demand for anonymous objects.
+- [ ] Implement COW break path and write-fault handling.
+- [ ] Implement bounded stack growth policy.
+- [ ] Add pager callback contract for file/pager-backed objects.
+- [ ] Define recover/kill/escalation policy per profile.
+
+## Phase 5 — NUMA and topology policies (Tier B/C)
+
+- [ ] Add node/domain abstraction and topology discovery hooks.
+- [ ] Add allocation policies: local-preferred/interleave/bind/fallback.
+- [ ] Add scheduler↔memory affinity hints.
+- [ ] Add migration hooks and huge-page node policy.
+- [ ] Add observability metrics for locality and remote-access cost.
+
+## Phase 6 — DMA/IOMMU memory lifecycle
+
+- [ ] Implement `dma_buffer_object` + pin budget accounting.
+- [ ] Add coherent vs streaming DMA APIs.
+- [ ] Add IOVA allocator and per-device domain model.
+- [ ] Add cache maintenance/sync primitives.
+- [ ] Add backend stubs/contracts for VT-d, SMMU, RISC-V platform variants.
+- [ ] Add bounce-buffer fallback for low-end/non-IOMMU profiles.
+
+## 6) Task slicing (recommended issue sequence)
+
+Use this sequence so each item is independently reviewable and testable:
+
+1. **MM contracts and header skeletons**
+2. **PMM metadata + refcounting**
+3. **PMM DMA zones + contiguous alloc**
+4. **Common `hal_pt` interface + x86_64 mapping parity**
+5. **arm64 descriptor/attribute parity + BBM flow**
+6. **riscv64 Sv39 parity + `sfence.vma` discipline**
+7. **`address_space_t` and region tree**
+8. **`vm_object_t` (anon/shared/file/device/dma) base ops**
+9. **Fault decode + demand-zero**
+10. **COW and fork cloning**
+11. **Pager/file-backed object path**
+12. **TLB shootdown SMP stress tests**
+13. **NUMA policy framework + metrics**
+14. **DMA buffer lifecycle + IOMMU domain abstraction**
+
+## 7) Definition of done (DoD)
+
+A memory subsystem milestone is complete only if all are true:
+
+- [ ] API contract documented and merged.
+- [ ] Unit/integration tests added and green in CI for applicable targets.
+- [ ] No mapping/refcount leaks under stress tests.
+- [ ] Fault behavior is deterministic and profile-compliant.
+- [ ] Architecture notes updated (`x86_64`, `arm64`, `riscv64`, `mpu-only`).
+- [ ] Observability added (counters/traces for map/unmap/fault/TLB shootdown).
+
+## 8) Immediate next 3 tasks (start now)
+
+1. Land memory-layer public headers + ownership contracts.
+2. Land PMM page metadata with refcount + DMA zone tagging.
+3. Land architecture-neutral `hal_pt` interface and x86_64 conformance first.
+
+These three unblock all later VM-object, fault, and pager work.

--- a/kernel/include/hal/hal_iommu.h
+++ b/kernel/include/hal/hal_iommu.h
@@ -1,0 +1,36 @@
+#ifndef BHARAT_HAL_HAL_IOMMU_H
+#define BHARAT_HAL_HAL_IOMMU_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    uint64_t domain_id;
+    uint32_t flags;
+} hal_iommu_domain_desc_t;
+
+int hal_iommu_domain_create(const hal_iommu_domain_desc_t *desc, void **out_domain);
+int hal_iommu_domain_destroy(void *domain);
+
+int hal_iommu_attach_device(void *domain, uint64_t device_id);
+int hal_iommu_detach_device(void *domain, uint64_t device_id);
+
+int hal_iommu_map_iova(void *domain,
+                       uint64_t iova,
+                       uint64_t phys,
+                       size_t length,
+                       uint64_t prot_flags);
+
+int hal_iommu_unmap_iova(void *domain,
+                         uint64_t iova,
+                         size_t length);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // BHARAT_HAL_HAL_IOMMU_H

--- a/kernel/include/hal/hal_pt.h
+++ b/kernel/include/hal/hal_pt.h
@@ -1,0 +1,63 @@
+#ifndef BHARAT_HAL_HAL_PT_H
+#define BHARAT_HAL_HAL_PT_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    uint32_t read       : 1;
+    uint32_t write      : 1;
+    uint32_t exec       : 1;
+    uint32_t user       : 1;
+    uint32_t global     : 1;
+    uint32_t device     : 1;
+    uint32_t uncached   : 1;
+    uint32_t huge       : 1;
+    uint32_t cow        : 1;
+    uint32_t shareable  : 1;
+    uint32_t reserved   : 22;
+} hal_pt_perms_t;
+
+typedef struct {
+    uint64_t phys_addr;
+    hal_pt_perms_t perms;
+    uint64_t page_size;
+} hal_pt_mapping_t;
+
+typedef struct {
+    uint64_t root;
+    uint16_t asid;
+} hal_pt_aspace_t;
+
+int hal_pt_aspace_create(hal_pt_aspace_t *out_aspace);
+int hal_pt_aspace_destroy(const hal_pt_aspace_t *aspace);
+int hal_pt_aspace_activate(const hal_pt_aspace_t *aspace);
+
+int hal_pt_map(const hal_pt_aspace_t *aspace,
+               uint64_t virt_addr,
+               uint64_t phys_addr,
+               uint64_t length,
+               hal_pt_perms_t perms);
+
+int hal_pt_unmap(const hal_pt_aspace_t *aspace,
+                 uint64_t virt_addr,
+                 uint64_t length);
+
+int hal_pt_protect(const hal_pt_aspace_t *aspace,
+                   uint64_t virt_addr,
+                   uint64_t length,
+                   hal_pt_perms_t perms);
+
+int hal_pt_query(const hal_pt_aspace_t *aspace,
+                 uint64_t virt_addr,
+                 hal_pt_mapping_t *out_mapping);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // BHARAT_HAL_HAL_PT_H

--- a/kernel/include/hal/hal_tlb.h
+++ b/kernel/include/hal/hal_tlb.h
@@ -1,0 +1,20 @@
+#ifndef BHARAT_HAL_HAL_TLB_H
+#define BHARAT_HAL_HAL_TLB_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int hal_tlb_invalidate_page_local(uint64_t virt_addr);
+int hal_tlb_invalidate_range_local(uint64_t virt_addr, uint64_t length);
+int hal_tlb_invalidate_asid_local(uint16_t asid);
+int hal_tlb_invalidate_global(void);
+int hal_tlb_shootdown_remote(uint64_t virt_addr, uint64_t length, uint16_t asid);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // BHARAT_HAL_HAL_TLB_H

--- a/kernel/include/mm/aspace.h
+++ b/kernel/include/mm/aspace.h
@@ -1,0 +1,37 @@
+#ifndef BHARAT_MM_ASPACE_H
+#define BHARAT_MM_ASPACE_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "vm_object.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct vm_address_space vm_address_space_t;
+
+typedef struct {
+    uint64_t base;
+    uint64_t length;
+    uint32_t prot;
+    uint32_t map_flags;
+    vm_object_t *object;
+    uint64_t object_offset;
+} vm_region_desc_t;
+
+int aspace_create(vm_address_space_t **out_aspace);
+int aspace_destroy(vm_address_space_t *aspace);
+
+int aspace_map_region(vm_address_space_t *aspace, const vm_region_desc_t *desc);
+int aspace_unmap_region(vm_address_space_t *aspace, uint64_t base, uint64_t length);
+int aspace_protect_region(vm_address_space_t *aspace, uint64_t base, uint64_t length, uint32_t new_prot);
+
+int aspace_find_region(vm_address_space_t *aspace, uint64_t vaddr, vm_region_desc_t *out_desc);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // BHARAT_MM_ASPACE_H

--- a/kernel/include/mm/dma.h
+++ b/kernel/include/mm/dma.h
@@ -1,0 +1,41 @@
+#ifndef BHARAT_MM_DMA_H
+#define BHARAT_MM_DMA_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    DMA_MAP_TO_DEVICE = 0,
+    DMA_MAP_FROM_DEVICE,
+    DMA_MAP_BIDIRECTIONAL,
+} dma_direction_t;
+
+typedef enum {
+    DMA_ALLOC_NONE      = 0u,
+    DMA_ALLOC_COHERENT  = 1u << 0,
+    DMA_ALLOC_DMA32     = 1u << 1,
+    DMA_ALLOC_ZERO      = 1u << 2,
+} dma_alloc_flags_t;
+
+typedef struct {
+    void *cpu_addr;
+    uint64_t phys_addr;
+    uint64_t iova;
+    size_t size;
+    uint32_t flags;
+} dma_buffer_t;
+
+int dma_buffer_alloc(size_t size, uint32_t flags, dma_buffer_t *out);
+int dma_buffer_free(dma_buffer_t *buffer);
+int dma_buffer_map_device(uint64_t device_id, dma_buffer_t *buffer, dma_direction_t dir);
+int dma_buffer_unmap_device(uint64_t device_id, dma_buffer_t *buffer, dma_direction_t dir);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // BHARAT_MM_DMA_H

--- a/kernel/include/mm/fault.h
+++ b/kernel/include/mm/fault.h
@@ -1,0 +1,39 @@
+#ifndef BHARAT_MM_FAULT_H
+#define BHARAT_MM_FAULT_H
+
+#include <stdint.h>
+
+#include "aspace.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    VM_FAULT_READ = 1u << 0,
+    VM_FAULT_WRITE = 1u << 1,
+    VM_FAULT_EXEC = 1u << 2,
+    VM_FAULT_USER = 1u << 3,
+} vm_fault_access_t;
+
+typedef enum {
+    VM_FAULT_RESOLVED = 0,
+    VM_FAULT_RETRY = 1,
+    VM_FAULT_KILL = 2,
+    VM_FAULT_PANIC = 3,
+} vm_fault_result_t;
+
+typedef struct {
+    vm_address_space_t *aspace;
+    uint64_t fault_addr;
+    uint32_t access;
+    uint32_t arch_code;
+} vm_fault_event_t;
+
+vm_fault_result_t vm_handle_fault(const vm_fault_event_t *event);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // BHARAT_MM_FAULT_H

--- a/kernel/include/mm/pmm.h
+++ b/kernel/include/mm/pmm.h
@@ -1,0 +1,44 @@
+#ifndef BHARAT_MM_PMM_H
+#define BHARAT_MM_PMM_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    PMM_ZONE_ANY = 0,
+    PMM_ZONE_DMA32,
+    PMM_ZONE_NORMAL,
+    PMM_ZONE_HIGHMEM,
+} pmm_zone_t;
+
+typedef enum {
+    PMM_ALLOC_NONE       = 0u,
+    PMM_ALLOC_ZERO       = 1u << 0,
+    PMM_ALLOC_CONTIGUOUS = 1u << 1,
+    PMM_ALLOC_PINNED     = 1u << 2,
+} pmm_alloc_flags_t;
+
+typedef struct {
+    uint64_t phys_addr;
+    uint32_t order;
+    uint32_t flags;
+} pmm_block_t;
+
+int pmm_alloc_pages(uint32_t order,
+                    pmm_zone_t zone,
+                    uint32_t alloc_flags,
+                    pmm_block_t *out_block);
+
+int pmm_free_pages(const pmm_block_t *block);
+int pmm_ref_get(uint64_t phys_addr);
+int pmm_ref_put(uint64_t phys_addr);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // BHARAT_MM_PMM_H

--- a/kernel/include/mm/vm_object.h
+++ b/kernel/include/mm/vm_object.h
@@ -1,0 +1,50 @@
+#ifndef BHARAT_MM_VM_OBJECT_H
+#define BHARAT_MM_VM_OBJECT_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    VM_OBJECT_ANON = 0,
+    VM_OBJECT_SHARED_ANON,
+    VM_OBJECT_FILE,
+    VM_OBJECT_DEVICE,
+    VM_OBJECT_DMA,
+} vm_object_kind_t;
+
+typedef struct vm_object vm_object_t;
+
+typedef struct {
+    uint64_t page_offset;
+    uint64_t fault_addr;
+    uint32_t access;
+    uint32_t fault_flags;
+} vm_fault_ctx_t;
+
+typedef struct {
+    int (*fault)(vm_object_t *obj, const vm_fault_ctx_t *ctx, uint64_t *out_phys_page);
+    int (*writeback)(vm_object_t *obj, uint64_t page_offset);
+    void (*release)(vm_object_t *obj);
+} vm_object_ops_t;
+
+struct vm_object {
+    vm_object_kind_t kind;
+    uint64_t size_bytes;
+    uint32_t object_flags;
+    uint32_t refcount;
+    const vm_object_ops_t *ops;
+    void *backend;
+};
+
+int vm_object_ref(vm_object_t *obj);
+int vm_object_unref(vm_object_t *obj);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // BHARAT_MM_VM_OBJECT_H


### PR DESCRIPTION
### Motivation

- Establish a clear public API and HAL contract surface for the memory subsystem to enable incremental implementation across PMM, VM objects, address spaces, page-table/TLB, pager, and DMA/IOMMU layers.
- Provide an executable backlog and acceptance criteria to close the current VM/MMU gaps across architectures and profiles.

### Description

- Add a new roadmap document `docs/architecture/memory-gap-closure-plan.md` that defines phases, layered boundaries, per-architecture criteria, backlog, and definition-of-done.
- Update `README.md` to clarify the memory management status and add a link to the new closure plan document.
- Introduce HAL interfaces for page-tables, TLB, and IOMMU via `kernel/include/hal/hal_pt.h`, `kernel/include/hal/hal_tlb.h`, and `kernel/include/hal/hal_iommu.h` to standardize map/unmap/protect/query, TLB invalidation/shootdown, and IOMMU domain/device mapping operations.
- Add memory-management public headers `kernel/include/mm/pmm.h`, `kernel/include/mm/vm_object.h`, `kernel/include/mm/aspace.h`, `kernel/include/mm/dma.h`, and `kernel/include/mm/fault.h` to define PMM zones/alloc APIs, VM object and fault contracts, address-space region APIs, DMA buffer lifecycle, and fault handling enums.

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b541fa68e0832081dce4a8ca99ebf4)