### PR TITLE
🔒 Enforce read-open flag in VFS file read path

### DIFF
--- a/kernel/src/fs/file.c
+++ b/kernel/src/fs/file.c
@@ -85,6 +85,10 @@ int vfs_read_file(int fd, void* buffer, size_t size, capability_t* caller_cap) {
         return -1;
     }
 
+    if ((entry->flags & VFS_OPEN_READ) == 0) {
+        return -1;
+    }
+
     // TODO: Verify caller_cap matches entry->handle_cap rights when initialized
     if (!vfs_cap_allows_file(entry, caller_cap, CAP_RIGHT_READ)) {
         return -1;

--- a/tests/test_vfs_file_caps.c
+++ b/tests/test_vfs_file_caps.c
@@ -107,6 +107,14 @@ int main(void) {
     assert(vfs_open_file("/", VFS_OPEN_READ, &good_cap, &read_fd) == 0);
     assert(vfs_read_file(read_fd, read_buf, 4, &good_cap) == 4);
     assert(memcmp(read_buf, "test", 4) == 0);
+
+    // Verify that a file opened as write-only cannot be read from
+    int write_only_fd;
+    assert(vfs_open_file("/", VFS_OPEN_WRITE, &good_cap, &write_only_fd) == 0);
+    // Read should be denied because handle lacks VFS_OPEN_READ, even though good_cap has CAP_RIGHT_READ
+    assert(vfs_read_file(write_only_fd, read_buf, 4, &good_cap) == -1);
+    assert(vfs_close_file(write_only_fd, &good_cap) == 0);
+
     assert(vfs_close_file(read_fd, &good_cap) == 0);
 
     // Close should be denied for bad object


### PR DESCRIPTION
🎯 What: added missing `VFS_OPEN_READ` validation in `vfs_read_file`.
⚠️ Risk: callers could read through write-only handles if node capabilities allowed it.
🛡️ Solution: require both the read-open flag and capability authorization before dispatching to the backend.

---
*PR created automatically by Jules for task [10712934533920458898](https://jules.google.com/task/10712934533920458898) started by @divyang4481*