### PR TITLE
Enforce address-space profile legality at central aspace creation

### DIFF
--- a/docs/architecture/memory/memory-model-capability-matrix.md
+++ b/docs/architecture/memory/memory-model-capability-matrix.md
@@ -27,6 +27,28 @@ These map logically to hardware profiles:
 
 By querying `aspace_profile_get_current()`, core process/scheduler implementations can reject advanced VM assumptions on constrained profiles seamlessly.
 
+### Mapping intent
+
+- `mem_model_t` answers: what protection mechanism exists?
+- `ASPACE_PROFILE_*` answers: what address-space creation semantics are allowed?
+
+“Flat” is an address-space/runtime profile concept, not a hardware memory model.
+
+### Enforcement rule
+
+Constrained profiles must reject unsupported rich/full-VM creation semantics explicitly.
+They must not silently proceed through the normal full-VM creation path.
+
+Current conservative rule:
+- `flags == 0` → basic creation
+- `flags != 0` → treated as rich/full-VM semantics unless explicitly classified otherwise
+
+Therefore:
+- `ASPACE_PROFILE_FULL` allows rich creation semantics
+- `ASPACE_PROFILE_SPLIT` is permissive in this PR
+- `ASPACE_PROFILE_FLAT` rejects rich creation semantics
+- `ASPACE_PROFILE_REGION_ONLY` rejects rich creation semantics
+
 ## The Memory Model Contract and Unsupported Operations
 
 When an architecture does not support a specific feature (e.g. page-granular protection on an MPU), it **must fail explicitly**.

--- a/kernel/src/mm/vm/aspace/aspace.c
+++ b/kernel/src/mm/vm/aspace/aspace.c
@@ -10,16 +10,61 @@
 
 static uint64_t next_as_id = 1;
 
+static bool aspace_flags_require_rich_vm(uint32_t flags)
+{
+    /*
+     * Conservative rule:
+     * - flags == 0 means basic creation
+     * - any unknown/non-zero flags are treated as requiring rich VM
+     *
+     * This keeps constrained profiles honest until a fuller flag taxonomy
+     * exists.
+     */
+    if (flags == 0) {
+        return false;
+    }
+
+    return true;
+}
+
+static bool aspace_profile_allows_create(aspace_profile_t profile, uint32_t flags)
+{
+    const bool rich = aspace_flags_require_rich_vm(flags);
+
+    if (!rich) {
+        return true;
+    }
+
+    switch (profile) {
+        case ASPACE_PROFILE_FULL:
+            return true;
+
+        case ASPACE_PROFILE_SPLIT:
+            /*
+             * Keep SPLIT permissive in this PR unless there is already an
+             * existing semantic in-tree that must be rejected.
+             */
+            return true;
+
+        case ASPACE_PROFILE_FLAT:
+        case ASPACE_PROFILE_REGION_ONLY:
+            return false;
+
+        default:
+            return false;
+    }
+}
+
 int aspace_create(address_space_t **out_aspace, uint32_t flags) {
     if (!out_aspace) return -1;
 
-    // Reject unsupported rich creation flags on constrained profiles
     aspace_profile_t profile = aspace_profile_get_current();
-    if (profile == ASPACE_PROFILE_REGION_ONLY || profile == ASPACE_PROFILE_FLAT) {
-        // Here we could explicitly check flags that imply full VM semantics (e.g. fork/clone like COW setup).
-        // Since we are maintaining existing behavior for FULL, we let normal setup proceed but
-        // explicitly fail if deep VM flags are passed which constrained modes don't support.
-        // For now, if someone passes clone_flags indicating full rich VM expectations, we would reject.
+    if (!aspace_profile_is_supported(mem_model_get_current(), profile)) {
+        return -1; // Or BHARAT_ERR_NOT_SUPPORTED equivalent
+    }
+
+    if (!aspace_profile_allows_create(profile, flags)) {
+        return -1; // Explicitly reject unsupported rich/full-VM semantics
     }
 
     address_space_t *as = (address_space_t *)kmalloc(sizeof(address_space_t));

--- a/kernel/src/mm/vm/distributed/vmm.c
+++ b/kernel/src/mm/vm/distributed/vmm.c
@@ -124,15 +124,40 @@ phys_addr_t vmm_get_kernel_root(void) {
     return kernel_root_pt;
 }
 
-address_space_t *mm_create_address_space(void) {
+static bool vmm_create_request_obviously_illegal(uint32_t flags)
+{
     aspace_profile_t profile = aspace_profile_get_current();
-    // Do not assume full VM creation if the profile does not support it
-    if (profile == ASPACE_PROFILE_REGION_ONLY) {
-        // Reject full VM address space creation entirely or pass explicit region-only flags in the future
+
+    if (!aspace_profile_is_supported(mem_model_get_current(), profile)) {
+        return true;
+    }
+
+    if (flags == 0) {
+        return false;
+    }
+
+    switch (profile) {
+        case ASPACE_PROFILE_FULL:
+        case ASPACE_PROFILE_SPLIT:
+            return false;
+
+        case ASPACE_PROFILE_FLAT:
+        case ASPACE_PROFILE_REGION_ONLY:
+            return true;
+
+        default:
+            return true;
+    }
+}
+
+address_space_t *mm_create_address_space(void) {
+    uint32_t create_flags = 0; // Legacy basic creation
+    if (vmm_create_request_obviously_illegal(create_flags)) {
+        return NULL;
     }
 
     address_space_t *as = NULL;
-    if (aspace_create(&as, 0) != 0) return NULL;
+    if (aspace_create(&as, create_flags) != 0) return NULL;
     return as;
 }
 

--- a/kernel/src/mm/vmm.c
+++ b/kernel/src/mm/vmm.c
@@ -206,17 +206,40 @@ int vmm_handle_cow_fault(address_space_t* as, virt_addr_t vaddr) {
     return (res == VM_FAULT_RESOLVED) ? 0 : -1;
 }
 
-address_space_t *mm_create_address_space(void) {
+static bool vmm_create_request_obviously_illegal(uint32_t flags)
+{
     aspace_profile_t profile = aspace_profile_get_current();
-    // Do not assume full VM creation if the profile does not support it
-    if (profile == ASPACE_PROFILE_REGION_ONLY) {
-        // Reject full VM address space creation entirely or pass explicit region-only flags in the future
-        // For now, if we are in a purely static MPU environment where dynamic aspace creation is unsupported:
-        // return NULL; (but for testing, we will just pass through to aspace_create which handles it)
+
+    if (!aspace_profile_is_supported(mem_model_get_current(), profile)) {
+        return true;
+    }
+
+    if (flags == 0) {
+        return false;
+    }
+
+    switch (profile) {
+        case ASPACE_PROFILE_FULL:
+        case ASPACE_PROFILE_SPLIT:
+            return false;
+
+        case ASPACE_PROFILE_FLAT:
+        case ASPACE_PROFILE_REGION_ONLY:
+            return true;
+
+        default:
+            return true;
+    }
+}
+
+address_space_t *mm_create_address_space(void) {
+    uint32_t create_flags = 0; // Legacy basic creation
+    if (vmm_create_request_obviously_illegal(create_flags)) {
+        return NULL;
     }
 
     address_space_t *as = NULL;
-    if (aspace_create(&as, 0) != 0) return NULL;
+    if (aspace_create(&as, create_flags) != 0) return NULL;
     return as;
 }
 

--- a/tests/test_vmm_aspace.c
+++ b/tests/test_vmm_aspace.c
@@ -4,6 +4,7 @@
 #include "../kernel/include/mm/aspace.h"
 #include "../kernel/include/mm/vm_object.h"
 #include "../kernel/include/hal/hal_pt.h"
+#include "../kernel/include/mm/aspace_profile.h"
 
 #define TEST(name) void name()
 #define ASSERT_EQ(a, b) assert((a) == (b))
@@ -225,6 +226,47 @@ TEST(vm_object_lifecycle_hardening) {
     printf("Passed vm_object_lifecycle_hardening\n");
 }
 
+// Mocks for mm_model and aspace_profile to test create constraints
+mem_model_t mock_mem_model = MEM_MODEL_MMU_FULL;
+// aspace_profile_t mock_aspace_profile = ASPACE_PROFILE_FULL; // Removed since we map directly from mem_model
+
+mem_model_t mem_model_get_current(void) {
+    return mock_mem_model;
+}
+
+TEST(aspace_create_profile_enforcement) {
+    printf("Running aspace_create_profile_enforcement...\n");
+    address_space_t *as = NULL;
+
+    // 1. FULL + rich create (flags=1) -> PASS
+    mock_mem_model = MEM_MODEL_MMU_FULL;
+    ASSERT_EQ(0, aspace_create(&as, 1));
+    aspace_destroy(as);
+
+    // 2. FULL + basic create (flags=0) -> PASS
+    mock_mem_model = MEM_MODEL_MMU_FULL;
+    ASSERT_EQ(0, aspace_create(&as, 0));
+    aspace_destroy(as);
+
+    // 3. REGION_ONLY + rich create -> FAIL
+    mock_mem_model = MEM_MODEL_MPU; // implies REGION_ONLY
+    ASSERT_NE(0, aspace_create(&as, 1));
+
+    // 4. REGION_ONLY + basic create -> PASS
+    mock_mem_model = MEM_MODEL_MPU; // implies REGION_ONLY
+    ASSERT_EQ(0, aspace_create(&as, 0));
+    aspace_destroy(as);
+
+    // 5. FLAT + rich create -> FAIL
+    // For tests, we use MMU_LITE which implies SPLIT in aspace_profile_get_for_model
+    // We cannot easily inject FLAT here without changing aspace_profile.h, but we can test
+    // that constrained profiles block rich. Since LITE defaults to SPLIT and we left SPLIT permissive,
+    // this test for FLAT would need us to be able to mock the profile directly, which is inline.
+    // Let's rely on MPU -> REGION_ONLY test for the rejection path logic.
+
+    printf("Passed aspace_create_profile_enforcement\n");
+}
+
 int main() {
     hal_pt_init(); // Needs mock
     extern void prot_domain_init(void);
@@ -237,6 +279,7 @@ int main() {
     aspace_lookup_authoritative_without_pt_mapping();
     vm_object_kinds_basic_construction();
     vm_object_lifecycle_hardening();
+    aspace_create_profile_enforcement();
 
     printf("All ASPACE tests passed successfully!\n");
     return 0;


### PR DESCRIPTION
This change makes ASPACE_PROFILE_* enforceable at the central address-space creation boundary.

Previously, constrained profiles such as FLAT and REGION_ONLY were recognized in comments but still fell through the normal creation path. This PR adds explicit legality checks so unsupported rich/full-VM semantics fail deterministically instead of silently succeeding.

This PR intentionally stays narrow:
- no new public flags
- no backend redesign
- no PMM/TLB/scheduler changes

The legality rule is conservative for now:
- flags == 0 => basic create
- flags != 0 => treated as rich/full-VM semantics

This keeps constrained targets honest until a fuller flag taxonomy is introduced later.

---
*PR created automatically by Jules for task [12227796289348575270](https://jules.google.com/task/12227796289348575270) started by @divyang4481*