### PR TITLE
🔒 Enforce capability-object binding for VFS read/write/close

### DIFF
--- a/kernel/src/fs/file.c
+++ b/kernel/src/fs/file.c
@@ -5,6 +5,22 @@
 
 static vfs_file_t g_open_files[VFS_MAX_OPEN_FILES];
 
+static int vfs_cap_allows_file(vfs_file_t* entry, capability_t* caller_cap, uint32_t required_rights) {
+    if (!entry || !entry->node || !caller_cap) {
+        return 0;
+    }
+
+    if ((caller_cap->rights_mask & required_rights) != required_rights) {
+        return 0;
+    }
+
+    if (caller_cap->target_object_id != entry->node->object_id) {
+        return 0;
+    }
+
+    return 1;
+}
+
 int vfs_open_file(const char* path, int flags, capability_t* caller_cap, int* out_fd) {
     size_t i;
     vfs_node_t *node;
@@ -30,6 +46,12 @@ int vfs_open_file(const char* path, int flags, capability_t* caller_cap, int* ou
             g_open_files[i].flags = flags;
             g_open_files[i].offset = 0;
             g_open_files[i].node = node;
+
+            // Explicitly zero-initialize handle_cap. It is not populated with real tokens yet.
+            g_open_files[i].handle_cap.capability_id = 0;
+            g_open_files[i].handle_cap.target_object_id = 0;
+            g_open_files[i].handle_cap.rights_mask = 0;
+            g_open_files[i].handle_cap.owner_core_id = 0;
 
             // Allow underlying implementation to populate/reject handle
             if (node->ops && node->ops->open) {
@@ -63,7 +85,10 @@ int vfs_read_file(int fd, void* buffer, size_t size, capability_t* caller_cap) {
         return -1;
     }
 
-    // TODO: Verify caller_cap matches entry->handle_cap rights
+    // TODO: Verify caller_cap matches entry->handle_cap rights when initialized
+    if (!vfs_cap_allows_file(entry, caller_cap, CAP_RIGHT_READ)) {
+        return -1;
+    }
 
     bytes = entry->node->ops->read(entry, entry->offset, buffer, size);
     if (bytes > 0) {
@@ -93,7 +118,10 @@ int vfs_write_file(int fd, const void* buffer, size_t size, capability_t* caller
         return -1;
     }
 
-    // TODO: Verify caller_cap matches entry->handle_cap rights
+    // TODO: Verify caller_cap matches entry->handle_cap rights when initialized
+    if (!vfs_cap_allows_file(entry, caller_cap, CAP_RIGHT_WRITE)) {
+        return -1;
+    }
 
     bytes = entry->node->ops->write(entry, entry->offset, buffer, size);
     if (bytes > 0) {
@@ -114,7 +142,10 @@ int vfs_close_file(int fd, capability_t* caller_cap) {
         return -1;
     }
 
-    // TODO: Verify caller_cap
+    // TODO: Verify caller_cap matches entry->handle_cap rights when initialized
+    if (!vfs_cap_allows_file(entry, caller_cap, 0)) {
+        return -1;
+    }
 
     if (entry->node && entry->node->ops && entry->node->ops->close) {
         entry->node->ops->close(entry);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -332,3 +332,8 @@ add_test(NAME test_smp_hal COMMAND test_smp_hal)
 add_executable(test_pmm_production test_pmm_production.c ../kernel/src/mm/pmm/pmm.c)
 target_include_directories(test_pmm_production PRIVATE ../kernel/include ../kernel/src)
 add_test(NAME test_pmm_production COMMAND test_pmm_production)
+
+add_executable(test_vfs_file_caps test_vfs_file_caps.c ../kernel/src/fs/vfs.c ../kernel/src/fs/mount.c ../kernel/src/fs/file.c ../kernel/src/fs/path.c ../kernel/src/lib/string.c)
+target_include_directories(test_vfs_file_caps PRIVATE ../kernel/include)
+target_compile_definitions(test_vfs_file_caps PRIVATE TESTING=1)
+add_test(NAME test_vfs_file_caps COMMAND test_vfs_file_caps)

--- a/tests/test_vfs_file_caps.c
+++ b/tests/test_vfs_file_caps.c
@@ -1,0 +1,120 @@
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "fs/vfs.h"
+#include "fs/file.h"
+#include "fs/mount.h"
+
+uint8_t g_memory_fs[1024] = {0};
+
+static int mem_read(vfs_file_t *file, uint64_t offset, void *buffer, size_t size) {
+    const char *src = (const char *)g_memory_fs;
+    size_t len = strlen(src);
+    if (offset >= len) {
+        return 0;
+    }
+    if (size > len - (size_t)offset) {
+        size = len - (size_t)offset;
+    }
+    memcpy(buffer, src + offset, size);
+    return (int)size;
+}
+
+static int mem_write(vfs_file_t *file, uint64_t offset, const void *buffer, size_t size) {
+    char *dst = (char *)g_memory_fs;
+    memcpy(dst + offset, buffer, size);
+    return (int)size;
+}
+
+int main(void) {
+    vfs_node_t fs_root = {0};
+    vfs_operations_t fs_ops = {
+        .read = mem_read,
+        .write = mem_write,
+        .open = NULL,
+        .close = NULL,
+        .readdir = NULL,
+        .finddir = NULL,
+        .ioctl = NULL,
+    };
+    char fs_data[64] = "hello-kernel-vfs";
+    char read_buf[64] = {0};
+    int fd;
+
+    vfs_test_reset_state();
+
+    fs_root.backend_type = VFS_BACKEND_FILESYSTEM;
+    fs_root.ops = &fs_ops;
+    fs_root.fs_data = fs_data;
+    fs_root.object_id = 42;
+
+    capability_t mount_cap = {0};
+    assert(vfs_mount_fs("/", &fs_root, &mount_cap) == 0);
+
+    capability_t good_cap = {
+        .capability_id = 1,
+        .target_object_id = 42,
+        .rights_mask = CAP_RIGHT_READ | CAP_RIGHT_WRITE,
+        .owner_core_id = 0,
+    };
+
+    capability_t bad_object_cap = {
+        .capability_id = 2,
+        .target_object_id = 99,
+        .rights_mask = CAP_RIGHT_READ | CAP_RIGHT_WRITE,
+        .owner_core_id = 0,
+    };
+
+    capability_t bad_rights_cap = {
+        .capability_id = 3,
+        .target_object_id = 42,
+        .rights_mask = 0,
+        .owner_core_id = 0,
+    };
+
+    assert(vfs_open_file("/", VFS_OPEN_READ | VFS_OPEN_WRITE, &good_cap, &fd) == 0);
+    assert(fd >= 0);
+
+    // Write should be denied when capability lacks right
+    assert(vfs_write_file(fd, "test", 4, &bad_rights_cap) == -1);
+
+    // Write should be denied when capability targets different object
+    assert(vfs_write_file(fd, "test", 4, &bad_object_cap) == -1);
+
+    // Write should succeed with good cap
+    assert(vfs_write_file(fd, "test", 4, &good_cap) == 4);
+
+    // Read should be denied when capability lacks right
+    assert(vfs_read_file(fd, read_buf, 4, &bad_rights_cap) == -1);
+
+    // Read should be denied when capability targets different object
+    assert(vfs_read_file(fd, read_buf, 4, &bad_object_cap) == -1);
+
+    // Read should succeed with good cap
+    // Note: since our mem_write just copies to g_memory_fs without updating any size metadata,
+    // we should make sure mem_read reads what we wrote, though we might read 0 if the size check fails.
+    // wait, mem_read checks `offset >= len`, where `len = strlen(src);`.
+    // so if the buffer has null bytes initially and we write "test", strlen is 4!
+    // wait, g_memory_fs was initialized to {0}, so strlen(g_memory_fs) is 0 before writing,
+    // and after writing "test", strlen(g_memory_fs) is 4.
+    // but the fd offset is already 4 after writing!
+    // So if offset=4, and len=4, `offset >= len` is true, so it returns 0!
+    // Let's reset the offset before reading. Oh wait, we don't have vfs_lseek.
+    // Let's open another fd for reading.
+
+    int read_fd;
+    assert(vfs_open_file("/", VFS_OPEN_READ, &good_cap, &read_fd) == 0);
+    assert(vfs_read_file(read_fd, read_buf, 4, &good_cap) == 4);
+    assert(memcmp(read_buf, "test", 4) == 0);
+    assert(vfs_close_file(read_fd, &good_cap) == 0);
+
+    // Close should be denied for bad object
+    assert(vfs_close_file(fd, &bad_object_cap) == -1);
+
+    // Close should succeed with good cap
+    assert(vfs_close_file(fd, &good_cap) == 0);
+
+    puts("test_vfs_file_caps: PASS");
+    return 0;
+}


### PR DESCRIPTION
🎯 **What:** Fixed missing capability enforcement in VFS file operations (`vfs_read_file`, `vfs_write_file`, and `vfs_close_file`).
⚠️ **Risk:** Without this, unrelated capabilities with broad rights (like `CAP_RIGHT_WRITE`) could access and mutate the wrong file object, leading to a confused-deputy vulnerability where a caller writes through an open file descriptor they shouldn't have access to.
🛡️ **Solution:** Required both the correct rights and a capability binding to the opened file's canonical object before allowing access. Introduced a local validation helper (`vfs_cap_allows_file`) and zero-initialized `handle_cap` until a true capability-issuance model is incorporated. Added corresponding tests.

---
*PR created automatically by Jules for task [12519401676123259708](https://jules.google.com/task/12519401676123259708) started by @divyang4481*