### PR TITLE
Call machine_probe_boot_video unconditionally; add ramfb to riscv64 QEMU GUI args

### DIFF
--- a/kernel/src/display/boot_video.c
+++ b/kernel/src/display/boot_video.c
@@ -5,18 +5,15 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-// Collect display info by asking the machine-specific module to provide a boot_video_handoff_t
+// Collect display info by asking the machine-specific module to provide a
+// boot_video_handoff_t.
 int boot_video_collect(boot_video_handoff_t *out) {
     if (!out) return -1;
     out->valid = false;
 
-    // In Phase 1 x86_64, machine_probe_boot_video will be implemented
-    // in the board or machine logic, linking back to UEFI GOP or text mode
+    // machine_probe_boot_video is provided by each board/arch implementation.
     display_probe_result_t probe_res = {0};
-    int ret = -1;
-#if defined(__x86_64__) || defined(_M_X64)
-    ret = machine_probe_boot_video(&probe_res, out);
-#endif
+    int ret = machine_probe_boot_video(&probe_res, out);
     if (ret != 0 || !probe_res.usable) {
         return -1; // Fallback
     }

--- a/tools/build.ps1
+++ b/tools/build.ps1
@@ -278,10 +278,12 @@ if ($Run) {
             $qemuArgs += @("-machine", $Machine, "-kernel", $OutELF, "-m", "256M", "-serial", "mon:stdio", "-no-reboot")
         }
         if ($BootGui -eq "ON") {
-            # riscv64 virt machine has no legacy VGA; use VirtIO GPU (MMIO transport)
-            # Route serial output to both the host terminal and a virtual console in the QEMU graphical window
+            # riscv64 virt machine has no legacy VGA. Keep VirtIO GPU for later-stage
+            # graphics and also attach ramfb so the firmware can expose an early
+            # simple-framebuffer handoff the kernel boot GUI can consume.
+            # Route serial output to both the host terminal and a virtual console in the QEMU graphical window.
             $qemuArgs = $qemuArgs -ne "-serial" -ne "mon:stdio" # Remove the default serial arg to replace it
-            $qemuArgs += @("-serial", "stdio", "-serial", "vc", "-device", "virtio-gpu-device")
+            $qemuArgs += @("-serial", "stdio", "-serial", "vc", "-device", "virtio-gpu-device", "-device", "ramfb")
         } else {
             $qemuArgs += @("-nographic")
         }


### PR DESCRIPTION
### Motivation
- Ensure the machine-specific boot video probe is always invoked so the kernel can obtain a `boot_video_handoff_t` from any board/arch implementation. 
- Improve early framebuffer handoff when running `riscv64` QEMU GUI by exposing a simple RAM framebuffer device for firmware to populate.

### Description
- Removed the architecture-guarded call and now call `machine_probe_boot_video(&probe_res, out)` unconditionally and updated the surrounding comment. 
- Tightened comments and minor formatting in `kernel/src/display/boot_video.c` and preserved existing validation logic in `boot_video_validate`. 
- Updated `tools/build.ps1` to attach `-device ramfb` alongside `virtio-gpu-device` for `riscv64` when `BootGui` is `ON`, and clarified the comment about using RAM framebuffer for early handoff. 

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bab30a6368832083cdb4d40c792bc4)