### PR TITLE
docs: sync README and networking docs with actual code status

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,16 @@ Bharat-OS is a capability-oriented microkernel project with a multikernel direct
 
 | Area | Current status | Notes |
 | --- | --- | --- |
-| Capability model and IPC baseline | Implemented baseline | Capability tables, delegated rights checks, endpoint IPC + URPC scaffolding. |
-| Memory management | Partial baseline | PMM/buddy allocator and software mapping registry are in place; production-grade hardware page-table lifecycle, SMP-safe TLB discipline, demand paging/COW, NUMA policy, and DMA/IOMMU mapping lifecycle remain in progress. |
-| Scheduler and AI hook points | Implemented baseline | Timer-driven scheduler path with bounded AI suggestion ingestion/processing; full SMP runqueues/context switching remain deferred. |
-| Driver and HAL model | Implemented baseline | HAL contracts and driver framework scaffolding exist across x86_64, riscv64, arm64. |
-| Distributed/multikernel scale-out | Early baseline | Per-core URPC matrix and multicore bootstrap hooks exist; production-grade topology and transport tuning are deferred. |
-| Diagnostics & Reliability | Implemented baseline | Structured kernel panic generation, architecture-specific trap/fault breadcrumbs, and PStore persistent recovery logging. |
+| Kernel architecture | Baseline implemented | Capability objects, syscall/uAPI surfaces, core scheduler hooks, and architecture-specific HAL paths are present for x86_64, riscv64, and arm64 builds. |
+| User-space service layer | Mixed (stubs + partial implementations) | Many services currently compile as lifecycle/event-loop stubs, while networking (`netmgr`, `netstack`) and crypto include concrete module logic. |
+| Networking split (`net` -> `netmgr` + `netstack`) | In progress | `netmgr` has control-plane tables + IPC op dispatch; `netstack` includes IPv4, ARP, ICMP, UDP, socket table, and loopback/ethernet paths. |
+| Build & test infrastructure | Active baseline | CMake presets/toolchains and host test integration are wired; architecture runtime maturity differs by target. |
+| Distributed/multikernel scale-out | Early baseline | Messaging-first direction is reflected in subsystem and service decomposition, but many production control-plane behaviors remain roadmap items. |
+| Documentation coverage | Expanded in this update | See `docs/current-code-status.md` for a code-backed implementation matrix across services/subsystems. |
 
 For architecture-level details and deferred boundaries, see `docs/architecture/` and ADRs in `docs/decisions/`. For the step-by-step closure plan, see `docs/architecture/memory-gap-closure-plan.md`. For our profile-driven, capability-safe communications and networking architecture, see [`docs/architecture/network-architecture.md`](docs/architecture/network-architecture.md).
+
+For a code-backed snapshot of what is implemented vs. stubbed right now, see [`docs/current-code-status.md`](docs/current-code-status.md).
 
 ## Device Profiles & Use-cases
 

--- a/docs/current-code-status.md
+++ b/docs/current-code-status.md
@@ -1,0 +1,104 @@
+# Bharat-OS Current Code Status (March 2026)
+
+This document summarizes **what is actually implemented in code today** versus what is still a scaffold/stub.
+It is intended to complement architecture roadmaps with a code-backed snapshot.
+
+## Scope and method
+
+- Reviewed top-level build wiring (`CMakeLists.txt`, `services/CMakeLists.txt`, `subsys/CMakeLists.txt`).
+- Reviewed service entry points (`services/*/main.c`, `services/*/src/main.c`).
+- Reviewed non-trivial networking control/data plane modules and selected subsystem modules.
+
+> Note: "Implemented" here means concrete logic exists in tree (not necessarily production-complete runtime behavior on all targets).
+
+---
+
+## 1) Build composition status
+
+### Kernel + libraries
+- Kernel, lib, drivers, subsystems, and services are all part of default top-level CMake build.
+- Host tests are optional through `BHARAT_BUILD_HOST_TESTS`.
+
+### Service composition
+- Always built: `process_manager`, `vm_manager`, `file_system`, `drivers`, `crypto`, `console`, `boot_displayd`, legacy `net`.
+- Default-on option groups:
+  - `BHARAT_BUILD_USER_SERVICES_STUBS=ON`: `init`, `namesvc`, `servicemgr`.
+  - `BHARAT_BUILD_CORE_SERVICES=ON`: `coremgr`, `memmgr`, `schedmgr`, `devmgr`, `accelmgr`, `storagemgr`, `faultmgr`, `telemetrymgr`.
+  - `BHARAT_BUILD_NETWORK_STUBS=ON`: `netmgr`, `netstack`, `netfast`.
+
+---
+
+## 2) Service implementation matrix
+
+| Service | Current code status | Evidence highlights |
+| --- | --- | --- |
+| `init` | Stub supervisor loop | Runtime bootstrap logs and TODO startup graph actions. |
+| `namesvc` | Stub registry loop | Runtime initialization and TODO endpoint/lookup handling. |
+| `servicemgr` | Stub | Prints init message and exits event loop placeholder. |
+| `coremgr` | Stub | Topology/control responsibilities documented, logic TODO. |
+| `memmgr` | Stub | Placeholder for page-fault/policy loop. |
+| `schedmgr` | Stub | Placeholder policy service loop only. |
+| `devmgr` | Stub | Placeholder for enumeration/hotplug. |
+| `accelmgr` | Stub | Placeholder accelerator orchestration loop. |
+| `storagemgr` | Stub | Placeholder storage policy loop. |
+| `faultmgr` | Stub | Placeholder crash containment loop. |
+| `telemetrymgr` | Stub | Placeholder metrics aggregation loop. |
+| `process_manager` | Stub | TODO-only main. |
+| `vm_manager` | Stub | TODO-only main. |
+| `drivers` | Stub | TODO-only main. |
+| `console` | Stub | Infinite loop with TODO URPC routing comments. |
+| `boot_displayd` | Partial demo implementation | Includes framebuffer rectangle drawing helper and mocked early UI flow. |
+| `file_system` | Partial scaffold | Calls `vfs_init()` and contains TODO mount/URPC flow. |
+| `crypto` | Partial implementation | Initializes DRBG/keystore and validates/dispatches protocol requests via service modules; IPC transport path is currently stubbed. |
+| `net` (legacy monolith) | Transitional + smoke-test logic | Control/data plane init and loopback smoke-test remain for compatibility. |
+| `netmgr` | Partial implementation | Initializes interface/address/route/neighbor/driver-health state and handles multiple IPC opcodes with capability checks. |
+| `netstack` | Partial implementation | Socket table + virtio adapter init plus protocol modules (IPv4, ARP, ICMP, UDP, loopback, Ethernet helpers). |
+| `netfast` | Stub | Placeholder fast-path main. |
+
+---
+
+## 3) Networking implementation details (current)
+
+## `services/netmgr` (control plane)
+Implemented modules include:
+- Interface table lifecycle (create/delete/get/admin-state).
+- Address table add/remove/get.
+- Route table add/remove/lookup (best prefix + metric tie-break).
+- Neighbor cache add/remove/flush/lookup.
+- Driver health registry/report/restart-intent bookkeeping.
+- IPC opcode dispatcher that maps request types to those modules and fills response structures.
+
+Current limitations:
+- Main event loop intentionally breaks immediately (daemon runtime not fully wired).
+- Capability checks currently allow all requests (`netmgr_cap_check_rights` returns true).
+- Restart behavior records intent only; no process-manager integration yet.
+
+## `services/netstack` (data plane)
+Implemented modules include:
+- Net buffer manipulation and checksum helpers.
+- IPv4 RX/TX parsing + checksum validation + local/loopback/broadcast handling.
+- UDP RX/TX with pseudo-header checksum and socket callback delivery.
+- ICMP/ARP/Ethernet/loopback modules and socket table support.
+
+Current limitations:
+- Main loop is scaffolded and not yet driving timers/driver polling end-to-end.
+- `driver_virtio_adapter` is an adapter stub path for future integration depth.
+
+---
+
+## 4) Subsystem layer snapshot
+
+- `subsys_manager` static library includes Linux/Windows compatibility shims, Android personality modules, automotive module, and SKB/test-runner wiring.
+- Optional `ai_governor` demo executable is buildable and linked against scheduler-related kernel sources plus URPC/POSIX stub libraries.
+- `subsys/network` defines the contract/types/uAPI surface for network manager and stack integration.
+
+---
+
+## 5) Practical takeaway for contributors
+
+- Treat most non-network service daemons as **API/lifecycle scaffolding** at this stage.
+- For concrete feature work, current depth is strongest in:
+  1. networking split (`netmgr`, `netstack`),
+  2. crypto service protocol/dispatch internals,
+  3. subsystem contract surfaces and build/profile plumbing.
+- If you are documenting capabilities externally, avoid calling all services "implemented"; classify many as "compiled stubs with defined responsibilities".

--- a/services/netfast/README.md
+++ b/services/netfast/README.md
@@ -10,5 +10,5 @@ Optional fast path for networking:
 This module is the high-performance data plane alternative designed for environments requiring low latency and high throughput, such as edge gateways and cloud nodes.
 
 ## Status
-* **Current:** Architectural stub.
-* **Roadmap:** Full capability-safe, hardware-accelerated, zero-copy fast path network stack.
+* **Current:** Architectural stub (placeholder `main` only).
+* **Roadmap:** Capability-safe, hardware-accelerated, zero-copy fast-path data plane.

--- a/services/netmgr/README.md
+++ b/services/netmgr/README.md
@@ -15,5 +15,8 @@ Owns:
 - **NIC Queue Ownership**: Direct authority over NIC queues.
 
 ## Status
-* **Current:** Architectural stub.
-* **Roadmap:** Policy enforcement, interface capability delegation, and orchestration agent.
+* **Current:** Partial implementation.
+  - In-memory interface/address/route/neighbor and driver-health modules are implemented.
+  - IPC dispatcher handles control-plane opcodes and populates typed responses.
+  - Main daemon loop remains scaffolded; full runtime wiring and strict capability enforcement are still in progress.
+* **Roadmap:** Full policy orchestration, distributed control-plane integration, and production capability checks.

--- a/services/netstack/README.md
+++ b/services/netstack/README.md
@@ -11,5 +11,8 @@ The minimum universal IP stack for Bharat-OS.
 Handles basic IPv4/IPv6, UDP, TCP, and ARP/NDP.
 
 ## Status
-* **Current:** Architectural stub.
-* **Roadmap:** Full capability-safe, multi-queue IP networking stack baseline.
+* **Current:** Partial implementation.
+  - Core protocol modules exist for IPv4, ARP, ICMP, UDP, socket table, loopback, and Ethernet framing helpers.
+  - Checksum and packet-buffer helper utilities are implemented.
+  - Main daemon loop is still scaffolded; timer/driver poll integration and full runtime orchestration are in progress.
+* **Roadmap:** Full capability-safe, multi-queue IP stack with broader transport/runtime coverage.


### PR DESCRIPTION
### Motivation

- Update top-level documentation to reflect the repository's true implementation maturity rather than overstating feature completion. 
- Provide contributors a code-backed snapshot that maps which services are stubs versus partially implemented so work can be triaged effectively. 
- Clarify the networking split (`net` -> `netmgr` + `netstack`) status where concrete module code exists in-tree.

### Description

- Revised the root `README.md` project-status table to reflect current state (kernel baseline, mixed user-space service maturity, networking progress) and added a link to a code-backed snapshot. 
- Added `docs/current-code-status.md` which inventories build composition, per-service implementation status, networking module details, and known runtime limitations. 
- Updated service documentation: `services/netmgr/README.md` and `services/netstack/README.md` now mark those components as "partial implementation" with brief evidence and limitations, and `services/netfast/README.md` clarifies it remains a placeholder. 

### Testing

- Ran `git diff --check` and it returned no whitespace or index errors (OK). 
- Verified repository status with `git status --short` showing the updated files were staged for commit. 
- Committed the changes successfully with a message describing the docs alignment; no automated CI tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbc952f0f883208b43afdf19913cea)