### PR TITLE
Enable x86_64 Boot UI display in QEMU

### DIFF
--- a/kernel/src/boot/x86_64/boot.S
+++ b/kernel/src/boot/x86_64/boot.S
@@ -46,7 +46,18 @@ mb2_start:
     .long  MB2_ARCH_X86
     .long  (mb2_end - mb2_start)
     .long  -(MB2_MAGIC + MB2_ARCH_X86 + (mb2_end - mb2_start))
+
+    /* Framebuffer Request Tag (Type 5) */
+    .align 8
+    .short 5            /* type = framebuffer */
+    .short 1            /* flags = optional */
+    .long  20           /* size = 20 bytes */
+    .long  1024         /* width */
+    .long  768          /* height */
+    .long  32           /* depth (bpp) */
+
     /* end tag */
+    .align 8
     .short 0
     .short 0
     .long  8

--- a/tools/build.ps1
+++ b/tools/build.ps1
@@ -257,23 +257,38 @@ if ($Run) {
     $qemuArgs = @()
 
     if ($Arch -eq "x86_64") {
-        $qemuArgs += @("-kernel", $KernelBinary, "-m", "256M", "-nographic", "-serial", "mon:stdio", "-no-reboot")
+        $qemuArgs += @("-kernel", $KernelBinary, "-m", "256M", "-serial", "mon:stdio", "-no-reboot")
+        if ($BootGui -eq "ON") {
+            $qemuArgs += @("-vga", "std")
+        } else {
+            $qemuArgs += @("-nographic")
+        }
     }
     elseif ($Arch -eq "riscv64") {
         if ($Payload) {
             if (Test-Path "$BuildDir\fw_payload.elf") {
-                $qemuArgs += @("-machine", $Machine, "-bios", "none", "-kernel", "$BuildDir\fw_payload.elf", "-m", "256M", "-nographic", "-serial", "mon:stdio", "-no-reboot")
+                $qemuArgs += @("-machine", $Machine, "-bios", "none", "-kernel", "$BuildDir\fw_payload.elf", "-m", "256M", "-serial", "mon:stdio", "-no-reboot")
             }
             else {
-                $qemuArgs += @("-machine", $Machine, "-bios", "$BuildDir\payload.bin", "-m", "256M", "-nographic", "-serial", "mon:stdio", "-no-reboot")
+                $qemuArgs += @("-machine", $Machine, "-bios", "$BuildDir\payload.bin", "-m", "256M", "-serial", "mon:stdio", "-no-reboot")
             }
         }
         else {
-            $qemuArgs += @("-machine", $Machine, "-kernel", $OutELF, "-m", "256M", "-nographic", "-serial", "mon:stdio", "-no-reboot")
+            $qemuArgs += @("-machine", $Machine, "-kernel", $OutELF, "-m", "256M", "-serial", "mon:stdio", "-no-reboot")
+        }
+        if ($BootGui -eq "ON") {
+            $qemuArgs += @("-vga", "std")
+        } else {
+            $qemuArgs += @("-nographic")
         }
     }
     elseif ($Arch -eq "arm64") {
-        $qemuArgs += @("-machine", $Machine, "-cpu", "cortex-a53", "-kernel", $OutELF, "-m", "256M", "-nographic", "-serial", "mon:stdio", "-no-reboot")
+        $qemuArgs += @("-machine", $Machine, "-cpu", "cortex-a53", "-kernel", $OutELF, "-m", "256M", "-serial", "mon:stdio", "-no-reboot")
+        if ($BootGui -eq "ON") {
+            $qemuArgs += @("-vga", "std")
+        } else {
+            $qemuArgs += @("-nographic")
+        }
     }
 
     if ($DebugQemu) {


### PR DESCRIPTION
When building for x86_64 via `./tools/build.ps1 -Arch x86_64 -Run` with BootGui ON, the qemu emulation did not show the boot display UI. The root cause was that `tools/build.ps1` was hardcoded to `-nographic` and the Multiboot2 header (`boot.S`) did not request a framebuffer from the bootloader. 

This PR fixes both issues by adding a type 5 request tag to the multiboot header and correctly adjusting the QEMU flags in the Windows build script.

---
*PR created automatically by Jules for task [875758886812920438](https://jules.google.com/task/875758886812920438) started by @divyang4481*