### PR TITLE
Phase 4 and Phase 5 Network Architecture Update

### DIFF
--- a/drivers/net/virtio_net.c
+++ b/drivers/net/virtio_net.c
@@ -1,5 +1,6 @@
 #include <stdint.h>
 #include <stddef.h>
+#include <bharat/packet/packet.h>
 
 /* virtio_net.c
  *
@@ -11,7 +12,7 @@
    It doesn't implement full DMA/descriptor ring logic yet, but acts
    as the boundary for the netstack to interface with hardware eventually. */
 
-static void (*netstack_rx_cb)(const uint8_t *data, size_t len) = NULL;
+static void (*netstack_rx_cb)(packet_buf_t *pkt) = NULL;
 
 int virtio_net_init(void) {
     /* Initialize global driver state */
@@ -28,7 +29,7 @@ int virtio_net_bind(void *device) {
     return 0;
 }
 
-int virtio_net_start(void *device, void (*rx_callback)(const uint8_t *, size_t)) {
+int virtio_net_start(void *device, void (*rx_callback)(packet_buf_t *)) {
     /* Configure rings, transition to DRIVER_OK, register RX callback */
     netstack_rx_cb = rx_callback;
     return 0;
@@ -40,9 +41,11 @@ int virtio_net_stop(void *device) {
     return 0;
 }
 
-int virtio_net_tx(void *device, const void *buffer, size_t length) {
+int virtio_net_tx(void *device, packet_buf_t *pkt) {
     /* Enqueue buffer into virtqueue for transmission.
        For the Phase 2 mock, we can just print or simulate sending. */
+    // Note: hardware tx would claim ownership, unref upon completion
+    packet_unref(pkt);
     return 0;
 }
 
@@ -51,9 +54,22 @@ int virtio_net_poll(void *device) {
     return 0;
 }
 
+// Declare memcpy locally or include string.h as allowed by environment
+extern void *memcpy(void *dest, const void *src, size_t n);
+
 /* Simulated RX for host testing/mocking in Phase 2 */
 void virtio_net_mock_rx(const void *buffer, size_t length) {
     if (netstack_rx_cb) {
-        netstack_rx_cb((const uint8_t *)buffer, length);
+        packet_buf_t *pkt = packet_alloc();
+        if (pkt) {
+            // Check if packet fits in the buffer
+            if (length <= pkt->tail_len) {
+                memcpy(pkt->data, buffer, length);
+                pkt->data_len = length;
+                netstack_rx_cb(pkt);
+            } else {
+                packet_free(pkt); // Drop packet, too large
+            }
+        }
     }
 }

--- a/lib/packet/CMakeLists.txt
+++ b/lib/packet/CMakeLists.txt
@@ -1,6 +1,12 @@
 cmake_minimum_required(VERSION 3.20)
-project(libpacket C)
+project(BharatOS_Packet_Lib C)
 
-add_library(packet STATIC src/packet.c)
-target_include_directories(packet PUBLIC include)
-target_compile_options(packet PRIVATE -Wall -ffreestanding -nostdlib)
+add_library(packet STATIC
+    src/packet.c
+)
+
+target_include_directories(packet PUBLIC
+    include
+)
+
+target_compile_options(packet PRIVATE -ffreestanding -nostdlib -Wall -fPIC)

--- a/lib/packet/include/bharat/packet/packet.h
+++ b/lib/packet/include/bharat/packet/packet.h
@@ -17,6 +17,7 @@
 #define PACKET_FLAG_BCAST           (1 << 2)
 #define PACKET_FLAG_MCAST           (1 << 3)
 #define PACKET_FLAG_VLAN            (1 << 4)
+#define PACKET_FLAG_DMA_MAPPED      (1 << 5)
 
 /**
  * @brief A packet buffer descriptor.
@@ -25,7 +26,7 @@
  * The memory is typically managed by a slab/pool allocator, and ownership
  * is passed between domains (NIC drivers -> netstack -> user apps).
  */
-typedef struct {
+typedef struct packet_buf_s {
     uint8_t *data;         // Pointer to the start of the buffer
     uint16_t head_len;     // Headroom size (for adding headers)
     uint16_t tail_len;     // Tailroom size (for adding trailers)
@@ -33,9 +34,24 @@ typedef struct {
     uint32_t data_len;     // Length of valid data within the buffer
     uint32_t flags;        // Packet flags (checksum, offloads, etc.)
 
+    uint32_t refcount;     // Reference count
+    struct packet_buf_s *next; // For fragment chaining
+
     // Placeholder for ownership tracking or reference counting
     void *owner_ctx;
 } packet_buf_t;
 
-// Basic initialization contract (stub)
+// Basic initialization contract
 void libpacket_init(void);
+
+// Allocate a packet buffer from the pool
+packet_buf_t *packet_alloc(void);
+
+// Free or unref a packet buffer
+void packet_free(packet_buf_t *pkt);
+
+// Increment refcount
+void packet_ref(packet_buf_t *pkt);
+
+// Decrement refcount, free if 0
+void packet_unref(packet_buf_t *pkt);

--- a/lib/packet/src/packet.c
+++ b/lib/packet/src/packet.c
@@ -1,5 +1,63 @@
-#include <stddef.h>
+#include <bharat/packet/packet.h>
+#include <stdbool.h>
 
-void packet_init(void) {
-    // Scaffold init
+#define PACKET_POOL_SIZE 256
+#define PACKET_BUFFER_SIZE 2048
+#define DEFAULT_HEADROOM 256
+
+static packet_buf_t pkt_pool[PACKET_POOL_SIZE];
+static uint8_t pkt_data_pool[PACKET_POOL_SIZE][PACKET_BUFFER_SIZE];
+static bool pkt_allocated[PACKET_POOL_SIZE];
+
+void libpacket_init(void) {
+    for (int i = 0; i < PACKET_POOL_SIZE; i++) {
+        pkt_allocated[i] = false;
+        pkt_pool[i].total_len = PACKET_BUFFER_SIZE;
+    }
+}
+
+packet_buf_t *packet_alloc(void) {
+    for (int i = 0; i < PACKET_POOL_SIZE; i++) {
+        if (!pkt_allocated[i]) {
+            pkt_allocated[i] = true;
+            packet_buf_t *pkt = &pkt_pool[i];
+            pkt->data = pkt_data_pool[i] + DEFAULT_HEADROOM;
+            pkt->head_len = DEFAULT_HEADROOM;
+            pkt->tail_len = PACKET_BUFFER_SIZE - DEFAULT_HEADROOM;
+            pkt->data_len = 0;
+            pkt->flags = 0;
+            pkt->refcount = 1;
+            pkt->next = NULL;
+            pkt->owner_ctx = NULL;
+            return pkt;
+        }
+    }
+    return NULL; // Pool exhausted
+}
+
+void packet_free(packet_buf_t *pkt) {
+    if (!pkt) return;
+
+    // Calculate index to free
+    int index = pkt - pkt_pool;
+    if (index >= 0 && index < PACKET_POOL_SIZE) {
+        pkt_allocated[index] = false;
+    }
+}
+
+void packet_ref(packet_buf_t *pkt) {
+    if (pkt) {
+        pkt->refcount++;
+    }
+}
+
+void packet_unref(packet_buf_t *pkt) {
+    if (pkt) {
+        if (pkt->refcount > 0) {
+            pkt->refcount--;
+            if (pkt->refcount == 0) {
+                packet_free(pkt);
+            }
+        }
+    }
 }

--- a/run_netstack_tests.sh
+++ b/run_netstack_tests.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+gcc -I../services/netstack/src -Ilib/packet/include \
+    tests/test_netstack_phase2.c \
+    services/netstack/src/netbuf.c \
+    services/netstack/src/checksum.c \
+    services/netstack/src/ethernet.c \
+    services/netstack/src/arp.c \
+    services/netstack/src/ipv4.c \
+    services/netstack/src/icmp.c \
+    services/netstack/src/udp.c \
+    services/netstack/src/tcp.c \
+    services/netstack/src/socket_table.c \
+    services/netstack/src/loopback.c \
+    services/netstack/src/driver_virtio_adapter.c \
+    drivers/net/virtio_net.c \
+    lib/packet/src/packet.c \
+    -o tests/test_netstack_phase2
+./tests/test_netstack_phase2

--- a/services/netstack/src/driver_virtio_adapter.c
+++ b/services/netstack/src/driver_virtio_adapter.c
@@ -2,18 +2,22 @@
 #include "ethernet.h"
 #include <stddef.h>
 
+#include <bharat/packet/packet.h>
+
 // Forward declare the driver entry points for Phase 2 integration
 extern int virtio_net_init(void);
 extern int virtio_net_probe(void *device);
 extern int virtio_net_bind(void *device);
-extern int virtio_net_start(void *device, void (*rx_callback)(const uint8_t *, size_t));
-extern int virtio_net_tx(void *device, const void *buffer, size_t length);
+extern int virtio_net_start(void *device, void (*rx_callback)(packet_buf_t *));
+extern int virtio_net_tx(void *device, packet_buf_t *pkt);
 
 // For simplicity, we assume a single device instance bound in the mock
 static void *mock_virtio_device = NULL;
 
-void virtio_adapter_rx(const uint8_t *data, size_t len) {
+void virtio_adapter_rx(packet_buf_t *pkt) {
+    size_t len = pkt->data_len;
     if (len > NETBUF_MAX_SIZE - NETBUF_DEFAULT_HEADROOM * 2) {
+        packet_unref(pkt);
         return; // Dropped, too large
     }
 
@@ -21,14 +25,22 @@ void virtio_adapter_rx(const uint8_t *data, size_t len) {
     netbuf_init(&nb);
 
     uint8_t *buf = netbuf_put(&nb, len);
-    if (!buf) return;
-    memcpy(buf, data, len);
+    if (!buf) {
+        packet_unref(pkt);
+        return;
+    }
+    memcpy(buf, pkt->data, len);
+
+    packet_unref(pkt);
 
     // Enter the network stack
     ethernet_rx(&nb);
 }
 
 int virtio_adapter_init(void) {
+    // Make sure libpacket is initialized before driver
+    libpacket_init();
+
     if (virtio_net_init() != 0) return -1;
     if (virtio_net_probe(mock_virtio_device) != 0) return -1;
     if (virtio_net_bind(mock_virtio_device) != 0) return -1;
@@ -37,5 +49,17 @@ int virtio_adapter_init(void) {
 }
 
 int virtio_adapter_tx(netbuf_t *nb) {
-    return virtio_net_tx(mock_virtio_device, netbuf_data(nb), netbuf_len(nb));
+    packet_buf_t *pkt = packet_alloc();
+    if (!pkt) return -1;
+
+    size_t len = netbuf_len(nb);
+    if (len > pkt->tail_len) {
+        packet_free(pkt);
+        return -1;
+    }
+
+    memcpy(pkt->data, netbuf_data(nb), len);
+    pkt->data_len = len;
+
+    return virtio_net_tx(mock_virtio_device, pkt);
 }

--- a/services/netstack/src/driver_virtio_adapter.h
+++ b/services/netstack/src/driver_virtio_adapter.h
@@ -2,6 +2,7 @@
 #define NETSTACK_DRIVER_VIRTIO_ADAPTER_H
 
 #include "netbuf.h"
+#include <bharat/packet/packet.h>
 
 /* Initialize the virtio adapter and bind it to the driver backend */
 int virtio_adapter_init(void);
@@ -10,6 +11,6 @@ int virtio_adapter_init(void);
 int virtio_adapter_tx(netbuf_t *nb);
 
 /* The RX callback from the virtio driver */
-void virtio_adapter_rx(const uint8_t *data, size_t len);
+void virtio_adapter_rx(packet_buf_t *pkt);
 
 #endif // NETSTACK_DRIVER_VIRTIO_ADAPTER_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -400,12 +400,14 @@ add_executable(test_netstack_phase2
     ../services/netstack/src/ipv4.c
     ../services/netstack/src/icmp.c
     ../services/netstack/src/udp.c
+    ../services/netstack/src/tcp.c
     ../services/netstack/src/socket_table.c
     ../services/netstack/src/loopback.c
     ../services/netstack/src/driver_virtio_adapter.c
     ../drivers/net/virtio_net.c
+    ../lib/packet/src/packet.c
 )
-target_include_directories(test_netstack_phase2 PRIVATE ../services/netstack/src)
+target_include_directories(test_netstack_phase2 PRIVATE ../services/netstack/src ../lib/packet/include)
 add_test(NAME test_netstack_phase2 COMMAND test_netstack_phase2)
 target_link_options(test_early_alloc
 test_panic


### PR DESCRIPTION
Implements Phase 4 and Phase 5 of the modular network architecture:
1. Created a static slab allocator for `packet_buf_t` in `lib/packet/src/packet.c` with headroom, tailroom, refcounting, and DMA mappable flags. 
2. Hooked up the `virtio-net` mock driver backend (`drivers/net/virtio_net.c`) to use `packet_buf_t*` instead of raw memory arrays for fast-path ring transactions. 
3. Fixed missing `#include <stdbool.h>` and a pre-existing build failure with `tcp.c` in the Phase 2 unit tests.

---
*PR created automatically by Jules for task [11183348373004741017](https://jules.google.com/task/11183348373004741017) started by @divyang4481*