### PR TITLE
docs: Add comprehensive SDK, libc, and POSIX architecture plan

### DIFF
--- a/docs/adr/009-sdk-libc-strategy.md
+++ b/docs/adr/009-sdk-libc-strategy.md
@@ -1,0 +1,45 @@
+# ADR 009: SDK & Libc Strategy for Bharat-OS
+
+## Status
+
+Accepted
+
+## Context
+
+Bharat-OS aims to target edge devices, drones, gateways, robotics nodes, and appliance-class systems. A critical hurdle to becoming a testable OS platform has been the "developer entry cost". Without a standard C runtime (libc) and Software Development Kit (SDK), porting utilities, benchmarks, third-party libraries, and writing standard tests are unnecessarily complex, as each component ends up reinventing the wheel (e.g., custom `stdio`, `string` routines, custom memory allocators).
+
+While POSIX compatibility is ultimately desired for code reuse and developer familiarity, building a monolithic, fully-featured POSIX implementation (similar to a glibc-based desktop Linux system) from day one is not the right fit for the multikernel, capability-driven architecture of Bharat-OS. Pushing POSIX semantics (like `fork`, signals, and implicit shared state) deep into the core kernel violates the principle that the kernel should export **mechanisms only**.
+
+Furthermore, attempting to write a full libc from scratch is a significant time sink and risks distracting from core architecture goals.
+
+## Decision
+
+We will adopt a **tiered, mechanism-first SDK/libc approach**, rather than a monolithic POSIX kernel. This strategy comprises:
+
+1. **Small, deterministic libc first.** A Core SDK libc and runtime layer that provides basic memory, string, `stdio`, `errno`, and standard C headers. This unlocks immediate value for embedded apps, kernel services, and test harnesses.
+2. **Selective POSIX compatibility second.** A POSIX library shim that implements an embedded subset (like `read`, `write`, `open`, `close`, threads, and poll) over the core SDK's syscall/IPC veneers. We will explicitly avoid complex, monolithic Unix semantics like full `fork()` initially, preferring `spawn`-based process models.
+3. **Personality layers third.** Behavioral compatibilities (e.g., Linux, RT/Embedded, Appliance, Drone) will live above the kernel and libc, mapping API behaviors, `errno` values, and subsystem expectations as independent runtime profiles.
+
+Architecturally, the kernel will remain focused on capabilities, address spaces, endpoint IPC, and threads. The libc will communicate with the kernel strictly via a stable **Bharat UAPI** (e.g., a `libbsys` layer), ensuring that POSIX remains a translation/adaptation layer.
+
+### Source Strategy: Hybrid Two-Step Approach
+
+Instead of writing a libc from scratch, we will implement a two-step adoption plan:
+
+* **Stage 1 (Minimal SDK Bootstrap):** We will use a `newlib` or `picolibc`-style minimal approach to establish the early SDK. This provides very fast embedded bring-up, allowing services and tests to compile cleanly without custom headers.
+* **Stage 2 (Hosted libc model):** We will eventually converge toward a `musl`-compatible hosted libc model for richer POSIX support. Musl is small, clean, and a better embedded fit than glibc, making it easier to adapt to our custom kernel.
+
+## Consequences
+
+### Positive
+
+* **Faster bring-up:** Immediate ability to compile tests, services, and embedded apps using standard standard C headers and minimal `stdio`/`string` routines.
+* **Architectural purity:** The kernel avoids being polluted with heavyweight, monolithic POSIX semantics like `fork` and complex signal handling. POSIX is strictly an emulation/shim layer.
+* **Clear progression:** The two-stage adoption (newlib/picolibc style -> musl style) gives a realistic roadmap without committing to an overwhelming initial effort.
+* **Targeted usage:** By separating POSIX subsets and personalities, we can tune the OS for drones, edge appliances, or generic porting, without forcing one size to fit all.
+
+### Negative
+
+* **Migration overhead:** We must plan for the eventual transition from Stage 1 (newlib/picolibc-style) to Stage 2 (musl-style).
+* **Emulation complexity:** Shimming POSIX over capabilities requires careful design of the internal UAPI (`libbsys`) and userspace service interaction (like file descriptor models mapping to VFS handles). Porting complex desktop software will be challenging until Phase 6 of the implementation plan.
+* **No `fork()`:** Applications relying heavily on `fork()` will need to be rewritten or adapted to use `posix_spawn()` or similar task-creation interfaces, which may slow down the porting of some legacy Unix tools.

--- a/docs/architecture/personality-model.md
+++ b/docs/architecture/personality-model.md
@@ -1,0 +1,60 @@
+# Personality Compatibility Model
+
+In a modern microkernel/multikernel architecture like Bharat-OS, forcing a single monolithic application binary interface (ABI) across all workloads limits flexibility and drags unnecessary state into the kernel.
+
+Instead, Bharat-OS supports **behavioral personalities** layered above the core capability-driven kernel primitives. This document outlines the distinct personality compatibilities we aim to implement to support different deployment profiles.
+
+## Core Principle
+
+**Kernel = Mechanisms. Libc / POSIX / Personality = Policy & Compatibility.**
+
+The kernel does not define a "POSIX process model" natively. It exports address spaces, threads, capability handles, endpoint IPC, timers, VM map/unmap, and per-core execution models. Personalities map these primitives into expected semantics for different application classes.
+
+---
+
+## Personality Types
+
+### 1. Linux Personality
+**Best for:** Developer adoption, general-purpose porting, tools, and testing.
+
+This personality is the first to build and aims to provide the familiar "Linux-like" behavior developers expect when cross-compiling or porting generic code.
+
+* **Maps:**
+  * Linux `errno` values (e.g., specific error codes returned by failed file operations).
+  * Linux flags and constants (e.g., `O_CLOEXEC`, `mmap` flags).
+  * Linux-ish file descriptor semantics (e.g., inheritance, duping).
+  * `pthread` expectations for synchronization and thread lifecycle.
+  * `mmap`/`prot`/flags translation down to Bharat-OS VM abstractions.
+  * A subset of socket `ioctls` (later).
+* **Limitations:** Does not promise 100% bug-for-bug compatibility with glibc/Linux internals. Heavyweight concepts like full `fork()` and complex signals are shimmed, stubbed, or deferred.
+
+### 2. Embedded / RT Personality
+**Best for:** Drones, robotics, edge control, and deterministic workloads.
+
+This personality focuses on predictable execution, strict bounds, and safety-critical patterns.
+
+* **Maps:**
+  * Deterministic startup and capability initialization.
+  * Fixed memory arenas (eschewing or strictly bounding dynamic `malloc`).
+  * Reduced signal complexity (or strictly synchronous exception delivery).
+  * Strict priority threading and affinity APIs.
+  * Watchdog and fault hooks deeply integrated into the runtime.
+  * **No `fork`/`exec` assumption:** Task creation is explicit, clone-like, or strictly capability-scoped `spawn`.
+
+### 3. Appliance Personality
+**Best for:** Routers, gateways, storage/network appliances.
+
+This personality bridges the gap between full general-purpose Linux and strict embedded RT, providing enough dynamic capability to run daemons while restricting arbitrary execution.
+
+* **Maps:**
+  * Service lifecycle management (launching, restarting, dependency tracking).
+  * Capability-limited filesystem and network access (e.g., a sandboxed daemon).
+  * Persistent configuration model exposed uniformly to applications.
+  * Low-footprint logging and crash capture semantics (tailored for reliable edge telemetry).
+
+## Architectural Placement
+
+These personalities reside as libraries or user-space services, forming the top layer of the Bharat-OS SDK:
+* `libsys` (Base UAPI) -> `libc` (Core runtime) -> `libposix` (POSIX subset) -> **`libpersonality-*`**
+
+For example, a service compiled with the Linux personality will link against `libpersonality-linux.a`, which intercepts or translates calls (like `open`, `ioctl`, or specific `mmap` requests) before passing them down through the POSIX shim or directly to `libsys` endpoint IPC.

--- a/docs/architecture/posix-compat-matrix.md
+++ b/docs/architecture/posix-compat-matrix.md
@@ -1,0 +1,40 @@
+# POSIX Compatibility Matrix
+
+POSIX compatibility is a profile, not an all-or-nothing guarantee. In Bharat-OS, POSIX is implemented via a multi-tiered compatibility strategy aimed at fast bring-up, deterministic edge deployment, and minimal monolithic assumptions in the core kernel.
+
+We define three profiles of POSIX support:
+
+* **Profile P0 — Bring-up POSIX**: For building core services and tests. Includes file I/O basics, memory allocation, time/sleep, environment, stdout/stderr, minimal threading, path operations, error codes, and handle/event polling.
+* **Profile P1 — Edge Appliance POSIX**: For gateways, routers, and industrial nodes. Adds sockets, basic DNS resolving, `select`/`poll`/`epoll`-like abstractions, daemon/service launching, config files, shared memory, and robust threading.
+* **Profile P2 — Drone/Autonomy POSIX**: For deterministic, resource-bounded deployments. Adds monotonic time correctness, bounded allocator modes, priority/affinity APIs, lock-free IPC wrappers, memory locking subsets, watchdog integration, and strict fault containment contracts. Crucially, desktop POSIX features are excluded or restricted here.
+
+## Support Labels
+
+We use explicit support labels to classify how an API maps to the underlying multikernel architecture:
+
+* **Native**: Backed directly by a Bharat-OS kernel or core service abstraction.
+* **Shim**: Emulated in the runtime/service compatibility layer without corresponding kernel mechanisms.
+* **Stub**: Declared to appease build systems, but strictly returns an error indicating it is not supported.
+* **Deferred**: Not yet implemented, but planned for a future phase.
+* **Forbidden**: Intentionally not supported or blocked in some profiles to maintain performance, determinism, or capability boundaries.
+
+## Compatibility Matrix
+
+The following matrix documents our intended support across the three primary API profiles.
+
+| API Area | Profile P0 (Bring-up) | Profile P1 (Edge) | Profile P2 (Drone/RT) | Notes |
+| --- | --- | --- | --- | --- |
+| **ISO C Core** | Native | Native | Native | Mandatory foundation |
+| **stdio Basic** | Native | Native | Native | Line-buffered is sufficient initially |
+| **File I/O** | Native/Shim | Native | Native | Backed by VFS/object handles |
+| **pthread Basic** | Deferred -> Native | Native | Native Subset | Avoid huge pthread surface early on |
+| **fork** | Deferred | Deferred | **Forbidden** | Replaced entirely by `spawn` |
+| **exec / spawn** | Shim/Native | Native | Native | Preferred process launch model |
+| **mmap** | Native Subset | Native | Native Bounded | Backed securely by VM regions |
+| **Sockets** | Deferred | Native (Later) | Optional Subset | Dependent on network stack readiness |
+| **Signals** | Stub/Minimal | Minimal | Restricted | Avoid overbuilding early |
+| **poll / select** | Shim/Native | Native | Native | Based entirely on waitable objects/endpoints |
+| **termios** | Stub | Optional | N/A | Not an urgent priority |
+| **Dynamic Loader** | Deferred | Later | Optional | Rely on static linking first |
+
+This matrix must be maintained and updated as capabilities are merged into the SDK and libc tiers to ensure we maintain an accurate contract for developers and system builders.

--- a/docs/architecture/sdk-libc-architecture.md
+++ b/docs/architecture/sdk-libc-architecture.md
@@ -1,0 +1,176 @@
+# Bharat-OS SDK and Libc Architecture
+
+For edge devices, drones, gateways, robotics nodes, and appliance-class systems, the winning move is not "full desktop POSIX first". The winning move is:
+
+1. **Small, deterministic libc first**
+2. **Selective POSIX compatibility second**
+3. **Personality layers third**
+
+This gives fast bring-up, app portability, and a clean architecture that does not drag monolithic Unix assumptions into the kernel.
+
+---
+
+## Why this matters now
+
+Without libc + SDK:
+* Every userspace service becomes special-case code.
+* Third-party code porting is painful.
+* Test harnesses are fragile.
+* Build failures around missing headers/string/stdio keep recurring.
+* Edge bring-up takes too much bespoke work.
+
+With a real SDK:
+* `services/netmgr`, `servicemgr`, drivers, and test apps stop reinventing runtime support.
+* Common embedded and systems code can be compiled quickly.
+* Utilities, benchmarks, and protocol stacks can be ported.
+* Kernel/services can be validated with realistic apps.
+* A path toward drone/edge appliances is created without waiting for a "full OS".
+
+---
+
+## The 3-Layer Design
+
+This architecture is designed as **3 layers**, not one giant "POSIX support" blob. Do **not** hardcode POSIX semantics into the kernel. Keep the kernel capability-oriented and message-driven. Let libc/personality adapt POSIX semantics onto Bharat-OS primitives.
+
+### 1. Core SDK libc/runtime
+* C runtime (`crt0`)
+* Memory / string / stdio basics
+* `errno`, `time`, `malloc`, `env`, startup, standard headers
+* Syscall veneer / service calls
+* Freestanding + hosted modes
+
+### 2. POSIX compatibility library
+* File descriptors
+* `read` / `write` / `open` / `close`
+* Fork-free process/thread model initially (`spawn`-based)
+* Signals subset
+* Pthread subset
+* Sockets shim (later)
+* Termios minimal or stubbed at first
+
+### 3. Personality compatibility
+* Linux personality first
+* Optional embedded/RT personality
+* "Micro-POSIX" profile for drones/edge
+* Subsystem personalities aligned with the multikernel direction
+
+---
+
+## The Target Model (Tiers)
+
+We do **not** need full glibc-class compatibility now. We need **three compatibility tiers**.
+
+### Tier A — SDK libc minimum viable platform
+Enough to compile real services and embedded apps. Must include:
+* `crt0` / process startup
+* `stdlib.h`, `stdint.h`, `stddef.h`, `stdbool.h`, `stdarg.h`
+* `string.h` (and optional `strings.h`)
+* `stdio.h` (minimal)
+* `errno.h`, `assert.h`, `ctype.h`, `limits.h`, `inttypes.h`
+* `time.h` (minimal)
+* `unistd.h`, `fcntl.h`, `sys/types.h`, `sys/stat.h` (subsets)
+* `sys/mman.h` (subset or stubbed)
+* `pthread.h` (very small subset or deferred)
+* Heap allocator
+* Thread-local `errno`
+* Syscall/service-call wrapper layer
+
+### Tier B — Embedded POSIX subset
+Enough to port lightweight Unix-style applications. Must prioritize:
+* `open` / `close` / `read` / `write` / `lseek`
+* `dup` / `dup2`
+* `pipe` or pipe-like channels
+* `poll` / `select` (minimal)
+* Directory ops, `stat` / `fstat`
+* `clock_gettime`, `nanosleep`
+* `getpid` / task id view
+* `pthread_create` / `join` / `mutex` / `cond`
+* `mmap` / `munmap` on top of VM abstractions
+* `socket` API subset (only if network stack is ready)
+
+**Avoid early obsession with:** full `fork`, full Unix `execve`, full signals, pty/tty complexity, locale/internationalization, and dynamic loader sophistication.
+
+### Tier C — Personality compatibility
+Expose a specific behavioral contract. This should live mostly above the kernel, not inside it.
+* **Linux-like personality** (easiest code porting)
+* **RT/embedded personality** (deterministic workloads)
+* **Appliance profile** (edge/router/gateway)
+* **Drone/autonomy profile** (stricter resource and fault contracts)
+
+---
+
+## Architecture Recommendations
+
+### 1. Kernel should expose mechanisms only
+Kernel exports: address spaces, threads/tasks, capability handles, endpoints/IPC, timers, VM map/unmap/protect, file/object handles, event/wait primitives, interrupt delivery, shared memory, and a per-core execution model.
+
+The kernel should **not** directly promise a "POSIX process model" as its native truth.
+
+### 2. Libc should sit on top of a stable UAPI
+Create a **Bharat UAPI** that libc calls into. This gives clean boundaries: the kernel evolves internally, libc depends only on the stable UAPI, and POSIX stays a translation layer.
+
+### 3. Services should provide Unix-like resources when needed
+* VFS/file service backs the file descriptor model.
+* Net service backs the socket personality.
+* Process/service manager backs the spawn/exec-like model.
+* Timer service backs clock/sleep APIs.
+* Signal/emergency fault model mapped in runtime, not kernel-first.
+
+---
+
+## Libc Internal Structure
+
+What libc should actually look like in Bharat-OS:
+
+### A. `libbcrt` — C runtime
+* Entry point
+* Constructor/destructor handling
+* TLS init
+* `argv`/`env` setup
+* Exit teardown
+* Stack protector hooks (if enabled)
+
+### B. `libbsys` — System interface layer
+* Syscall stubs or endpoint IPC wrappers
+* Handle/object abstraction
+* Thread creation primitive
+* Virtual memory requests
+* Timer requests
+* fd/object translation helpers
+
+*This is the lowest stable user ABI.*
+
+### C. `libc` — ISO C library
+* Pure C functions
+* `stdio`
+* `malloc`/`free`
+* String/memory routines
+* Formatted I/O
+* Time conversion basics
+* Environment handling
+* `errno`
+
+### D. `libposix`
+* `open` / `read` / `write` / ...
+* `pthread_*`
+* Path + stat wrappers
+* Polling/event waiting
+* Signals subset
+* Process/task facade
+
+### E. `libpersonality-linux`
+* Linux errno behavior nuances
+* Linux API quirks where needed
+* Flags translation
+* `/proc` expectations (via virtual service if chosen)
+* Compatibility constants and structure behavior
+
+---
+
+## What Not To Do
+
+1. **Do not make `fork` a day-1 requirement.** `fork` is expensive architecturally and infects everything. Treat full `fork()` as later, optional, or personality-specific. Use `spawn`, `posix_spawn`, exec-style launch, or clone-like threaded tasks if needed.
+2. **Do not let libc talk to unstable internal kernel structures.** Everything should go through a narrow UAPI.
+3. **Do not bury POSIX semantics in many services ad hoc.** Create a single compatibility ownership model.
+4. **Do not promise full glibc desktop compatibility.** That will swamp the project.
+5. **Do not overbuild heavy Unix ecosystems early.** Locale, i18n, iconv, NSS, PAM, etc., are not relevant for the immediate edge/drone target.

--- a/docs/architecture/sdk-libc-plan.md
+++ b/docs/architecture/sdk-libc-plan.md
@@ -1,0 +1,177 @@
+# Bharat-OS SDK and Libc Implementation Plan
+
+This document outlines the phased implementation plan for the Bharat-OS SDK and libc layer, transforming the kernel into a testable OS platform.
+
+## Phase 0 — Define ABI and Profiles
+
+**Goal:** Establish the foundational contracts before writing code.
+
+* **Deliverables:**
+  * Bharat user ABI spec
+  * libc support matrix
+  * POSIX subset matrix
+  * Personality compatibility matrix
+  * Error code mapping
+  * Handle/fd model
+  * Startup ABI: `argv` / `env` / `auxv` / TLS
+* **Output Documents:**
+  * `docs/architecture/sdk-libc-plan.md` (This document)
+  * `docs/architecture/posix-compat-matrix.md`
+  * `docs/architecture/personality-model.md`
+
+## Phase 1 — Minimal SDK Libc
+
+**Goal:** Build a usable SDK for Bharat-OS native services and tests.
+
+* **Implement:**
+  * `crt0`
+  * `libbsys`
+  * `errno`
+  * `malloc` / `free`
+  * `memcpy` / `memset` / `memmove` / `strcmp` / ...
+  * Minimal `printf` / `stdio`
+  * `abort` / `exit` / `assert`
+  * `time` and `clock_gettime` (minimal)
+  * `read` / `write` / `open` / `close` wrappers (if backend exists)
+  * Header package for cross-compilation
+* **Definition of Done:**
+  * Services compile without hacking missing standard headers.
+  * Test apps can print/log, allocate memory, sleep, and access basic handles.
+  * Toolchain can target Bharat-OS cleanly.
+
+## Phase 2 — Hosted Libc + fd Model
+
+**Goal:** Introduce a robust file descriptor and I/O model.
+
+* **Implement:**
+  * Userspace fd table or kernel fd table contract
+  * Stdio streams over fd model
+  * Path-based `open` / `stat` APIs
+  * Directory iteration
+  * `mmap` / `munmap` / `protect`
+  * `poll` / `select` (minimal)
+  * Environment and startup polish
+* **Definition of Done:**
+  * Simple Unix-style tools compile.
+  * Service processes stop using one-off runtime code.
+  * VFS tests and libc tests run end-to-end.
+
+## Phase 3 — Pthread and Synchronization Subset
+
+**Goal:** Enable multithreaded services and portable code.
+
+* **Implement:**
+  * `pthread_create` / `join`
+  * `pthread_mutex_*`
+  * `pthread_cond_*`
+  * TLS
+  * `pthread_once` / init
+  * Semaphores (optional)
+  * Thread naming and priority hooks
+* **Definition of Done:**
+  * Common libraries with pthread subset build.
+  * Network/control-plane services can use portable threading abstractions.
+
+## Phase 4 — POSIX Profile for Edge/Appliance
+
+**Goal:** Support networking and lightweight daemons.
+
+* **Implement:**
+  * Socket layer (if net stack is ready)
+  * DNS / basic resolver path
+  * `epoll` / `poll` personality choice
+  * `posix_spawn`
+  * Signals (minimal)
+  * Logging/syslog compatibility stub or service
+* **Definition of Done:**
+  * Lightweight network daemons can be ported.
+  * Router/gateway-class services can run.
+
+## Phase 5 — Drone/RT Profile
+
+**Goal:** Ensure determinism and strict resource control.
+
+* **Implement:**
+  * Monotonic deterministic timing
+  * Affinity/priority APIs
+  * Watchdog hooks
+  * Bounded allocator mode
+  * Capability-scoped process profile
+  * Fail-fast runtime mode
+* **Definition of Done:**
+  * Flight-control-adjacent support code can run in a controlled userland profile.
+  * Runtime behavior is analyzable and resource-bounded.
+
+## Phase 6 — Linux Personality Widening
+
+**Goal:** Improve broad compatibility (Later stage only).
+
+* **Implement Selectively:**
+  * Wider ioctl surface
+  * More errno/flags quirks
+  * `procfs` personality (if useful)
+  * Fuller socket semantics
+  * Shared library/runtime loader maturity
+
+---
+
+## Suggested Repo Structure
+
+A clean layout to support this phased rollout:
+
+```text
+sdk/
+  include/
+    stdio.h
+    stdlib.h
+    string.h
+    ...
+  crt/
+    crt0.c
+    crt_arch_*.S
+  libsys/
+    syscall.c
+    ipc_calls.c
+    handles.c
+    time.c
+    vm.c
+    thread.c
+  libc/
+    string/
+    stdio/
+    stdlib/
+    errno/
+    time/
+    malloc/
+  libposix/
+    unistd/
+    fcntl/
+    stat/
+    dirent/
+    pthread/
+    poll/
+    mmap/
+    spawn/
+  personalities/
+    linux/
+    embedded/
+    appliance/
+    drone_rt/
+```
+
+---
+
+## Concrete Next-Task Board
+
+To immediately execute this plan, the following sequence of tasks should be completed:
+
+* [ ] **Task 1:** Define Bharat user ABI and syscall/service boundary.
+* [ ] **Task 2:** Create `sdk/include` and minimal CRT.
+* [ ] **Task 3:** Implement `libsys` for thread, vm, time, IPC/wait, and object/handle ops.
+* [ ] **Task 4:** Implement libc core: string, stdlib, errno, assert, minimal stdio, malloc.
+* [ ] **Task 5:** Create POSIX subset matrix and mark each API: native, shim, stub, deferred.
+* [ ] **Task 6:** Implement fd/object model over VFS/service handles.
+* [ ] **Task 7:** Add pthread minimal layer.
+* [ ] **Task 8:** Add `posix_spawn` style launcher before even thinking about `fork`.
+* [ ] **Task 9:** Define Linux personality mapping document.
+* [ ] **Task 10:** Create appliance and drone runtime profiles.


### PR DESCRIPTION
This pull request adds detailed architectural documentation, an ADR, and phased implementation plans for the Bharat-OS SDK, libc, and POSIX compatibility layers.

As requested by the user, these documents define a tiered, mechanism-first approach rather than attempting a monolithic glibc-class implementation inside the core kernel. The new documentation is organized under `docs/architecture/` and `docs/adr/` and covers:
*   **The 3-Layer Architecture:** Details the Core SDK, POSIX shim, and Personality layers.
*   **Target Tiers:** Clarifies the minimal viable platform (Tier A), embedded POSIX subset (Tier B), and personality contracts (Tier C).
*   **Implementation Plan:** A concrete, 6-phase execution plan and task board.
*   **Compatibility Matrix:** Explicit mapping of POSIX support across different profiles (Bring-up, Edge Appliance, Drone/RT).
*   **Personality Model:** Details the behavioral API mapping for the Linux, RT, and Appliance profiles.

---
*PR created automatically by Jules for task [14337714836245028305](https://jules.google.com/task/14337714836245028305) started by @divyang4481*