### PR TITLE
build: route serial console properly for QEMU BootGui mode

### DIFF
--- a/tools/build.ps1
+++ b/tools/build.ps1
@@ -260,7 +260,7 @@ if ($Run) {
         $qemuArgs += @("-kernel", $KernelBinary, "-m", "256M", "-serial", "mon:stdio", "-no-reboot")
         if ($BootGui -eq "ON") {
             $qemuArgs = $qemuArgs -ne "-serial" -ne "mon:stdio"
-            $qemuArgs += @("-serial", "stdio", "-serial", "vc", "-vga", "std")
+            $qemuArgs += @("-serial", "vc", "-vga", "std")
         } else {
             $qemuArgs += @("-nographic")
         }
@@ -281,9 +281,9 @@ if ($Run) {
             # riscv64 virt machine has no legacy VGA. Keep VirtIO GPU for later-stage
             # graphics and also attach ramfb so the firmware can expose an early
             # simple-framebuffer handoff the kernel boot GUI can consume.
-            # Route serial output to both the host terminal and a virtual console in the QEMU graphical window.
+            # Route serial output only to the virtual console in the QEMU graphical window.
             $qemuArgs = $qemuArgs -ne "-serial" -ne "mon:stdio" # Remove the default serial arg to replace it
-            $qemuArgs += @("-serial", "stdio", "-serial", "vc", "-device", "virtio-gpu-device", "-device", "ramfb")
+            $qemuArgs += @("-serial", "vc", "-device", "virtio-gpu-device", "-device", "ramfb")
         } else {
             $qemuArgs += @("-nographic")
         }
@@ -292,9 +292,9 @@ if ($Run) {
         $qemuArgs += @("-machine", $Machine, "-cpu", "cortex-a53", "-kernel", $OutELF, "-m", "256M", "-serial", "mon:stdio", "-no-reboot")
         if ($BootGui -eq "ON") {
             # arm64 virt machine has no legacy VGA; use VirtIO GPU which the virt machine supports
-            # Route serial output to both the host terminal and a virtual console in the QEMU graphical window
+            # Route serial output only to the virtual console in the QEMU graphical window.
             $qemuArgs = $qemuArgs -ne "-serial" -ne "mon:stdio" # Remove the default serial arg to replace it
-            $qemuArgs += @("-serial", "stdio", "-serial", "vc", "-device", "virtio-gpu-pci")
+            $qemuArgs += @("-serial", "vc", "-device", "virtio-gpu-pci")
         } else {
             $qemuArgs += @("-nographic")
         }

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -139,7 +139,7 @@ if [ "$RUN" = true ]; then
         SERIAL_ARGS="-serial mon:stdio"
         if [ "$BOOT_GUI" = "ON" ] || [ "$BOOT_GUI" = "true" ] || [ "$BOOT_GUI" = "1" ]; then
             GUI_ARGS="-vga std"
-            SERIAL_ARGS="-serial stdio -serial vc"
+            SERIAL_ARGS="-serial vc"
         else
             GUI_ARGS="-nographic"
         fi
@@ -156,8 +156,8 @@ if [ "$RUN" = true ]; then
         if [ "$BOOT_GUI" = "ON" ] || [ "$BOOT_GUI" = "true" ] || [ "$BOOT_GUI" = "1" ]; then
             # riscv64 virt has no legacy VGA — VirtIO GPU is the correct device
             GUI_ARGS="-device virtio-gpu-pci"
-            # Route serial output to both the host terminal and a virtual console in the QEMU graphical window
-            SERIAL_ARGS="-serial stdio -serial vc"
+            # Route serial output only to the virtual console in the QEMU graphical window
+            SERIAL_ARGS="-serial vc"
         else
             GUI_ARGS="-nographic"
         fi
@@ -175,8 +175,8 @@ if [ "$RUN" = true ]; then
         if [ "$BOOT_GUI" = "ON" ] || [ "$BOOT_GUI" = "true" ] || [ "$BOOT_GUI" = "1" ]; then
             # arm64 virt has no legacy VGA — VirtIO GPU is the correct device
             GUI_ARGS="-device virtio-gpu-pci"
-            # Route serial output to both the host terminal and a virtual console in the QEMU graphical window
-            SERIAL_ARGS="-serial stdio -serial vc"
+            # Route serial output only to the virtual console in the QEMU graphical window
+            SERIAL_ARGS="-serial vc"
         else
             GUI_ARGS="-nographic"
         fi


### PR DESCRIPTION
Resolves an issue where kernel and OpenSBI boot logs did not appear in the QEMU graphical window's Virtual Console when booting with `-BootGui ON`.

---
*PR created automatically by Jules for task [8449690977463358793](https://jules.google.com/task/8449690977463358793) started by @divyang4481*