### PR TITLE
docs: update netmgr capability check status

### DIFF
--- a/docs/architecture/contracts/bidl-overview.md
+++ b/docs/architecture/contracts/bidl-overview.md
@@ -19,7 +19,7 @@ BIDL is designed to act as the single source of truth for all cross-boundary int
 Bharat-OS relies heavily on isolated components communicating via endpoint IPC and cross-core uRPC. However, without a contract definition layer:
 
 1. **Interface Drift:** Ad-hoc request structs and handwritten opcode definitions lead to incompatible ABI breakages.
-2. **Weak Enforcement:** In critical services (like `netmgr`), capability checks currently only verify that a token exists, failing to automatically map specific operations to the granular object rights they require.
+2. **Weak Enforcement:** In critical services (like `netmgr`), capability checks currently fail-closed without an explicit valid token, but they still fail to automatically map specific operations to the granular object rights they require. (The prior unconditional bypass was removed).
 3. **Scaffolded Boilerplate:** Services like `namesvc` and `servicemgr` remain in scaffold states partially because defining their true IPC loops using raw C macros is tedious and error-prone.
 4. **Discovery Disconnect:** Without a structured way to declare an interface version, `namesvc` cannot reliably match clients to compatible service endpoints.
 

--- a/docs/dev/current-code-status.md
+++ b/docs/dev/current-code-status.md
@@ -79,7 +79,7 @@ Implemented modules include:
 
 Current limitations:
 - Main event loop intentionally breaks immediately (daemon runtime not fully wired).
-- Capability checks currently allow all requests (`netmgr_cap_check_rights` returns true).
+- Capability checks now use a strict fail-closed shim via `bharat_cap_validate()` (denies by default). The previous permissive bypass is obsolete, though the full capability lookup engine is still pending.
 - Restart behavior records intent only; no process-manager integration yet.
 
 ## `services/netstack` (data plane)
@@ -98,7 +98,7 @@ Current limitations:
 ## 4) Gap summary (docs-to-code)
 
 1. **Status precision gap**: several services are buildable but still lifecycle scaffolds.
-2. **Enforcement gap**: capability checks in some manager paths are placeholder-permissive.
+2. **Enforcement gap**: capability checks in some manager paths were historically placeholder-permissive; however, the major `netmgr` bypass has been closed (fail-closed shim). Full capability routing is still needed.
 3. **Runtime wiring gap**: multiple daemons initialize state but do not yet run complete production event loops.
 4. **Hardening gap**: observability, failure semantics, and profile-specific guarantees need deeper closure.
 

--- a/docs/gap_analysis/latest_gap_analysis.md
+++ b/docs/gap_analysis/latest_gap_analysis.md
@@ -273,7 +273,7 @@ This roadmap focuses on **closing correctness, ownership, and runtime gaps first
 
 1. Fix scheduler global state → per-core ownership
 2. Redesign TLB shootdown protocol
-3. Implement capability validation in netmgr (pilot)
+3. Implement full capability validation engine in netmgr (pilot)
 4. Build invariant test harness (scheduler + memory)
 5. Convert netmgr into fully running daemon
 
@@ -381,8 +381,8 @@ This roadmap focuses on **closing correctness, ownership, and runtime gaps first
 
 **Tasks**
 
-* Replace permissive token-valid logic with object/right/scope validation
-* Add deny-by-default behavior
+* Replace basic fail-closed shim with full object/right/scope validation
+* Maintain deny-by-default behavior (implemented via shim)
 * Add audit logging for capability failures
 * Add negative-path tests for unauthorized IPC
 
@@ -691,7 +691,7 @@ This roadmap focuses on **closing correctness, ownership, and runtime gaps first
 
 * E0-S1 Eliminate global scheduler registries
 * E0-S2 Bounded TLB shootdown protocol
-* E1-S1 Pilot strict capability checks in netmgr
+* E1-S1 Pilot full capability enforcement in netmgr
 * E0-S3 PMM ownership and per-core magazines
 
 ### Sprint Block B — Runtime Legitimacy
@@ -724,7 +724,7 @@ This roadmap focuses on **closing correctness, ownership, and runtime gaps first
 
 1. Scheduler per-core ownership
 2. TLB shootdown redesign
-3. netmgr strict capability enforcement
+3. netmgr full capability enforcement
 4. PMM per-core magazines + ownership tests
 5. process_manager / memory runtime implementation by profile
 


### PR DESCRIPTION
Reflect that `netmgr_cap_check_rights` no longer permits an unconditional bypass and uses a strict fail-closed shim instead across architecture and gap analysis documents.

---
*PR created automatically by Jules for task [9825673537996950554](https://jules.google.com/task/9825673537996950554) started by @divyang4481*