### PR TITLE
Add Multi-Kernel Message Wire Format and Substrate

### DIFF
--- a/docs/architecture/bidl-v1.md
+++ b/docs/architecture/bidl-v1.md
@@ -1,0 +1,137 @@
+# Bharat-OS IDL (BIDL) v1 Grammar
+
+## 1. Overview
+The **Bharat-OS Interface Definition Language (BIDL)** is a minimal, language-agnostic schema format used to generate binary serializers, parsers, and RPC dispatch stubs for the Bharat-OS Message Wire Format.
+
+BIDL v1 prioritizes:
+- Simplicity (Python stdlib-only parser)
+- Determinism (No hidden types or unbounded sizes)
+- C-language codegen (Inline structs for bounded buffers)
+
+---
+
+## 2. Basic Syntax
+
+### Services
+A `service` block groups related RPC methods and assigns a global `service_id`.
+
+```idl
+service <qualified_name> = <service_id> {
+  // Methods
+}
+```
+
+### RPC Methods
+An `rpc` definition defines a request message and its corresponding response message. Attributes can be specified within the block to dictate transport behavior (QoS, timeouts).
+
+```idl
+  rpc <MethodName>(<RequestType>) -> <ResponseType> {
+    qos = reliable | best_effort;
+    timeout_ms = <int>;
+    idempotent = true | false;
+    auth = required | optional;
+    criticality = rt_ctl | rt_data | best_effort | bulk | debug;
+  }
+```
+
+### Messages
+A `message` is a struct-like collection of typed fields. It maps directly to an inline C-struct payload format.
+
+```idl
+message <MessageName> {
+  <type> <field_name>;
+}
+```
+
+---
+
+## 3. Supported Data Types
+
+BIDL v1 strictly defines sizes and bounds on the wire.
+
+### Primitives
+- `u8`, `u16`, `u32`, `u64` (unsigned integers)
+- `i8`, `i16`, `i32`, `i64` (signed integers)
+- `bool` (boolean, encoded as `u8`)
+
+### Bounded Complex Types
+These generate inline bounded structs in C. No heap allocation is required during decode.
+
+- `string<N>`: A UTF-8 string with a maximum length of `N` bytes (excluding length prefix).
+- `bytes<N>`: An opaque binary blob with a maximum length of `N` bytes.
+- `array<T, N>`: A fixed-size array of exactly `N` elements of type `T`.
+- `vec<T, N>`: A variable-sized list (vector) of up to `N` elements of type `T`.
+
+### Capability and OOL Types
+- `cap_descriptor`: Represents a delegated capability exported onto the wire.
+- `ool_descriptor`: Represents a pointer to an out-of-line memory payload (e.g., shared memory).
+
+---
+
+## 4. Example Schema
+
+```idl
+service bharat.monitor.v1 = 1 {
+  rpc Heartbeat(HeartbeatReq) -> HeartbeatResp {
+    qos = reliable;
+    timeout_ms = 100;
+    idempotent = true;
+    criticality = rt_ctl;
+  }
+
+  rpc NodeJoin(NodeJoinReq) -> NodeJoinResp {
+    qos = reliable;
+    timeout_ms = 500;
+    auth = required;
+    criticality = rt_ctl;
+  }
+}
+
+message HeartbeatReq {
+  u32 node_id;
+  u64 monotonic_time_ns;
+  u32 health_flags;
+}
+
+message HeartbeatResp {
+  u32 accepted;
+}
+
+message NodeJoinReq {
+  u32 protocol_version;
+  u32 arch;
+  u64 boot_nonce;
+  string<64> node_name;
+  bytes<128> topology_digest;
+}
+
+message NodeJoinResp {
+  u32 accepted;
+  u32 assigned_node_id;
+  u64 session_nonce;
+}
+```
+
+---
+
+## 5. Code Generation Target
+
+The generated C structures will flatten dynamically sized items (like `string<64>`) into inline arrays to maintain bounded memory lifetimes and avoid `malloc`.
+
+```c
+typedef struct {
+    uint32_t protocol_version;
+    uint32_t arch;
+    uint64_t boot_nonce;
+    struct {
+        uint32_t len;
+        char data[64];
+    } node_name;
+    struct {
+        uint32_t len;
+        uint8_t data[128];
+    } topology_digest;
+} bharat_monitor_v1_node_join_req_t;
+```
+
+The codec APIs will iterate field-by-field, copying from the wire buffer into these structured targets while asserting `len <= MAX`.

--- a/docs/architecture/msg-wire-format-v1.md
+++ b/docs/architecture/msg-wire-format-v1.md
@@ -1,0 +1,124 @@
+# Bharat-OS Message Wire Format v1
+
+## 1. Overview
+Bharat-OS implements a **transport-neutral binary message ABI** as the control-plane communication foundation. It supports local IPC, URPC (multi-core), and future distributed-kernel coordination.
+
+This protocol is:
+- Cross-architecture safe (little-endian, deterministic alignment).
+- Compact and explicit (no hidden padding).
+- Transport-independent (usable over ring buffers, endpoints, or sockets).
+- Capability-aware (supports remote delegation/revocation descriptors).
+- Bounded (no unchecked dynamic allocations on decode).
+
+---
+
+## 2. Canonical Message Header
+
+Every message on the wire begins with a fixed, unpadded header encoded in canonical little-endian format. The header provides parsing bounds before payload or capability arrays are read.
+
+| Offset | Field Name       | Type     | Description |
+|--------|------------------|----------|-------------|
+| 0x00   | `magic`          | `u32`    | Must be `0x42485254` ('BHRT') |
+| 0x04   | `version_major`  | `u8`     | Protocol major version (v1) |
+| 0x05   | `version_minor`  | `u8`     | Protocol minor version |
+| 0x06   | `header_len`     | `u16`    | Size of this header in bytes |
+| 0x08   | `service_id`     | `u16`    | ID of the target service |
+| 0x0A   | `opcode`         | `u16`    | ID of the method being called |
+| 0x0C   | `flags`          | `u32`    | Bitmask of message properties |
+| 0x10   | `total_len`      | `u32`    | Total message length including header, inline payload, and descriptors |
+| 0x14   | `request_id`     | `u64`    | Opaque correlation ID for req/resp pairs |
+| 0x1C   | `src_node`       | `u32`    | Origin node identifier |
+| 0x20   | `dst_node`       | `u32`    | Destination node identifier |
+| 0x24   | `cap_count`      | `u16`    | Number of capability descriptors trailing the payload |
+| 0x26   | `desc_count`     | `u16`    | Number of OOL payload descriptors trailing the cap array |
+| 0x28   | `header_crc`     | `u32`    | Optional CRC/Checksum over the header bytes (0 if unused) |
+
+*Note: All multi-byte fields must be written to and read from the wire using explicit little-endian operations. Decoders must never overlay a C `struct` directly onto the transport buffer.*
+
+### Validation Rules
+- **Magic:** Must equal the defined protocol magic.
+- **Major Version:** Must match the supported major version. Minor mismatches are permitted if extensions are ignored.
+- **Header Length:** `header_len >= 0x2C` (44 bytes). If `header_len` is larger, the parser must skip the extra header bytes before starting the payload.
+- **Total Length:** `total_len >= header_len`. Messages exceeding MTU must be rejected before service dispatch.
+- **Counts:** `cap_count` and `desc_count` arrays must fit within `total_len`.
+
+---
+
+## 3. Flag Space
+
+| Flag | Name | Semantics |
+|------|------|-----------|
+| `1 << 0` | `MSG_FLAG_REQUEST`     | Message is an RPC request |
+| `1 << 1` | `MSG_FLAG_RESPONSE`    | Message is an RPC response |
+| `1 << 2` | `MSG_FLAG_EVENT`       | Message is a one-way event/datagram |
+| `1 << 3` | `MSG_FLAG_ERROR`       | Message payload represents an error |
+| `1 << 4` | `MSG_FLAG_ACK_REQ`     | Requires transport-level ACK |
+| `1 << 5` | `MSG_FLAG_RELIABLE`    | Sent over/requires a reliable transport |
+| `1 << 6` | `MSG_FLAG_FRAGMENTED`  | Part of a fragmented stream (reserved) |
+| `1 << 7` | `MSG_FLAG_HAS_CAPS`    | Contains capability descriptors |
+| `1 << 8` | `MSG_FLAG_HAS_OOL`     | Contains Out-Of-Line descriptors |
+
+---
+
+## 4. Payload Encoding Rules
+
+Payloads immediately follow the header (starting at byte `header_len`).
+
+### Primitives
+- **Integers:** `u8`, `u16`, `u32`, `u64`, `i8`, `i16`, `i32`, `i64` encoded in little-endian.
+- **Booleans:** Encoded as a single `u8` byte (`1` for true, `0` for false).
+- **Enums:** Encoded as explicit `u16` or `u32` integers.
+
+### Bounded Complex Types
+- **Strings (`string<N>`):** Encoded as a `u32` byte-length followed by the UTF-8 bytes. No null terminator is sent on the wire.
+- **Bytes (`bytes<N>`):** Encoded as a `u32` byte-length followed by the opaque payload bytes.
+- **Arrays (`array<T, N>`):** Fixed arrays encode `N` elements back-to-back. Variable vectors (`vec<T, N>`) encode a `u32` element count followed by the elements.
+- **Optional Fields:** Supported via a presence flag (usually a `u8` boolean) preceding the field.
+
+### Alignment
+- There is **no implicit padding** in the payload. A `u8` followed by a `u64` occupies exactly 9 bytes.
+- Generated decoders use byte-by-byte copies to extract fields, avoiding unaligned access traps on platforms like older ARMs.
+
+---
+
+## 5. Capability on Wire (Capwire)
+
+A local capability table index (handle) is meaningless on a different kernel node. When a capability is sent, it must be exported into a **Capability Wire Descriptor**.
+
+Cap descriptors are stored sequentially at the end of the inline payload.
+
+### Cap Descriptor Layout
+
+| Offset | Field          | Type   | Description |
+|--------|----------------|--------|-------------|
+| 0x00   | `cap_type`     | `u8`   | Type of the capability being transferred (e.g., Service, Shmem, Endpoint) |
+| 0x01   | `transfer_mode`| `u8`   | COPY(0), MOVE(1), BORROW(2), DELEGATE_ATTENUATED(3) |
+| 0x02   | `rights_mask`  | `u32`  | The access rights granted over the object |
+| 0x06   | `origin_node`  | `u32`  | Node ID that hosts the real object |
+| 0x0A   | `issuer_id`    | `u32`  | Security/Auth domain of the issuer |
+| 0x0E   | `object_id`    | `u64`  | Global or exported ID of the backing object |
+| 0x16   | `nonce`        | `u64`  | Cryptographic/Random nonce for replay protection |
+| 0x1E   | `generation`   | `u32`  | Version tracking to aid revocation |
+
+When received, the importing node verifies the descriptor and instantiates a proxy object (`OBJ_TYPE_CAP_PROXY`) in its local tables, retaining origin, object, and nonce information to satisfy later method invocations.
+
+---
+
+## 6. Out-of-Line (OOL) Payload Descriptors
+
+To avoid memcpying large payloads (like network frames or camera buffers), OOL descriptors define memory regions that back the message.
+
+| Offset | Field          | Type   | Description |
+|--------|----------------|--------|-------------|
+| 0x00   | `desc_type`    | `u8`   | SHMEM(0), DMA(1), BLOB(2), PACKET(3) |
+| 0x01   | `flags`        | `u8`   | READ_ONLY, READ_WRITE, VOLATILE, etc. |
+| 0x02   | `region_id`    | `u64`  | ID of the referenced shared memory region |
+| 0x0A   | `offset`       | `u64`  | Start offset within the region |
+| 0x12   | `length`       | `u64`  | Length of the referenced data chunk |
+
+---
+
+## 7. Versioning
+
+- **Protocol Version:** Dictates the layout of the canonical header. Breaking changes require a `version_major` bump.
+- **Service Version:** Contained within the `service_id` (e.g., `bharat.monitor.v1` is assigned ID `1`). Breaking schema changes to a service's payload require defining a new `service_id`. Minor backward-compatible field additions can occur if clients are tolerant of longer-than-expected payloads.

--- a/kernel/include/capability.h
+++ b/kernel/include/capability.h
@@ -20,6 +20,7 @@ typedef enum {
     CAP_OBJ_NETDEV = 10,
     CAP_OBJ_NET_QUEUE = 11,
     CAP_OBJ_NET_BUFFER = 12,
+    CAP_OBJ_IMPORTED_PROXY = 13, // Remote/delegated capability on wire
 } cap_object_type_t;
 
 typedef enum {

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -24,3 +24,35 @@ if(BHARAT_BUILD_NETWORK_STUBS)
     add_subdirectory(net)
     add_subdirectory(packet)
 endif()
+
+# Phase 2: Message/Wire Runtime
+add_library(msg STATIC
+    msg/wire.c
+    msg/validate.c
+    msg/crc.c
+)
+target_include_directories(msg PUBLIC ../subsys/include)
+target_sources(msg PRIVATE msg/encode.c msg/decode.c)
+
+# Phase 3: Capability on Wire
+add_library(capwire STATIC
+    capwire/cap_codec.c
+    capwire/cap_validate.c
+)
+target_include_directories(capwire PUBLIC ../subsys/include)
+target_link_libraries(capwire PRIVATE msg)
+
+# Phase 4: Out Of Line (OOL) Descriptors
+add_library(ool_desc STATIC
+    ool/ool_codec.c
+    ool/ool_validate.c
+)
+target_include_directories(ool_desc PUBLIC ../subsys/include)
+target_link_libraries(ool_desc PRIVATE msg)
+
+# Phase 5: Transport Abstraction
+add_library(transport STATIC
+    transport/loopback.c
+)
+target_include_directories(transport PUBLIC ../subsys/include)
+target_link_libraries(transport PRIVATE msg)

--- a/lib/capwire/cap_codec.c
+++ b/lib/capwire/cap_codec.c
@@ -1,0 +1,48 @@
+#include "bharat/idl/capwire.h"
+
+// ============================================================================
+// Encoding/Decoding (Wire representation)
+// ============================================================================
+
+int bharat_capwire_encode(bharat_msg_builder_t* b, const bharat_capwire_desc_t* desc) {
+    if (!b || !desc) {
+        return BHARAT_MSG_ERR_MALFORMED_PAYLOAD;
+    }
+
+    // A Capwire Descriptor is strictly 34 bytes (0x22). See msg-wire-format-v1.md.
+    if (b->cap - b->off < 34) {
+        return BHARAT_MSG_ERR_BUFFER_OVERFLOW;
+    }
+
+    bharat_msg_build_u8(b, desc->cap_type);
+    bharat_msg_build_u8(b, desc->transfer_mode);
+    bharat_msg_build_u32(b, desc->rights_mask);
+    bharat_msg_build_u32(b, desc->origin_node);
+    bharat_msg_build_u32(b, desc->issuer_id);
+    bharat_msg_build_u64(b, desc->object_id);
+    bharat_msg_build_u64(b, desc->nonce);
+    bharat_msg_build_u32(b, desc->generation);
+
+    return BHARAT_MSG_OK;
+}
+
+int bharat_capwire_decode(bharat_msg_reader_t* r, bharat_capwire_desc_t* desc) {
+    if (!r || !desc) {
+        return BHARAT_MSG_ERR_MALFORMED_PAYLOAD;
+    }
+
+    if (r->len - r->off < 34) {
+        return BHARAT_MSG_ERR_TRUNCATED;
+    }
+
+    bharat_msg_read_u8(r, &desc->cap_type);
+    bharat_msg_read_u8(r, &desc->transfer_mode);
+    bharat_msg_read_u32(r, &desc->rights_mask);
+    bharat_msg_read_u32(r, &desc->origin_node);
+    bharat_msg_read_u32(r, &desc->issuer_id);
+    bharat_msg_read_u64(r, &desc->object_id);
+    bharat_msg_read_u64(r, &desc->nonce);
+    bharat_msg_read_u32(r, &desc->generation);
+
+    return BHARAT_MSG_OK;
+}

--- a/lib/capwire/cap_validate.c
+++ b/lib/capwire/cap_validate.c
@@ -1,0 +1,35 @@
+#include "bharat/idl/capwire.h"
+
+// ============================================================================
+// Protocol Decoding
+// ============================================================================
+
+int bharat_capwire_validate(const bharat_capwire_desc_t* desc) {
+    if (!desc) {
+        return BHARAT_MSG_ERR_MALFORMED_PAYLOAD;
+    }
+
+    if (desc->transfer_mode > BHARAT_CAP_XFER_DELEGATE_ATTENUATED) {
+        return BHARAT_MSG_ERR_INVALID_CAP; // Unknown transfer semantic
+    }
+
+    // A capability must originate from somewhere and be over something.
+    // 0 is often considered a null/invalid ID, so let's reject completely null tokens
+    if (desc->origin_node == 0 || desc->object_id == 0) {
+        return BHARAT_MSG_ERR_INVALID_CAP;
+    }
+
+    // A delegated token without a nonce is unsafe to import
+    if (desc->nonce == 0) {
+        return BHARAT_MSG_ERR_UNAUTHORIZED;
+    }
+
+    return BHARAT_MSG_OK;
+}
+
+void bharat_capwire_attenuate(bharat_capwire_desc_t* desc, uint32_t allowed_rights) {
+    if (desc) {
+        // Strip any bits that are not present in allowed_rights
+        desc->rights_mask &= allowed_rights;
+    }
+}

--- a/lib/msg/crc.c
+++ b/lib/msg/crc.c
@@ -1,0 +1,20 @@
+#include <stdint.h>
+#include <stddef.h>
+
+// A simple software CRC32 for validating the headers
+// Standard IEEE 802.3 polynomial (Ethernet, gzip) = 0xEDB88320
+
+uint32_t bharat_msg_crc32(const uint8_t *data, size_t len) {
+    uint32_t crc = 0xFFFFFFFF;
+    for (size_t i = 0; i < len; i++) {
+        crc ^= data[i];
+        for (int j = 0; j < 8; j++) {
+            if (crc & 1) {
+                crc = (crc >> 1) ^ 0xEDB88320;
+            } else {
+                crc >>= 1;
+            }
+        }
+    }
+    return crc ^ 0xFFFFFFFF;
+}

--- a/lib/msg/decode.c
+++ b/lib/msg/decode.c
@@ -1,0 +1,84 @@
+#include "bharat/msg/payload.h"
+
+int bharat_msg_read_u8(bharat_msg_reader_t* r, uint8_t* out) {
+    if (r->len - r->off < sizeof(uint8_t)) {
+        return BHARAT_MSG_ERR_TRUNCATED;
+    }
+    *out = r->buf[r->off++];
+    return BHARAT_MSG_OK;
+}
+
+int bharat_msg_read_u16(bharat_msg_reader_t* r, uint16_t* out) {
+    if (r->len - r->off < sizeof(uint16_t)) {
+        return BHARAT_MSG_ERR_TRUNCATED;
+    }
+    *out = bharat_load_le16(r->buf + r->off);
+    r->off += sizeof(uint16_t);
+    return BHARAT_MSG_OK;
+}
+
+int bharat_msg_read_u32(bharat_msg_reader_t* r, uint32_t* out) {
+    if (r->len - r->off < sizeof(uint32_t)) {
+        return BHARAT_MSG_ERR_TRUNCATED;
+    }
+    *out = bharat_load_le32(r->buf + r->off);
+    r->off += sizeof(uint32_t);
+    return BHARAT_MSG_OK;
+}
+
+int bharat_msg_read_u64(bharat_msg_reader_t* r, uint64_t* out) {
+    if (r->len - r->off < sizeof(uint64_t)) {
+        return BHARAT_MSG_ERR_TRUNCATED;
+    }
+    *out = bharat_load_le64(r->buf + r->off);
+    r->off += sizeof(uint64_t);
+    return BHARAT_MSG_OK;
+}
+
+int bharat_msg_read_bool(bharat_msg_reader_t* r, bool* out) {
+    uint8_t val;
+    int rc = bharat_msg_read_u8(r, &val);
+    if (rc == BHARAT_MSG_OK) {
+        *out = (val != 0);
+    }
+    return rc;
+}
+
+int bharat_msg_read_bytes_bounded(bharat_msg_reader_t* r, uint8_t* dst, uint32_t dst_max, uint32_t* out_len) {
+    uint32_t len;
+    int rc = bharat_msg_read_u32(r, &len);
+    if (rc != BHARAT_MSG_OK) {
+        return rc;
+    }
+
+    if (len > dst_max) {
+        return BHARAT_MSG_ERR_BUFFER_OVERFLOW;
+    }
+
+    if (r->len - r->off < len) {
+        return BHARAT_MSG_ERR_TRUNCATED;
+    }
+
+    if (len > 0) {
+        memcpy(dst, r->buf + r->off, len);
+        r->off += len;
+    }
+    *out_len = len;
+    return BHARAT_MSG_OK;
+}
+
+int bharat_msg_read_string_bounded(bharat_msg_reader_t* r, char* dst, uint32_t dst_max, uint32_t* out_len) {
+    // A string is just encoded as length-prefixed bytes
+    uint32_t len;
+    int rc = bharat_msg_read_bytes_bounded(r, (uint8_t*)dst, dst_max - 1, &len); // reserve 1 byte for null terminator
+    if (rc != BHARAT_MSG_OK) {
+        return rc;
+    }
+
+    // Always null terminate strings for safe C-layer usage
+    dst[len] = '\0';
+    if (out_len) {
+        *out_len = len;
+    }
+    return BHARAT_MSG_OK;
+}

--- a/lib/msg/encode.c
+++ b/lib/msg/encode.c
@@ -1,0 +1,60 @@
+#include "bharat/msg/payload.h"
+
+int bharat_msg_build_u8(bharat_msg_builder_t* b, uint8_t v) {
+    if (b->cap - b->off < sizeof(uint8_t)) {
+        return BHARAT_MSG_ERR_BUFFER_OVERFLOW;
+    }
+    b->buf[b->off++] = v;
+    return BHARAT_MSG_OK;
+}
+
+int bharat_msg_build_u16(bharat_msg_builder_t* b, uint16_t v) {
+    if (b->cap - b->off < sizeof(uint16_t)) {
+        return BHARAT_MSG_ERR_BUFFER_OVERFLOW;
+    }
+    bharat_store_le16(b->buf + b->off, v);
+    b->off += sizeof(uint16_t);
+    return BHARAT_MSG_OK;
+}
+
+int bharat_msg_build_u32(bharat_msg_builder_t* b, uint32_t v) {
+    if (b->cap - b->off < sizeof(uint32_t)) {
+        return BHARAT_MSG_ERR_BUFFER_OVERFLOW;
+    }
+    bharat_store_le32(b->buf + b->off, v);
+    b->off += sizeof(uint32_t);
+    return BHARAT_MSG_OK;
+}
+
+int bharat_msg_build_u64(bharat_msg_builder_t* b, uint64_t v) {
+    if (b->cap - b->off < sizeof(uint64_t)) {
+        return BHARAT_MSG_ERR_BUFFER_OVERFLOW;
+    }
+    bharat_store_le64(b->buf + b->off, v);
+    b->off += sizeof(uint64_t);
+    return BHARAT_MSG_OK;
+}
+
+int bharat_msg_build_bool(bharat_msg_builder_t* b, bool v) {
+    return bharat_msg_build_u8(b, v ? 1 : 0);
+}
+
+int bharat_msg_build_bytes(bharat_msg_builder_t* b, const uint8_t* data, uint32_t len) {
+    // 4-byte length prefix + actual bytes
+    if (b->cap - b->off < sizeof(uint32_t) + len) {
+        return BHARAT_MSG_ERR_BUFFER_OVERFLOW;
+    }
+    bharat_store_le32(b->buf + b->off, len);
+    b->off += sizeof(uint32_t);
+
+    if (len > 0) {
+        memcpy(b->buf + b->off, data, len);
+        b->off += len;
+    }
+    return BHARAT_MSG_OK;
+}
+
+int bharat_msg_build_string(bharat_msg_builder_t* b, const char* str) {
+    uint32_t len = str ? (uint32_t)strlen(str) : 0;
+    return bharat_msg_build_bytes(b, (const uint8_t*)str, len);
+}

--- a/lib/msg/validate.c
+++ b/lib/msg/validate.c
@@ -1,0 +1,57 @@
+#include "bharat/msg/validate.h"
+
+int bharat_msg_header_validate(const bharat_msg_header_t* hdr, size_t max_mtu) {
+    if (!hdr) {
+        return BHARAT_MSG_ERR_MALFORMED_HEADER;
+    }
+
+    // Versioning
+    if (hdr->version_major != BHARAT_MSG_VERSION_MAJOR) {
+        return BHARAT_MSG_ERR_UNSUPPORTED_VER;
+    }
+
+    // Length sanity bounds
+    if (hdr->header_len < BHARAT_MSG_HEADER_MIN_LEN) {
+        return BHARAT_MSG_ERR_MALFORMED_HEADER;
+    }
+
+    if (hdr->total_len < hdr->header_len) {
+        return BHARAT_MSG_ERR_MALFORMED_PAYLOAD;
+    }
+
+    if (max_mtu > 0 && hdr->total_len > max_mtu) {
+        return BHARAT_MSG_ERR_TOO_LARGE;
+    }
+
+    // Check mutually exclusive message kinds (Request vs Response vs Event)
+    uint32_t type_mask = BHARAT_MSG_FLAG_REQUEST | BHARAT_MSG_FLAG_RESPONSE | BHARAT_MSG_FLAG_EVENT;
+    uint32_t set_types = hdr->flags & type_mask;
+
+    // Only one core message type is allowed at a time.
+    if (set_types != BHARAT_MSG_FLAG_REQUEST &&
+        set_types != BHARAT_MSG_FLAG_RESPONSE &&
+        set_types != BHARAT_MSG_FLAG_EVENT) {
+        return BHARAT_MSG_ERR_MALFORMED_HEADER;
+    }
+
+    // Cap/Descriptor bounds sanity checking
+    // Each capability descriptor is 34 bytes (0x22 bytes: 1+1+4+4+4+8+8+4)
+    // Each OOL descriptor is 26 bytes (0x1A bytes: 1+1+8+8+8)
+    size_t expected_cap_bytes = (size_t)hdr->cap_count * 34;
+    size_t expected_ool_bytes = (size_t)hdr->desc_count * 26;
+
+    if (expected_cap_bytes + expected_ool_bytes + hdr->header_len > hdr->total_len) {
+        return BHARAT_MSG_ERR_MALFORMED_PAYLOAD;
+    }
+
+    // If caps count > 0, the HAS_CAPS flag must be set
+    if (hdr->cap_count > 0 && !bharat_msg_has_caps(hdr->flags)) {
+        return BHARAT_MSG_ERR_MALFORMED_PAYLOAD;
+    }
+
+    if (hdr->desc_count > 0 && !bharat_msg_has_ool(hdr->flags)) {
+        return BHARAT_MSG_ERR_MALFORMED_PAYLOAD;
+    }
+
+    return BHARAT_MSG_OK;
+}

--- a/lib/msg/wire.c
+++ b/lib/msg/wire.c
@@ -1,0 +1,94 @@
+#include "bharat/msg/wire.h"
+#include <string.h>
+
+// ============================================================================
+// Protocol Decoding
+// ============================================================================
+
+int bharat_msg_header_decode(const uint8_t* buf, size_t buf_len, bharat_msg_header_t* hdr) {
+    if (!buf || !hdr) {
+        return BHARAT_MSG_ERR_MALFORMED_HEADER;
+    }
+
+    if (buf_len < BHARAT_MSG_HEADER_MIN_LEN) {
+        return BHARAT_MSG_ERR_TRUNCATED;
+    }
+
+    // Verify magic
+    uint32_t magic = bharat_load_le32(buf + 0x00);
+    if (magic != BHARAT_MSG_MAGIC) {
+        return BHARAT_MSG_ERR_MALFORMED_HEADER;
+    }
+
+    // Decode directly into the normalized structure
+    hdr->version_major = buf[0x04];
+    hdr->version_minor = buf[0x05];
+    hdr->header_len    = bharat_load_le16(buf + 0x06);
+    hdr->service_id    = bharat_load_le16(buf + 0x08);
+    hdr->opcode        = bharat_load_le16(buf + 0x0A);
+    hdr->flags         = bharat_load_le32(buf + 0x0C);
+    hdr->total_len     = bharat_load_le32(buf + 0x10);
+    hdr->request_id    = bharat_load_le64(buf + 0x14);
+    hdr->src_node      = bharat_load_le32(buf + 0x1C);
+    hdr->dst_node      = bharat_load_le32(buf + 0x20);
+    hdr->cap_count     = bharat_load_le16(buf + 0x24);
+    hdr->desc_count    = bharat_load_le16(buf + 0x26);
+    hdr->header_crc    = bharat_load_le32(buf + 0x28);
+
+    // Initial length boundaries
+    if (hdr->header_len < BHARAT_MSG_HEADER_MIN_LEN) {
+        return BHARAT_MSG_ERR_MALFORMED_HEADER;
+    }
+
+    if (buf_len < hdr->header_len) {
+        return BHARAT_MSG_ERR_TRUNCATED;
+    }
+
+    // Must be supported version
+    if (hdr->version_major != BHARAT_MSG_VERSION_MAJOR) {
+        return BHARAT_MSG_ERR_UNSUPPORTED_VER;
+    }
+
+    return BHARAT_MSG_OK;
+}
+
+// ============================================================================
+// Protocol Encoding
+// ============================================================================
+
+int bharat_msg_header_encode(const bharat_msg_header_t* hdr, uint8_t* buf, size_t buf_len) {
+    if (!hdr || !buf) {
+        return BHARAT_MSG_ERR_MALFORMED_HEADER;
+    }
+
+    if (buf_len < hdr->header_len || buf_len < BHARAT_MSG_HEADER_MIN_LEN) {
+        return BHARAT_MSG_ERR_TOO_LARGE; // Actually, the output buffer is too small
+    }
+
+    // Write Magic (always BHRT)
+    bharat_store_le32(buf + 0x00, BHARAT_MSG_MAGIC);
+
+    // Write Version
+    buf[0x04] = hdr->version_major;
+    buf[0x05] = hdr->version_minor;
+
+    // Remaining basic scalar fields
+    bharat_store_le16(buf + 0x06, hdr->header_len);
+    bharat_store_le16(buf + 0x08, hdr->service_id);
+    bharat_store_le16(buf + 0x0A, hdr->opcode);
+    bharat_store_le32(buf + 0x0C, hdr->flags);
+    bharat_store_le32(buf + 0x10, hdr->total_len);
+    bharat_store_le64(buf + 0x14, hdr->request_id);
+    bharat_store_le32(buf + 0x1C, hdr->src_node);
+    bharat_store_le32(buf + 0x20, hdr->dst_node);
+    bharat_store_le16(buf + 0x24, hdr->cap_count);
+    bharat_store_le16(buf + 0x26, hdr->desc_count);
+    bharat_store_le32(buf + 0x28, hdr->header_crc);
+
+    // Future-proof: Zero-out any remaining padding bytes up to header_len
+    if (hdr->header_len > BHARAT_MSG_HEADER_MIN_LEN) {
+        memset(buf + BHARAT_MSG_HEADER_MIN_LEN, 0, hdr->header_len - BHARAT_MSG_HEADER_MIN_LEN);
+    }
+
+    return BHARAT_MSG_OK;
+}

--- a/lib/ool/ool_codec.c
+++ b/lib/ool/ool_codec.c
@@ -1,0 +1,38 @@
+#include "bharat/idl/ool.h"
+
+int bharat_ool_encode(bharat_msg_builder_t* b, const bharat_ool_desc_t* desc) {
+    if (!b || !desc) {
+        return BHARAT_MSG_ERR_MALFORMED_PAYLOAD;
+    }
+
+    // An OOL descriptor is strictly 26 bytes (0x1A bytes). See msg-wire-format-v1.md.
+    if (b->cap - b->off < 26) {
+        return BHARAT_MSG_ERR_BUFFER_OVERFLOW;
+    }
+
+    bharat_msg_build_u8(b, desc->desc_type);
+    bharat_msg_build_u8(b, desc->flags);
+    bharat_msg_build_u64(b, desc->region_id);
+    bharat_msg_build_u64(b, desc->offset);
+    bharat_msg_build_u64(b, desc->length);
+
+    return BHARAT_MSG_OK;
+}
+
+int bharat_ool_decode(bharat_msg_reader_t* r, bharat_ool_desc_t* desc) {
+    if (!r || !desc) {
+        return BHARAT_MSG_ERR_MALFORMED_PAYLOAD;
+    }
+
+    if (r->len - r->off < 26) {
+        return BHARAT_MSG_ERR_TRUNCATED;
+    }
+
+    bharat_msg_read_u8(r, &desc->desc_type);
+    bharat_msg_read_u8(r, &desc->flags);
+    bharat_msg_read_u64(r, &desc->region_id);
+    bharat_msg_read_u64(r, &desc->offset);
+    bharat_msg_read_u64(r, &desc->length);
+
+    return BHARAT_MSG_OK;
+}

--- a/lib/ool/ool_validate.c
+++ b/lib/ool/ool_validate.c
@@ -1,0 +1,24 @@
+#include "bharat/idl/ool.h"
+
+int bharat_ool_validate(const bharat_ool_desc_t* desc) {
+    if (!desc) {
+        return BHARAT_MSG_ERR_MALFORMED_PAYLOAD;
+    }
+
+    if (desc->desc_type > BHARAT_OOL_TYPE_PACKET) {
+        return BHARAT_MSG_ERR_MALFORMED_PAYLOAD;
+    }
+
+    if (desc->length == 0) {
+        // Zero-length OOL descriptor usually indicates an implementation bug,
+        // there's no reason to send an empty out-of-line mapping
+        return BHARAT_MSG_ERR_MALFORMED_PAYLOAD;
+    }
+
+    // region_id must exist
+    if (desc->region_id == 0) {
+        return BHARAT_MSG_ERR_MALFORMED_PAYLOAD;
+    }
+
+    return BHARAT_MSG_OK;
+}

--- a/lib/transport/loopback.c
+++ b/lib/transport/loopback.c
@@ -1,0 +1,102 @@
+#include "bharat/msg/transport.h"
+#include <stdlib.h>
+#include <string.h>
+
+// A very simple synchronous loopback ring buffer for unit testing.
+// Real implementations will use URPC or Endpoint IPC.
+
+typedef struct {
+    uint8_t* buffer;
+    size_t   stored_len;
+    size_t   mtu;
+} loopback_ctx_t;
+
+static int lb_send(bharat_transport_t* self, const uint8_t* buf, size_t len) {
+    loopback_ctx_t* ctx = (loopback_ctx_t*)self->ctx;
+    if (len > ctx->mtu) return BHARAT_MSG_ERR_TOO_LARGE;
+
+    // Synchronous overwrite of the single slot buffer (simple test mode)
+    memcpy(ctx->buffer, buf, len);
+    ctx->stored_len = len;
+
+    return BHARAT_MSG_OK;
+}
+
+static int lb_recv(bharat_transport_t* self, uint8_t* buf, size_t cap, size_t* out_len) {
+    loopback_ctx_t* ctx = (loopback_ctx_t*)self->ctx;
+    if (ctx->stored_len == 0) return BHARAT_MSG_ERR_TIMEOUT;
+
+    if (cap < ctx->stored_len) {
+        return BHARAT_MSG_ERR_BUFFER_OVERFLOW;
+    }
+
+    memcpy(buf, ctx->buffer, ctx->stored_len);
+    *out_len = ctx->stored_len;
+
+    // Clear out
+    ctx->stored_len = 0;
+
+    return BHARAT_MSG_OK;
+}
+
+static uint32_t lb_get_caps(bharat_transport_t* self) {
+    (void)self;
+    // Loopback allows everything within a local context.
+    return BHARAT_TRANSPORT_CAP_RELIABLE | BHARAT_TRANSPORT_CAP_ORDERED | BHARAT_TRANSPORT_CAP_LOCAL_ONLY;
+}
+
+static size_t lb_get_mtu(bharat_transport_t* self) {
+    loopback_ctx_t* ctx = (loopback_ctx_t*)self->ctx;
+    return ctx->mtu;
+}
+
+static int lb_poll(bharat_transport_t* self, int timeout_ms) {
+    (void)timeout_ms;
+    loopback_ctx_t* ctx = (loopback_ctx_t*)self->ctx;
+    return (ctx->stored_len > 0) ? 1 : 0;
+}
+
+static int lb_ack(bharat_transport_t* self, uint64_t request_id) {
+    (void)self;
+    (void)request_id;
+    return BHARAT_MSG_OK;
+}
+
+static int lb_close(bharat_transport_t* self) {
+    if (self->ctx) {
+        loopback_ctx_t* ctx = (loopback_ctx_t*)self->ctx;
+        free(ctx->buffer);
+        free(ctx);
+        self->ctx = NULL;
+    }
+    return BHARAT_MSG_OK;
+}
+
+static const bharat_transport_ops_t lb_ops = {
+    .send     = lb_send,
+    .recv     = lb_recv,
+    .get_caps = lb_get_caps,
+    .get_mtu  = lb_get_mtu,
+    .poll     = lb_poll,
+    .ack      = lb_ack,
+    .close    = lb_close,
+};
+
+int bharat_transport_loopback_create(bharat_transport_t* t, size_t max_mtu) {
+    loopback_ctx_t* ctx = (loopback_ctx_t*)malloc(sizeof(loopback_ctx_t));
+    if (!ctx) return -1;
+
+    ctx->buffer = (uint8_t*)malloc(max_mtu);
+    if (!ctx->buffer) {
+        free(ctx);
+        return -1;
+    }
+
+    ctx->stored_len = 0;
+    ctx->mtu = max_mtu;
+
+    t->ops = &lb_ops;
+    t->ctx = ctx;
+    t->local_id = 0; // Loopback usually resolves to ID 0
+    return BHARAT_MSG_OK;
+}

--- a/subsys/include/bharat/idl/capwire.h
+++ b/subsys/include/bharat/idl/capwire.h
@@ -1,0 +1,81 @@
+#ifndef BHARAT_IDL_CAPWIRE_H
+#define BHARAT_IDL_CAPWIRE_H
+
+#include "bharat/msg/types.h"
+#include "bharat/msg/errors.h"
+#include "bharat/msg/payload.h"
+
+// Do not include kernel-internal headers directly here to remain transport/app agnostic.
+// We strictly define the wire format for capabilities.
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// ============================================================================
+// Transfer Modes
+// ============================================================================
+
+#define BHARAT_CAP_XFER_COPY                0
+#define BHARAT_CAP_XFER_MOVE                1
+#define BHARAT_CAP_XFER_BORROW              2
+#define BHARAT_CAP_XFER_DELEGATE_ATTENUATED 3
+
+// ============================================================================
+// Capwire Descriptor (Normalized In-Memory)
+// ============================================================================
+// Represents the remote capability token transmitted across the wire.
+// ============================================================================
+
+typedef struct {
+    uint8_t  cap_type;      // e.g. CAP_OBJ_ENDPOINT, CAP_OBJ_MEMORY, etc.
+    uint8_t  transfer_mode; // BHARAT_CAP_XFER_*
+    uint32_t rights_mask;   // Access rights authorized
+    uint32_t origin_node;   // ID of the node originating this cap
+    uint32_t issuer_id;     // ID of the issuer domain
+    uint64_t object_id;     // ID of the underlying resource/object
+    uint64_t nonce;         // Cryptographic random nonce for replay/revocation checks
+    uint32_t generation;    // Helps track versioning or revoke status
+} bharat_capwire_desc_t;
+
+// ============================================================================
+// Capwire Codec API
+// ============================================================================
+
+/**
+ * @brief Encode a capability descriptor into the payload builder.
+ * @param b Builder cursor
+ * @param desc Descriptor to encode
+ * @return BHARAT_MSG_OK or negative error
+ */
+int bharat_capwire_encode(bharat_msg_builder_t* b, const bharat_capwire_desc_t* desc);
+
+/**
+ * @brief Decode a capability descriptor from the payload reader.
+ * @param r Reader cursor
+ * @param desc Output descriptor
+ * @return BHARAT_MSG_OK or negative error
+ */
+int bharat_capwire_decode(bharat_msg_reader_t* r, bharat_capwire_desc_t* desc);
+
+// ============================================================================
+// Internal Validation & Proxy Hooks (Implemented in capwire library)
+// ============================================================================
+
+/**
+ * @brief Validate the semantics of a wire descriptor.
+ * Checks for invalid transfer modes or malformed IDs before proxying.
+ */
+int bharat_capwire_validate(const bharat_capwire_desc_t* desc);
+
+/**
+ * @brief Attenuate the rights mask.
+ * Drops bits not present in the allowed mask.
+ */
+void bharat_capwire_attenuate(bharat_capwire_desc_t* desc, uint32_t allowed_rights);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // BHARAT_IDL_CAPWIRE_H

--- a/subsys/include/bharat/idl/ool.h
+++ b/subsys/include/bharat/idl/ool.h
@@ -1,0 +1,78 @@
+#ifndef BHARAT_IDL_OOL_H
+#define BHARAT_IDL_OOL_H
+
+#include "bharat/msg/types.h"
+#include "bharat/msg/errors.h"
+#include "bharat/msg/payload.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// ============================================================================
+// OOL Descriptor Types
+// ============================================================================
+
+#define BHARAT_OOL_TYPE_SHMEM  0
+#define BHARAT_OOL_TYPE_DMA    1
+#define BHARAT_OOL_TYPE_BLOB   2
+#define BHARAT_OOL_TYPE_PACKET 3
+
+// ============================================================================
+// OOL Descriptor Flags
+// ============================================================================
+
+#define BHARAT_OOL_FLAG_READ_ONLY   (1U << 0)
+#define BHARAT_OOL_FLAG_READ_WRITE  (1U << 1)
+#define BHARAT_OOL_FLAG_VOLATILE    (1U << 2)
+
+// ============================================================================
+// OOL Descriptor (Normalized In-Memory)
+// ============================================================================
+// Represents a reference to an Out-Of-Line memory block or region, typically
+// trailing the capwire array at the end of a message payload.
+// ============================================================================
+
+typedef struct {
+    uint8_t  desc_type; // BHARAT_OOL_TYPE_*
+    uint8_t  flags;     // BHARAT_OOL_FLAG_*
+    uint64_t region_id; // ID of the referenced object/memory region
+    uint64_t offset;    // Starting offset within the region
+    uint64_t length;    // Total length of the referenced chunk
+} bharat_ool_desc_t;
+
+// ============================================================================
+// OOL Codec API
+// ============================================================================
+
+/**
+ * @brief Encode an OOL descriptor into the payload builder.
+ * @param b Builder cursor
+ * @param desc Descriptor to encode
+ * @return BHARAT_MSG_OK or negative error
+ */
+int bharat_ool_encode(bharat_msg_builder_t* b, const bharat_ool_desc_t* desc);
+
+/**
+ * @brief Decode an OOL descriptor from the payload reader.
+ * @param r Reader cursor
+ * @param desc Output descriptor
+ * @return BHARAT_MSG_OK or negative error
+ */
+int bharat_ool_decode(bharat_msg_reader_t* r, bharat_ool_desc_t* desc);
+
+// ============================================================================
+// Validation Hook
+// ============================================================================
+
+/**
+ * @brief Validate the logical structure of the OOL descriptor
+ * Reject invalid types, unmapped flags, or zero-length payload claims
+ */
+int bharat_ool_validate(const bharat_ool_desc_t* desc);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // BHARAT_IDL_OOL_H

--- a/subsys/include/bharat/msg/errors.h
+++ b/subsys/include/bharat/msg/errors.h
@@ -1,0 +1,33 @@
+#ifndef BHARAT_MSG_ERRORS_H
+#define BHARAT_MSG_ERRORS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// ============================================================================
+// Protocol Error Codes
+// ============================================================================
+
+#define BHARAT_MSG_OK                     0
+#define BHARAT_MSG_ERR_MALFORMED_HEADER  -1
+#define BHARAT_MSG_ERR_MALFORMED_PAYLOAD -2
+#define BHARAT_MSG_ERR_UNSUPPORTED_VER   -3
+#define BHARAT_MSG_ERR_UNKNOWN_SERVICE   -4
+#define BHARAT_MSG_ERR_UNKNOWN_OPCODE    -5
+#define BHARAT_MSG_ERR_UNAUTHORIZED      -6
+#define BHARAT_MSG_ERR_TRANSPORT_FAIL    -7
+#define BHARAT_MSG_ERR_TIMEOUT           -8
+#define BHARAT_MSG_ERR_TOO_LARGE         -9
+#define BHARAT_MSG_ERR_UNSUPPORTED_FEAT  -10
+#define BHARAT_MSG_ERR_INVALID_CAP       -11
+#define BHARAT_MSG_ERR_CAP_REVOKED       -12
+#define BHARAT_MSG_ERR_INCOMPAT_TRANS    -13
+#define BHARAT_MSG_ERR_TRUNCATED         -14
+#define BHARAT_MSG_ERR_BUFFER_OVERFLOW   -15
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // BHARAT_MSG_ERRORS_H

--- a/subsys/include/bharat/msg/flags.h
+++ b/subsys/include/bharat/msg/flags.h
@@ -1,0 +1,63 @@
+#ifndef BHARAT_MSG_FLAGS_H
+#define BHARAT_MSG_FLAGS_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// ============================================================================
+// Protocol Magic and Versioning
+// ============================================================================
+
+#define BHARAT_MSG_MAGIC         0x42485254  // "BHRT"
+#define BHARAT_MSG_VERSION_MAJOR 1
+#define BHARAT_MSG_VERSION_MINOR 0
+
+// Minimum allowed length for the base header (44 bytes as defined in v1 spec)
+#define BHARAT_MSG_HEADER_MIN_LEN 44
+
+// ============================================================================
+// Header Flag Masks
+// ============================================================================
+
+#define BHARAT_MSG_FLAG_REQUEST      (1U << 0)
+#define BHARAT_MSG_FLAG_RESPONSE     (1U << 1)
+#define BHARAT_MSG_FLAG_EVENT        (1U << 2)
+#define BHARAT_MSG_FLAG_ERROR        (1U << 3)
+#define BHARAT_MSG_FLAG_ACK_REQ      (1U << 4)
+#define BHARAT_MSG_FLAG_RELIABLE     (1U << 5)
+#define BHARAT_MSG_FLAG_FRAGMENTED   (1U << 6)
+#define BHARAT_MSG_FLAG_HAS_CAPS     (1U << 7)
+#define BHARAT_MSG_FLAG_HAS_OOL      (1U << 8)
+
+// ============================================================================
+// Flag Helpers
+// ============================================================================
+
+static inline int bharat_msg_is_request(uint32_t flags) {
+    return (flags & BHARAT_MSG_FLAG_REQUEST) != 0;
+}
+
+static inline int bharat_msg_is_response(uint32_t flags) {
+    return (flags & BHARAT_MSG_FLAG_RESPONSE) != 0;
+}
+
+static inline int bharat_msg_is_error(uint32_t flags) {
+    return (flags & BHARAT_MSG_FLAG_ERROR) != 0;
+}
+
+static inline int bharat_msg_has_caps(uint32_t flags) {
+    return (flags & BHARAT_MSG_FLAG_HAS_CAPS) != 0;
+}
+
+static inline int bharat_msg_has_ool(uint32_t flags) {
+    return (flags & BHARAT_MSG_FLAG_HAS_OOL) != 0;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // BHARAT_MSG_FLAGS_H

--- a/subsys/include/bharat/msg/payload.h
+++ b/subsys/include/bharat/msg/payload.h
@@ -1,0 +1,75 @@
+#ifndef BHARAT_MSG_PAYLOAD_H
+#define BHARAT_MSG_PAYLOAD_H
+
+#include "bharat/msg/types.h"
+#include "bharat/msg/errors.h"
+#include <string.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// ============================================================================
+// Bounded Codec Types
+// ============================================================================
+
+// A reader strictly bound to an incoming buffer length.
+typedef struct {
+    const uint8_t* buf;
+    size_t len;
+    size_t off;
+} bharat_msg_reader_t;
+
+// A writer strictly bound to an outgoing buffer capacity.
+typedef struct {
+    uint8_t* buf;
+    size_t cap;
+    size_t off;
+} bharat_msg_builder_t;
+
+// ============================================================================
+// Initialization
+// ============================================================================
+
+static inline void bharat_msg_reader_init(bharat_msg_reader_t* r, const uint8_t* buf, size_t len, size_t initial_offset) {
+    r->buf = buf;
+    r->len = len;
+    r->off = initial_offset;
+}
+
+static inline void bharat_msg_builder_init(bharat_msg_builder_t* b, uint8_t* buf, size_t cap, size_t initial_offset) {
+    b->buf = buf;
+    b->cap = cap;
+    b->off = initial_offset;
+}
+
+// ============================================================================
+// Codec API signatures (implemented in encode.c / decode.c)
+// ============================================================================
+
+// ---- Builders (Encode) ----
+int bharat_msg_build_u8(bharat_msg_builder_t* b, uint8_t v);
+int bharat_msg_build_u16(bharat_msg_builder_t* b, uint16_t v);
+int bharat_msg_build_u32(bharat_msg_builder_t* b, uint32_t v);
+int bharat_msg_build_u64(bharat_msg_builder_t* b, uint64_t v);
+int bharat_msg_build_bool(bharat_msg_builder_t* b, bool v);
+
+int bharat_msg_build_bytes(bharat_msg_builder_t* b, const uint8_t* data, uint32_t len);
+int bharat_msg_build_string(bharat_msg_builder_t* b, const char* str);
+
+// ---- Readers (Decode) ----
+int bharat_msg_read_u8(bharat_msg_reader_t* r, uint8_t* out);
+int bharat_msg_read_u16(bharat_msg_reader_t* r, uint16_t* out);
+int bharat_msg_read_u32(bharat_msg_reader_t* r, uint32_t* out);
+int bharat_msg_read_u64(bharat_msg_reader_t* r, uint64_t* out);
+int bharat_msg_read_bool(bharat_msg_reader_t* r, bool* out);
+
+// Bounded readers (Copy data off the wire into inline destination buffers)
+int bharat_msg_read_bytes_bounded(bharat_msg_reader_t* r, uint8_t* dst, uint32_t dst_max, uint32_t* out_len);
+int bharat_msg_read_string_bounded(bharat_msg_reader_t* r, char* dst, uint32_t dst_max, uint32_t* out_len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // BHARAT_MSG_PAYLOAD_H

--- a/subsys/include/bharat/msg/transport.h
+++ b/subsys/include/bharat/msg/transport.h
@@ -1,0 +1,89 @@
+#ifndef BHARAT_MSG_TRANSPORT_H
+#define BHARAT_MSG_TRANSPORT_H
+
+#include "bharat/msg/wire.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// ============================================================================
+// Transport Capability Flags
+// ============================================================================
+
+#define BHARAT_TRANSPORT_CAP_RELIABLE    (1U << 0)
+#define BHARAT_TRANSPORT_CAP_ORDERED     (1U << 1)
+#define BHARAT_TRANSPORT_CAP_OOL         (1U << 2)
+#define BHARAT_TRANSPORT_CAP_CAPS        (1U << 3)
+#define BHARAT_TRANSPORT_CAP_FRAGMENT    (1U << 4)
+#define BHARAT_TRANSPORT_CAP_LOCAL_ONLY  (1U << 5)
+#define BHARAT_TRANSPORT_CAP_SHMEM       (1U << 6)
+
+// ============================================================================
+// Transport Abstract Operations
+// ============================================================================
+
+struct bharat_transport;
+
+typedef struct {
+    /**
+     * @brief Send a fully serialized message (header + payload) over the transport.
+     */
+    int (*send)(struct bharat_transport* self, const uint8_t* buf, size_t len);
+
+    /**
+     * @brief Block/Poll to receive a message.
+     */
+    int (*recv)(struct bharat_transport* self, uint8_t* buf, size_t cap, size_t* out_len);
+
+    /**
+     * @brief Returns the capabilities supported by this transport.
+     */
+    uint32_t (*get_caps)(struct bharat_transport* self);
+
+    /**
+     * @brief Returns the Maximum Transmission Unit (MTU) size for inline payloads.
+     */
+    size_t (*get_mtu)(struct bharat_transport* self);
+
+    /**
+     * @brief Wait for data to be ready (optional).
+     */
+    int (*poll)(struct bharat_transport* self, int timeout_ms);
+
+    /**
+     * @brief Acknowledge receipt if transport requires explicit ACK.
+     */
+    int (*ack)(struct bharat_transport* self, uint64_t request_id);
+
+    /**
+     * @brief Close the transport connection/binding.
+     */
+    int (*close)(struct bharat_transport* self);
+
+} bharat_transport_ops_t;
+
+// ============================================================================
+// Transport Instance
+// ============================================================================
+
+typedef struct bharat_transport {
+    const bharat_transport_ops_t* ops;
+    void* ctx;         // Private pointer for the specific transport backend
+    uint32_t local_id; // Identifies this endpoint
+} bharat_transport_t;
+
+// ============================================================================
+// Concrete Bindings Declarations (Implemented elsewhere)
+// ============================================================================
+
+/**
+ * @brief Create a local in-memory loopback transport for tests.
+ */
+int bharat_transport_loopback_create(bharat_transport_t* t, size_t max_mtu);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // BHARAT_MSG_TRANSPORT_H

--- a/subsys/include/bharat/msg/types.h
+++ b/subsys/include/bharat/msg/types.h
@@ -1,0 +1,52 @@
+#ifndef BHARAT_MSG_TYPES_H
+#define BHARAT_MSG_TYPES_H
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// ============================================================================
+// Endian Helpers (Always encode little-endian on the wire)
+// ============================================================================
+
+static inline uint16_t bharat_load_le16(const uint8_t* p) {
+    return (uint16_t)((uint16_t)p[0] | ((uint16_t)p[1] << 8));
+}
+
+static inline uint32_t bharat_load_le32(const uint8_t* p) {
+    return (uint32_t)((uint32_t)p[0] | ((uint32_t)p[1] << 8) |
+                      ((uint32_t)p[2] << 16) | ((uint32_t)p[3] << 24));
+}
+
+static inline uint64_t bharat_load_le64(const uint8_t* p) {
+    uint32_t lo = bharat_load_le32(p);
+    uint32_t hi = bharat_load_le32(p + 4);
+    return ((uint64_t)hi << 32) | lo;
+}
+
+static inline void bharat_store_le16(uint8_t* p, uint16_t v) {
+    p[0] = (uint8_t)(v & 0xFF);
+    p[1] = (uint8_t)((v >> 8) & 0xFF);
+}
+
+static inline void bharat_store_le32(uint8_t* p, uint32_t v) {
+    p[0] = (uint8_t)(v & 0xFF);
+    p[1] = (uint8_t)((v >> 8) & 0xFF);
+    p[2] = (uint8_t)((v >> 16) & 0xFF);
+    p[3] = (uint8_t)((v >> 24) & 0xFF);
+}
+
+static inline void bharat_store_le64(uint8_t* p, uint64_t v) {
+    bharat_store_le32(p, (uint32_t)(v & 0xFFFFFFFF));
+    bharat_store_le32(p + 4, (uint32_t)((v >> 32) & 0xFFFFFFFF));
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // BHARAT_MSG_TYPES_H

--- a/subsys/include/bharat/msg/validate.h
+++ b/subsys/include/bharat/msg/validate.h
@@ -1,0 +1,27 @@
+#ifndef BHARAT_MSG_VALIDATE_H
+#define BHARAT_MSG_VALIDATE_H
+
+#include "bharat/msg/wire.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Strictly validate the logical correctness of a decoded header.
+ *
+ * Ensures length boundaries (total_len >= header_len),
+ * valid flag combinations, and sane field sizes prior to service dispatch.
+ * Does NOT check CRC (that is usually done during decode/transport stage).
+ *
+ * @param hdr The parsed internal header.
+ * @param max_mtu Maximum valid total size on this node/transport (or 0 for unconstrained).
+ * @return BHARAT_MSG_OK if valid, negative BHARAT_MSG_ERR_* code otherwise.
+ */
+int bharat_msg_header_validate(const bharat_msg_header_t* hdr, size_t max_mtu);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // BHARAT_MSG_VALIDATE_H

--- a/subsys/include/bharat/msg/wire.h
+++ b/subsys/include/bharat/msg/wire.h
@@ -1,0 +1,64 @@
+#ifndef BHARAT_MSG_WIRE_H
+#define BHARAT_MSG_WIRE_H
+
+#include "bharat/msg/types.h"
+#include "bharat/msg/flags.h"
+#include "bharat/msg/errors.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// ============================================================================
+// Normalized Internal Header Structure
+// ============================================================================
+// Used within the host environment. Must not be overlayed directly on buffers.
+// ============================================================================
+
+typedef struct {
+    uint8_t  version_major;
+    uint8_t  version_minor;
+    uint16_t header_len;
+    uint16_t service_id;
+    uint16_t opcode;
+    uint32_t flags;
+    uint32_t total_len;
+    uint64_t request_id;
+    uint32_t src_node;
+    uint32_t dst_node;
+    uint16_t cap_count;
+    uint16_t desc_count;
+    uint32_t header_crc;
+} bharat_msg_header_t;
+
+// ============================================================================
+// Codec Signatures
+// ============================================================================
+
+/**
+ * @brief Decode the raw bytes from `buf` into the normalized `hdr`.
+ *
+ * Enforces basic structural constraints (length boundaries).
+ *
+ * @param buf Raw incoming buffer bytes.
+ * @param buf_len Total available bytes in buffer.
+ * @param hdr Output normalized struct.
+ * @return BHARAT_MSG_OK on success, negative error code otherwise.
+ */
+int bharat_msg_header_decode(const uint8_t* buf, size_t buf_len, bharat_msg_header_t* hdr);
+
+/**
+ * @brief Encode the normalized `hdr` into `buf`.
+ *
+ * @param hdr The normalized internal header struct.
+ * @param buf Pre-allocated buffer to hold at least `hdr->header_len` bytes.
+ * @param buf_len Available size in `buf`.
+ * @return BHARAT_MSG_OK on success, BHARAT_MSG_ERR_TOO_LARGE if buf is small.
+ */
+int bharat_msg_header_encode(const bharat_msg_header_t* hdr, uint8_t* buf, size_t buf_len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // BHARAT_MSG_WIRE_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -407,3 +407,29 @@ add_executable(test_netstack_phase2
 )
 target_include_directories(test_netstack_phase2 PRIVATE ../services/netstack/src)
 add_test(NAME test_netstack_phase2 COMMAND test_netstack_phase2)
+
+# Message/Wire Tests
+add_executable(test_wire_format test_wire_format.c)
+target_include_directories(test_wire_format PRIVATE ../subsys/include)
+target_link_libraries(test_wire_format PRIVATE msg)
+add_test(NAME test_wire_format COMMAND test_wire_format)
+
+add_executable(test_payload_codec test_payload_codec.c)
+target_include_directories(test_payload_codec PRIVATE ../subsys/include)
+target_link_libraries(test_payload_codec PRIVATE msg)
+add_test(NAME test_payload_codec COMMAND test_payload_codec)
+
+add_executable(test_capwire test_capwire.c)
+target_include_directories(test_capwire PRIVATE ../subsys/include)
+target_link_libraries(test_capwire PRIVATE capwire msg)
+add_test(NAME test_capwire COMMAND test_capwire)
+
+add_executable(test_ool test_ool.c)
+target_include_directories(test_ool PRIVATE ../subsys/include)
+target_link_libraries(test_ool PRIVATE ool_desc msg)
+add_test(NAME test_ool COMMAND test_ool)
+
+add_executable(test_transport_loopback test_transport_loopback.c)
+target_include_directories(test_transport_loopback PRIVATE ../subsys/include)
+target_link_libraries(test_transport_loopback PRIVATE transport msg)
+add_test(NAME test_transport_loopback COMMAND test_transport_loopback)

--- a/tests/test_capwire.c
+++ b/tests/test_capwire.c
@@ -1,0 +1,88 @@
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include "bharat/idl/capwire.h"
+
+void test_capwire_roundtrip() {
+    uint8_t buffer[128];
+    bharat_msg_builder_t b;
+    bharat_msg_builder_init(&b, buffer, sizeof(buffer), 0);
+
+    bharat_capwire_desc_t original = {0};
+    original.cap_type = 42; // arbitrary
+    original.transfer_mode = BHARAT_CAP_XFER_BORROW;
+    original.rights_mask = 0xFFFF;
+    original.origin_node = 1;
+    original.issuer_id = 999;
+    original.object_id = 0x1234567812345678ULL;
+    original.nonce = 0xABCDEFABCDEFABCDULL;
+    original.generation = 5;
+
+    assert(bharat_capwire_encode(&b, &original) == BHARAT_MSG_OK);
+    assert(b.off == 34);
+
+    bharat_msg_reader_t r;
+    bharat_msg_reader_init(&r, buffer, b.off, 0);
+
+    bharat_capwire_desc_t decoded = {0};
+    assert(bharat_capwire_decode(&r, &decoded) == BHARAT_MSG_OK);
+
+    assert(decoded.cap_type == original.cap_type);
+    assert(decoded.transfer_mode == original.transfer_mode);
+    assert(decoded.rights_mask == original.rights_mask);
+    assert(decoded.origin_node == original.origin_node);
+    assert(decoded.issuer_id == original.issuer_id);
+    assert(decoded.object_id == original.object_id);
+    assert(decoded.nonce == original.nonce);
+    assert(decoded.generation == original.generation);
+}
+
+void test_capwire_validation() {
+    bharat_capwire_desc_t desc = {0};
+    desc.cap_type = 1;
+    desc.transfer_mode = BHARAT_CAP_XFER_COPY;
+    desc.origin_node = 1;
+    desc.object_id = 1;
+    desc.nonce = 1;
+
+    // Baseline OK
+    assert(bharat_capwire_validate(&desc) == BHARAT_MSG_OK);
+
+    // Invalid Transfer Mode
+    desc.transfer_mode = 99;
+    assert(bharat_capwire_validate(&desc) == BHARAT_MSG_ERR_INVALID_CAP);
+    desc.transfer_mode = BHARAT_CAP_XFER_COPY;
+
+    // Missing Origin
+    desc.origin_node = 0;
+    assert(bharat_capwire_validate(&desc) == BHARAT_MSG_ERR_INVALID_CAP);
+    desc.origin_node = 1;
+
+    // Missing Object
+    desc.object_id = 0;
+    assert(bharat_capwire_validate(&desc) == BHARAT_MSG_ERR_INVALID_CAP);
+    desc.object_id = 1;
+
+    // Missing Nonce
+    desc.nonce = 0;
+    assert(bharat_capwire_validate(&desc) == BHARAT_MSG_ERR_UNAUTHORIZED);
+}
+
+void test_capwire_attenuation() {
+    bharat_capwire_desc_t desc = {0};
+    desc.rights_mask = 0x0F;
+
+    // Strip rights 0x0C, keeping 0x03
+    bharat_capwire_attenuate(&desc, 0x03);
+
+    assert(desc.rights_mask == 0x03);
+}
+
+int main() {
+    printf("Running Capwire tests...\n");
+    test_capwire_roundtrip();
+    test_capwire_validation();
+    test_capwire_attenuation();
+    printf("All Capwire tests passed!\n");
+    return 0;
+}

--- a/tests/test_ool.c
+++ b/tests/test_ool.c
@@ -1,0 +1,63 @@
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include "bharat/idl/ool.h"
+
+void test_ool_roundtrip() {
+    uint8_t buffer[64];
+    bharat_msg_builder_t b;
+    bharat_msg_builder_init(&b, buffer, sizeof(buffer), 0);
+
+    bharat_ool_desc_t original = {0};
+    original.desc_type = BHARAT_OOL_TYPE_SHMEM;
+    original.flags = BHARAT_OOL_FLAG_READ_ONLY | BHARAT_OOL_FLAG_VOLATILE;
+    original.region_id = 0x8877665544332211ULL;
+    original.offset = 4096;
+    original.length = 8192;
+
+    assert(bharat_ool_encode(&b, &original) == BHARAT_MSG_OK);
+    // 26 bytes: u8 + u8 + u64 + u64 + u64
+    assert(b.off == 26);
+
+    bharat_msg_reader_t r;
+    bharat_msg_reader_init(&r, buffer, b.off, 0);
+
+    bharat_ool_desc_t decoded = {0};
+    assert(bharat_ool_decode(&r, &decoded) == BHARAT_MSG_OK);
+
+    assert(decoded.desc_type == original.desc_type);
+    assert(decoded.flags == original.flags);
+    assert(decoded.region_id == original.region_id);
+    assert(decoded.offset == original.offset);
+    assert(decoded.length == original.length);
+}
+
+void test_ool_validation() {
+    bharat_ool_desc_t desc = {0};
+    desc.desc_type = BHARAT_OOL_TYPE_DMA;
+    desc.region_id = 100;
+    desc.length = 500;
+    assert(bharat_ool_validate(&desc) == BHARAT_MSG_OK);
+
+    // Invalid Type
+    desc.desc_type = 99;
+    assert(bharat_ool_validate(&desc) == BHARAT_MSG_ERR_MALFORMED_PAYLOAD);
+    desc.desc_type = BHARAT_OOL_TYPE_DMA;
+
+    // Zero Region ID
+    desc.region_id = 0;
+    assert(bharat_ool_validate(&desc) == BHARAT_MSG_ERR_MALFORMED_PAYLOAD);
+    desc.region_id = 100;
+
+    // Zero length
+    desc.length = 0;
+    assert(bharat_ool_validate(&desc) == BHARAT_MSG_ERR_MALFORMED_PAYLOAD);
+}
+
+int main() {
+    printf("Running OOL tests...\n");
+    test_ool_roundtrip();
+    test_ool_validation();
+    printf("All OOL tests passed!\n");
+    return 0;
+}

--- a/tests/test_payload_codec.c
+++ b/tests/test_payload_codec.c
@@ -1,0 +1,105 @@
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include "bharat/msg/payload.h"
+
+void test_primitives_roundtrip() {
+    uint8_t buffer[128];
+    bharat_msg_builder_t b;
+    bharat_msg_builder_init(&b, buffer, sizeof(buffer), 0);
+
+    bharat_msg_build_u8(&b, 0x42);
+    bharat_msg_build_u16(&b, 0x1234);
+    bharat_msg_build_u32(&b, 0x87654321);
+    bharat_msg_build_u64(&b, 0xDEADBEEFCAFEBAB0ULL);
+    bharat_msg_build_bool(&b, true);
+    bharat_msg_build_bool(&b, false);
+
+    assert(b.off == 1 + 2 + 4 + 8 + 1 + 1);
+
+    bharat_msg_reader_t r;
+    bharat_msg_reader_init(&r, buffer, b.off, 0);
+
+    uint8_t v8;
+    uint16_t v16;
+    uint32_t v32;
+    uint64_t v64;
+    bool b1, b2;
+
+    assert(bharat_msg_read_u8(&r, &v8) == BHARAT_MSG_OK);
+    assert(v8 == 0x42);
+
+    assert(bharat_msg_read_u16(&r, &v16) == BHARAT_MSG_OK);
+    assert(v16 == 0x1234);
+
+    assert(bharat_msg_read_u32(&r, &v32) == BHARAT_MSG_OK);
+    assert(v32 == 0x87654321);
+
+    assert(bharat_msg_read_u64(&r, &v64) == BHARAT_MSG_OK);
+    assert(v64 == 0xDEADBEEFCAFEBAB0ULL);
+
+    assert(bharat_msg_read_bool(&r, &b1) == BHARAT_MSG_OK);
+    assert(b1 == true);
+
+    assert(bharat_msg_read_bool(&r, &b2) == BHARAT_MSG_OK);
+    assert(b2 == false);
+
+    assert(r.off == b.off);
+}
+
+void test_bounded_strings_roundtrip() {
+    uint8_t buffer[128];
+    bharat_msg_builder_t b;
+    bharat_msg_builder_init(&b, buffer, sizeof(buffer), 0);
+
+    const char* original = "Hello, Bharat-OS!";
+    bharat_msg_build_string(&b, original);
+
+    bharat_msg_reader_t r;
+    bharat_msg_reader_init(&r, buffer, b.off, 0);
+
+    char decoded[32];
+    uint32_t len = 0;
+
+    // Read the string bounded to a capacity of 32
+    assert(bharat_msg_read_string_bounded(&r, decoded, 32, &len) == BHARAT_MSG_OK);
+    assert(len == strlen(original));
+    assert(strcmp(decoded, original) == 0);
+}
+
+void test_buffer_overflow_protection() {
+    uint8_t buffer[8];
+    bharat_msg_builder_t b;
+    bharat_msg_builder_init(&b, buffer, sizeof(buffer), 0);
+
+    assert(bharat_msg_build_u64(&b, 0) == BHARAT_MSG_OK);
+    // Over the edge!
+    assert(bharat_msg_build_u8(&b, 0) == BHARAT_MSG_ERR_BUFFER_OVERFLOW);
+}
+
+void test_truncated_decode_protection() {
+    uint8_t buffer[4];
+    bharat_msg_builder_t b;
+    bharat_msg_builder_init(&b, buffer, sizeof(buffer), 0);
+
+    // Encode a u32 length of 100
+    bharat_msg_build_u32(&b, 100);
+
+    bharat_msg_reader_t r;
+    bharat_msg_reader_init(&r, buffer, 4, 0);
+
+    uint8_t out_buf[128];
+    uint32_t out_len = 0;
+    // Buffer only has 4 bytes (the length header), but length header claims 100 more bytes follow.
+    assert(bharat_msg_read_bytes_bounded(&r, out_buf, sizeof(out_buf), &out_len) == BHARAT_MSG_ERR_TRUNCATED);
+}
+
+int main() {
+    printf("Running Payload Codec tests...\n");
+    test_primitives_roundtrip();
+    test_bounded_strings_roundtrip();
+    test_buffer_overflow_protection();
+    test_truncated_decode_protection();
+    printf("All Payload Codec tests passed!\n");
+    return 0;
+}

--- a/tests/test_transport_loopback.c
+++ b/tests/test_transport_loopback.c
@@ -1,0 +1,40 @@
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include "bharat/msg/transport.h"
+
+void test_loopback_transport() {
+    bharat_transport_t transport;
+    assert(bharat_transport_loopback_create(&transport, 1024) == BHARAT_MSG_OK);
+
+    // Empty poll
+    assert(transport.ops->poll(&transport, 0) == 0);
+
+    const char* payload = "Hello Transport";
+    size_t payload_len = strlen(payload) + 1;
+
+    // Send
+    assert(transport.ops->send(&transport, (const uint8_t*)payload, payload_len) == BHARAT_MSG_OK);
+
+    // Should be ready now
+    assert(transport.ops->poll(&transport, 0) == 1);
+
+    // Receive
+    uint8_t rx_buf[1024];
+    size_t rx_len = 0;
+    assert(transport.ops->recv(&transport, rx_buf, sizeof(rx_buf), &rx_len) == BHARAT_MSG_OK);
+    assert(rx_len == payload_len);
+    assert(strcmp((const char*)rx_buf, payload) == 0);
+
+    // Verify empty state
+    assert(transport.ops->poll(&transport, 0) == 0);
+
+    assert(transport.ops->close(&transport) == BHARAT_MSG_OK);
+}
+
+int main() {
+    printf("Running Transport Loopback tests...\n");
+    test_loopback_transport();
+    printf("All Transport Loopback tests passed!\n");
+    return 0;
+}

--- a/tests/test_wire_format.c
+++ b/tests/test_wire_format.c
@@ -1,0 +1,114 @@
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include "bharat/msg/wire.h"
+#include "bharat/msg/validate.h"
+
+// Forward-declare CRC for tests
+extern uint32_t bharat_msg_crc32(const uint8_t *data, size_t len);
+
+void test_endian_helpers() {
+    uint8_t buf[8];
+    bharat_store_le16(buf, 0x1234);
+    assert(buf[0] == 0x34 && buf[1] == 0x12);
+    assert(bharat_load_le16(buf) == 0x1234);
+
+    bharat_store_le32(buf, 0x12345678);
+    assert(buf[0] == 0x78 && buf[1] == 0x56 && buf[2] == 0x34 && buf[3] == 0x12);
+    assert(bharat_load_le32(buf) == 0x12345678);
+
+    bharat_store_le64(buf, 0x1122334455667788ULL);
+    assert(buf[0] == 0x88 && buf[7] == 0x11);
+    assert(bharat_load_le64(buf) == 0x1122334455667788ULL);
+}
+
+void test_crc32() {
+    const char* text = "123456789";
+    uint32_t crc = bharat_msg_crc32((const uint8_t*)text, 9);
+    assert(crc == 0xCBF43926);
+}
+
+void test_header_encode_decode() {
+    bharat_msg_header_t in_hdr = {0};
+    in_hdr.version_major = BHARAT_MSG_VERSION_MAJOR;
+    in_hdr.version_minor = 1;
+    in_hdr.header_len    = BHARAT_MSG_HEADER_MIN_LEN;
+    in_hdr.service_id    = 42;
+    in_hdr.opcode        = 7;
+    in_hdr.flags         = BHARAT_MSG_FLAG_REQUEST | BHARAT_MSG_FLAG_RELIABLE;
+    in_hdr.total_len     = BHARAT_MSG_HEADER_MIN_LEN + 100;
+    in_hdr.request_id    = 0xDEADBEEFCAFEBABEULL;
+    in_hdr.src_node      = 1001;
+    in_hdr.dst_node      = 1002;
+    in_hdr.cap_count     = 0;
+    in_hdr.desc_count    = 0;
+    in_hdr.header_crc    = 0; // Filled later
+
+    uint8_t buf[128];
+    memset(buf, 0xAA, sizeof(buf));
+
+    int rc = bharat_msg_header_encode(&in_hdr, buf, sizeof(buf));
+    assert(rc == BHARAT_MSG_OK);
+
+    // Compute CRC on raw wire bytes (excluding the CRC field itself at offset 0x28)
+    in_hdr.header_crc = bharat_msg_crc32(buf, 0x28);
+    bharat_store_le32(buf + 0x28, in_hdr.header_crc);
+
+    bharat_msg_header_t out_hdr = {0};
+    rc = bharat_msg_header_decode(buf, sizeof(buf), &out_hdr);
+    assert(rc == BHARAT_MSG_OK);
+
+    assert(out_hdr.version_major == in_hdr.version_major);
+    assert(out_hdr.header_len == in_hdr.header_len);
+    assert(out_hdr.service_id == in_hdr.service_id);
+    assert(out_hdr.flags == in_hdr.flags);
+    assert(out_hdr.request_id == in_hdr.request_id);
+    assert(out_hdr.header_crc == in_hdr.header_crc);
+
+    rc = bharat_msg_header_validate(&out_hdr, 4096);
+    assert(rc == BHARAT_MSG_OK);
+}
+
+void test_header_validation_failures() {
+    bharat_msg_header_t hdr = {0};
+    hdr.version_major = BHARAT_MSG_VERSION_MAJOR;
+    hdr.header_len = BHARAT_MSG_HEADER_MIN_LEN;
+    hdr.flags = BHARAT_MSG_FLAG_REQUEST;
+    hdr.total_len = BHARAT_MSG_HEADER_MIN_LEN + 50;
+
+    // Valid baseline
+    assert(bharat_msg_header_validate(&hdr, 4096) == BHARAT_MSG_OK);
+
+    // Test MTU overflow
+    assert(bharat_msg_header_validate(&hdr, 32) == BHARAT_MSG_ERR_TOO_LARGE);
+
+    // Test header larger than total_len
+    hdr.total_len = BHARAT_MSG_HEADER_MIN_LEN - 10;
+    assert(bharat_msg_header_validate(&hdr, 4096) == BHARAT_MSG_ERR_MALFORMED_PAYLOAD);
+    hdr.total_len = BHARAT_MSG_HEADER_MIN_LEN + 50;
+
+    // Test missing message kind flag
+    hdr.flags = BHARAT_MSG_FLAG_RELIABLE;
+    assert(bharat_msg_header_validate(&hdr, 4096) == BHARAT_MSG_ERR_MALFORMED_HEADER);
+
+    // Test multiple message kind flags
+    hdr.flags = BHARAT_MSG_FLAG_REQUEST | BHARAT_MSG_FLAG_RESPONSE;
+    assert(bharat_msg_header_validate(&hdr, 4096) == BHARAT_MSG_ERR_MALFORMED_HEADER);
+    hdr.flags = BHARAT_MSG_FLAG_REQUEST;
+
+    // Test cap bounds exceeding payload
+    hdr.flags |= BHARAT_MSG_FLAG_HAS_CAPS;
+    hdr.cap_count = 10; // 10 * 34 = 340 bytes
+    hdr.total_len = BHARAT_MSG_HEADER_MIN_LEN + 50; // Not enough room!
+    assert(bharat_msg_header_validate(&hdr, 4096) == BHARAT_MSG_ERR_MALFORMED_PAYLOAD);
+}
+
+int main() {
+    printf("Running Wire Format tests...\n");
+    test_endian_helpers();
+    test_crc32();
+    test_header_encode_decode();
+    test_header_validation_failures();
+    printf("All wire format tests passed!\n");
+    return 0;
+}


### PR DESCRIPTION
Implements the first phases (Spec freeze through OOL descriptors and Loopback Transport) of the Multi-Kernel Wire Format architecture, as outlined in the detailed design request. This includes architecture documentation, binary protocol primitives, validation routines, capwire tokens, and tests configured for host execution.

---
*PR created automatically by Jules for task [15032949811827298381](https://jules.google.com/task/15032949811827298381) started by @divyang4481*