### PR TITLE
Fix multiple build errors and warnings on riscv64

### DIFF
--- a/kernel/src/apps/bharat_demo.c
+++ b/kernel/src/apps/bharat_demo.c
@@ -30,7 +30,7 @@
 
 static void demo_print_hex(uint64_t val)
 {
-    static const char hex_digit[16] = "0123456789abcdef";
+    static const char hex_digit[17] = "0123456789abcdef";
     char buf[19]; /* "0x" + 16 digits + NUL */
     buf[0]  = '0';
     buf[1]  = 'x';

--- a/kernel/src/hal/riscv/vmm.c
+++ b/kernel/src/hal/riscv/vmm.c
@@ -18,10 +18,6 @@ typedef struct {
     uint64_t entries[512];
 } pte_table_t;
 
-static virt_addr_t align_down(virt_addr_t value) {
-    return value & ~(virt_addr_t)(PAGE_SIZE - 1U);
-}
-
 
 
 #include "../../../include/hal/hal_pt.h"
@@ -37,10 +33,6 @@ static uint64_t hal_get_satp(void) {
     __asm__ volatile("csrr %0, satp" : "=r"(satp));
     // Extracts physical address from satp (assuming Sv39, ppn is lower 44 bits)
     return (satp & ((1ULL << 44) - 1)) << 12;
-}
-
-static void hal_sfence_vma(virt_addr_t vaddr) {
-    __asm__ volatile("sfence.vma %0" :: "r"(vaddr) : "memory");
 }
 
 int hal_vmm_map_page(phys_addr_t root_table, virt_addr_t vaddr, phys_addr_t paddr, uint32_t flags) {

--- a/kernel/src/mm/vm/objects/vm_object.c
+++ b/kernel/src/mm/vm/objects/vm_object.c
@@ -4,7 +4,6 @@
 #include "../../../../include/mm.h"
 #include "../../../../include/numa.h"
 #include "../../../../include/mm/numa_policy.h"
-#include "../../../../include/console.h"
 #include "../../../../include/slab.h"
 
 // ============================================================================

--- a/ui/fbui/core/fb_demo_app.c
+++ b/ui/fbui/core/fb_demo_app.c
@@ -15,15 +15,6 @@
 #define DUMMY_FB_HEIGHT 240
 static uint32_t dummy_vram[DUMMY_FB_WIDTH * DUMMY_FB_HEIGHT];
 
-static bharat_display_mode_t dummy_mode = {
-    .width = DUMMY_FB_WIDTH,
-    .height = DUMMY_FB_HEIGHT,
-    .stride = DUMMY_FB_WIDTH * 4,
-    .bpp = 32,
-    .format = BHARAT_PIXEL_FORMAT_ARGB8888,
-    .refresh_rate = 60
-};
-
 static bharat_display_device_t dummy_display = {
     .name = "Dummy Display",
     .id = 0,

--- a/ui/fbui/widgets/fb_widgets.c
+++ b/ui/fbui/widgets/fb_widgets.c
@@ -47,6 +47,8 @@ static void label_draw(fbui_widget_t *w, fbui_render_context_t *ctx) {
 }
 
 static bool label_handle_event(fbui_widget_t *w, const fbui_event_t *ev) {
+    (void)w;
+    (void)ev;
     return false; // Labels usually don't consume events
 }
 


### PR DESCRIPTION
Resolves build failures and unused variable warnings during `riscv64` generic build process when using the `DESKTOP` profile and `BootGui ON`.

---
*PR created automatically by Jules for task [10752722241298119906](https://jules.google.com/task/10752722241298119906) started by @divyang4481*