### PR TITLE
🧹 Replace URPC capacity bit hack with standard power-of-two fallback

### DIFF
--- a/lib/urpc/urpc.c
+++ b/lib/urpc/urpc.c
@@ -1,20 +1,27 @@
 #include "urpc.h"
 
+static uint32_t round_down_pow2_u32(uint32_t x) {
+    x |= x >> 1;
+    x |= x >> 2;
+    x |= x >> 4;
+    x |= x >> 8;
+    x |= x >> 16;
+    return x - (x >> 1);
+}
+
 int urpc_init_channel(urpc_channel_t* channel, void* shared_mem, uint32_t size_bytes) {
     if (!channel || !shared_mem || size_bytes < sizeof(urpc_msg_t)) {
         return URPC_ERR_INVALID;
     }
 
     uint32_t capacity = size_bytes / sizeof(urpc_msg_t);
-    // Ensure capacity is a power of 2 for fast modulo
-    if ((capacity & (capacity - 1)) != 0) {
-        // Fallback or bit hack to get previous power of 2
-        while ((capacity & (capacity - 1)) != 0) {
-            capacity = capacity & (capacity - 1);
-        }
-    }
 
     if (capacity == 0) return URPC_ERR_INVALID;
+
+    // Round capacity down to the previous power of two.
+    if ((capacity & (capacity - 1)) != 0) {
+        capacity = round_down_pow2_u32(capacity);
+    }
 
     channel->head = 0;
     channel->tail = 0;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,6 +35,10 @@ target_include_directories(test_hal_interrupts PRIVATE ../kernel/include)
 add_test(NAME test_hal_interrupts COMMAND test_hal_interrupts)
 
 
+add_executable(test_urpc_init_channel test_urpc_init_channel.c ../lib/urpc/urpc.c)
+target_include_directories(test_urpc_init_channel PRIVATE ../lib/urpc)
+add_test(NAME test_urpc_init_channel COMMAND test_urpc_init_channel)
+
 add_executable(test_urpc_ring test_urpc_ring.c benchmark_stubs.c ../kernel/src/ipc/multikernel.c ../kernel/src/ipc/mk_dispatch.c)
 add_executable(test_ipc_async_timeout test_ipc_async_timeout.c ../kernel/src/ipc/async_ipc.c ../kernel/src/ipc/ipc_timeout.c)
 target_include_directories(test_ipc_async_timeout PRIVATE ../kernel/include)

--- a/tests/test_urpc_init_channel.c
+++ b/tests/test_urpc_init_channel.c
@@ -1,0 +1,55 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include "urpc.h"
+
+// Macro to assert conditions
+#define ASSERT(cond) \
+    do { \
+        if (!(cond)) { \
+            fprintf(stderr, "Assertion failed: %s, file %s, line %d\n", \
+                    #cond, __FILE__, __LINE__); \
+            exit(1); \
+        } \
+    } while (0)
+
+int main() {
+    urpc_channel_t channel;
+    uint8_t buffer[1024]; // Large enough for our tests
+
+    int ret;
+
+    // Test 1: size_bytes < sizeof(urpc_msg_t) -> Returns invalid
+    ret = urpc_init_channel(&channel, buffer, sizeof(urpc_msg_t) - 1);
+    ASSERT(ret == URPC_ERR_INVALID);
+
+    // Test 2: size_bytes == sizeof(urpc_msg_t) -> Capacity is 1
+    ret = urpc_init_channel(&channel, buffer, sizeof(urpc_msg_t));
+    ASSERT(ret == URPC_SUCCESS);
+    ASSERT(channel.capacity == 1);
+
+    // Test 3: size_bytes == 3 * sizeof(urpc_msg_t) -> Capacity rounded down to 2
+    ret = urpc_init_channel(&channel, buffer, 3 * sizeof(urpc_msg_t));
+    ASSERT(ret == URPC_SUCCESS);
+    ASSERT(channel.capacity == 2);
+
+    // Test 4: size_bytes == 4 * sizeof(urpc_msg_t) -> Capacity stays 4
+    ret = urpc_init_channel(&channel, buffer, 4 * sizeof(urpc_msg_t));
+    ASSERT(ret == URPC_SUCCESS);
+    ASSERT(channel.capacity == 4);
+
+    // Test 5: size_bytes == 7 * sizeof(urpc_msg_t) -> Capacity rounded down to 4
+    ret = urpc_init_channel(&channel, buffer, 7 * sizeof(urpc_msg_t));
+    ASSERT(ret == URPC_SUCCESS);
+    ASSERT(channel.capacity == 4);
+
+    // Additional Test: Null pointers
+    ret = urpc_init_channel(NULL, buffer, sizeof(urpc_msg_t));
+    ASSERT(ret == URPC_ERR_INVALID);
+
+    ret = urpc_init_channel(&channel, NULL, sizeof(urpc_msg_t));
+    ASSERT(ret == URPC_ERR_INVALID);
+
+    printf("All urpc_init_channel tests passed.\n");
+    return 0;
+}


### PR DESCRIPTION
🎯 **What:** Replaced the iterative bit-clearing loop in `urpc_init_channel` with a standard round-down-to-power-of-two implementation.
💡 **Why:** Improves readability, portability, and maintainability in low-level sizing logic.
✅ **Verification:** Added edge-case tests for zero, exact power-of-two, and non-power-of-two capacities, and ran the existing test suite.
✨ **Result:** Same behavior, clearer implementation, easier future maintenance.

---
*PR created automatically by Jules for task [1099183268797802444](https://jules.google.com/task/1099183268797802444) started by @divyang4481*