### PR TITLE
Limit scheduler demo thread log spam in QEMU runs

### DIFF
--- a/kernel/src/apps/bharat_demo.c
+++ b/kernel/src/apps/bharat_demo.c
@@ -121,24 +121,39 @@ static void demo_memory(void)
 /* Simple thread entry points ------------------------------------------------ */
 static volatile uint32_t g_hi_done  = 0U;
 static volatile uint32_t g_lo_done  = 0U;
+static volatile uint32_t g_hi_log_count = 0U;
+static volatile uint32_t g_lo_log_count = 0U;
+static const uint32_t g_sched_demo_log_limit = 1U;
 
 static void high_priority_thread(void)
 {
-    DEMO_PRINT("  [SCHED]   thread HI-PRI running.\n");
+    if (g_hi_log_count < g_sched_demo_log_limit) {
+        DEMO_PRINT("  [SCHED]   thread HI-PRI running.\n");
+        g_hi_log_count++;
+    }
     g_hi_done = 1U;
-    sched_yield();
+    while (1) {
+        sched_yield();
+    }
 }
 
 static void low_priority_thread(void)
 {
-    DEMO_PRINT("  [SCHED]   thread LO-PRI running.\n");
+    if (g_lo_log_count < g_sched_demo_log_limit) {
+        DEMO_PRINT("  [SCHED]   thread LO-PRI running.\n");
+        g_lo_log_count++;
+    }
     g_lo_done = 1U;
-    sched_yield();
+    while (1) {
+        sched_yield();
+    }
 }
 
 static void demo_scheduler(void)
 {
     demo_section("PROCESS & THREAD SCHEDULER");
+    g_hi_log_count = 0U;
+    g_lo_log_count = 0U;
 
     DEMO_PRINT("  [SCHED] Creating kernel process...\n");
     kprocess_t *proc = process_create("bharat-demo");


### PR DESCRIPTION
### Motivation
- Prevent the scheduler demo from flooding the host/QEMU serial console with repeated `HI-PRI`/`LO-PRI` lines during long-running QEMU sessions.
- Ensure the demo threads remain runnable for scheduling examples without repeatedly re-printing the same log messages.

### Description
- Added per-thread log counters `g_hi_log_count` and `g_lo_log_count` and a limit `g_sched_demo_log_limit` to bound demo log output to one print per run.
- Changed both demo worker functions to enter a persistent `while (1) { sched_yield(); }` loop after their first work to avoid repeated entry logging on re-scheduling.
- Reset the per-thread log counters at the start of `demo_scheduler()` so each demo run prints the bounded messages again.

### Testing
- Ran `git diff --check` to validate there are no whitespace or diff issues and it passed.
- Ran `git -C /workspace/Bharat-OS status --short` to verify the working tree shows the single modified file and it passed.
- Inspected the updated source with `nl -ba /workspace/Bharat-OS/kernel/src/apps/bharat_demo.c | sed -n '115,190p'` to confirm the bounded-log and loop-yield changes were applied and it matched expectations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bab1929be48320997e73d5b14ee399)