### PR TITLE
Network Phase 1: Establish structure and stable contracts

### DIFF
--- a/drivers/CMakeLists.txt
+++ b/drivers/CMakeLists.txt
@@ -4,6 +4,7 @@ project(BharatOS_Drivers C ASM)
 # Add driver subdirectories
 add_library(bharatos_drivers STATIC
     net/ptp_clock.c
+    net/virtio_net.c
     accel/fpga_mgr.c
     bus/cluster_bus.c
     src/automotive/can_loopback.c

--- a/drivers/net/virtio_net.c
+++ b/drivers/net/virtio_net.c
@@ -1,0 +1,54 @@
+#include <stdint.h>
+#include <stddef.h>
+
+/* virtio_net.c
+ *
+ * Baseline virtio-net driver skeleton for BharatOS.
+ * Target: First real NIC target.
+ */
+
+/* TODO: Include proper subsystem networking types and virtio specs */
+
+int virtio_net_init(void) {
+    /* TODO: Implement global driver initialization */
+    return 0;
+}
+
+int virtio_net_probe(void *device) {
+    /* TODO: Probe for PCI/MMIO virtio device and verify virtio-net features */
+    return 0;
+}
+
+int virtio_net_bind(void *device) {
+    /* TODO: Bind driver to the hardware device, allocate rings and basic structures */
+    return 0;
+}
+
+int virtio_net_start(void *device) {
+    /* TODO: Configure rings, set MAC address, and transition device to DRIVER_OK state */
+    return 0;
+}
+
+int virtio_net_stop(void *device) {
+    /* TODO: Halt queues, disable interrupts, reset the device */
+    return 0;
+}
+
+int virtio_net_tx(void *device, void *buffer, size_t length) {
+    /* TODO: Enqueue buffer into virtqueue for transmission */
+    return 0;
+}
+
+int virtio_net_rx(void *device, void **buffer, size_t *length) {
+    /* TODO: Dequeue received buffer from virtqueue and return it */
+    return 0;
+}
+
+int virtio_net_poll(void *device) {
+    /* TODO: Check ring status without interrupts and process pending packets */
+    return 0;
+}
+
+void virtio_net_irq(void *device) {
+    /* TODO: Handle device interrupts (e.g. queue activity, config changes) */
+}

--- a/services/CMakeLists.txt
+++ b/services/CMakeLists.txt
@@ -24,4 +24,5 @@ option(BHARAT_BUILD_NETWORK_STUBS "Build network manager and stack user-space st
 if(BHARAT_BUILD_NETWORK_STUBS)
     add_subdirectory(netmgr)
     add_subdirectory(netstack)
+    add_subdirectory(netfast)
 endif()

--- a/services/netfast/CMakeLists.txt
+++ b/services/netfast/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.20)
+project(netfast C)
+
+add_executable(netfast src/main.c)
+target_compile_options(netfast PRIVATE -Wall -ffreestanding -nostdlib -fPIE -fPIC)
+target_link_options(netfast PRIVATE -nostdlib -no-pie)
+# Link against necessary system primitives/stubs here in the future

--- a/services/netfast/README.md
+++ b/services/netfast/README.md
@@ -1,0 +1,14 @@
+# Bharat-OS `services/netfast`
+
+## Role
+
+Optional fast path for networking:
+- appliance/datacenter profiles
+- fast-path routing
+- zero-copy packet processing
+
+This module is the high-performance data plane alternative designed for environments requiring low latency and high throughput, such as edge gateways and cloud nodes.
+
+## Status
+* **Current:** Architectural stub.
+* **Roadmap:** Full capability-safe, hardware-accelerated, zero-copy fast path network stack.

--- a/services/netfast/src/main.c
+++ b/services/netfast/src/main.c
@@ -1,0 +1,12 @@
+#include <stdint.h>
+#include <stddef.h>
+
+// Placeholder for future netfast main
+// This service will act as a fast-path/zero-copy/appliance-profile network processing entity.
+// It is intended for hardware-accelerated and high-performance routing capabilities,
+// complementing or replacing the standard netstack data plane in applicable profiles.
+
+int main(int argc, char *argv[]) {
+    // Architectural stub - implementation pending
+    return 0;
+}

--- a/subsys/include/bharat/network/capabilities.h
+++ b/subsys/include/bharat/network/capabilities.h
@@ -1,0 +1,21 @@
+#ifndef BHARAT_NETWORK_CAPABILITIES_H
+#define BHARAT_NETWORK_CAPABILITIES_H
+
+/* Capability bits/rights specific to networking */
+
+#define BNET_CAP_IFACE_MANAGE   (1ULL << 0)
+#define BNET_CAP_ROUTE_MANAGE   (1ULL << 1)
+#define BNET_CAP_ADDR_MANAGE    (1ULL << 2)
+
+#define BNET_CAP_QUEUE_BIND     (1ULL << 3)
+#define BNET_CAP_FASTPATH_BIND  (1ULL << 4)
+
+#define BNET_CAP_PACKET_TX      (1ULL << 5)
+#define BNET_CAP_PACKET_RX      (1ULL << 6)
+
+#define BNET_CAP_RAW_SOCKET     (1ULL << 7)
+#define BNET_CAP_PROMISC        (1ULL << 8)
+
+#define BNET_CAP_PTP_CONTROL    (1ULL << 9)
+
+#endif // BHARAT_NETWORK_CAPABILITIES_H

--- a/subsys/include/bharat/network/contracts.h
+++ b/subsys/include/bharat/network/contracts.h
@@ -1,0 +1,31 @@
+#ifndef BHARAT_NETWORK_CONTRACTS_H
+#define BHARAT_NETWORK_CONTRACTS_H
+
+#include "version.h"
+
+/*
+ * Bharat-OS Subsystem Network Contracts
+ *
+ * Top-level stable subsystem contract definitions:
+ * - ABI Version limits and compatibility.
+ * - Service names for discovery.
+ * - Architectural boundaries and ownership models.
+ */
+
+#define BNET_MGR_SERVICE_NAME   "bharat.netmgr"
+#define BNET_STACK_SERVICE_NAME "bharat.netstack"
+#define BNET_FAST_SERVICE_NAME  "bharat.netfast"
+
+/*
+ * Object Model Notes:
+ * - netmgr: Owns the control plane. Manages interface lifecycles, assigns configurations,
+ *           maintains routing and policy models.
+ * - netstack: Owns the baseline L2/L3/L4 data plane processing and socket layer.
+ * - netfast: Optional high-performance fast path. Takes queue registrations directly
+ *            and bypasses slow paths for appliance profiles.
+ * - drivers: Hardware abstractions (e.g. virtio_net). Handled by IO subsystem and mapped
+ *            to netstack or netfast via memory-mapped queues.
+ * - clients: Request sockets, establish streams. Bounded by capabilities and namespace routing.
+ */
+
+#endif // BHARAT_NETWORK_CONTRACTS_H

--- a/subsys/include/bharat/network/control.h
+++ b/subsys/include/bharat/network/control.h
@@ -1,0 +1,32 @@
+#ifndef BHARAT_NETWORK_CONTROL_H
+#define BHARAT_NETWORK_CONTROL_H
+
+#include "types.h"
+#include "errors.h"
+
+/* Control-plane API contracts */
+
+/* Interface Operations */
+int bnet_ctrl_create_interface(bnet_mac_type_t type, bnet_interface_id_t *out_id);
+int bnet_ctrl_delete_interface(bnet_interface_id_t id);
+
+int bnet_ctrl_set_link_state(bnet_interface_id_t id, bnet_link_state_t state);
+int bnet_ctrl_set_admin_state(bnet_interface_id_t id, bnet_link_state_t state);
+
+/* Addressing */
+int bnet_ctrl_assign_address(bnet_interface_id_t id, const bnet_ip_prefix_t *prefix);
+int bnet_ctrl_remove_address(bnet_interface_id_t id, const bnet_ip_prefix_t *prefix);
+
+/* Routing */
+int bnet_ctrl_route_add(const bnet_route_key_t *route);
+int bnet_ctrl_route_remove(const bnet_route_key_t *route);
+
+/* Neighbors */
+int bnet_ctrl_neighbor_add(bnet_interface_id_t id, const bnet_ip_addr_t *ip, const bnet_mac_addr_t *mac);
+int bnet_ctrl_neighbor_remove(bnet_interface_id_t id, const bnet_ip_addr_t *ip);
+
+/* Telemetry and Queries */
+int bnet_ctrl_get_stats(bnet_interface_id_t id, bnet_stats_t *out_stats);
+int bnet_ctrl_get_features(bnet_interface_id_t id, uint64_t *out_features);
+
+#endif // BHARAT_NETWORK_CONTROL_H

--- a/subsys/include/bharat/network/datapath.h
+++ b/subsys/include/bharat/network/datapath.h
@@ -1,0 +1,33 @@
+#ifndef BHARAT_NETWORK_DATAPATH_H
+#define BHARAT_NETWORK_DATAPATH_H
+
+#include "types.h"
+
+/* Data-plane-facing contracts */
+
+typedef struct {
+    void *ring_base;
+    uint32_t ring_size;
+    uint16_t descriptor_size;
+} bnet_ring_handoff_t;
+
+/* Buffer Ownership States */
+typedef enum {
+    BNET_BUF_OWN_CLIENT = 0,
+    BNET_BUF_OWN_STACK,
+    BNET_BUF_OWN_HW
+} bnet_buffer_owner_t;
+
+/* Queue Capabilities */
+#define BNET_QUEUE_CAP_ZERO_COPY  (1 << 0)
+#define BNET_QUEUE_CAP_OFFLOAD_CS (1 << 1)
+#define BNET_QUEUE_CAP_OFFLOAD_TS (1 << 2)
+
+/* Data-plane API */
+int bnet_dp_queue_register(bnet_interface_id_t iface_id, bnet_queue_id_t q_id, const bnet_ring_handoff_t *handoff);
+int bnet_dp_queue_unregister(bnet_interface_id_t iface_id, bnet_queue_id_t q_id);
+
+int bnet_dp_notify_tx(bnet_interface_id_t iface_id, bnet_queue_id_t q_id);
+int bnet_dp_poll_rx(bnet_interface_id_t iface_id, bnet_queue_id_t q_id, uint32_t count, void **out_buffers);
+
+#endif // BHARAT_NETWORK_DATAPATH_H

--- a/subsys/include/bharat/network/errors.h
+++ b/subsys/include/bharat/network/errors.h
@@ -1,0 +1,26 @@
+#ifndef BHARAT_NETWORK_ERRORS_H
+#define BHARAT_NETWORK_ERRORS_H
+
+/* Stable networking error codes layered over system errno-style values */
+
+#define BNET_OK             0
+
+#define BNET_ERR_INVAL     -1   /* Invalid argument */
+#define BNET_ERR_NOENT     -2   /* No such file or directory / not found */
+#define BNET_ERR_NOMEM     -3   /* Out of memory */
+#define BNET_ERR_ACCESS    -4   /* Permission denied / Capability fault */
+#define BNET_ERR_BUSY      -5   /* Device or resource busy */
+#define BNET_ERR_EXIST     -6   /* File or resource exists */
+#define BNET_ERR_NOTSUP    -7   /* Operation not supported */
+#define BNET_ERR_IO        -8   /* I/O error */
+#define BNET_ERR_TIMEOUT   -9   /* Operation timed out */
+
+/* Network specific errors */
+#define BNET_ERR_NETDOWN   -100 /* Network is down */
+#define BNET_ERR_NETUNREACH -101 /* Network is unreachable */
+#define BNET_ERR_HOSTUNREACH -102 /* No route to host */
+#define BNET_ERR_CONNREFUSED -103 /* Connection refused */
+#define BNET_ERR_ADDRINUSE   -104 /* Address already in use */
+#define BNET_ERR_ADDRNOTAVAIL -105 /* Cannot assign requested address */
+
+#endif // BHARAT_NETWORK_ERRORS_H

--- a/subsys/include/bharat/network/types.h
+++ b/subsys/include/bharat/network/types.h
@@ -1,0 +1,68 @@
+#ifndef BHARAT_NETWORK_TYPES_H
+#define BHARAT_NETWORK_TYPES_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+typedef uint32_t bnet_interface_id_t;
+typedef uint16_t bnet_queue_id_t;
+
+typedef enum {
+    BNET_MAC_TYPE_ETHERNET = 1,
+    BNET_MAC_TYPE_WIFI,
+    BNET_MAC_TYPE_VIRTUAL
+} bnet_mac_type_t;
+
+typedef enum {
+    BNET_IP_FAMILY_V4 = 1,
+    BNET_IP_FAMILY_V6
+} bnet_ip_family_t;
+
+typedef enum {
+    BNET_LINK_STATE_DOWN = 0,
+    BNET_LINK_STATE_UP,
+    BNET_LINK_STATE_UNKNOWN
+} bnet_link_state_t;
+
+typedef struct {
+    uint8_t addr[6];
+} bnet_mac_addr_t;
+
+typedef struct {
+    bnet_ip_family_t family;
+    union {
+        uint32_t v4;
+        uint8_t v6[16];
+    } addr;
+} bnet_ip_addr_t;
+
+typedef struct {
+    bnet_ip_addr_t prefix;
+    uint8_t length;
+} bnet_ip_prefix_t;
+
+typedef struct {
+    bnet_ip_prefix_t dest;
+    bnet_ip_addr_t gateway;
+    bnet_interface_id_t iface_id;
+    uint32_t metric;
+} bnet_route_key_t;
+
+typedef struct {
+    uint64_t rx_packets;
+    uint64_t tx_packets;
+    uint64_t rx_bytes;
+    uint64_t tx_bytes;
+    uint64_t rx_errors;
+    uint64_t tx_errors;
+    uint64_t rx_dropped;
+    uint64_t tx_dropped;
+} bnet_stats_t;
+
+typedef struct {
+    uint32_t flags;
+    uint16_t length;
+    uint16_t offload;
+} bnet_packet_meta_t;
+
+#endif // BHARAT_NETWORK_TYPES_H

--- a/subsys/include/bharat/network/version.h
+++ b/subsys/include/bharat/network/version.h
@@ -1,0 +1,14 @@
+#ifndef BHARAT_NETWORK_VERSION_H
+#define BHARAT_NETWORK_VERSION_H
+
+/* ABI version macros and compatibility guards */
+
+#define BNET_ABI_VERSION_MAJOR 1
+#define BNET_ABI_VERSION_MINOR 0
+
+#define BNET_ABI_VERSION ((BNET_ABI_VERSION_MAJOR << 16) | (BNET_ABI_VERSION_MINOR))
+
+#define BNET_CHECK_ABI_COMPAT(client_version) \
+    (((client_version) >> 16) == BNET_ABI_VERSION_MAJOR)
+
+#endif // BHARAT_NETWORK_VERSION_H


### PR DESCRIPTION
Creates the Phase 1 Network Infrastructure Skeleton for BharatOS, adhering to the profile-driven architecture.

Changes include:
- `services/netfast`: A placeholder for an optional fast-path networking service.
- `drivers/net/virtio_net.c`: A baseline Virtio-net driver skeleton with basic stubs.
- `subsys/include/bharat/network/*`: A complete set of stable subsystem networking contracts (`types.h`, `contracts.h`, `control.h`, `datapath.h`, `capabilities.h`, `errors.h`, `version.h`).

---
*PR created automatically by Jules for task [9827072972098411271](https://jules.google.com/task/9827072972098411271) started by @divyang4481*