### PR TITLE
build: fix serial output missing in qemu window on riscv64/arm64 with gui enabled

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -215,3 +215,29 @@ You can tune early boot behavior without source edits:
 - `BHARAT_BOOT_HW_PROFILE` (`generic`, `desktop`, `server`, `vm`, `laptop`): picks hardware profile compile definitions for boot policy and defaults.
 
 These are wired through both build scripts and raw CMake cache entries.
+
+### GUI and Serial Console Output (`-BootGui ON`)
+
+When `BHARAT_BOOT_GUI` is enabled (e.g. passing `-BootGui ON` to `build.ps1` or `--boot-gui=ON` to `build.sh`), QEMU is launched with a graphical window.
+
+To ensure early kernel logs are visible during UI development, the build scripts automatically route QEMU serial output to both your host terminal and a Virtual Console (`vc`) inside the QEMU GUI using the `-serial stdio -serial vc` flags.
+
+**Architecture specific behaviors with GUI enabled:**
+- **`x86_64`:** Uses standard VGA (`-vga std`). The serial `vc` output appears natively.
+- **`riscv64` & `arm64`:** These `virt` machines do not support legacy VGA. The build scripts use VirtIO GPU (`-device virtio-gpu-device` or `-device virtio-gpu-pci`). The kernel text output is displayed in a QEMU Virtual Console tab. *Note: If you are using the QEMU GTK/SDL UI, you can switch to the Virtual Console (usually via `View -> serial0` or `Ctrl-Alt-2`) to see the text logs if they don't appear immediately.*
+
+**Example Build Commands:**
+```powershell
+# Windows (PowerShell)
+# Build and run x86_64 with GUI enabled
+.\tools\build.ps1 -Arch x86_64 -Clean -Run -BootGui ON
+
+# Build and run RISC-V with GUI enabled
+.\tools\build.ps1 -Arch riscv64 -Clean -Run -BootGui ON
+```
+
+```bash
+# WSL / Linux / macOS (Bash)
+# Build and run ARM64 with GUI enabled
+./tools/build.sh --arch=arm64 --clean --run --boot-gui=ON
+```

--- a/tools/build.ps1
+++ b/tools/build.ps1
@@ -259,7 +259,8 @@ if ($Run) {
     if ($Arch -eq "x86_64") {
         $qemuArgs += @("-kernel", $KernelBinary, "-m", "256M", "-serial", "mon:stdio", "-no-reboot")
         if ($BootGui -eq "ON") {
-            $qemuArgs += @("-vga", "std")
+            $qemuArgs = $qemuArgs -ne "-serial" -ne "mon:stdio"
+            $qemuArgs += @("-serial", "stdio", "-serial", "vc", "-vga", "std")
         } else {
             $qemuArgs += @("-nographic")
         }
@@ -278,7 +279,9 @@ if ($Run) {
         }
         if ($BootGui -eq "ON") {
             # riscv64 virt machine has no legacy VGA; use VirtIO GPU (MMIO transport)
-            $qemuArgs += @("-device", "virtio-gpu-device")
+            # Route serial output to both the host terminal and a virtual console in the QEMU graphical window
+            $qemuArgs = $qemuArgs -ne "-serial" -ne "mon:stdio" # Remove the default serial arg to replace it
+            $qemuArgs += @("-serial", "stdio", "-serial", "vc", "-device", "virtio-gpu-device")
         } else {
             $qemuArgs += @("-nographic")
         }
@@ -287,7 +290,9 @@ if ($Run) {
         $qemuArgs += @("-machine", $Machine, "-cpu", "cortex-a53", "-kernel", $OutELF, "-m", "256M", "-serial", "mon:stdio", "-no-reboot")
         if ($BootGui -eq "ON") {
             # arm64 virt machine has no legacy VGA; use VirtIO GPU which the virt machine supports
-            $qemuArgs += @("-device", "virtio-gpu-pci")
+            # Route serial output to both the host terminal and a virtual console in the QEMU graphical window
+            $qemuArgs = $qemuArgs -ne "-serial" -ne "mon:stdio" # Remove the default serial arg to replace it
+            $qemuArgs += @("-serial", "stdio", "-serial", "vc", "-device", "virtio-gpu-pci")
         } else {
             $qemuArgs += @("-nographic")
         }

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -136,23 +136,28 @@ if [ "$RUN" = true ]; then
 
     if [ "$ARCH" == "x86_64" ]; then
         GUI_ARGS=""
+        SERIAL_ARGS="-serial mon:stdio"
         if [ "$BOOT_GUI" = "ON" ] || [ "$BOOT_GUI" = "true" ] || [ "$BOOT_GUI" = "1" ]; then
             GUI_ARGS="-vga std"
+            SERIAL_ARGS="-serial stdio -serial vc"
         else
             GUI_ARGS="-nographic"
         fi
         qemu-system-x86_64 \
             -kernel "$KERNEL_BIN" \
             -m 256M \
-            -serial mon:stdio \
+            $SERIAL_ARGS \
             -no-reboot \
             $GUI_ARGS
 
     elif [ "$ARCH" == "riscv64" ]; then
         GUI_ARGS=""
+        SERIAL_ARGS="-serial mon:stdio"
         if [ "$BOOT_GUI" = "ON" ] || [ "$BOOT_GUI" = "true" ] || [ "$BOOT_GUI" = "1" ]; then
             # riscv64 virt has no legacy VGA — VirtIO GPU is the correct device
             GUI_ARGS="-device virtio-gpu-pci"
+            # Route serial output to both the host terminal and a virtual console in the QEMU graphical window
+            SERIAL_ARGS="-serial stdio -serial vc"
         else
             GUI_ARGS="-nographic"
         fi
@@ -160,15 +165,18 @@ if [ "$RUN" = true ]; then
             -machine virt \
             -kernel "$KERNEL_BIN" \
             -m 256M \
-            -serial mon:stdio \
+            $SERIAL_ARGS \
             -no-reboot \
             $GUI_ARGS
 
     elif [ "$ARCH" == "arm64" ]; then
         GUI_ARGS=""
+        SERIAL_ARGS="-serial mon:stdio"
         if [ "$BOOT_GUI" = "ON" ] || [ "$BOOT_GUI" = "true" ] || [ "$BOOT_GUI" = "1" ]; then
             # arm64 virt has no legacy VGA — VirtIO GPU is the correct device
             GUI_ARGS="-device virtio-gpu-pci"
+            # Route serial output to both the host terminal and a virtual console in the QEMU graphical window
+            SERIAL_ARGS="-serial stdio -serial vc"
         else
             GUI_ARGS="-nographic"
         fi
@@ -177,7 +185,7 @@ if [ "$RUN" = true ]; then
             -cpu cortex-a72 \
             -kernel "$KERNEL_BIN" \
             -m 256M \
-            -serial mon:stdio \
+            $SERIAL_ARGS \
             -no-reboot \
             $GUI_ARGS
     fi


### PR DESCRIPTION
Fixes an issue where kernel logs were not visible in the QEMU graphical window when running with `-BootGui ON` on architectures lacking legacy VGA support (like `riscv64` and `arm64`).

Updates:
* `tools/build.ps1` and `tools/build.sh` updated to pass `-serial stdio -serial vc` to QEMU when the GUI is requested.
* QEMU instances will now output to both the host terminal and a virtual console tab in the QEMU UI.
* Updated `BUILD.md` with an explanation of this console behavior and usage examples.

---
*PR created automatically by Jules for task [10042396471004722012](https://jules.google.com/task/10042396471004722012) started by @divyang4481*