### PR TITLE
docs: update file system subsystem documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Bharat-OS is a capability-oriented microkernel project with a multikernel direct
 | --- | --- | --- |
 | Kernel architecture | Baseline implemented | Capability objects, syscall/uAPI surfaces, core scheduler hooks, and architecture-specific HAL paths are present for x86_64, riscv64, and arm64 builds. |
 | User-space service layer | Mixed (stubs + partial implementations) | Many services currently compile as lifecycle/event-loop stubs, while networking (`netmgr`, `netstack`) and crypto include concrete module logic. |
+| Filesystem & Storage | Partial scaffold | VFS kernel headers present; `services/file_system` is a compiled stub. Persistent storage (FAT/littlefs) and OTA recovery support are roadmap items. |
 | Networking split (`net` -> `netmgr` + `netstack`) | In progress | `netmgr` has control-plane tables + IPC op dispatch; `netstack` includes IPv4, ARP, ICMP, UDP, socket table, and loopback/ethernet paths. |
 | Build & test infrastructure | Active baseline | CMake presets/toolchains and host test integration are wired; architecture runtime maturity differs by target. |
 | Distributed/multikernel scale-out | Early baseline | Messaging-first direction is reflected in subsystem and service decomposition, but many production control-plane behaviors remain roadmap items. |
@@ -331,6 +332,7 @@ Bharat-OS defines explicit subsystem groups to ensure scalable and tailored func
 * **Input Subsystem:** Modular routing for keyboards, touch panels, rotary encoders, and GPIO buttons.
 * **Heterogeneous Accelerator Subsystem:** DMA engines, DSPs, NPUs, and ISP abstractions for edge AI and multimedia tasks.
 * **Embedded Device Services:** Kiosk shells, watchdog timers, OTA recovery, and lightweight local storage.
+* **Filesystem & Storage Subsystem:** VFS abstraction mapping capability-based IO to block, blob, and persistent storage drivers (e.g., FAT, littlefs) necessary for stateful edge devices and OTA recovery.
 * **Desktop Graphics Subsystem:** An advanced layer reserved for devices with capable hardware and full compositor needs.
 
 ### Display & GUI Strategy

--- a/docs/current-code-status.md
+++ b/docs/current-code-status.md
@@ -48,7 +48,7 @@ It is intended to complement architecture roadmaps with a code-backed snapshot.
 | `drivers` | Stub | TODO-only main. |
 | `console` | Stub | Infinite loop with TODO URPC routing comments. |
 | `boot_displayd` | Partial demo implementation | Includes framebuffer rectangle drawing helper and mocked early UI flow. |
-| `file_system` | Partial scaffold | Calls `vfs_init()` and contains TODO mount/URPC flow. |
+| `file_system` | Partial scaffold | Calls `vfs_init()` and contains TODO mount/URPC flow. Roadmap includes FAT/littlefs support, persistent storage for IoT/edge, and OTA recovery. |
 | `crypto` | Partial implementation | Initializes DRBG/keystore and validates/dispatches protocol requests via service modules; IPC transport path is currently stubbed. |
 | `net` (legacy monolith) | Transitional + smoke-test logic | Control/data plane init and loopback smoke-test remain for compatibility. |
 | `netmgr` | Partial implementation | Initializes interface/address/route/neighbor/driver-health state and handles multiple IPC opcodes with capability checks. |

--- a/services/file_system/README.md
+++ b/services/file_system/README.md
@@ -1,0 +1,32 @@
+# File System Service (`services/file_system`)
+
+## Overview
+The `file_system` service is responsible for providing a unified namespace and persistent storage management for the Bharat-OS microkernel. It acts as the user-space Virtual File System (VFS) daemon, routing IPC and URPC requests (such as `open()`, `read()`, `write()`, `close()`) from applications and compatibility personalities to underlying storage backends (e.g., FAT, littlefs, or block devices).
+
+This persistent storage layer is crucial for saving state, managing logs, and supporting critical functionality like Over-The-Air (OTA) updates on IoT, edge devices, and richer OS profiles.
+
+## Responsibilities
+- **Namespace Management**: Mount and manage a hierarchical view of underlying filesystems and storage drivers.
+- **Request Dispatch**: Handle incoming capability-checked VFS operations over IPC/URPC.
+- **Backend Abstraction**: Map unified filesystem requests to concrete block drivers or raw blob storage.
+- **Storage Profiles**: Support small, deterministic backends (e.g., `littlefs`) for the RTOS/Edge profiles, and richer, scalable backends for desktop/cloud environments.
+- **OTA Recovery Storage**: Ensure robust fallback, dual-bank, or A/B storage abstractions for fail-safe updates.
+
+## Current Status
+- **Status**: Scaffold / Stub
+- The core headers (`kernel/include/fs/vfs.h`) provide the capability-aware VFS structure.
+- `services/file_system/main.c` currently starts and calls an empty initialization stub (`vfs_init()`).
+- No concrete filesystem drivers (like FAT or littlefs) or block storage integration are implemented yet.
+
+## Planned API & Dependencies
+- **Dependencies**:
+  - `lib/urpc` for high-throughput, asynchronous IO.
+  - `subsys_manager` for integration with POSIX and other personalities.
+  - `drivers/storage` (Planned) for block-device primitives.
+- **Forbidden Dependencies**: The `file_system` must not directly interface with hardware MMIO; it should rely on capability-mediated URPC messages to separate driver instances.
+
+## Roadmap
+1. Implement in-memory `ramfs` or `tmpfs` for early boot support.
+2. Integrate a small footprint persistent filesystem (like `littlefs` or `FAT32`) for Edge and IoT profiles.
+3. Bridge `services/file_system` with block device IPC (e.g., to an NVMe or eMMC user-space driver).
+4. Introduce directory caching and distributed VFS resolution for multikernel environments.

--- a/subsys/include/bharat/fs/fs_service.h
+++ b/subsys/include/bharat/fs/fs_service.h
@@ -1,0 +1,58 @@
+#ifndef BHARAT_FS_SERVICE_H
+#define BHARAT_FS_SERVICE_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+/*
+ * Bharat-OS Subsystem Contract: File System Service
+ *
+ * Defines the user-space contract and wire formats for communicating with
+ * the `services/file_system` daemon over IPC/URPC.
+ */
+
+#define FS_OP_MOUNT   0x01
+#define FS_OP_OPEN    0x02
+#define FS_OP_CLOSE   0x03
+#define FS_OP_READ    0x04
+#define FS_OP_WRITE   0x05
+#define FS_OP_STAT    0x06
+#define FS_OP_READDIR 0x07
+
+// Basic file system IPC response structure
+typedef struct {
+    int32_t status;        // 0 on success, < 0 on error (e.g., -ENOENT)
+    uint32_t bytes_xfer;   // Bytes read or written
+    uint32_t object_id;    // Handle returned by open
+} fs_response_t;
+
+// Open request
+typedef struct {
+    uint32_t opcode;       // FS_OP_OPEN
+    uint32_t flags;        // VFS_OPEN_READ, VFS_OPEN_WRITE
+    char path[256];
+} fs_open_req_t;
+
+// Read request (URPC bound for larger transfers)
+typedef struct {
+    uint32_t opcode;       // FS_OP_READ
+    uint32_t object_id;
+    uint64_t offset;
+    uint32_t size;
+} fs_read_req_t;
+
+// Write request (URPC bound for larger transfers)
+typedef struct {
+    uint32_t opcode;       // FS_OP_WRITE
+    uint32_t object_id;
+    uint64_t offset;
+    uint32_t size;
+} fs_write_req_t;
+
+// Close request
+typedef struct {
+    uint32_t opcode;       // FS_OP_CLOSE
+    uint32_t object_id;
+} fs_close_req_t;
+
+#endif // BHARAT_FS_SERVICE_H


### PR DESCRIPTION
Adds details about the `file_system` subsystem and services. This update includes mentions to persistent storage drivers, capability mapping, FAT, littlefs, OTA recovery capabilities and VFS abstractions. A new subsystem contract header `fs_service.h` was also added in `subsys/include/bharat/fs`.

---
*PR created automatically by Jules for task [1001397917712644789](https://jules.google.com/task/1001397917712644789) started by @divyang4481*