### PR TITLE
docs: Update AI agent rules to enforce strict execution directives and layering

### DIFF
--- a/.agent/agent.md
+++ b/.agent/agent.md
@@ -33,6 +33,10 @@ Before and during implementation, you MUST reference the `/docs` directory to en
 - **Design Decisions**: Align with recorded ADRs in `/docs/adr`.
 - **Project Context**: Reference `docs/current-code-status.md` and `docs/developer_guidelines.md`.
 
+## Strict Execution Directives (Mandatory)
+
+Do not ask broad clarification questions when the requested change can be inferred from repo context, architecture docs, and existing code. Make a best-effort implementation. Respect Bharat-OS layering: kernel for mechanisms only, services for policy, stacks for composed subsystems, arch for ISA-specific code, hal for contracts/glue, platform for board/machine integration. Any code change must include relevant host/e2e test updates and matching documentation updates. Never state that work is complete unless the relevant tests were executed and their outcomes are reported.
+
 ## Role
 
 You are acting as a **Low-Level Operating System and Kernel Architect** working on the **Bharat-OS** project.

--- a/.clinerules
+++ b/.clinerules
@@ -3,6 +3,12 @@
 - **Role**: Low-Level OS/Kernel Architect.
 - **Goal**: Implement high-performance, hardware-aware kernel subsystems.
 
+## Strict Execution Directives (Mandatory)
+- Do not ask broad clarification questions when the requested change can be inferred from repo context, architecture docs, and existing code. Make a best-effort implementation.
+- Respect Bharat-OS layering: kernel for mechanisms only, services for policy, stacks for composed subsystems, arch for ISA-specific code, hal for contracts/glue, platform for board/machine integration.
+- Any code change must include relevant host/e2e test updates and matching documentation updates.
+- Never state that work is complete unless the relevant tests were executed and their outcomes are reported.
+
 ## Mandatory Compliance
 1. **CMake Policy**: Always use `BharatComponentPolicy.cmake` for new components.
 2. **Profiles**: Adapt subsystems to `BHARAT_DEVICE_PROFILE` (RTOS, WATCH, MOBILE, SERVER, etc.).

--- a/.cursorrules
+++ b/.cursorrules
@@ -18,6 +18,12 @@ Focus on micro-architectural efficiency and hardware-aware programming.
 - `memset_explicit` for sensitive model weights/keys.
 - Validate pointers and alignment for DMA.
 
+## Strict Execution Directives
+- Do not ask broad clarification questions when the requested change can be inferred from repo context, architecture docs, and existing code. Make a best-effort implementation.
+- Respect Bharat-OS layering: kernel for mechanisms only, services for policy, stacks for composed subsystems, arch for ISA-specific code, hal for contracts/glue, platform for board/machine integration.
+- Any code change must include relevant host/e2e test updates and matching documentation updates.
+- Never state that work is complete unless the relevant tests were executed and their outcomes are reported.
+
 ## Workflow Rules (Strict)
 1. **Research First**: Consult `/docs/architecture` and `/docs/adr` before coding.
 2. **Test Always**: Implement Host/Harness/E2E tests after code completion.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,6 +6,9 @@ When you modify build wiring, follow Bharat-OS CMake governance:
 - Respect cache variables: `BHARAT_DEVICE_PROFILE`, `BHARAT_PERSONALITY_PROFILE`, `BHARAT_TARGET_BOARD`.
 - Keep driver/service/subsystem target inclusion policy-driven via `BHARAT_ENABLE_*`.
 
+## Strict Execution Directives (Mandatory)
+Do not ask broad clarification questions when the requested change can be inferred from repo context, architecture docs, and existing code. Make a best-effort implementation. Respect Bharat-OS layering: kernel for mechanisms only, services for policy, stacks for composed subsystems, arch for ISA-specific code, hal for contracts/glue, platform for board/machine integration. Any code change must include relevant host/e2e test updates and matching documentation updates. Never state that work is complete unless the relevant tests were executed and their outcomes are reported.
+
 ## Role & Mission
 You are a Low-Level Operating System and Kernel Architect for Bharat-OS.
 Assist in building a modular kernel for embedded, watch, mobile, automotive, desktop, and datacenter profiles.

--- a/docs/ai-agents/standards/AGENT.md
+++ b/docs/ai-agents/standards/AGENT.md
@@ -4,6 +4,8 @@ Use this document as the shared baseline for any code agent operating in the rep
 
 ## 1) Core Behavior
 
+- **Strict Execution Directives**: Do not ask broad clarification questions when the requested change can be inferred from repo context, architecture docs, and existing code. Make a best-effort implementation.
+- **Respect Layering**: Respect Bharat-OS layering: kernel for mechanisms only, services for policy, stacks for composed subsystems, arch for ISA-specific code, hal for contracts/glue, platform for board/machine integration.
 - Prefer minimal, reversible changes.
 - Read repository instructions before editing (e.g., `AGENTS.md`, contribution docs).
 - Explain assumptions before risky operations.
@@ -32,6 +34,8 @@ Use this document as the shared baseline for any code agent operating in the rep
 
 ## 5) Validation
 
+- Any code change must include relevant host/e2e test updates and matching documentation updates.
+- Never state that work is complete unless the relevant tests were executed and their outcomes are reported.
 - Run the smallest meaningful test set first.
 - If full tests are expensive, run targeted checks and state coverage limits.
 - If checks cannot run, explain the environment limitation clearly.


### PR DESCRIPTION
This pull request updates the documentation instructions for various AI agents (Jules, GitHub Copilot, Cline/Claude, and Cursor) to enforce strict execution directives. These instructions explicitly tell agents to:
- Not ask broad clarification questions when tasks are implementable from context.
- Respect Bharat-OS layering conventions (kernel = mechanisms, services = policy, stacks = composed subsystems, arch = ISA-specific, hal = contracts/glue, platform = board integration).
- Ensure any code change includes relevant host/e2e test updates and matching documentation updates.
- Verify that relevant tests have actually been executed and their outcomes are reported before claiming completion.

These changes apply to `.agent/agent.md`, `.github/copilot-instructions.md`, `.clinerules`, `.cursorrules`, and `docs/ai-agents/standards/AGENT.md`.

---
*PR created automatically by Jules for task [4379769648074454247](https://jules.google.com/task/4379769648074454247) started by @divyang4481*