### PR TITLE
Add main-branch validation doc for external production-gap review

### DIFF
--- a/docs/reviews/main-branch-gap-validation.md
+++ b/docs/reviews/main-branch-gap-validation.md
@@ -1,0 +1,191 @@
+# Main-branch validation of external production-gap review
+
+## Scope and method
+
+This validation cross-checks the external review against the **current main-branch code and docs**, then re-prioritizes work to stay aligned with Bharat-OS goals: multikernel/distributed operation, multiple profiles/personality layers, RT + non-RT support, per-core scheduling, IPC/URPC, and multi-architecture portability.
+
+---
+
+## Executive result
+
+The external review is directionally useful but **partially outdated** against current main.
+
+- **Correct concerns (still true):** deep hardening and production-depth gaps remain in DMA/IOMMU enforcement depth, observability maturity, formal verification proof chain, and some driver completeness.
+- **Overstated/incorrect claims:** several items marked "missing" are already implemented at baseline level (hardware page-table walkers, CoW path, per-core runqueues/affinity + idle halt, ACPI/FDT parsing, GICv3/SBI integration hooks, panic dump path, and bounded IPC payload checks/timeouts).
+
+Conclusion: treat the review as a **production hardening checklist**, not as an accurate snapshot of what is currently absent.
+
+---
+
+## Validation by subsystem
+
+## 1) Memory management
+
+### What is already implemented in main
+- Architecture page-table implementations exist for x86_64/arm64/riscv and are wired through generic MMU ops (`create/map/unmap/query/protect/tlb`).
+- x86_64 map/unmap walks PML4/PDPT/PD/PT and does local `invlpg` on active CR3 mappings.
+- Generic VMM already includes URPC-driven TLB shootdown notifications and IPI nudges.
+- CoW fault handler exists and performs copy + remap with write restoration.
+- PMM includes NUMA-aware allocation APIs and buddy management with node-aware paths.
+
+### What remains to implement/harden
+- Remote shootdown correctness needs stronger acknowledgement/completion semantics (not just best-effort send).
+- Huge-page lifecycle and fragmentation policy are not yet first-class.
+- Kernel heap hardening (redzones/canaries/KASAN-like checks) remains incomplete.
+- Guard-page policy for all kernel/user stacks needs systematic enforcement and tests.
+
+**Verdict on external review:** partially correct. The "no hardware page tables" and "no CoW" claims are no longer accurate on main.
+
+---
+
+## 2) IPC / URPC
+
+### What is already implemented in main
+- Endpoint IPC has bounded payload length checks.
+- Endpoint IPC has timeout/deadline behavior integrated with scheduler wakeups.
+- URPC has lockless ring semantics with explicit atomic memory ordering and per-core channel matrix initialization.
+
+### What remains to implement/harden
+- Capability transfer **inside** endpoint message payload path is still limited (delegation exists in capability subsystem, but not as an atomic endpoint message primitive).
+- Backpressure/flow-control policy across all URPC producers/consumers needs stronger system-level handling.
+- Fastpath direct context-switch IPC optimization is still a performance opportunity.
+- Cross-node/fabric transport beyond intra-machine per-core channels is still roadmap-level.
+
+**Verdict on external review:** mostly correct on production-depth concerns, but wrong on “no timeout” and “no message bound checks”.
+
+---
+
+## 3) Capability system
+
+### What is already implemented in main
+- Capability tables support grant/lookup/delegate/revoke operations.
+- Delegation tracks parent/child/sibling lineage handles.
+- Revoke includes bounded transitive walk over derived caps.
+
+### What remains to implement/harden
+- Formal proof artifacts are not present at seL4-level assurance.
+- Temporal/expiry capabilities are not present in current data model.
+- Retype invariants and memory-object lifecycle need deeper validation/auditing.
+- Security audit is present but should be expanded to full capability-event provenance and export tooling.
+
+**Verdict on external review:** partially correct. “No revocation tree” is inaccurate for current main.
+
+---
+
+## 4) Scheduler (RT/non-RT + per-core)
+
+### What is already implemented in main
+- Per-core runqueue structures are present with core-local locks.
+- Idle thread exists and halts CPU (`hal_cpu_halt`).
+- Affinity masks and syscall path for setting affinity exist.
+- Priority inheritance hooks exist around mutex wait/acquire/release.
+- Context switch path exists with arch save/restore hooks and explicit switch boundary.
+- Policy enum includes priority/round-robin/EDF/RMS modes.
+
+### What remains to implement/harden
+- EDF/RMS need stronger admission-control and deadline accounting semantics for strict RT guarantees.
+- Full SMP balancing and remote wakeup behavior need more stress/latency validation.
+- AI suggestion queue requires explicit adversarial-rate controls + formal boundedness tests in mixed RT/non-RT workloads.
+
+**Verdict on external review:** mixed. Several "missing" items (SMP runqueues, affinity, PI, idle halt) are already implemented at baseline.
+
+---
+
+## 5) HAL / multi-arch
+
+### What is already implemented in main
+- x86 ACPI topology parser includes MADT/HPET/MCFG/DMAR discovery hooks.
+- Common FDT parser exists and is used for arm64/riscv discovery paths.
+- Arm64 GICv3 path exists (including ITS/MSI domain stubs).
+- RISC-V SBI boot/timer/IPI integration hooks exist.
+
+### What remains to implement/harden
+- ACPI SRAT/SLIT NUMA depth and robust table validation remain incomplete.
+- Several arch drivers are still functional stubs or minimally wired.
+- MSI/MSI-X and interrupt remap require fuller device-level integration and validation beyond skeleton support.
+
+**Verdict on external review:** partially outdated; framework coverage is better than described, production depth is still incomplete.
+
+---
+
+## 6) Driver model
+
+### What is already implemented in main
+- PCI discovery baseline exists (x86 config-space probing).
+- IOMMU backends exist for VT-d/SMMU as integration points.
+
+### What remains to implement/harden
+- Existing IOMMU backends are still largely stubbed and need real map/unmap domain enforcement.
+- Driver breadth (NVMe, virtio maturity, USB/xHCI depth) remains incomplete for production boot-to-user workflows.
+- Driver lifecycle/crash cleanup needs stronger guarantees and tests.
+
+**Verdict on external review:** largely correct on criticality, but should distinguish “absent” from “present but stubbed”.
+
+---
+
+## 7) Security hardening
+
+### What is already implemented in main
+- Secure-boot policy and architecture check hook exist.
+- Stack protector path exists (`__stack_chk_fail` -> panic).
+- Panic path persists message to pstore and dumps arch CPU state.
+- Security audit subsystem exists.
+
+### What remains to implement/harden
+- Full measured/verified boot chain integration with TPM/attestation artifacts.
+- Spectre/Meltdown class mitigations and policy controls need explicit implementation matrix.
+- KASLR/kernel CFI/shadow stack and memory-tagging support are not complete.
+
+**Verdict on external review:** correct on production-hardening gap, but not "zero implementation".
+
+---
+
+## 8) Observability
+
+### What is already implemented in main
+- Kernel trace ring buffer exists.
+- Panic path includes serial output + architecture state dump + pstore write.
+
+### What remains to implement/harden
+- Per-core lockless trace buffers with timestamps and event schemas need maturation.
+- Metrics export pipeline and crash dump tooling (kdump-like) are not complete.
+- Watchdog integration is profile-specific and not yet systematically enforced.
+
+**Verdict on external review:** concern is valid; maturity is low, but some baseline exists.
+
+---
+
+## Alignment check against Bharat-OS strategic goals
+
+## Multikernel/distributed kernel
+- Current main already carries per-core channel matrix and URPC delivery plumbing, so roadmap should prioritize **reliability/ordering/backpressure/fabric transport** rather than re-creating primitives.
+
+## Multiple profiles + RT/non-RT
+- Profile framework exists and should now drive **hard policy deltas** (e.g., RT profile: strict admission + bounded AI influence; cloud profile: throughput/fairness + NUMA balancing).
+
+## Multiple personalities
+- Personality-neutral kernel core remains aligned; next milestones should focus on syscall translation quality and IPC contract stability at personality boundaries.
+
+## Multi-architecture support
+- Multi-arch HAL scaffolding is in place; now prioritize **depth parity** (feature completeness and validation parity across x86_64/arm64/riscv64).
+
+---
+
+## Recommended implementation order (updated)
+
+1. **IOMMU enforcement depth (VT-d/SMMU) + DMA isolation tests**.
+2. **TLB shootdown + URPC transport hardening** (ack/completion semantics, queue backpressure, failure handling, and SMP stress tests across per-core channels).
+3. **RT scheduler hardening** (EDF/RMS admission, deadline tests, AI-bound guards).
+4. **Observability foundation** (timestamped per-core traces, metrics export, watchdog policy).
+5. **Capability lifecycle hardening** (temporal caps, richer audit provenance, retype invariants).
+6. **Cross-node transport** for distributed multikernel messaging.
+7. **Driver completeness priorities** (virtio baseline first for QEMU workflows, then NVMe/USB).
+8. **Security hardening phase** (secure boot attestation chain, mitigation matrix, KASLR/CFI/shadow-stack roadmap).
+
+---
+
+## Short answer to the user question
+
+- The external review is **not fully correct for latest main**.
+- It is best interpreted as a **production-hardening backlog**, not as a statement of what is currently absent.
+- For Bharat-OS strategic alignment (multikernel + multi-profile + multi-personality + RT/non-RT + multi-arch), the immediate priority is to harden existing primitives rather than re-implementing them from scratch.


### PR DESCRIPTION
### Motivation
- Cross-check the external production-gap review against the current `main` branch to clarify which concerns are stale, which are valid, and to re-prioritize work to align with Bharat-OS strategic goals.
- Provide a subsystem-by-subsystem validation and a concise verdict to convert the external review into an actionable production-hardening backlog. 
- Surface an updated recommended implementation order that focuses on hardening existing primitives rather than re-implementing them.

### Description
- Add `docs/reviews/main-branch-gap-validation.md` which compares the external review to current `main` across memory management, IPC/URPC, capability system, scheduler, HAL/multi-arch, drivers, security hardening, and observability. 
- Record which items are already implemented at baseline and which require further hardening, and include explicit verdicts on where the external review is correct, partially correct, or outdated. 
- Provide strategic alignment notes for multikernel/multi-profile/multi-personality/multi-architecture goals and a prioritized implementation checklist for production hardening. 

### Testing
- No unit-code changes were made; documentation changes were validated with `markdownlint` to check formatting and style and with `mkdocs build` to verify the docs site builds successfully. 
- Both `markdownlint` and `mkdocs build` completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6d88034e88320ada7ed1d4c01e808)