### PR TITLE
docs: update documentation for structured panics and FBUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Bharat-OS is a capability-oriented microkernel project with a multikernel direct
 | Scheduler and AI hook points | Implemented baseline | Timer-driven scheduler path with bounded AI suggestion ingestion/processing; full SMP runqueues/context switching remain deferred. |
 | Driver and HAL model | Implemented baseline | HAL contracts and driver framework scaffolding exist across x86_64, riscv64, arm64. |
 | Distributed/multikernel scale-out | Early baseline | Per-core URPC matrix and multicore bootstrap hooks exist; production-grade topology and transport tuning are deferred. |
+| Diagnostics & Reliability | Implemented baseline | Structured kernel panic generation, architecture-specific trap/fault breadcrumbs, and PStore persistent recovery logging. |
 
 For architecture-level details and deferred boundaries, see `docs/architecture/` and ADRs in `docs/decisions/`. For the step-by-step closure plan, see `docs/architecture/memory-gap-closure-plan.md`.
 
@@ -38,11 +39,13 @@ Bharat-OS targets multiple deployment classes. These profiles describe **how the
 ### High-Level Architecture
 
 ```mermaid
+%%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#ffcccc', 'edgeLabelBackground':'#ffffff'}}}%%
 graph TD
     subgraph UserSpace [User-Space Domains]
         subgraph Subsystems [Subsystems Model]
             Console[Console Subsystem]
             FB[Framebuffer & Embedded GUI]
+            FBUI[FBUI Widgets & Toolkit]
             Desktop[Desktop GUI Compositor]
             Input[Input Subsystem]
             Accel[Accelerator Subsystem]
@@ -68,6 +71,7 @@ graph TD
         Sched[Scheduler & AI Hooks]
         VMM[VMM & Memory Registry]
         Cap[Capability System]
+        Diag[Diagnostics & PStore]
     end
 
     subgraph Hardware [Hardware Abstraction Layer]
@@ -77,6 +81,7 @@ graph TD
     %% Relationships
     App --> Subsystems
     Subsystems <--> IPC
+    FB --> FBUI
     Drivers <--> IPC
     Policy <--> IPC
 
@@ -110,6 +115,7 @@ graph TD
 The Bharat-OS multi-personality strategy does not bake monolithic compatibility subsystems into the core kernel. Instead, it maintains a small, verifiable, distributed kernel that exposes personality-neutral primitives (tasks, memory objects, capabilities). Layered compatibility subsystems translate these core primitives into personality-specific abstractions (Linux POSIX, Android, Windows NT).
 
 ```mermaid
+%%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#cceeff', 'edgeLabelBackground':'#ffffff'}}}%%
 graph TD
     subgraph Personalities [User-Space Personalities & Apps]
         subgraph Android [Android Personality]
@@ -159,6 +165,7 @@ graph TD
 Bharat-OS enforces security through a mathematically verifiable Capability System. There are no global Access Control Lists (ACLs), user IDs, or root privileges inside the kernel. A capability is an unforgeable, kernel-managed token that pairs an object reference with a set of permitted operations.
 
 ```mermaid
+%%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#eebbff', 'edgeLabelBackground':'#ffffff'}}}%%
 graph TD
     subgraph Thread [Thread Domain]
         CSpace[Capability Space]
@@ -198,6 +205,7 @@ graph TD
 #### Memory Management Architecture
 
 ```mermaid
+%%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#ddffcc', 'edgeLabelBackground':'#ffffff'}}}%%
 graph TD
     subgraph UserSpace [User-Space Memory Policy]
         BharatRT[Bharat-RT Static / No-Paging]
@@ -229,6 +237,7 @@ graph TD
 We utilize two distinct IPC models to serve both deterministic bounds (Bharat-RT) and massive scalability (Bharat-Cloud). **Synchronous Endpoint IPC** is fast, blocking, and unbuffered for strict procedural calls. **Lockless URPC** (User-level Remote Procedure Call) is designed for cross-core, multikernel messaging, scaling across high-core-count processors without shared-kernel locks.
 
 ```mermaid
+%%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#ffeecc', 'edgeLabelBackground':'#ffffff'}}}%%
 graph TD
     subgraph UserSpace [User-Space Domains]
         Sender[Sender Domain]
@@ -268,6 +277,7 @@ graph TD
 Bharat-OS is intentionally profile-driven instead of forcing one heavyweight image on every board. Boot behavior and subsystem initialization are determined dynamically by the detected hardware profile.
 
 ```mermaid
+%%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#ffccff', 'edgeLabelBackground':'#ffffff'}}}%%
 graph LR
     subgraph CoreBoot [Core Kernel Bring-up]
         HAL[HAL & Arch Init] --> Cap[Capability Table Init]
@@ -369,6 +379,7 @@ Bharat-OS keeps AI policy outside ring-0 while exposing bounded kernel mechanism
 #### Scheduler & AI Hooks Architecture
 
 ```mermaid
+%%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#ccffdd', 'edgeLabelBackground':'#ffffff'}}}%%
 graph TD
     subgraph UserSpace [User-Space Policy]
         AIGov[AI Governor]

--- a/docs/architecture/000_KERNEL_ARCHITECTURE.md
+++ b/docs/architecture/000_KERNEL_ARCHITECTURE.md
@@ -349,6 +349,17 @@ Security subsystems include:
 
 Future work may include:
 
+---
+
+# Diagnostics and Reliability
+
+Bharat-OS includes a robust and structured diagnostic system to capture state during critical faults:
+
+- **Structured Panic Context (`panic_context_t`)**: When a kernel panic occurs, the system generates a structured payload capturing the fault address, instruction pointer, stack pointer, core ID, thread ID, process ID, last system call, and the architecture-specific trap frame.
+- **Fault Breadcrumbs**: To aid in debugging complex state transitions, the kernel maintains a ring of breadcrumbs (e.g., the last executed system call number) which are attached to the panic context.
+- **PStore Persistent Recovery Logging**: Critical diagnostic information is written to a designated persistent storage (PStore) memory region before the system halts or reboots. This allows post-mortem analysis of the crash reason even after a hard reset.
+- **Architecture State Dumps**: Architecture-specific implementations dump detailed hardware states (e.g., segment registers, control registers) to the serial console and logs before halting.
+
 - capability-based security models
 - trusted execution support
 

--- a/docs/architecture/display_subsystem.md
+++ b/docs/architecture/display_subsystem.md
@@ -30,8 +30,9 @@ This is the core target for many edge and embedded devices.
 
 ### 4. Tier 3: Embedded Lightweight UI
 For kiosks, industrial panels, and appliances, the UI lives just above the framebuffer.
-* A tiny toolkit of widgets: labels, buttons, progress bars, menus.
-* Scene/view management, directly routing touch/key events to focused components.
+* **FBUI Toolkit**: A lightweight toolkit of widgets currently implemented including labels, buttons, and progress bars.
+* **FBUI Render Context**: Implements software-rendered fills, blitting, and line drawing.
+* **FBUI Events**: Implements touch/key event routing, hit testing, and scene/view management.
 * No complex window management, just full-screen or simple layout partitions.
 
 ### 5. Tier 4: Desktop Graphics Subsystem

--- a/docs/decisions/ADR-011-structured-kernel-panic-and-diagnostics.md
+++ b/docs/decisions/ADR-011-structured-kernel-panic-and-diagnostics.md
@@ -1,0 +1,33 @@
+# ADR 011: Structured Kernel Panic and Diagnostics
+
+## Status
+
+Accepted
+
+## Context
+
+As Bharat-OS matures, debugging kernel crashes and diagnosing unrecoverable faults has become more complex. Historically, kernel panics merely printed a string message and halted the system. In edge computing and automotive contexts, merely halting the machine or displaying a raw string without capturing actionable execution state makes root cause analysis extremely difficult, especially when the system automatically reboots and console logs are lost.
+
+Furthermore, fault boundaries span multiple architectures, and we need a consistent way to pass architecture-specific trap frames to a unified diagnostic formatter.
+
+## Decision
+
+We will implement a structured diagnostic and panic reporting system:
+
+1. **`panic_context_t`:** Introduce a standardized context struct that captures instruction pointers, stack pointers, core IDs, thread/process context, and the memory address of the fault.
+2. **Fault Breadcrumbs (`fault_diag.h`):** Track lightweight breadcrumbs (e.g., the last executed system call number) during hot execution paths. When a panic occurs, these breadcrumbs are gathered and attached to the panic context.
+3. **PStore (Persistent Storage) Recovery Logging:** Write the generated panic diagnostic string to a designated memory region defined by linker scripts (`_pstore_start` to `_pstore_end`). This region is preserved across warm reboots, allowing the system to read and transmit the crash reason during the subsequent boot cycle.
+4. **Architecture State Integration:** Delegate hardware-specific register dumping to the HAL layer via `hal_cpu_dump_trap_frame()` and `hal_cpu_dump_state()`.
+
+## Consequences
+
+### Positive
+
+- **Deeper Observability:** Maintainers and tools can parse structured panic attributes rather than relying strictly on ad-hoc print formatting.
+- **Resilience:** Unattended edge devices will preserve panic logs across reboots in PStore, improving remote fleet diagnostics.
+- **Traceability:** Fault breadcrumbs provide insight into the exact system calls or transitions that preceded the crash.
+
+### Negative
+
+- **Storage Cost:** PStore requires reserving a chunk of RAM that cannot be used by the general allocator.
+- **Performance:** Tracking breadcrumbs in hot paths (like system call entry) introduces slight overhead, though it is designed to be minimal.


### PR DESCRIPTION
This PR updates the root `README.md`, architecture documents, and adds a new Architectural Decision Record (ADR) to reflect the recently merged features:
- Structured kernel panics and PStore recovery tracking (`panic_context_t`).
- FBUI (`Framebuffer UI`) embedded lightweight graphics subsystem.
- Improved the visual appeal of Mermaid diagrams in the README using embedded themes.

---
*PR created automatically by Jules for task [10905701467995274604](https://jules.google.com/task/10905701467995274604) started by @divyang4481*