### PR TITLE
docs and refactor: correct architecture claims and trap authority

### DIFF
--- a/docs/architecture/000_KERNEL_ARCHITECTURE.md
+++ b/docs/architecture/000_KERNEL_ARCHITECTURE.md
@@ -181,7 +181,7 @@ Bharat-OS embraces the multikernel architecture model (inspired by Barrelfish). 
 
 Features include:
 
-- **Per-CPU State (`cpu_local_t`)**: Each core maintains its own isolated runqueue, capability table, physical memory manager shard, and URPC endpoint configurations. Global arrays have been eliminated.
+- **Per-CPU State (`cpu_local_t`)**: Each core maintains its own isolated runqueue, capability table, physical memory manager shard, and URPC endpoint configurations. Bharat-OS currently uses a hybrid transitional model. Per-core ownership exists for core-local execution state, but global registries still remain for some kernel objects such as thread/process pools. The roadmap target is monitor-mediated per-core ownership and migration.
 - **Monitor Process**: A privileged monitor runs on every core. It acts as the local agent for cross-core coordination, handling URPC messages for memory mapping requests, capability revocations, and lifecycle events.
 - **Dynamic URPC Binding**: Inter-core IPC channels are established dynamically. A core discovers another through the topology and binds a lockless ring buffer using `URPC_BIND_REQ` and `URPC_BIND_ACK` protocols.
 - **System Knowledge Base (SKB)**: Hardware topology (NUMA nodes, L3 caches) is discovered during boot and registered in the SKB. The SKB router uses this topology to pick the optimal interconnect transport mechanism (e.g., pure shared memory URPC for co-located L3 caches vs IPI-assisted for remote NUMA nodes).

--- a/kernel/include/mm.h
+++ b/kernel/include/mm.h
@@ -121,7 +121,7 @@ int vmm_map_device_mmio_token(virt_addr_t vaddr, phys_addr_t paddr,
 // Create a new empty hardware address space
 address_space_t *mm_create_address_space(void);
 
-void vmm_process_urpc_messages(void);
+void vmm_process_local_urpc_messages(uint32_t core_id);
 
 #endif // BHARAT_MM_H
 

--- a/kernel/include/sched.h
+++ b/kernel/include/sched.h
@@ -57,6 +57,7 @@ typedef struct {
 } kthread_attr_t;
 
 typedef struct kthread kthread_t;
+typedef struct kprocess kprocess_t;
 
 typedef enum {
     THREAD_FAULT_NONE = 0,
@@ -84,6 +85,7 @@ typedef struct {
 struct kthread {
     uint64_t thread_id;
     uint64_t process_id;
+    kprocess_t* process;
 
     // CPU Architectural Context (Registers)
     void* cpu_context;
@@ -131,7 +133,7 @@ struct kthread {
 
 int thread_raise_fault(kthread_t *thread, thread_fault_t fault);
 
-typedef struct {
+struct kprocess {
     uint64_t process_id;
     address_space_t* addr_space;
     kthread_t* main_thread;
@@ -145,7 +147,7 @@ typedef struct {
     // Ownership tracking
     uint32_t owner_core_id;
     uint64_t object_id;
-} kprocess_t;
+};
 
 // Scheduler Core
 void sched_init(void);
@@ -155,6 +157,11 @@ kprocess_t* process_create(const char* name);
 int process_destroy(kprocess_t* process);
 kthread_t* thread_create(kprocess_t* parent, void (*entry_point)(void));
 int thread_destroy(kthread_t* thread);
+
+// Current Context Helpers
+kprocess_t* sched_current_process(void);
+address_space_t* sched_current_aspace(void);
+struct capability_table* sched_current_cap_table(void);
 
 // Wait Queues
 void sched_wait_queue_init(wait_queue_t* queue);

--- a/kernel/src/mm/vmm_legacy/vmm.c
+++ b/kernel/src/mm/vmm_legacy/vmm.c
@@ -45,14 +45,19 @@ static mmu_flags_t convert_vmm_flags(uint32_t flags) {
 #define KERNEL_AS_ID 0
 #endif
 
-void vmm_process_urpc_messages(void) {
-    uint32_t current_core = hal_cpu_get_id();
+// Process URPC messages bound for this specific core only, with a strict budget to avoid infinite looping
+// in trap return or scheduler context. This is stage A of moving cross-core work to local monitor threads.
+void vmm_process_local_urpc_messages(uint32_t core_id) {
     uint64_t msg;
+    int messages_processed = 0;
+    const int MAX_MESSAGES_PER_TRAP = 16;
 
+    // Check all channels *sending to* this core_id
     for (uint32_t src = 0; src < BHARAT_MAX_CPUS; src++) {
-        if (src == current_core) continue;
+        if (src == core_id) continue;
         
-        while (urpc_bootstrap_recv(src, &msg) == 0) {
+        while (messages_processed < MAX_MESSAGES_PER_TRAP && urpc_bootstrap_recv(src, &msg) == 0) {
+            messages_processed++;
             urpc_msg_type_t type;
             uint64_t payload;
             urpc_unpack_msg(msg, &type, &payload);
@@ -70,7 +75,7 @@ void vmm_process_urpc_messages(void) {
                 urpc_bootstrap_send(src, ack_msg);
             } else if (type == URPC_MM_MAILBOX) {
                 // Structured MM Control Message
-                mm_mailbox_slot_t* mailbox = &g_mm_mailboxes[current_core];
+                mm_mailbox_slot_t* mailbox = &g_mm_mailboxes[core_id];
                 if (mailbox->valid) {
                     if (mailbox->msg.type == MM_MSG_TLB_FLUSH) {
                         if (mailbox->msg.as_id == KERNEL_AS_ID || core_current_as_id() == mailbox->msg.as_id) {
@@ -84,6 +89,11 @@ void vmm_process_urpc_messages(void) {
                     mailbox->valid = 0; // Clear it for next usage
                 }
             }
+        }
+
+        if (messages_processed >= MAX_MESSAGES_PER_TRAP) {
+            // Note: In Stage B, if we hit the limit, we should wake up the local monitor thread to finish draining.
+            break;
         }
     }
 }

--- a/kernel/src/sched.c
+++ b/kernel/src/sched.c
@@ -341,6 +341,7 @@ kthread_t *thread_create(kprocess_t *parent, void (*entry_point)(void)) {
 
   slot->thread.thread_id = g_next_thread_id++;
   slot->thread.process_id = parent ? parent->process_id : 0U;
+  slot->thread.process = parent;
   slot->thread.personality = PERSONALITY_NATIVE;
   slot->thread.state = THREAD_STATE_READY;
   slot->thread.priority = 1U;
@@ -621,7 +622,8 @@ static void sched_switch_to(kthread_t *next, uint32_t core_id) {
   }
 
     // Process incoming URPC messages before doing the switch
-    vmm_process_urpc_messages();
+    extern void vmm_process_local_urpc_messages(uint32_t core_id);
+    vmm_process_local_urpc_messages(core_id);
 
   if (fv_secure_context_switch) {
     fv_secure_context_switch(next_ctx);
@@ -877,6 +879,21 @@ kthread_t *sched_current_thread(void) {
 }
 
 kthread_t *sched_current(void) { return sched_current_thread(); }
+
+kprocess_t *sched_current_process(void) {
+  kthread_t *t = sched_current_thread();
+  return t ? t->process : NULL;
+}
+
+address_space_t *sched_current_aspace(void) {
+  kprocess_t *p = sched_current_process();
+  return p ? p->addr_space : NULL;
+}
+
+struct capability_table *sched_current_cap_table(void) {
+  kprocess_t *p = sched_current_process();
+  return p ? (struct capability_table *)p->security_sandbox_ctx : NULL;
+}
 
 uint64_t sched_get_ticks(void) { return g_sched_ticks; }
 void sched_set_policy(sched_policy_t policy) {

--- a/kernel/src/trap/trap.c
+++ b/kernel/src/trap/trap.c
@@ -39,8 +39,33 @@ extern bool core_is_rt(void);
 
 static kprocess_t g_syscall_proc;
 
+// Architectural guardrail: The `g_syscall_proc` singleton is a bootstrap fallback only.
+// In steady state, syscalls and faults must resolve authority against the current thread/process.
+// Cross-core URPC processing in the trap return path is strictly bounded and local.
+
 static capability_table_t *trap_current_cap_table(void) {
+  capability_table_t *table = sched_current_cap_table();
+  if (table) {
+    return table;
+  }
+  // Fallback for early bootstrap when no user context exists
   return (capability_table_t *)g_syscall_proc.security_sandbox_ctx;
+}
+
+static kprocess_t *trap_current_process(void) {
+  kprocess_t *proc = sched_current_process();
+  if (proc) {
+    return proc;
+  }
+  return &g_syscall_proc;
+}
+
+static address_space_t *trap_current_aspace(void) {
+  address_space_t *as = sched_current_aspace();
+  if (as) {
+    return as;
+  }
+  return g_syscall_proc.addr_space;
 }
 
 static int trap_user_ptr_valid(uint64_t ptr) {
@@ -91,7 +116,7 @@ long syscall_dispatch(syscall_id_t id, uint64_t arg0, uint64_t arg1,
       return TRAP_ERR_INVAL;
     }
     return (long)sched_sys_thread_create(
-        &g_syscall_proc, (void (*)(void))(uintptr_t)arg0, out_tid);
+        trap_current_process(), (void (*)(void))(uintptr_t)arg0, out_tid);
   }
   case SYSCALL_THREAD_DESTROY:
     return (long)sched_sys_thread_destroy(arg0);
@@ -187,7 +212,7 @@ long trap_handle(trap_frame_t *frame) {
     if (current && current->process_id != 0) {
       // Address space from current process
       // For proper hardware demand-paging, we call into the VMM.
-      int rc = vmm_handle_cow_fault(g_syscall_proc.addr_space, stval);
+      int rc = vmm_handle_cow_fault(trap_current_aspace(), stval);
       if (rc == 0) {
           return 0;
       }
@@ -229,7 +254,7 @@ long trap_handle(trap_frame_t *frame) {
     if (current && current->process_id != 0) {
       // Address space from current process
       // For proper hardware demand-paging, we call into the VMM.
-      int rc = vmm_handle_cow_fault(g_syscall_proc.addr_space, cr2);
+      int rc = vmm_handle_cow_fault(trap_current_aspace(), cr2);
       if (rc == 0) {
           return 0;
       }
@@ -284,7 +309,7 @@ long trap_handle(trap_frame_t *frame) {
       }
 
       // For proper hardware demand-paging, we call into the VMM.
-      int rc = vmm_handle_cow_fault(g_syscall_proc.addr_space, far);
+      int rc = vmm_handle_cow_fault(trap_current_aspace(), far);
       if (rc == 0) {
           return 0;
       }
@@ -316,8 +341,10 @@ long trap_handle(trap_frame_t *frame) {
 
   // Before returning to user space, process any pending incoming URPC messages
   // like TLB shootdowns to ensure consistency.
-  extern void vmm_process_urpc_messages(void);
-  vmm_process_urpc_messages();
+  // We process only local messages for the current core to maintain multikernel
+  // architecture separation.
+  extern void vmm_process_local_urpc_messages(uint32_t core_id);
+  vmm_process_local_urpc_messages(hal_cpu_get_id());
 
   if (frame->from_user == 0U) {
     return TRAP_ERR_PERM;


### PR DESCRIPTION
This PR addresses the critical gap between the architectural claims and the implementation of the multikernel model.
    
**🎯 What**
- The architecture docs incorrectly stated "global arrays have been eliminated".
- The `trap.c` implementation heavily relied on a single `g_syscall_proc` to evaluate syscall and page fault authority, blocking real multikernel and capability isolation per process.
- `vmm_process_urpc_messages()` was implemented as an inline loop over all cores during trap return, which violates multikernel isolation.

**⚠️ Risk**
Future features relying on false architecture claims, and security/isolation bypass where all user space apps incorrectly run under `g_syscall_proc`'s namespace.

**🛡️ Solution**
- Modified architecture docs to note the hybrid transitional state toward monitor-mediated per-core ownership.
- Modified `kthread_t` and scheduler to properly trace the current `kprocess_t` and `address_space_t`.
- `trap.c` authority resolving now falls back to `g_syscall_proc` only during bootstrap/no-thread cases; it prioritizes current thread/process authority.
- `vmm_process_local_urpc_messages()` now strictly bounds cross-core URPC processing per-core.

---
*PR created automatically by Jules for task [4130059974154024575](https://jules.google.com/task/4130059974154024575) started by @divyang4481*