### PR TITLE
✨ Add structured panic formatting and fault breadcrumbs

### DIFF
--- a/kernel/include/fault_diag.h
+++ b/kernel/include/fault_diag.h
@@ -1,0 +1,31 @@
+#ifndef BHARAT_FAULT_DIAG_H
+#define BHARAT_FAULT_DIAG_H
+
+#include "panic.h"
+#include <stdint.h>
+#include <stddef.h>
+
+#define FAULT_DIAG_MAX_CORES 8 // Must match MAX_SUPPORTED_CORES or at least handle typical configs
+
+// Core-local diagnostic breadcrumbs
+typedef struct {
+    uint64_t last_syscall_nr;
+    uint64_t last_fault_va;
+    uint64_t last_trap_cause;
+    uint64_t last_exception_vector;
+} fault_breadcrumbs_t;
+
+// Record breadcrumbs
+void fault_diag_record_syscall(uint64_t syscall_nr);
+void fault_diag_record_fault(uint64_t fault_va, uint64_t trap_cause);
+
+// Retrieve breadcrumbs for current core
+const fault_breadcrumbs_t* fault_diag_get_breadcrumbs(void);
+
+// Formatting helpers (reusable)
+void panic_emit_header(const panic_context_t *ctx);
+void panic_emit_thread_info(const panic_context_t *ctx);
+void panic_emit_fault_info(const panic_context_t *ctx);
+void panic_emit_breadcrumbs(const panic_context_t *ctx);
+
+#endif // BHARAT_FAULT_DIAG_H

--- a/kernel/include/hal/hal.h
+++ b/kernel/include/hal/hal.h
@@ -10,6 +10,7 @@
 void hal_cpu_halt(void);
 void hal_cpu_reboot(void);
 void hal_cpu_dump_state(void);
+void hal_cpu_dump_trap_frame(const void *trap_frame);
 void hal_cpu_enable_interrupts(void);
 void hal_cpu_disable_interrupts(void);
 void hal_init(void);

--- a/kernel/include/panic.h
+++ b/kernel/include/panic.h
@@ -1,0 +1,33 @@
+#ifndef BHARAT_PANIC_H
+#define BHARAT_PANIC_H
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+
+typedef struct panic_context {
+    const char *message;
+    const char *cause_str;
+    uint64_t cause_code;
+    uint64_t fault_addr;
+    uint64_t ip;
+    uint64_t sp;
+    uint64_t core_id;
+    uint64_t thread_id;
+    uint64_t process_id;
+    uint64_t aspace_id;
+    uint64_t last_syscall_nr;
+    const void *trap_frame;
+    uint32_t flags;
+} panic_context_t;
+
+// Standard kernel panic, wrappers internally over kernel_panic_ex
+void kernel_panic(const char *message);
+
+// Extended kernel panic with structured diagnostic context
+void kernel_panic_ex(const panic_context_t *ctx);
+
+// Hooks for flushing logs safely during a panic
+void panic_flush_logs(void);
+
+#endif // BHARAT_PANIC_H

--- a/kernel/src/fault_diag.c
+++ b/kernel/src/fault_diag.c
@@ -1,0 +1,83 @@
+#include "fault_diag.h"
+#include "hal/hal.h"
+#include "sched.h"
+
+// Hardcode max cores for diagnostic tracking to avoid dynamic allocation
+#ifndef MAX_SUPPORTED_CORES
+#define MAX_SUPPORTED_CORES 8U
+#endif
+
+static fault_breadcrumbs_t g_core_breadcrumbs[MAX_SUPPORTED_CORES] = {0};
+
+void fault_diag_record_syscall(uint64_t syscall_nr) {
+    uint32_t core = hal_cpu_get_id();
+    if (core < MAX_SUPPORTED_CORES) {
+        g_core_breadcrumbs[core].last_syscall_nr = syscall_nr;
+    }
+}
+
+void fault_diag_record_fault(uint64_t fault_va, uint64_t trap_cause) {
+    uint32_t core = hal_cpu_get_id();
+    if (core < MAX_SUPPORTED_CORES) {
+        g_core_breadcrumbs[core].last_fault_va = fault_va;
+        g_core_breadcrumbs[core].last_trap_cause = trap_cause;
+    }
+}
+
+const fault_breadcrumbs_t* fault_diag_get_breadcrumbs(void) {
+    uint32_t core = hal_cpu_get_id();
+    if (core < MAX_SUPPORTED_CORES) {
+        return &g_core_breadcrumbs[core];
+    }
+    return NULL;
+}
+
+void panic_emit_header(const panic_context_t *ctx) {
+    hal_serial_write("\n================ KERNEL PANIC ================\n");
+    hal_serial_write("message      : ");
+    hal_serial_write(ctx->message ? ctx->message : "(unknown)");
+    hal_serial_write("\ncause        : ");
+    hal_serial_write(ctx->cause_str ? ctx->cause_str : "N/A");
+    hal_serial_write("\ncause_code   : ");
+    hal_serial_write_hex(ctx->cause_code);
+    hal_serial_write("\n");
+}
+
+void panic_emit_thread_info(const panic_context_t *ctx) {
+    hal_serial_write("core         : ");
+    hal_serial_write_hex(ctx->core_id);
+    hal_serial_write("\nthread       : ");
+    hal_serial_write_hex(ctx->thread_id);
+    hal_serial_write("\nprocess      : ");
+    hal_serial_write_hex(ctx->process_id);
+    hal_serial_write("\naspace       : ");
+    hal_serial_write_hex(ctx->aspace_id);
+    hal_serial_write("\n");
+}
+
+void panic_emit_fault_info(const panic_context_t *ctx) {
+    hal_serial_write("last_syscall : ");
+    hal_serial_write_hex(ctx->last_syscall_nr);
+    hal_serial_write("\nfault_va     : ");
+    hal_serial_write_hex(ctx->fault_addr);
+    hal_serial_write("\nip           : ");
+    hal_serial_write_hex(ctx->ip);
+    hal_serial_write("\nsp           : ");
+    hal_serial_write_hex(ctx->sp);
+    hal_serial_write("\n==============================================\n");
+}
+
+void panic_emit_breadcrumbs(const panic_context_t *ctx) {
+    (void)ctx;
+    const fault_breadcrumbs_t *bc = fault_diag_get_breadcrumbs();
+    if (bc) {
+        hal_serial_write("\n--- Breadcrumbs ---\n");
+        hal_serial_write("last_syscall : ");
+        hal_serial_write_hex(bc->last_syscall_nr);
+        hal_serial_write("\nlast_fault_va: ");
+        hal_serial_write_hex(bc->last_fault_va);
+        hal_serial_write("\nlast_trap    : ");
+        hal_serial_write_hex(bc->last_trap_cause);
+        hal_serial_write("\n-------------------\n");
+    }
+}

--- a/kernel/src/hal/arm64/hal_cpu.c
+++ b/kernel/src/hal/arm64/hal_cpu.c
@@ -88,6 +88,34 @@ void hal_serial_write_hex(uint64_t val) {
   hal_serial_write(buf);
 }
 
+#include "trap.h"
+
+__attribute__((weak)) void hal_cpu_dump_trap_frame(const void *trap_frame) {
+  if (!trap_frame) {
+    return;
+  }
+  const trap_frame_t *tf = (const trap_frame_t *)trap_frame;
+  hal_serial_write("\n--- ARM64 Trap Frame Dump ---\n");
+  hal_serial_write("CAUSE (ESR): ");
+  hal_serial_write_hex(tf->cause);
+  hal_serial_write("\n");
+  hal_serial_write("PC:          ");
+  hal_serial_write_hex(tf->pc);
+  hal_serial_write("\n");
+  hal_serial_write("SP:          ");
+  hal_serial_write_hex(tf->sp);
+  hal_serial_write("\n");
+  hal_serial_write("X0:          "); hal_serial_write_hex(tf->gpr[0]); hal_serial_write("\n");
+  hal_serial_write("X1:          "); hal_serial_write_hex(tf->gpr[1]); hal_serial_write("\n");
+  hal_serial_write("X2:          "); hal_serial_write_hex(tf->gpr[2]); hal_serial_write("\n");
+  hal_serial_write("X3:          "); hal_serial_write_hex(tf->gpr[3]); hal_serial_write("\n");
+  hal_serial_write("X4:          "); hal_serial_write_hex(tf->gpr[4]); hal_serial_write("\n");
+  hal_serial_write("X5:          "); hal_serial_write_hex(tf->gpr[5]); hal_serial_write("\n");
+  hal_serial_write("X6:          "); hal_serial_write_hex(tf->gpr[6]); hal_serial_write("\n");
+  hal_serial_write("X7:          "); hal_serial_write_hex(tf->gpr[7]); hal_serial_write("\n");
+  hal_serial_write("-----------------------------\n");
+}
+
 void hal_cpu_dump_state(void) {
   uint64_t far_el1, esr_el1, elr_el1, spsr_el1, x29, sp;
   __asm__ volatile("mrs %0, far_el1" : "=r"(far_el1));

--- a/kernel/src/hal/riscv/hal_cpu.c
+++ b/kernel/src/hal/riscv/hal_cpu.c
@@ -121,6 +121,34 @@ void hal_serial_write_hex(uint64_t val) {
   hal_serial_write(buf);
 }
 
+#include "trap.h"
+
+__attribute__((weak)) void hal_cpu_dump_trap_frame(const void *trap_frame) {
+  if (!trap_frame) {
+    return;
+  }
+  const trap_frame_t *tf = (const trap_frame_t *)trap_frame;
+  hal_serial_write("\n--- RISC-V Trap Frame Dump ---\n");
+  hal_serial_write("SCAUSE: ");
+  hal_serial_write_hex(tf->cause);
+  hal_serial_write("\n");
+  hal_serial_write("SEPC:   ");
+  hal_serial_write_hex(tf->pc);
+  hal_serial_write("\n");
+  hal_serial_write("SP:     ");
+  hal_serial_write_hex(tf->sp);
+  hal_serial_write("\n");
+  hal_serial_write("A0:     "); hal_serial_write_hex(tf->gpr[0]); hal_serial_write("\n");
+  hal_serial_write("A1:     "); hal_serial_write_hex(tf->gpr[1]); hal_serial_write("\n");
+  hal_serial_write("A2:     "); hal_serial_write_hex(tf->gpr[2]); hal_serial_write("\n");
+  hal_serial_write("A3:     "); hal_serial_write_hex(tf->gpr[3]); hal_serial_write("\n");
+  hal_serial_write("A4:     "); hal_serial_write_hex(tf->gpr[4]); hal_serial_write("\n");
+  hal_serial_write("A5:     "); hal_serial_write_hex(tf->gpr[5]); hal_serial_write("\n");
+  hal_serial_write("A6:     "); hal_serial_write_hex(tf->gpr[6]); hal_serial_write("\n");
+  hal_serial_write("A7:     "); hal_serial_write_hex(tf->gpr[7]); hal_serial_write("\n");
+  hal_serial_write("------------------------------\n");
+}
+
 void hal_cpu_dump_state(void) {
   uint64_t sepc, scause, stval, sstatus, fp, sp;
   __asm__ volatile("csrr %0, sepc" : "=r"(sepc));

--- a/kernel/src/hal/x86_64/hal_cpu.c
+++ b/kernel/src/hal/x86_64/hal_cpu.c
@@ -181,6 +181,34 @@ void hal_serial_write_hex(uint64_t val) {
   hal_serial_write(buf);
 }
 
+#include "trap.h"
+
+__attribute__((weak)) void hal_cpu_dump_trap_frame(const void *trap_frame) {
+  if (!trap_frame) {
+    return;
+  }
+  const trap_frame_t *tf = (const trap_frame_t *)trap_frame;
+  hal_serial_write("\n--- x86_64 Trap Frame Dump ---\n");
+  hal_serial_write("CAUSE: ");
+  hal_serial_write_hex(tf->cause);
+  hal_serial_write("\n");
+  hal_serial_write("PC:    ");
+  hal_serial_write_hex(tf->pc);
+  hal_serial_write("\n");
+  hal_serial_write("SP:    ");
+  hal_serial_write_hex(tf->sp);
+  hal_serial_write("\n");
+  // Dump some general registers, usually gpr[0]-gpr[5] hold arg0-arg5 in syscalls
+  hal_serial_write("RAX:   "); hal_serial_write_hex(tf->gpr[0]); hal_serial_write("\n");
+  hal_serial_write("RDI:   "); hal_serial_write_hex(tf->gpr[1]); hal_serial_write("\n");
+  hal_serial_write("RSI:   "); hal_serial_write_hex(tf->gpr[2]); hal_serial_write("\n");
+  hal_serial_write("RDX:   "); hal_serial_write_hex(tf->gpr[3]); hal_serial_write("\n");
+  hal_serial_write("RCX:   "); hal_serial_write_hex(tf->gpr[4]); hal_serial_write("\n");
+  hal_serial_write("R8:    "); hal_serial_write_hex(tf->gpr[5]); hal_serial_write("\n");
+  hal_serial_write("R9:    "); hal_serial_write_hex(tf->gpr[6]); hal_serial_write("\n");
+  hal_serial_write("------------------------------\n");
+}
+
 void hal_cpu_dump_state(void) {
   uint64_t cr2, cr3, rbp, rsp;
   __asm__ volatile("mov %%cr2, %0" : "=r"(cr2));

--- a/kernel/src/panic.c
+++ b/kernel/src/panic.c
@@ -1,8 +1,11 @@
+#include "panic.h"
+#include "fault_diag.h"
 #include "hal/hal.h"
 #include "kernel.h"
-
+#include "sched.h"
 
 #include <stdint.h>
+#include <stddef.h>
 
 #ifndef PANIC_RECOVERY_MODE
 // 0: Halt (Development), 1: Reboot (Production)
@@ -43,7 +46,11 @@ static void pstore_write(const char *msg) {
 
 static int g_in_panic = 0;
 
-void kernel_panic(const char *message) {
+__attribute__((weak)) void panic_flush_logs(void) {
+    // Stub for now. If there's an internal logging buffer, it should be flushed here.
+}
+
+void kernel_panic_ex(const panic_context_t *ctx) {
   if (g_in_panic) {
     // Recursive panic, just halt
     while (1) {
@@ -54,16 +61,66 @@ void kernel_panic(const char *message) {
 
   hal_cpu_disable_interrupts();
 
-  // UART dump
-  hal_serial_write("\nKERNEL PANIC: ");
-  hal_serial_write(message ? message : "(no message)");
-  hal_serial_write("\n");
+  // Early flush to push any pending print buffers
+  panic_flush_logs();
+
+  panic_context_t local_ctx;
+  if (ctx) {
+      local_ctx = *ctx;
+  } else {
+      local_ctx.message = "(no message)";
+      local_ctx.cause_str = "unknown";
+      local_ctx.cause_code = 0;
+      local_ctx.fault_addr = 0;
+      local_ctx.ip = 0;
+      local_ctx.sp = 0;
+      local_ctx.core_id = hal_cpu_get_id();
+      local_ctx.thread_id = 0;
+      local_ctx.process_id = 0;
+      local_ctx.aspace_id = 0;
+      local_ctx.last_syscall_nr = 0;
+      local_ctx.trap_frame = NULL;
+      local_ctx.flags = 0;
+  }
+
+  // Backfill context
+  local_ctx.core_id = hal_cpu_get_id();
+  kthread_t *thread = sched_current_thread();
+  if (thread) {
+      if (local_ctx.thread_id == 0) {
+          local_ctx.thread_id = thread->thread_id;
+      }
+      if (local_ctx.process_id == 0) {
+          local_ctx.process_id = thread->process_id;
+      }
+      // Note: mapping process_id to aspace_id for simplicity since we don't track aspace IDs yet
+      if (local_ctx.aspace_id == 0) {
+          local_ctx.aspace_id = thread->process_id;
+      }
+  }
+
+  const fault_breadcrumbs_t* bc = fault_diag_get_breadcrumbs();
+  if (bc && local_ctx.last_syscall_nr == 0) {
+      local_ctx.last_syscall_nr = bc->last_syscall_nr;
+  }
+
+  panic_emit_header(&local_ctx);
+  panic_emit_thread_info(&local_ctx);
+  panic_emit_fault_info(&local_ctx);
+
+  if (local_ctx.trap_frame) {
+      hal_cpu_dump_trap_frame(local_ctx.trap_frame);
+  }
+
+  panic_emit_breadcrumbs(&local_ctx);
 
   // Dump architecture specific CPU state
   hal_cpu_dump_state();
 
   // Save to persistent storage
-  pstore_write(message);
+  pstore_write(local_ctx.message);
+
+  panic_flush_logs();
 
   if (PANIC_RECOVERY_MODE == 1) {
     hal_serial_write("Rebooting system...\n");
@@ -74,4 +131,23 @@ void kernel_panic(const char *message) {
       hal_cpu_halt();
     }
   }
+}
+
+void kernel_panic(const char *message) {
+    panic_context_t ctx = {
+        .message = message,
+        .cause_str = "panic",
+        .cause_code = 0,
+        .fault_addr = 0,
+        .ip = 0,
+        .sp = 0,
+        .core_id = hal_cpu_get_id(),
+        .thread_id = 0,
+        .process_id = 0,
+        .aspace_id = 0,
+        .last_syscall_nr = 0,
+        .trap_frame = NULL,
+        .flags = 0
+    };
+    kernel_panic_ex(&ctx);
 }

--- a/kernel/src/trap/trap.c
+++ b/kernel/src/trap/trap.c
@@ -10,6 +10,7 @@
 #include "kernel_safety.h"
 #include "mm.h"
 #include "mm/mm_local.h"
+#include "fault_diag.h"
 
 
 #include <stddef.h>
@@ -162,10 +163,21 @@ long trap_handle(trap_frame_t *frame) {
     uint64_t stval;
     __asm__ volatile("csrr %0, stval" : "=r"(stval));
 
+    fault_diag_record_fault(stval, frame->cause);
+
     // Check if it's a guard page hit
     if (current && current->kernel_stack != 0 && stval >= current->kernel_stack && stval < current->kernel_stack + PAGE_SIZE) {
         if (core_is_rt()) {
-            kernel_panic("Stack overflow on RT core! Guard page hit.");
+            panic_context_t pctx = {
+                .message = "Stack overflow on RT core! Guard page hit.",
+                .cause_str = "stack_overflow/guard_page",
+                .cause_code = frame->cause,
+                .fault_addr = stval,
+                .ip = frame->pc,
+                .sp = frame->sp,
+                .trap_frame = frame
+            };
+            kernel_panic_ex(&pctx);
         } else {
             thread_raise_fault(current, THREAD_FAULT_STACK_OVERFLOW);
             return 0;
@@ -193,10 +205,21 @@ long trap_handle(trap_frame_t *frame) {
     uint64_t cr2;
     __asm__ volatile("mov %%cr2, %0" : "=r"(cr2));
 
+    fault_diag_record_fault(cr2, frame->cause);
+
     // Check if it's a guard page hit
     if (current && current->kernel_stack != 0 && cr2 >= current->kernel_stack && cr2 < current->kernel_stack + PAGE_SIZE) {
         if (core_is_rt()) {
-            kernel_panic("Stack overflow on RT core! Guard page hit.");
+            panic_context_t pctx = {
+                .message = "Stack overflow on RT core! Guard page hit.",
+                .cause_str = "stack_overflow/guard_page",
+                .cause_code = frame->cause,
+                .fault_addr = cr2,
+                .ip = frame->pc,
+                .sp = frame->sp,
+                .trap_frame = frame
+            };
+            kernel_panic_ex(&pctx);
         } else {
             thread_raise_fault(current, THREAD_FAULT_STACK_OVERFLOW);
             return 0;
@@ -238,11 +261,22 @@ long trap_handle(trap_frame_t *frame) {
       uint64_t far;
       __asm__ volatile("mrs %0, far_el1" : "=r"(far));
 
+      fault_diag_record_fault(far, frame->cause);
+
       kthread_t *current = sched_current_thread();
       // Check if it's a guard page hit
       if (current && current->kernel_stack != 0 && far >= current->kernel_stack && far < current->kernel_stack + PAGE_SIZE) {
           if (core_is_rt()) {
-              kernel_panic("Stack overflow on RT core! Guard page hit.");
+              panic_context_t pctx = {
+                .message = "Stack overflow on RT core! Guard page hit.",
+                .cause_str = "stack_overflow/guard_page",
+                .cause_code = frame->cause,
+                .fault_addr = far,
+                .ip = frame->pc,
+                .sp = frame->sp,
+                .trap_frame = frame
+              };
+              kernel_panic_ex(&pctx);
           } else {
               thread_raise_fault(current, THREAD_FAULT_STACK_OVERFLOW);
               return 0;
@@ -260,7 +294,15 @@ long trap_handle(trap_frame_t *frame) {
 
   if (frame->cause != TRAP_CAUSE_SYSCALL) {
     if (frame->from_user == 0U) {
-      kernel_panic("Kernel exception");
+      panic_context_t pctx = {
+          .message = "Kernel exception",
+          .cause_str = "unhandled_kernel_trap",
+          .cause_code = frame->cause,
+          .ip = frame->pc,
+          .sp = frame->sp,
+          .trap_frame = frame
+      };
+      kernel_panic_ex(&pctx);
     } else {
       kthread_t *current = sched_current_thread();
       if (current) {
@@ -280,6 +322,8 @@ long trap_handle(trap_frame_t *frame) {
   if (frame->from_user == 0U) {
     return TRAP_ERR_PERM;
   }
+
+  fault_diag_record_syscall(frame->gpr[0]);
 
   kthread_t *current = sched_current_thread();
   long rc = 0;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,7 +6,7 @@ enable_testing()
 add_executable(test_early_alloc test_early_alloc.c)
 target_include_directories(test_early_alloc PRIVATE ../kernel/include)
 
-add_executable(test_panic test_panic.c ../kernel/src/panic.c)
+add_executable(test_panic test_panic.c benchmark_stubs.c ../kernel/src/panic.c ../kernel/src/fault_diag.c ../kernel/src/sched.c ../kernel/src/sched_deg.c ../kernel/src/ai_sched.c ../kernel/src/capability.c ../kernel/src/device/device_manager.c ../kernel/src/algo_matrix.c ../kernel/src/mm/pmm/numa.c)
 
 add_executable(test_stress_concurrency test_stress_concurrency.c
     benchmark_stubs.c

--- a/tests/benchmark_stubs.c
+++ b/tests/benchmark_stubs.c
@@ -117,6 +117,13 @@ int __attribute__((weak)) hal_vmm_update_mapping(phys_addr_t root_table, virt_ad
     return -1;
 }
 
+__attribute__((weak)) void hal_serial_write(const char *s) { (void)s; }
+__attribute__((weak)) void hal_serial_write_hex(uint64_t val) { (void)val; }
+__attribute__((weak)) void hal_cpu_dump_trap_frame(const void *trap_frame) { (void)trap_frame; }
+__attribute__((weak)) void hal_cpu_dump_state(void) {}
+__attribute__((weak)) void hal_cpu_disable_interrupts(void) {}
+__attribute__((weak)) void hal_cpu_reboot(void) {}
+
 // kmalloc and kfree for testing
 void* __attribute__((weak)) kmalloc(size_t size) {
     return malloc(size);


### PR DESCRIPTION
This pull request introduces a structured panic header and unifies fault formatting to greatly improve diagnostic capabilities during kernel panics.

**🎯 What:**
The `kernel_panic` behavior has been enhanced to include detailed context. A new `kernel_panic_ex` function allows passing a `panic_context_t` with explicit cause, fault address, instruction pointer, and a trap frame. If not provided, it backfills core/thread/process/aspace info using the current execution context. A new breadcrumb system tracks the last syscall and fault VA without lock contention, and architectures now feature optional trap frame pretty-printers.

**⚠️ Risk:**
Low risk. The original `kernel_panic` signature is preserved as a wrapper to avoid massive repo-wide breakage. The new logic is localized to the panic reporting and trap escalation paths. Breadcrumb tracking simply writes to an array keyed by core ID.

**🛡️ Solution:**
- Created `panic.h` and `fault_diag.h` with structures and helpers.
- Reimplemented `kernel_panic` to internally call `kernel_panic_ex`.
- Added `hal_cpu_dump_trap_frame` for x86_64, arm64, and riscv.
- Updated `trap.c` fatal paths to populate `panic_context_t` and call `kernel_panic_ex`.
- Recorded breadcrumbs (syscall, fault VA) during normal execution.

---
*PR created automatically by Jules for task [4119530667977649101](https://jules.google.com/task/4119530667977649101) started by @divyang4481*