### PR TITLE
🧪 Add edge-case coverage for subsys_destroy

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -128,6 +128,10 @@ add_executable(test_windows_compat_init test_windows_compat_init.c ../subsys/win
 target_include_directories(test_windows_compat_init PRIVATE ../kernel/include ../subsys/include)
 add_test(NAME test_windows_compat_init COMMAND test_windows_compat_init)
 
+add_executable(test_subsys_manager test_subsys_manager.c benchmark_stubs.c ../subsys/src/manager.c ../subsys/linux/linux_compat.c ../subsys/windows/win_compat.c ../subsys/src/subsys_test_runner.c ../kernel/src/boot/boot_args.c ../kernel/src/lib/string.c)
+target_include_directories(test_subsys_manager PRIVATE ../subsys/include ../kernel/include)
+add_test(NAME test_subsys_manager COMMAND test_subsys_manager)
+
 add_executable(test_vm_stress test_vm_stress.c benchmark_stubs.c ../kernel/src/mm/vmm_legacy/vmm.c)
 target_include_directories(test_vm_stress PRIVATE ../kernel/include)
 add_test(NAME test_vm_stress COMMAND test_vm_stress)

--- a/tests/test_subsys_manager.c
+++ b/tests/test_subsys_manager.c
@@ -1,0 +1,53 @@
+#include <assert.h>
+#include <stdio.h>
+
+#include "../subsys/include/subsys.h"
+
+// Stubs for subsys_test_runner.c
+#include "../subsys/include/bharat/subsys_test.h"
+const subsys_test_t __subsys_tests_start[0] = {};
+const subsys_test_t __subsys_tests_end[0] = {};
+
+void hal_serial_write(char c) {
+    (void)c;
+}
+
+void kernel_panic(const char* msg) {
+    (void)msg;
+    while(1);
+}
+
+
+static void test_subsys_destroy_null_returns_error(void) {
+    assert(-1 == subsys_destroy(NULL));
+    printf("[PASS] test_subsys_destroy_null_returns_error\n");
+}
+
+static void test_subsys_destroy_stops_running_instance(void) {
+    subsys_instance_t instance = {0};
+    instance.is_running = 1;
+
+    assert(0 == subsys_destroy(&instance));
+    assert(0 == instance.is_running);
+    printf("[PASS] test_subsys_destroy_stops_running_instance\n");
+}
+
+static void test_subsys_destroy_on_stopped_instance_is_safe(void) {
+    subsys_instance_t instance = {0};
+    instance.is_running = 0;
+
+    assert(0 == subsys_destroy(&instance));
+    assert(0 == instance.is_running);
+    printf("[PASS] test_subsys_destroy_on_stopped_instance_is_safe\n");
+}
+
+int main(void) {
+    printf("Running Subsystem Manager tests...\n");
+
+    test_subsys_destroy_null_returns_error();
+    test_subsys_destroy_stops_running_instance();
+    test_subsys_destroy_on_stopped_instance_is_safe();
+
+    printf("Subsystem Manager tests passed successfully.\n");
+    return 0;
+}


### PR DESCRIPTION
🎯 **What:** Added focused tests for `subsys_destroy` in `subsys/src/manager.c`, especially the null-pointer guard path.
📊 **Coverage:** Valid instance destroy, null instance destroy, and safe repeated destroy behavior on a stopped instance.
✨ **Result:** Improves reliability of subsystem manager tests by covering a simple but important defensive branch that was previously untested.

---
*PR created automatically by Jules for task [12060067003229222148](https://jules.google.com/task/12060067003229222148) started by @divyang4481*