### PR TITLE
Implement architectural gaps in VMM, IOMMU, Scheduler, and Timers

### DIFF
--- a/kernel/include/mm.h
+++ b/kernel/include/mm.h
@@ -115,6 +115,8 @@ int vmm_map_device_mmio_token(virt_addr_t vaddr, phys_addr_t paddr,
 // Create a new empty hardware address space
 address_space_t *mm_create_address_space(void);
 
+void vmm_process_urpc_messages(void);
+
 #endif // BHARAT_MM_H
 
 void tlb_shootdown(virt_addr_t vaddr);

--- a/kernel/src/arch/arm64/context_switch.S
+++ b/kernel/src/arch/arm64/context_switch.S
@@ -50,6 +50,9 @@ arch_context_switch:
     ldr x29,      [x1, #80]
 
     // Call arch_post_switch to release runqueue lock
+    // It is called after switching the stack and basic state,
+    // but before executing user code or returning to the thread's execution path.
+    // Preserve x0, x1 as they might be used by the caller
     stp x0, x1, [sp, #-16]!
     stp x29, x30, [sp, #-16]!
     mov x29, sp

--- a/kernel/src/arch/riscv64/context_switch.S
+++ b/kernel/src/arch/riscv64/context_switch.S
@@ -91,15 +91,18 @@ arch_context_switch:
     ld s11, 88(a1)   # regs[11]
 
     # Call post switch hook to release runqueue lock
-    # We must preserve a0 and a1. Also need to ensure sp is 16-byte aligned.
-    # It should be 16-byte aligned already by C convention, but we'll just push them safely.
-    addi sp, sp, -16
+    # It is called after restoring the state, before returning.
+    # Ensure sp is 16-byte aligned, preserve ra (which is currently correct).
+    # Preserve a0, a1 as they might be used by the caller.
+    addi sp, sp, -32
     sd a0, 0(sp)
     sd a1, 8(sp)
+    sd ra, 16(sp)
     call arch_post_switch
+    ld ra, 16(sp)
     ld a1, 8(sp)
     ld a0, 0(sp)
-    addi sp, sp, 16
+    addi sp, sp, 32
 
     # Return
     ret

--- a/kernel/src/arch/x86_64/context_switch.S
+++ b/kernel/src/arch/x86_64/context_switch.S
@@ -74,24 +74,21 @@ arch_context_switch:
     movq 32(%rsi), %r14
     movq 40(%rsi), %r15
 
-    # Release runqueue lock if necessary here (we'll implement this via a call hook)
-    pushq %rdi
+    # Release runqueue lock if necessary here via post-switch hook
+    # Note: `arch_post_switch` shouldn't take arguments, but we preserve registers just in case.
+    # Align stack before C function call (SysV ABI requires 16-byte alignment before 'call')
+    # Save volatile registers that we need after the call (like %rsi)
     pushq %rsi
-    # Align stack before C function call
-    # SysV ABI: %rsp must be 16-byte aligned *before* the call instruction.
-    movq %rsp, %rax
-    andq $0xFFFFFFFFFFFFFFF0, %rsp
-    # The stack is now 16-byte aligned. But if we push %rax, it becomes 8-byte aligned again.
-    # We must push %rax (8 bytes) and then subtract 8 bytes to maintain 16-byte alignment before 'call'.
-    pushq %rax
-    subq $8, %rsp
+    pushq %rbx                # Save %rbx on the stack so we don't clobber the context's saved value
+    movq %rsp, %rbx           # Temporarily save unaligned rsp
+    andq $-16, %rsp           # Align to 16 bytes
+    # The 'call' instruction pushes 8 bytes (RIP), so the stack will be (rsp % 16 == 8) on entry
+    # to the C function, which complies exactly with the System V AMD64 ABI.
     call arch_post_switch
-    addq $8, %rsp
-    popq %rax
-    movq %rax, %rsp
+    movq %rbx, %rsp           # Restore stack pointer to where the return address is
+    popq %rbx                 # Restore the true %rbx
     popq %rsi
-    popq %rdi
 
-    # Pop the return address into rax to maintain stack alignment, then jmp to it.
+    # Pop the return address into rax, then jmp to it.
     popq %rax
     jmp *%rax

--- a/kernel/src/hal/arm64/smmu.c
+++ b/kernel/src/hal/arm64/smmu.c
@@ -1,9 +1,21 @@
 #include "hal/iommu.h"
 #include <stddef.h>
 
-// Mock SMMU v2/v3 operations
+#include "hal/hal.h"
+#include "profile.h"
+
+static bool smmu_found = false;
+
+// SMMU v2/v3 operations
 static int smmu_init(void) {
-    // Locate via FDT
+    // Locate via FDT/ACPI IORT
+    // Stub: Parse FDT for "arm,smmu-v3" or "arm,mmu-500"
+    smmu_found = true; // Assume found for now
+
+    if (!smmu_found) {
+        // Degrade to no-IOMMU
+        return -1;
+    }
     return 0;
 }
 
@@ -69,6 +81,11 @@ static hal_iommu_ops_t smmu_ops = {
 };
 
 void arm64_iommu_detect(void) {
-    // Real implementation checks FDT for smmu.
-    hal_iommu_register_ops(&smmu_ops);
+    // IOMMU backends must be discovered via firmware/board descriptors (FDT/ACPI)
+    // rather than ad-hoc probing.
+    if (smmu_init() == 0) {
+        hal_iommu_register_ops(&smmu_ops);
+    } else {
+        // Policy-driven degradation handled by isolation layer
+    }
 }

--- a/kernel/src/hal/arm64/timer_generic.c
+++ b/kernel/src/hal/arm64/timer_generic.c
@@ -15,34 +15,45 @@ static inline void write_cntp_ctl(uint32_t val) {
     __asm__ volatile("msr cntp_ctl_el0, %0" : : "r" (val));
 }
 
-int hal_timer_init(uint32_t tick_hz) {
+void hal_timer_init(void) {
     // Generic timer is always on, frequency in CNTFRQ_EL0
-    return 0;
 }
 
-int hal_timer_init_cpu_local(uint32_t tick_hz) {
+void hal_timer_init_cpu_local(uint32_t cpu_id) {
+    (void)cpu_id;
     // Enable timer, unmask interrupt
     write_cntp_ctl(1);
-    return 0;
 }
 
-int hal_timer_set_periodic(uint32_t tick_hz) {
-    // We prefer one-shot, but for periodic we'd read frq and div
+void hal_timer_program_periodic(uint64_t ns) {
     uint64_t frq;
     __asm__ volatile("mrs %0, cntfrq_el0" : "=r" (frq));
-    write_cntp_tval(frq / tick_hz);
-    return 0;
+    uint32_t ticks = (uint32_t)((frq * ns) / 1000000000ULL);
+    write_cntp_tval(ticks);
 }
 
-int hal_timer_set_oneshot(uint64_t ns_delay) {
+void hal_timer_program_oneshot(uint64_t ns) {
     uint64_t frq;
     __asm__ volatile("mrs %0, cntfrq_el0" : "=r" (frq));
     // Calculate ticks from ns delay
-    uint32_t ticks = (frq / 1000000000) * ns_delay;
+    uint32_t ticks = (uint32_t)((frq * ns) / 1000000000ULL);
     write_cntp_tval(ticks);
-    return 0;
+}
+
+uint64_t hal_timer_read_counter(void) {
+    return read_cntpct();
+}
+
+uint64_t hal_timer_read_freq(void) {
+    uint64_t frq;
+    __asm__ volatile("mrs %0, cntfrq_el0" : "=r" (frq));
+    return frq;
 }
 
 uint64_t hal_timer_monotonic_ticks(void) {
     return read_cntpct();
+}
+
+bool hal_timer_is_per_cpu(void) {
+    return true; // ARM Generic Timer is per-core
 }

--- a/kernel/src/hal/riscv/iopmp.c
+++ b/kernel/src/hal/riscv/iopmp.c
@@ -1,9 +1,21 @@
 #include "hal/iommu.h"
 #include <stddef.h>
 
-// Mock IOPMP / RISC-V IOMMU operations
+#include "hal/hal.h"
+#include "profile.h"
+
+static bool iopmp_found = false;
+
+// IOPMP / RISC-V IOMMU operations
 static int iopmp_init(void) {
     // Locate via FDT/BSP
+    // Stub: Parse FDT for "riscv,iopmp" or similar
+    iopmp_found = true; // Assume found
+
+    if (!iopmp_found) {
+        // Degrade to no-IOMMU
+        return -1;
+    }
     return 0;
 }
 
@@ -69,6 +81,11 @@ static hal_iommu_ops_t iopmp_ops = {
 };
 
 void riscv_iommu_detect(void) {
-    // Real implementation checks FDT for iopmp.
-    hal_iommu_register_ops(&iopmp_ops);
+    // IOMMU backends must be discovered via firmware/board descriptors (FDT)
+    // rather than ad-hoc probing.
+    if (iopmp_init() == 0) {
+        hal_iommu_register_ops(&iopmp_ops);
+    } else {
+        // Policy-driven degradation handled by isolation layer
+    }
 }

--- a/kernel/src/hal/riscv/sbi_timer_ipi.c
+++ b/kernel/src/hal/riscv/sbi_timer_ipi.c
@@ -23,21 +23,21 @@ void hal_timer_init_cpu_local(uint32_t cpu_id) {
 
 void hal_timer_program_periodic(uint64_t ns) {
     uint64_t current_time;
-    __asm__ volatile("csrr %0, time" : "=r"(current_time));
+    __asm__ volatile("rdtime %0" : "=r"(current_time));
     uint64_t ticks = (g_timer_timebase_freq * ns) / 1000000000ULL;
     sbi_set_timer(current_time + ticks);
 }
 
 void hal_timer_program_oneshot(uint64_t ns) {
     uint64_t current_time;
-    __asm__ volatile("csrr %0, time" : "=r"(current_time));
+    __asm__ volatile("rdtime %0" : "=r"(current_time));
     uint64_t ticks = (g_timer_timebase_freq * ns) / 1000000000ULL;
     sbi_set_timer(current_time + ticks);
 }
 
 uint64_t hal_timer_read_counter(void) {
     uint64_t current_time;
-    __asm__ volatile("csrr %0, time" : "=r"(current_time));
+    __asm__ volatile("rdtime %0" : "=r"(current_time));
     return current_time;
 }
 

--- a/kernel/src/hal/riscv64/timer_sbi.c
+++ b/kernel/src/hal/riscv64/timer_sbi.c
@@ -37,31 +37,43 @@ static inline uint64_t read_time(void) {
     return time;
 }
 
-int hal_timer_init(uint32_t tick_hz) {
+void hal_timer_init(void) {
     // Rely on mtime CSR provided by the platform
-    return 0;
 }
 
-int hal_timer_init_cpu_local(uint32_t tick_hz) {
-    // Read current time, add frequency/hz and schedule
-    // We assume an explicit set_periodic or set_oneshot will do it
-    return 0;
+void hal_timer_init_cpu_local(uint32_t cpu_id) {
+    (void)cpu_id;
+    // Enable STIE (Supervisor Timer Interrupt Enable) in sie
+    __asm__ volatile("csrs sie, %0" : : "r"(32)); // STIE is bit 5
 }
 
-int hal_timer_set_periodic(uint32_t tick_hz) {
-    // In multikernel, we emulate periodic with recurring oneshots
-    uint64_t next_tick = read_time() + (10000000 / tick_hz); // Assuming 10MHz timebase
+void hal_timer_program_periodic(uint64_t ns) {
+    // Emulate periodic with recurring oneshots
+    // Assuming 10MHz timebase (typical for QEMU/RISC-V)
+    uint64_t ticks = (10000000ULL * ns) / 1000000000ULL;
+    uint64_t next_tick = read_time() + ticks;
     sbi_ecall(SBI_EXT_TIME, SBI_EXT_TIME_SET_TIMER, next_tick, 0, 0, 0, 0, 0);
-    return 0;
 }
 
-int hal_timer_set_oneshot(uint64_t ns_delay) {
+void hal_timer_program_oneshot(uint64_t ns) {
     // Calculate ticks based on timebase
-    uint64_t next_tick = read_time() + (ns_delay / 100);
+    uint64_t ticks = (10000000ULL * ns) / 1000000000ULL;
+    uint64_t next_tick = read_time() + ticks;
     sbi_ecall(SBI_EXT_TIME, SBI_EXT_TIME_SET_TIMER, next_tick, 0, 0, 0, 0, 0);
-    return 0;
+}
+
+uint64_t hal_timer_read_counter(void) {
+    return read_time();
+}
+
+uint64_t hal_timer_read_freq(void) {
+    return 10000000ULL; // Return 10MHz assuming generic RISC-V timebase
 }
 
 uint64_t hal_timer_monotonic_ticks(void) {
     return read_time();
+}
+
+bool hal_timer_is_per_cpu(void) {
+    return true; // RISC-V timer (mtimecmp via SBI) is per-hart
 }

--- a/kernel/src/hal/x86_64/vtd_iommu.c
+++ b/kernel/src/hal/x86_64/vtd_iommu.c
@@ -1,10 +1,26 @@
 #include "hal/iommu.h"
 #include <stddef.h>
 
-// A mock basic implementation of VT-d using hal_iommu_ops_t
-// A real implementation would parse DMAR table from ACPI
+#include "hal/hal.h"
+#include "profile.h"
+
+// Basic VT-d discovery via ACPI DMAR parsing stub
+static bool dmar_found = false;
+
 static int vtd_init(void) {
     // Locate DMAR via ACPI
+    // Stub: Check if DMAR table exists in ACPI
+    // In actual implementation, parse the ACPI DMAR table.
+    // If not found, use policy-driven degradation.
+
+    // Simulating ACPI probe
+    dmar_found = true; // Assume found for testing purposes, but check profile
+
+    if (!dmar_found) {
+        // Degrade to no-IOMMU based on profile policy
+        return -1;
+    }
+
     return 0;
 }
 
@@ -71,8 +87,15 @@ static hal_iommu_ops_t vtd_ops = {
 };
 
 void x86_iommu_detect(void) {
-    // Fallback/detection logic: in a real implementation this checks ACPI DMAR.
-    // We register the operations if DMAR is found.
-    // For now we assume found.
-    hal_iommu_register_ops(&vtd_ops);
+    // IOMMU backends must be discovered via firmware/board descriptors (ACPI)
+    // rather than ad-hoc probing.
+    // Simulation: check if ACPI has DMAR
+    if (vtd_init() == 0) {
+        hal_iommu_register_ops(&vtd_ops);
+    } else {
+        // Policy-driven degradation
+        // e.g. blocking untrusted DMA devices in high isolation profiles
+        // allowing trusted-only operation in edge profiles.
+        // Isolation layer handles policy, we just don't register ops.
+    }
 }

--- a/kernel/src/mm/vmm.c
+++ b/kernel/src/mm/vmm.c
@@ -29,8 +29,39 @@ static mmu_flags_t convert_vmm_flags(uint32_t flags) {
     return mmu_flags;
 }
 
+#include "../../include/profile.h"
+#include "../../include/urpc/urpc_bootstrap.h"
+
+#define URPC_MSG_TLB_SHOOTDOWN 0x01
+
+void vmm_process_urpc_messages(void) {
+    uint32_t current_core = hal_cpu_get_id();
+    uint64_t msg;
+
+    // Drain messages
+    while (urpc_recv(current_core, &msg) == 0) {
+        uint64_t type = msg & 0xFFF; // Extract type from bottom 12 bits
+        virt_addr_t vaddr = (virt_addr_t)(msg & ~0xFFFULL); // Recover 4K aligned address
+
+        if (type == URPC_MSG_TLB_SHOOTDOWN) {
+            if (active_mmu && active_mmu->tlb_flush_page) {
+                active_mmu->tlb_flush_page(vaddr);
+            } else {
+                hal_tlb_flush((unsigned long long)vaddr);
+            }
+        }
+    }
+}
+
 int vmm_init(void) {
     arch_mmu_init();
+
+    if (get_memory_model() == MEM_MODEL_MPU || get_memory_model() == MEM_MODEL_FLAT) {
+        // MPU and FLAT memory models do not use traditional VMM page tables.
+        // Return 0 indicating success, but VMM operations will be no-ops or handled
+        // by specific MPU region managers not present in this generic VMM.
+        return 0;
+    }
 
     if (!active_mmu) {
         return -1; // Fallback or unsupported architecture
@@ -46,6 +77,10 @@ int vmm_init(void) {
 }
 
 int mm_vmm_map_page(address_space_t* as, virt_addr_t vaddr, phys_addr_t paddr, uint32_t flags) {
+    if (get_memory_model() != MEM_MODEL_MMU) {
+        return 0; // No-op for MPU/FLAT
+    }
+
     if (!as || as->root_table == 0U || paddr == 0U) {
         return -1;
     }
@@ -73,7 +108,7 @@ int mm_vmm_map_page(address_space_t* as, virt_addr_t vaddr, phys_addr_t paddr, u
     return active_mmu->map(as->root_table, vaddr, paddr, PAGE_SIZE, mmu_flags);
 }
 
-// Global TLB shootdown function
+// Global TLB shootdown function via URPC
 void tlb_shootdown(virt_addr_t vaddr) {
     if (active_mmu && active_mmu->tlb_flush_page) {
         active_mmu->tlb_flush_page(vaddr);
@@ -81,16 +116,28 @@ void tlb_shootdown(virt_addr_t vaddr) {
         hal_tlb_flush((unsigned long long)vaddr);
     }
 
-    // IPI based shootdown for cores executing the same process (or system wide for kernel mappings)
+    // URPC based shootdown
     uint32_t current_core = hal_cpu_get_id();
+    // Pack message type into the bottom 12 bits (assuming vaddr is 4K aligned)
+    uint64_t msg = ((uint64_t)vaddr & ~0xFFFULL) | (URPC_MSG_TLB_SHOOTDOWN & 0xFFF);
+
     for (uint32_t i = 0; i < 8; ++i) { // MAX_SUPPORTED_CORES is 8
-        if (i != current_core) {
-            hal_send_ipi_payload(i, (uint64_t)vaddr);
+        if (i != current_core && urpc_is_ready(i)) {
+            // Attempt to send via URPC; if full, we could fall back to IPI
+            // but the architecture calls for URPC as the primary vehicle.
+            urpc_send(i, msg);
+            // We should also trigger an IPI to notify the remote core that a message
+            // is waiting in its queue, as URPC_send is just a queue primitive.
+            hal_send_ipi_payload(i, 0);
         }
     }
 }
 
 int mm_vmm_unmap_page(address_space_t* as, virt_addr_t vaddr) {
+    if (get_memory_model() != MEM_MODEL_MMU) {
+        return 0; // No-op for MPU/FLAT
+    }
+
     if (!as || as->root_table == 0U) {
         return -1;
     }
@@ -154,6 +201,17 @@ int vmm_map_device_mmio_token(virt_addr_t vaddr, phys_addr_t paddr, uint64_t siz
 }
 
 address_space_t* mm_create_address_space(void) {
+    if (get_memory_model() != MEM_MODEL_MMU) {
+        // For MPU/FLAT return a valid pointer, but no page tables are cloned.
+        address_space_t* as = (address_space_t*)(uintptr_t)mm_alloc_page(NUMA_NODE_ANY);
+        if (as) {
+            as->root_table = 0;
+            as->owner_core_id = hal_cpu_get_id();
+            as->object_id = (uint64_t)(uintptr_t)as;
+        }
+        return as;
+    }
+
     if (!active_mmu) return NULL;
 
     phys_addr_t root = active_mmu->clone_kernel(kernel_space.root_table);
@@ -175,6 +233,10 @@ address_space_t* mm_create_address_space(void) {
 
 // Copy-on-Write Fault Handler
 int vmm_handle_cow_fault(address_space_t* as, virt_addr_t vaddr) {
+    if (get_memory_model() != MEM_MODEL_MMU) {
+        return -1; // MPU/FLAT do not support demand paging / CoW
+    }
+
     if (!as || as->root_table == 0U) return -1;
 
     phys_addr_t old_phys = 0;

--- a/kernel/src/sched.c
+++ b/kernel/src/sched.c
@@ -581,9 +581,16 @@ static void sched_switch_to(kthread_t *next, uint32_t core_id) {
     arch_ext_state_save(current);
   }
 
+    // Process incoming URPC messages before doing the switch
+    vmm_process_urpc_messages();
+
   if (fv_secure_context_switch) {
     fv_secure_context_switch(next_ctx);
   } else {
+        // The runqueue lock (g_runqueues[core_id].lock) is currently held.
+        // It will be explicitly released by arch_post_switch() which is
+        // called from the assembly arch_context_switch once we are on the
+        // next thread's stack.
     arch_context_switch(prev_ctx, next_ctx);
   }
 

--- a/kernel/src/trap/trap.c
+++ b/kernel/src/trap/trap.c
@@ -231,6 +231,11 @@ long trap_handle(trap_frame_t *frame) {
     return 0; // Return gracefully after handling exception (if user thread)
   }
 
+  // Before returning to user space, process any pending incoming URPC messages
+  // like TLB shootdowns to ensure consistency.
+  extern void vmm_process_urpc_messages(void);
+  vmm_process_urpc_messages();
+
   if (frame->from_user == 0U) {
     return TRAP_ERR_PERM;
   }


### PR DESCRIPTION
Addresses architectural gaps identified in the `KERNEL_ARCHITECTURE.md` documentation by implementing necessary hardware discovery interfaces, cross-core TLB flushing, and scheduler context switch lock mechanisms.

Key changes:
1. **IOMMU Subsystem**: Added firmware-based discovery parsing stubs for `vtd_iommu.c`, `smmu.c`, and `iopmp.c`.
2. **VMM/MPU Separation**: Used `get_memory_model()` to bypass standard MMU routines when the MPU/FLAT profiles are active.
3. **URPC TLB Shootdowns**: Substituted ad-hoc IPI payload sending with a fully packed URPC message mechanism (utilizing the lower 12 bits for message type) and a synchronous dispatch loop `vmm_process_urpc_messages()` called on the trap entry path.
4. **Context Switch / Scheduler**: Ensured that `x86_64`, `arm64`, and `riscv64` assembly routines correctly preserve volatile ABI registers and maintain a strictly aligned stack when executing the `arch_post_switch` C hook to release the runqueue spinlock.
5. **Timers**: Aligned `arm64` and `riscv64` clock drivers to faithfully map to the `hal_timer.h` APIs, segregating monotonic counts from programmed event deadlines.

---
*PR created automatically by Jules for task [17442319119980732196](https://jules.google.com/task/17442319119980732196) started by @divyang4481*