### PR TITLE
Fix x86_64 arch_vm_ops stubs and trap frames

### DIFF
--- a/kernel/include/hal/x86_64/trap_frame_x86.h
+++ b/kernel/include/hal/x86_64/trap_frame_x86.h
@@ -1,0 +1,12 @@
+#ifndef BHARAT_HAL_X86_TRAP_FRAME_H
+#define BHARAT_HAL_X86_TRAP_FRAME_H
+
+#include "../../../include/trap.h"
+
+typedef struct {
+    trap_frame_t base;    // must be first — generic code casts to this
+    uint64_t error_code;  // x86-only: pushed by CPU or trap_entry.S
+    uint64_t cr2;         // faulting VA — read once in entry, stored here
+} x86_trap_frame_t;
+
+#endif // BHARAT_HAL_X86_TRAP_FRAME_H

--- a/kernel/src/hal/x86_64/arch_vm.c
+++ b/kernel/src/hal/x86_64/arch_vm.c
@@ -1,87 +1,116 @@
 #include "../../../include/mm/arch_vm.h"
 #include "../../../include/hal/hal.h"
 #include "../../../include/hal/mmu_ops.h"
+#include "../../../include/hal/x86_64/trap_frame_x86.h"
 #include "../../../include/mm.h"
 #include <stddef.h>
 #include <stdint.h>
 
-// Mock definitions for the underlying HW
-extern void write_cr3(phys_addr_t cr3);
-extern phys_addr_t read_cr3(void);
-extern void invlpg(uintptr_t addr);
+extern phys_addr_t vmm_get_kernel_root(void);
 
 static int x86_64_kernel_init(void) {
-    // Bootstrap the global higher-half mapping
+    // Kernel higher-half mapping is established in boot.S / mmu_init.c
+    // before this point. Nothing to do here.
     return 0;
 }
 
 static int x86_64_space_init(vm_space_t *space, vm_core_state_t *local) {
-    if (!space || !local) return -1;
+    if (!space || !local || !active_mmu) return -1;
 
-    // Allocate PML4 root table
-    // For MVP, just return a mocked value or reuse basic allocator
-    local->root_pa = 0x1000; // Mock PA
+    // Clone kernel page table so upper-half kernel mappings are shared
+    phys_addr_t root = active_mmu->clone_kernel(vmm_get_kernel_root());
+    if (!root) return -1;
+
+    local->root_pa = root;
+    local->core_id = hal_cpu_get_id();
     local->state = VM_REALIZE_VALID;
     return 0;
 }
 
 static void x86_64_space_destroy(vm_space_t *space, vm_core_state_t *local) {
-    if (!space || !local) return;
-    // Walk PML4, free PTs, free root
-    local->root_pa = 0;
+    if (!space || !local || !active_mmu) return;
+
+    if (local->root_pa) {
+        active_mmu->destroy_table(local->root_pa);
+        local->root_pa = 0;
+    }
     local->state = VM_REALIZE_NONE;
 }
 
 static int x86_64_map(vm_space_t *space, vm_core_state_t *local,
                       uintptr_t va, uintptr_t pa, size_t len,
                       uint64_t prot, uint64_t mem_type, uint64_t flags) {
-    (void)space; (void)local; (void)va; (void)pa; (void)len; (void)prot; (void)mem_type; (void)flags;
-    // Local PT write using PML4 -> PDPT -> PD -> PT logic
-    return 0;
+    (void)space; (void)mem_type; (void)flags;
+    if (!active_mmu || !local) return -1;
+    return active_mmu->map(local->root_pa, va, pa, len, (mmu_flags_t)prot);
 }
 
 static int x86_64_unmap(vm_space_t *space, vm_core_state_t *local,
                         uintptr_t va, size_t len) {
-    (void)space; (void)local; (void)va; (void)len;
-    // Remove local PT entries
-    // invlpg(va);
-    return 0;
+    (void)space;
+    if (!active_mmu || !local) return -1;
+    return active_mmu->unmap(local->root_pa, va, len, NULL);
 }
 
 static int x86_64_protect(vm_space_t *space, vm_core_state_t *local,
                           uintptr_t va, size_t len,
                           uint64_t prot, uint64_t mem_type) {
-    (void)space; (void)local; (void)va; (void)len; (void)prot; (void)mem_type;
-    // Modify existing local PT permissions
-    // invlpg(va);
-    return 0;
+    (void)space; (void)mem_type;
+    if (!active_mmu || !local) return -1;
+    return active_mmu->protect(local->root_pa, va, len, (mmu_flags_t)prot);
 }
 
 static int x86_64_activate(vm_space_t *space, vm_core_state_t *local) {
-    if (!space || !local) return -1;
+    (void)space;
+    if (!active_mmu || !local) return -1;
 
-    // In actual implementation: write_cr3(local->root_pa);
+    active_mmu->activate(local->root_pa);
+    if (active_mmu->tlb_flush_all) {
+        active_mmu->tlb_flush_all();
+    }
     return 0;
 }
 
 static int x86_64_invalidate_range(vm_space_t *space, vm_core_state_t *local,
                                    uintptr_t va, size_t len, uint64_t flags) {
-    (void)space; (void)local; (void)va; (void)len; (void)flags;
-    // Execute multiple invlpg
+    (void)space; (void)local; (void)flags;
+    if (!active_mmu || !active_mmu->tlb_flush_page) return -1;
+
+    size_t offset = 0;
+    while (offset < len) {
+        active_mmu->tlb_flush_page(va + offset);
+        offset += PAGE_SIZE;
+    }
     return 0;
 }
 
 static int x86_64_invalidate_all(vm_space_t *space, vm_core_state_t *local) {
     (void)space; (void)local;
-    // Reload CR3
-    // write_cr3(read_cr3());
+    if (!active_mmu || !active_mmu->tlb_flush_all) return -1;
+
+    active_mmu->tlb_flush_all();
     return 0;
 }
 
 static int x86_64_fault_decode(arch_trap_frame_t *tf, vm_fault_info_t *out) {
-    (void)tf; (void)out;
-    // Read CR2
-    // Decode error code
+    if (!tf || !out) return -1;
+
+    // Safe cast — trap_entry.S always builds a full x86_trap_frame_t on x86
+    const x86_trap_frame_t *x86tf = (const x86_trap_frame_t *)tf;
+
+    out->addr   = x86tf->cr2;
+    uint64_t ec     = x86tf->error_code;
+
+    bool is_present = (ec >> 0) & 1;   // 0 = not-present, 1 = protection
+    out->is_write   = (ec >> 1) & 1;   // write fault
+    out->is_user    = (ec >> 2) & 1;   // user mode
+    out->is_exec    = (ec >> 4) & 1;   // NX / instruction fetch
+
+    out->not_present = !is_present;
+    out->permission_fault = is_present;
+
+    out->arch_code = ec;
+
     return 0;
 }
 

--- a/kernel/src/hal/x86_64/trap_entry.S
+++ b/kernel/src/hal/x86_64/trap_entry.S
@@ -62,9 +62,11 @@ ISR_NOERRCODE 128
 
 .global trap_common
 trap_common:
-    # Build trap_frame_t. Size is 288 bytes.
-    # struct is: uint64_t gpr[31], sp, pc, cause, status, type(uint32), from_user(uint32)
-    subq $288, %rsp
+    # We allocate space for x86_trap_frame_t. Size of generic trap_frame_t is 288 bytes.
+    # x86_trap_frame_t adds 16 bytes for error_code and cr2, total 304 bytes allocated on top of vector/error_code.
+    # struct is: trap_frame_t base, uint64_t error_code, uint64_t cr2
+    # The CPU/stubs pushed vector and error_code. We allocate 304 bytes.
+    subq $304, %rsp
 
     # Save General Purpose Registers (map x86_64 to gpr[0..14])
     movq %rax, 0(%rsp)     # gpr[0]
@@ -83,33 +85,33 @@ trap_common:
     movq %r14, 104(%rsp)   # gpr[13]
     movq %r15, 112(%rsp)   # gpr[14]
 
-    # Hardware/Stub pushed state (offsets relative to current rsp):
-    # [rsp+288] = Vector (cause)
-    # [rsp+296] = Error Code
-    # [rsp+304] = RIP (pc)
-    # [rsp+312] = CS
-    # [rsp+320] = RFLAGS (status)
-    # [rsp+328] = RSP (sp)
-    # [rsp+336] = SS
+    # Hardware/Stub pushed state (offsets relative to current rsp due to subq 304):
+    # [rsp+304] = Vector (cause)
+    # [rsp+312] = Error Code
+    # [rsp+320] = RIP (pc)
+    # [rsp+328] = CS
+    # [rsp+336] = RFLAGS (status)
+    # [rsp+344] = RSP (sp)
+    # [rsp+352] = SS
 
     # pc
-    movq 304(%rsp), %rax
+    movq 320(%rsp), %rax
     movq %rax, 256(%rsp)
 
     # sp
-    movq 328(%rsp), %rax
+    movq 344(%rsp), %rax
     movq %rax, 248(%rsp)
 
     # cause (vector number)
-    movq 288(%rsp), %rax
+    movq 304(%rsp), %rax
     movq %rax, 264(%rsp)
 
     # status (RFLAGS)
-    movq 320(%rsp), %rax
+    movq 336(%rsp), %rax
     movq %rax, 272(%rsp)
 
     # Determine type: Vector < 32 or Vector == 128 is SYNC (0), else IRQ (1)
-    movq 288(%rsp), %rax # Vector
+    movq 304(%rsp), %rax # Vector
     cmpq $32, %rax
     jb .L_is_sync
     cmpq $128, %rax
@@ -121,19 +123,27 @@ trap_common:
 .L_type_done:
 
     # from_user: (CS & 3) == 3
-    movq 312(%rsp), %rax # CS
+    movq 328(%rsp), %rax # CS
     andq $3, %rax
     cmpq $3, %rax
     sete %al
     movzx %al, %eax
     movl %eax, 284(%rsp) # from_user (uint32_t)
 
+    # Copy Error Code to x86_trap_frame_t extension
+    movq 312(%rsp), %rax
+    movq %rax, 288(%rsp) # error_code
+
+    # Read CR2 and copy to x86_trap_frame_t extension
+    movq %cr2, %rax
+    movq %rax, 296(%rsp) # cr2
+
     movq %rsp, %rdi
     call trap_handle
 
     # Reload pc in case it changed
     movq 256(%rsp), %rax
-    movq %rax, 304(%rsp)
+    movq %rax, 320(%rsp)
 
     # Restore registers
     movq 0(%rsp), %rax
@@ -152,7 +162,5 @@ trap_common:
     movq 104(%rsp), %r14
     movq 112(%rsp), %r15
 
-    addq $304, %rsp # Skip trap_frame(288) + vector(8) + error_code(8) = 304? No.
-    # subq was 288. Vector is at 288. Error code at 296.
-    # Total to skip = 288 + 8 + 8 = 304. Yes.
+    addq $320, %rsp # Skip x86_trap_frame(304) + vector(8) + error_code(8) = 320
     iretq

--- a/kernel/src/mm/vmm.c
+++ b/kernel/src/mm/vmm.c
@@ -20,6 +20,10 @@
 
 static address_space_t kernel_space;
 
+phys_addr_t vmm_get_kernel_root(void) {
+    return kernel_space.root_table;
+}
+
 // Helper to translate old VMM flags to new MMU flags
 static mmu_flags_t convert_vmm_flags(uint32_t flags) {
     mmu_flags_t mmu_flags = MMU_READ;


### PR DESCRIPTION
Implement the stubbed x86_64 `arch_vm_ops_t` and `arch_trap_frame_t` implementations to correctly resolve `arch_vm_ops` using `active_mmu`. Included updates to `trap_entry.S` to create proper extension structures.

---
*PR created automatically by Jules for task [10977379952272413428](https://jules.google.com/task/10977379952272413428) started by @divyang4481*