### PR TITLE
feat(net): scaffold profile-driven network architecture and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Bharat-OS is a capability-oriented microkernel project with a multikernel direct
 | Distributed/multikernel scale-out | Early baseline | Per-core URPC matrix and multicore bootstrap hooks exist; production-grade topology and transport tuning are deferred. |
 | Diagnostics & Reliability | Implemented baseline | Structured kernel panic generation, architecture-specific trap/fault breadcrumbs, and PStore persistent recovery logging. |
 
-For architecture-level details and deferred boundaries, see `docs/architecture/` and ADRs in `docs/decisions/`. For the step-by-step closure plan, see `docs/architecture/memory-gap-closure-plan.md`.
+For architecture-level details and deferred boundaries, see `docs/architecture/` and ADRs in `docs/decisions/`. For the step-by-step closure plan, see `docs/architecture/memory-gap-closure-plan.md`. For our profile-driven, capability-safe networking architecture, see [`docs/architecture/network-architecture.md`](docs/architecture/network-architecture.md).
 
 ## Device Profiles & Use-cases
 

--- a/docs/architecture/network-architecture.md
+++ b/docs/architecture/network-architecture.md
@@ -1,0 +1,120 @@
+# Bharat-OS Network Architecture
+
+This document defines the capability-safe, profile-driven networking and communications architecture for Bharat-OS. It outlines the strategic move from a basic network placeholder to a first-class subsystem designed for multiple device classes (embedded, edge gateways, automotive, robotics, and cloud nodes).
+
+## Why Networking is a First-Class Subsystem
+
+Networking in Bharat-OS is not merely a set of drivers. It is a fundamental operational plane that requires:
+* Capability-mediated access control (between applications, stacks, and NICs).
+* Deterministic behavior for RTOS/Automotive profiles.
+* High throughput and zero-copy semantics for Edge Gateway and Cloud Node profiles.
+* Clean separation of control policy from the fast data path.
+
+Because networking spans across these deeply divergent constraints, it is elevated to a first-class subsystem (`subsys/network`), comparable to the Memory Management and Subsystems domains.
+
+## Why `services/net` is No Longer Enough
+
+The original `services/net` directory acted as a monolithic blob that attempted to hold drivers, stacks, and routing policy in one place. A monolithic user-space network service fails to scale:
+* **Performance:** Forcing all packet processing (control, forwarding, routing) through a single user-space domain introduces unacceptable IPC overhead and locking contention.
+* **Security & Reliability:** A single crash in a generic driver or protocol parser would take down the entire network stack.
+* **Profile Flexibility:** Embedded devices cannot afford a monolithic TCP/IP stack, while Edge Gateways require high-speed dataplane logic (like XDP or DPDK) completely separated from configuration agents.
+
+To solve this, `services/net` is being explicitly decomposed into a multi-layered structure.
+
+## Layered Model
+
+The Bharat-OS network architecture is split into three primary layers, ensuring that policy, basic connectivity, and high-speed data flow remain isolated and configurable.
+
+### 1. Minimum Universal Core
+This is the **always-on baseline** for any build requiring networking.
+* **Ownership:** `services/netstack` and `lib/net`
+* **Responsibilities:**
+  * NIC discovery and link state.
+  * Ethernet, VLAN, ARP/NDP.
+  * IPv4 and IPv6.
+  * ICMP/ICMPv6, UDP, basic TCP.
+  * Socket-like API contracts.
+  * Basic routing and DHCP client operations.
+
+### 2. Profile-Specific Feature Planes
+Above the baseline, extra capabilities are activated based on the build profile (e.g., Automotive vs. Cloud).
+* **Ownership:** `services/netmgr`, `subsys/network`, and targeted services (e.g., future `services/netsec`).
+* **Responsibilities:**
+  * Stateful firewalls and NAT (Security Appliances).
+  * Policy routing and VRF (Cloud Nodes/Gateways).
+  * Multiqueue NIC scaling (Cloud Nodes).
+  * Power-aware networking (Mobile/Edge).
+
+### 3. Fast Path / Acceleration Plane (Roadmap)
+A dedicated lane for line-rate packet processing that bypasses the control plane entirely.
+* **Ownership:** Future `services/netfast`
+* **Responsibilities:**
+  * Zero-copy RX/TX rings (`lib/packet`).
+  * Lock-minimized, per-core queues.
+  * XDP-like early packet drop/steering.
+  * Hardware accelerator / NIC DMA integration.
+
+## Networking vs Communications
+
+While Bharat-OS networking starts with an IP networking core, the long-term architecture must also support bus-oriented, deterministic, and industrial communications.
+
+* **Current Focus (Phase N1):** IP-based Ethernet connectivity (`subsys/network`, `services/netstack`).
+* **Future Evolution:**
+  * `subsys/vehicle` and `subsys/rtcomms`
+  * `lib/bus`
+  * `services/busmgr` (CAN/LIN/FlexRay/SOME/IP)
+  * `services/gatewayd` (Bridging distinct comms domains)
+  * `services/time-syncd` (PTP/TSN orchestration)
+  * `services/netqosd` (Traffic shaping and deterministic queues)
+
+## Profile Model Matrix
+
+The following matrix anchors the roadmap. Features marked **baseline target** are the immediate goals, while others remain **future phases**.
+
+| Profile | IP Stack | Bus Support | Gatewaying | QoS / Traffic Classes | Fast Path / Acceleration | Overlay / Tunnels | TSN / Time Sync | Security Features |
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+| **Minimal Embedded** | Baseline Target | Future | Not Implemented | Baseline Target | Not Implemented | Not Implemented | Future | Baseline Target |
+| **Edge Gateway** | Baseline Target | Future | Future | Future | Future | Future | Future | Future |
+| **Automotive** | Baseline Target | Future | Future | Future | Not Implemented | Not Implemented | Future | Baseline Target |
+| **Drone / Robotics** | Baseline Target | Future | Future | Future | Not Implemented | Not Implemented | Future | Baseline Target |
+| **Security Appliance** | Baseline Target | Not Implemented | Not Implemented | Future | Future | Future | Not Implemented | Future |
+| **Cloud Node** | Baseline Target | Not Implemented | Not Implemented | Future | Future | Future | Not Implemented | Future |
+
+## Repo Structure
+
+To support this architecture, the repository is structured as follows:
+
+* `subsys/network/` - The network subsystem contract layer (native API contracts, profile feature flags).
+* `lib/net/` - Common network definitions (interface IDs, address families).
+* `lib/packet/` - Packet buffer descriptors, ring abstractions, and headroom/tailroom flags.
+* `services/netstack/` - The minimum universal IP stack (ARP, IP, UDP, TCP).
+* `services/netmgr/` - Orchestration, interface lifecycle, policy distribution, and routing table ownership.
+* `services/net/` - **Legacy / Transitional.** The old monolithic stack. It remains for now so builds don't break but will be decomposed.
+
+## Phase Roadmap
+
+### Phase N1 — Universal Baseline (Current Scaffold)
+* Scaffold `lib/net`, `lib/packet`, `subsys/network`, `services/netstack`, `services/netmgr`.
+* Define early contracts, packet structures, and capability boundaries.
+
+### Phase N2 — Robustness (Future)
+* Implement functional Ethernet, IPv4/v6, ARP, UDP, TCP.
+* Basic routing, loopback, and DHCP.
+
+### Phase N3 — Appliance/Cloud Acceleration (Future)
+* Zero-copy packet path, flow steering, and `services/netfast`.
+
+### Phase N4 — Vertical Profiles & Comms (Future)
+* Automotive CAN/TSN gateways, edge/mobile power states, `services/busmgr`.
+
+## Dependency Rules
+* The control plane (`netmgr`) configures state via capabilities.
+* The data plane (`netstack`, `netfast`) executes fast forwarding.
+* Drivers (`drivers/net/*`) own hardware interactions and offload reporting.
+* **Crucial Rule:** Do not force all packets through one heavy user-space service path. The data plane must be per-core, lock-light, and zero-copy.
+
+## Non-Goals for this Phase
+* Full TCP/UDP implementations.
+* Hardware-specific driver code.
+* Deletion or destructive refactoring of `services/net`.
+* Implementation of DPDK/XDP equivalents.

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -15,3 +15,6 @@ target_include_directories(urpc PUBLIC urpc)
 target_compile_options(urpc PRIVATE -ffreestanding -nostdlib -Wall)
 add_subdirectory(elf)
 add_subdirectory(syscall)
+
+add_subdirectory(net)
+add_subdirectory(packet)

--- a/lib/net/CMakeLists.txt
+++ b/lib/net/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.20)
+project(BharatOS_LibNet C)
+
+add_library(net STATIC src/net.c)
+target_include_directories(net PUBLIC include)
+target_compile_options(net PRIVATE -ffreestanding -nostdlib -Wall -Wextra)

--- a/lib/net/README.md
+++ b/lib/net/README.md
@@ -1,0 +1,13 @@
+# lib/net (Network Common Library)
+
+**Status:** Stub / Baseline Target
+
+This library defines the common network contracts and types for Bharat-OS. It is intended to be shared across `subsys/network`, `services/netstack`, `services/netmgr`, and user-space network drivers.
+
+## Scope
+* Interface identifiers (`if_id_t`).
+* Address family enumerations (IPv4, IPv6).
+* Link state enums (UP, DOWN, UNKNOWN).
+* Route and endpoint placeholder structures.
+
+This library does *not* contain protocol implementations, socket logic, or buffer management (see `lib/packet`).

--- a/lib/net/include/bharat/net/net.h
+++ b/lib/net/include/bharat/net/net.h
@@ -1,0 +1,41 @@
+#pragma once
+#include <stdint.h>
+#include <stdbool.h>
+
+/**
+ * @file net.h
+ * @brief Common network definitions for Bharat-OS.
+ *
+ * Provides interface identifiers, address families, and link state
+ * enums used across the network subsystem and services.
+ */
+
+// Interface identifier
+typedef uint32_t net_if_id_t;
+
+#define NET_IF_ID_INVALID 0
+
+// Address families
+typedef enum {
+    NET_AF_UNSPEC = 0,
+    NET_AF_INET = 1,   // IPv4
+    NET_AF_INET6 = 2,  // IPv6
+    NET_AF_PACKET = 3  // Raw packet access
+} net_af_t;
+
+// Link state
+typedef enum {
+    NET_LINK_DOWN = 0,
+    NET_LINK_UP = 1,
+    NET_LINK_UNKNOWN = 2
+} net_link_state_t;
+
+// Placeholder for an interface configuration structure
+typedef struct {
+    net_if_id_t id;
+    net_link_state_t state;
+    uint32_t mtu;
+} net_if_config_t;
+
+// Basic initialization contract (stub)
+void libnet_init(void);

--- a/lib/net/src/net.c
+++ b/lib/net/src/net.c
@@ -1,0 +1,5 @@
+#include <bharat/net/net.h>
+
+void libnet_init(void) {
+    // Stub implementation for initialization
+}

--- a/lib/packet/CMakeLists.txt
+++ b/lib/packet/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.20)
+project(BharatOS_LibPacket C)
+
+add_library(packet STATIC src/packet.c)
+target_include_directories(packet PUBLIC include)
+target_compile_options(packet PRIVATE -ffreestanding -nostdlib -Wall -Wextra)

--- a/lib/packet/README.md
+++ b/lib/packet/README.md
@@ -1,0 +1,13 @@
+# lib/packet (Packet Buffer Abstractions)
+
+**Status:** Stub / Baseline Target
+
+This library defines early packet abstractions and buffer descriptors.
+
+## Scope
+* Packet buffer descriptors (`packet_buf_t`).
+* Buffer ownership tracking and lifetime comments.
+* Headroom, tailroom fields, and total length.
+* Flags for checksum and offload intents (future).
+
+This library does *not* contain protocol parsers, routing logic, or socket implementations (see `lib/net` and `services/netstack`).

--- a/lib/packet/include/bharat/packet/packet.h
+++ b/lib/packet/include/bharat/packet/packet.h
@@ -1,0 +1,41 @@
+#pragma once
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+
+/**
+ * @file packet.h
+ * @brief Common packet abstractions for Bharat-OS.
+ *
+ * Defines the buffer descriptor structure, ownership, headroom, tailroom,
+ * and future flags for checksum offloads.
+ */
+
+// Packet flags
+#define PACKET_FLAG_RX_CSUM_VALID   (1 << 0)
+#define PACKET_FLAG_TX_CSUM_REQ     (1 << 1)
+#define PACKET_FLAG_BCAST           (1 << 2)
+#define PACKET_FLAG_MCAST           (1 << 3)
+#define PACKET_FLAG_VLAN            (1 << 4)
+
+/**
+ * @brief A packet buffer descriptor.
+ *
+ * Describes a region of memory containing network data.
+ * The memory is typically managed by a slab/pool allocator, and ownership
+ * is passed between domains (NIC drivers -> netstack -> user apps).
+ */
+typedef struct {
+    uint8_t *data;         // Pointer to the start of the buffer
+    uint16_t head_len;     // Headroom size (for adding headers)
+    uint16_t tail_len;     // Tailroom size (for adding trailers)
+    uint32_t total_len;    // Total allocated size of the buffer
+    uint32_t data_len;     // Length of valid data within the buffer
+    uint32_t flags;        // Packet flags (checksum, offloads, etc.)
+
+    // Placeholder for ownership tracking or reference counting
+    void *owner_ctx;
+} packet_buf_t;
+
+// Basic initialization contract (stub)
+void libpacket_init(void);

--- a/lib/packet/src/packet.c
+++ b/lib/packet/src/packet.c
@@ -1,0 +1,5 @@
+#include <bharat/packet/packet.h>
+
+void libpacket_init(void) {
+    // Stub implementation for initialization
+}

--- a/services/CMakeLists.txt
+++ b/services/CMakeLists.txt
@@ -8,4 +8,13 @@ add_subdirectory(drivers)
 add_subdirectory(crypto)
 add_subdirectory(console)
 add_subdirectory(boot_displayd)
+
+# Legacy monolithic network service (transitional)
 add_subdirectory(net)
+
+# Profile-driven network stack and manager
+option(BHARAT_BUILD_NETWORK_STUBS "Build network manager and stack user-space stubs" ON)
+if(BHARAT_BUILD_NETWORK_STUBS)
+    add_subdirectory(netmgr)
+    add_subdirectory(netstack)
+endif()

--- a/services/net/README.md
+++ b/services/net/README.md
@@ -1,0 +1,16 @@
+# services/net (Legacy Network Monolith)
+
+**Status:** Legacy / Transitional
+
+This is the original monolithic placeholder for the Bharat-OS network service.
+It attempted to combine routing policy, interface lifecycle, and data-plane packet processing into a single user-space domain.
+
+This design does not scale to high-speed profiles (Edge Gateways/Cloud Nodes) and is a single-point-of-failure for the whole network stack.
+
+## Deprecation Notice
+
+This directory is kept temporarily to ensure existing build paths and experiments remain functional during the transition.
+It will eventually be fully decomposed into:
+* `services/netmgr` (Policy, orchestration, routing table ownership).
+* `services/netstack` (Universal IP stack, L3/L4 baseline).
+* `services/netfast` (Roadmap fast path / appliance dataplane).

--- a/services/net/main.c
+++ b/services/net/main.c
@@ -5,6 +5,12 @@
 /*
  * Bharat-OS User-Space Network Service (L2/L3/L4)
  *
+ * [LEGACY / TRANSITIONAL]
+ * This monolithic network service is being deprecated. Its functionality
+ * will be decomposed into `services/netmgr` (control/policy plane) and
+ * `services/netstack` (data plane / IP stack) to better support the
+ * Bharat-OS profile-driven architecture.
+ *
  * Manages protocol stacks, IP addressing, sockets, and interacts with
  * physical network devices via capability-bounded zero-copy I/O rings.
  */

--- a/services/netmgr/CMakeLists.txt
+++ b/services/netmgr/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.20)
+project(BharatOS_NetMgr_Service C)
+
+add_executable(netmgr main.c)
+
+target_include_directories(netmgr PRIVATE
+    ../../kernel/include
+    ../../subsys/include
+    ../../lib/net/include
+    ../../lib/packet/include
+    ../../lib/urpc
+)
+
+target_compile_options(netmgr PRIVATE -ffreestanding -nostdlib -Wall -Wextra)
+
+# Link against subsystem, URPC, and networking libs
+target_link_libraries(netmgr PRIVATE urpc subsys_manager net packet)

--- a/services/netmgr/README.md
+++ b/services/netmgr/README.md
@@ -1,0 +1,14 @@
+# services/netmgr (Network Orchestration & Policy)
+
+**Status:** Stub / Baseline Target
+
+This service owns the orchestration and policy plane for the Bharat-OS network stack.
+
+## Scope
+* Interface lifecycle (bringing links up/down).
+* DHCP and static IP configuration coordination.
+* Routing table ownership and policy distribution.
+* Firewall rule installation (to be enforced by the fast path or stack).
+* Profile activation and telemetry aggregation.
+
+This daemon stays message-heavy and capability-rich. It does **not** process packets in the data plane (see `services/netstack`).

--- a/services/netmgr/main.c
+++ b/services/netmgr/main.c
@@ -1,0 +1,25 @@
+#include <stdint.h>
+#include <stddef.h>
+#include <bharat/net/net.h>
+
+/*
+ * Bharat-OS User-Space Network Manager
+ *
+ * Orchestration, policy, DHCP, and routing table ownership.
+ * Control-plane focused. Does not handle line-rate packets.
+ */
+
+int main(int argc, char** argv) {
+    (void)argc;
+    (void)argv;
+
+    // TODO: Acquire capability to talk to netstack and drivers.
+    // TODO: Start interface monitoring loop.
+
+    while(1) {
+        // Poll control plane messages (URPC / IPC)
+        // Manage link states, DHCP leases, and route tables
+    }
+
+    return 0;
+}

--- a/services/netstack/CMakeLists.txt
+++ b/services/netstack/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.20)
+project(BharatOS_NetStack_Service C)
+
+add_executable(netstack main.c)
+
+target_include_directories(netstack PRIVATE
+    ../../kernel/include
+    ../../subsys/include
+    ../../lib/net/include
+    ../../lib/packet/include
+    ../../lib/urpc
+)
+
+target_compile_options(netstack PRIVATE -ffreestanding -nostdlib -Wall -Wextra)
+
+# Link against subsystem, URPC, and networking libs
+target_link_libraries(netstack PRIVATE urpc subsys_manager net packet)

--- a/services/netstack/README.md
+++ b/services/netstack/README.md
@@ -1,0 +1,14 @@
+# services/netstack (Minimum Universal IP Stack)
+
+**Status:** Stub / Baseline Target
+
+This service provides the baseline IP stack for Bharat-OS. It serves as the standard path for devices that do not require high-speed bypass (like an appliance dataplane).
+
+## Scope
+* Ethernet, ARP, NDP.
+* IPv4, IPv6, ICMP.
+* UDP, TCP.
+* Fragmentation and reassembly.
+* Base forwarding path and socket endpoints.
+
+This service is distinct from the control plane (`services/netmgr`) and the optional zero-copy dataplane (`services/netfast`).

--- a/services/netstack/main.c
+++ b/services/netstack/main.c
@@ -1,0 +1,27 @@
+#include <stdint.h>
+#include <stddef.h>
+#include <bharat/net/net.h>
+#include <bharat/packet/packet.h>
+
+/*
+ * Bharat-OS Minimum Universal IP Stack
+ *
+ * Provides Ethernet, ARP, IP, UDP, and TCP.
+ * Sits below the socket layer and above the NIC drivers.
+ */
+
+int main(int argc, char** argv) {
+    (void)argc;
+    (void)argv;
+
+    // TODO: Register packet ring capabilities with NICs.
+    // TODO: Setup communication channel with netmgr.
+
+    while(1) {
+        // Dequeue packets from NIC RX rings
+        // Run protocol parsers (L2 -> L3 -> L4)
+        // Deliver to socket endpoints
+    }
+
+    return 0;
+}

--- a/subsys/CMakeLists.txt
+++ b/subsys/CMakeLists.txt
@@ -46,5 +46,8 @@ if(BHARAT_BUILD_AI_GOVERNOR)
     target_compile_options(ai_governor PRIVATE -fPIE -fPIC)
     target_link_options(ai_governor PRIVATE "-no-pie")
 endif()
+
+add_subdirectory(network)
+
 # Might need host headers if it's considered user-space mock,
 # for now compiled natively or with suitable toolchain for user-space

--- a/subsys/network/CMakeLists.txt
+++ b/subsys/network/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.20)
+project(BharatOS_Network_Subsys C)
+
+# For now, this is purely an interface layer placeholder.
+add_custom_target(subsys_network_stub ALL
+    COMMAND ${CMAKE_COMMAND} -E echo "Building subsys/network stub"
+)

--- a/subsys/network/README.md
+++ b/subsys/network/README.md
@@ -1,0 +1,13 @@
+# subsys/network
+
+**Status:** Stub / Baseline Target
+
+This is the network personality/subsystem contract layer. It defines how applications and user-space domains view networking operations in Bharat-OS.
+
+## Scope
+* Native socket/session model.
+* Interface objects and capability surfaces.
+* Route and policy abstractions.
+* Service discovery hooks and profile feature flags (Embedded, Automotive, Cloud, Edge).
+
+This directory does **not** contain the TCP/IP implementation (which lives in `services/netstack`) or interface lifecycle orchestration (which lives in `services/netmgr`). Instead, it acts as the stable contract API and RPC boundary.


### PR DESCRIPTION
This PR establishes the foundational scaffolding for Bharat-OS's profile-driven network architecture.

It implements the requested architectural shift: moving from a monolithic `services/net` placeholder to a tiered, capability-safe subsystem.

Deliverables included:
1. **Architecture Document:** `docs/architecture/network-architecture.md` outlining the layered model (Universal Core, Profile Features, Fast Path), the distinction between Networking and Communications, and a strict phase roadmap.
2. **Library Contracts:** `lib/net` (interfaces, address families) and `lib/packet` (buffer structures, offload flags) with thin, stable API definitions.
3. **Subsystem Contract:** `subsys/network` to provide the stable API/RPC boundary for applications.
4. **Service Decompositions:** Initial scaffolding for `services/netmgr` (control/policy plane) and `services/netstack` (data plane/IP stack).
5. **Transitional Safety:** The existing `services/net` directory is explicitly marked as legacy but is kept to ensure no existing experiments or builds break during the transition. The user-space service stubs are protected behind a `BHARAT_BUILD_NETWORK_STUBS` CMake flag.

---
*PR created automatically by Jules for task [17136228264115088840](https://jules.google.com/task/17136228264115088840) started by @divyang4481*