### PR TITLE
Fix data corruption in CoW fault handler

### DIFF
--- a/kernel/include/mm.h
+++ b/kernel/include/mm.h
@@ -86,10 +86,13 @@ int mm_free_dma_pages(phys_addr_t phys, void *kernel_virt, size_t size);
 void mm_inc_page_ref(phys_addr_t page);
 
 // Virtual Memory Management (Architecture agnostic paging)
+#include "spinlock.h"
+
 typedef struct {
   phys_addr_t root_table; // CR3 on x86, satp on RISC-V
   uint32_t owner_core_id;
   uint64_t object_id;
+  spinlock_t lock;
 } address_space_t;
 
 int vmm_init(void);

--- a/kernel/src/mm/vmm.c
+++ b/kernel/src/mm/vmm.c
@@ -254,6 +254,7 @@ address_space_t* mm_create_address_space(void) {
             as->root_table = 0;
             as->owner_core_id = hal_cpu_get_id();
             as->object_id = (uint64_t)(uintptr_t)as;
+            spin_lock_init(&as->lock);
         }
         return as;
     }
@@ -274,6 +275,7 @@ address_space_t* mm_create_address_space(void) {
     as->root_table = root;
     as->owner_core_id = hal_cpu_get_id(); // The core creating it initially owns it
     as->object_id = (uint64_t)(uintptr_t)as; // Simple object ID for now
+    spin_lock_init(&as->lock);
     return as;
 }
 
@@ -283,23 +285,40 @@ int vmm_handle_cow_fault(address_space_t* as, virt_addr_t vaddr) {
         return -1; // MPU/FLAT do not support demand paging / CoW
     }
 
-    if (!as || as->root_table == 0U) return -1;
+    if (!as || as->root_table == 0U || !active_mmu) {
+        return -1;
+    }
+
+    virt_addr_t aligned_vaddr = vaddr & ~(PAGE_SIZE - 1U);
+
+    spin_lock(&as->lock);
 
     phys_addr_t old_phys = 0;
     mmu_flags_t old_mmu_flags = 0;
 
-    int ret = active_mmu->query(as->root_table, vaddr, &old_phys, &old_mmu_flags);
-    if (ret < 0 || old_phys == 0) return -2;
+    int ret = active_mmu->query(as->root_table, aligned_vaddr, &old_phys, &old_mmu_flags);
+    if (ret < 0 || old_phys == 0) {
+        spin_unlock(&as->lock);
+        return -2;
+    }
+
+    if ((old_mmu_flags & MMU_COW) == 0) {
+        spin_unlock(&as->lock);
+        return -3; // Not a CoW fault
+    }
 
     // Convert back if necessary or handle logic based on generic flags. For now we emulate the old behavior:
     uint32_t old_flags = 0;
     if (old_mmu_flags & MMU_WRITE) old_flags |= CAP_RIGHT_WRITE;
     if (old_mmu_flags & MMU_USER)  old_flags |= PAGE_USER;
-    if (old_mmu_flags & MMU_COW)   old_flags |= PAGE_COW;
+    // We intentionally don't set PAGE_COW on old_flags so it gets cleared.
 
     // Allocate new page
     phys_addr_t new_phys = mm_alloc_page(NUMA_NODE_ANY);
-    if (!new_phys) return -1;
+    if (!new_phys) {
+        spin_unlock(&as->lock);
+        return -4;
+    }
 
     // Copy data
     uint8_t* src = (uint8_t*)P2V(old_phys);
@@ -309,18 +328,33 @@ int vmm_handle_cow_fault(address_space_t* as, virt_addr_t vaddr) {
     }
 
     // Update mapping with Write permission, clear CoW
-    uint32_t new_flags = (old_flags | CAP_RIGHT_WRITE) & ~PAGE_COW;
+    uint32_t new_flags = old_flags | CAP_RIGHT_WRITE;
     mmu_flags_t new_mmu_flags = convert_vmm_flags(new_flags);
 
-    ret = active_mmu->protect(as->root_table, vaddr, PAGE_SIZE, new_mmu_flags);
+    // Safest generic path if there is no explicit remap API: unmap + map
+    phys_addr_t unmapped_phys = 0;
+    ret = active_mmu->unmap(as->root_table, aligned_vaddr, PAGE_SIZE, &unmapped_phys);
     if (ret < 0) {
         mm_free_page(new_phys);
+        spin_unlock(&as->lock);
         return ret;
     }
 
-    // Decrement old page reference
+    ret = active_mmu->map(as->root_table, aligned_vaddr, new_phys, PAGE_SIZE, new_mmu_flags);
+    if (ret < 0) {
+        // Attempt rollback
+        (void)active_mmu->map(as->root_table, aligned_vaddr, old_phys, PAGE_SIZE, old_mmu_flags);
+        mm_free_page(new_phys);
+        spin_unlock(&as->lock);
+        return ret;
+    }
+
+    spin_unlock(&as->lock);
+
+    tlb_shootdown(aligned_vaddr);
+
+    // Decrement old page reference (after we have updated the mapping)
     mm_free_page(old_phys);
 
-    tlb_shootdown(vaddr);
     return 0;
 }


### PR DESCRIPTION
Fixes P0 data corruption issue in the CoW (Copy-on-Write) fault handler.

The previous implementation of `vmm_handle_cow_fault` failed to verify if the faulting page actually possessed the `MMU_COW` flag, potentially misrouting standard protection faults. More critically, it allocated a new physical page and copied data to it, but failed to actually remap the Virtual Address to this new physical page. It used `active_mmu->protect()`, which only updates mapping flags, then proceeded to free the *old* physical page while the VA still pointed to it.

This patch addresses these issues by:
1. Adding validation for the `MMU_COW` flag.
2. Replacing the `protect()` call with an `unmap()` followed by a `map()` call to properly install the new physical page, including a rollback if mapping fails.
3. Adding a per-address space spinlock to serialize modifications and prevent races during CoW resolution.
4. Correcting the order of TLB shootdown and physical page release.

---
*PR created automatically by Jules for task [2615595235397050002](https://jules.google.com/task/2615595235397050002) started by @divyang4481*