### PR TITLE
build: Support uniquely named dynamic build artifact folders

### DIFF
--- a/tools/build.ps1
+++ b/tools/build.ps1
@@ -26,7 +26,9 @@ param(
     [string]$Machine = "",
     [ValidateSet("ON", "OFF")][string]$BootGui = "ON",
     [string]$HardwareProfile = "",
-    [string]$BootTier = ""
+    [string]$BootTier = "",
+    [string]$Profile = "desktop",
+    [string]$Personality = "none"
 )
 
 Set-StrictMode -Version Latest
@@ -68,9 +70,16 @@ if ($Machine -eq "") { $Machine = "virt" }
 if ($HardwareProfile -eq "") { $HardwareProfile = "generic" }
 if ($BootTier -eq "") { $BootTier = "LINUX_LIKE" }
 
-$BuildDir = "$Root\build\$Arch"
+$ProfileClean = $Profile -replace ',', '-'
+$PersonalityClean = $Personality -replace ',', '-'
+
+$BuildDir = "$Root\build\${Arch}_${ProfileClean}_${HardwareProfile}_${PersonalityClean}"
+if ($Board -ne "") {
+    $BuildDir = "${BuildDir}_${Board}"
+}
+
 if ($Payload -and $Arch -eq "riscv64") {
-    $BuildDir = "$Root\build\$Arch-gcc"
+    $BuildDir = "$BuildDir-gcc"
 }
 
 $OutELF = "$BuildDir\kernel\kernel.elf"
@@ -143,6 +152,23 @@ if (-not (Test-Path "$BuildDir\CMakeCache.txt")) {
         "-G", "Ninja",
         "--no-warn-unused-cli"
     )
+
+    if ($Profile -ne "") {
+        $Profiles = $Profile.Split(',')
+        foreach ($p in $Profiles) {
+            $pUpper = $p.ToUpper()
+            $cmakeArgs += "-DBHARAT_PROFILE_$pUpper=1"
+        }
+    }
+
+    if ($Personality -ne "") {
+        $Personalities = $Personality.Split(',')
+        foreach ($p in $Personalities) {
+            $pUpper = $p.ToUpper()
+            $cmakeArgs += "-DBHARAT_PERSONALITY_$pUpper=1"
+        }
+    }
+
     & cmake @cmakeArgs
     if ($LASTEXITCODE -ne 0) { fail "CMake configure failed" }
 }

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -15,6 +15,8 @@ BOOT_GUI=""
 BOOT_HW="generic"
 MACHINE=""
 BOOT_TIER=""
+PROFILE="desktop"
+PERSONALITY="none"
 
 # Parse arguments
 for arg in "$@"; do
@@ -31,6 +33,8 @@ for arg in "$@"; do
         --hw=*) BOOT_HW="${arg#*=}" ;;
         --machine=*) MACHINE="${arg#*=}" ;;
         --tier=*) BOOT_TIER="${arg#*=}" ;;
+        --profile=*) PROFILE="${arg#*=}" ;;
+        --personality=*) PERSONALITY="${arg#*=}" ;;
         *)
             # If no equal sign, assume first argument is ARCH for backwards compatibility
             if [[ ! "$arg" == --* ]] && [[ -z "$ARCH_SET" ]]; then
@@ -41,7 +45,13 @@ for arg in "$@"; do
     esac
 done
 
-BUILD_DIR="build/${ARCH}"
+PROFILE_CLEAN="${PROFILE//,/-}"
+PERSONALITY_CLEAN="${PERSONALITY//,/-}"
+
+BUILD_DIR="build/${ARCH}_${PROFILE_CLEAN}_${BOOT_HW}_${PERSONALITY_CLEAN}"
+if [ -n "$BOARD" ]; then
+    BUILD_DIR="${BUILD_DIR}_${BOARD}"
+fi
 
 if [ "$CLEAN" = true ]; then
     echo "Cleaning build directory: ${BUILD_DIR}"
@@ -49,6 +59,18 @@ if [ "$CLEAN" = true ]; then
 fi
 
 CMAKE_ARGS=""
+
+IFS=',' read -ra PROFILE_ARR <<< "$PROFILE"
+for prof in "${PROFILE_ARR[@]}"; do
+    prof_upper=$(echo "$prof" | tr '[:lower:]' '[:upper:]')
+    CMAKE_ARGS="${CMAKE_ARGS} -DBHARAT_PROFILE_${prof_upper}=1"
+done
+
+IFS=',' read -ra PERSONALITY_ARR <<< "$PERSONALITY"
+for pers in "${PERSONALITY_ARR[@]}"; do
+    pers_upper=$(echo "$pers" | tr '[:lower:]' '[:upper:]')
+    CMAKE_ARGS="${CMAKE_ARGS} -DBHARAT_PERSONALITY_${pers_upper}=1"
+done
 
 if [ -n "$BOARD" ]; then
     # Map boards to appropriate profiles


### PR DESCRIPTION
Implemented dynamic, uniquely named build directories across `build.ps1` and `build.sh` based on the specified parameters (`ARCH`, `PROFILE`, `BOOT_HW`, `PERSONALITY`, and `BOARD`) to ensure compilation artifacts do not collide. Supports comma-separated strings for multikernel profiles.

---
*PR created automatically by Jules for task [999933509061523148](https://jules.google.com/task/999933509061523148) started by @divyang4481*