### PR TITLE
Fix duplicate netmgr target in CMake configuration

### DIFF
--- a/services/netmgr/CMakeLists.txt
+++ b/services/netmgr/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 3.20)
 project(netmgr C)
 
-add_executable(netmgr src/main.c)
-target_compile_options(netmgr PRIVATE -Wall -ffreestanding -nostdlib )
 set(NETMGR_SOURCES
     src/main.c
     src/interface_table.c


### PR DESCRIPTION
### Motivation
- CMake configure was failing with a CMP0002 name collision because `netmgr` was declared twice in `services/netmgr/CMakeLists.txt`.

### Description
- Remove the initial duplicate `add_executable(netmgr src/main.c)` and its redundant `target_compile_options`, leaving a single `add_executable(netmgr ${NETMGR_SOURCES})` with the intended include, compile and link options.

### Testing
- Ran `cmake -S . -B build/verify-netmgr -G Ninja -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/x86_64-elf.cmake -DBHARAT_BOOT_GUI=ON -DBHARAT_BOOT_HW_PROFILE=generic -DBHARAT_BOOT_TIER=LINUX_LIKE -DBHARAT_PROFILE_DESKTOP=1 -DBHARAT_PERSONALITY_NONE=1 --no-warn-unused-cli` which completed successfully and generated build files in `build/verify-netmgr`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbd1f6b11c8320999775eae4554cc0)