### PR TITLE
Enforce constrained address-space profile legality in central aspace creation

### DIFF
--- a/kernel/src/mm/vm/aspace/aspace.c
+++ b/kernel/src/mm/vm/aspace/aspace.c
@@ -7,6 +7,7 @@
 #include "../../../../include/numa.h"
 #include "../../../../include/slab.h"
 #include "../../../../include/mm/aspace_profile.h"
+#include "../../../../include/kernel/status.h"
 
 static uint64_t next_as_id = 1;
 
@@ -56,19 +57,19 @@ static bool aspace_profile_allows_create(aspace_profile_t profile, uint32_t flag
 }
 
 int aspace_create(address_space_t **out_aspace, uint32_t flags) {
-    if (!out_aspace) return -1;
+    if (!out_aspace) return K_ERR_INVALID_ARG;
 
     aspace_profile_t profile = aspace_profile_get_current();
     if (!aspace_profile_is_supported(mem_model_get_current(), profile)) {
-        return -1; // Or BHARAT_ERR_NOT_SUPPORTED equivalent
+        return K_ERR_UNSUPPORTED; // Explicitly reject unsupported combinations
     }
 
     if (!aspace_profile_allows_create(profile, flags)) {
-        return -1; // Explicitly reject unsupported rich/full-VM semantics
+        return K_ERR_PROFILE_RESTRICTED; // Explicitly reject unsupported rich/full-VM semantics
     }
 
     address_space_t *as = (address_space_t *)kmalloc(sizeof(address_space_t));
-    if (!as) return -1;
+    if (!as) return K_ERR_NO_MEMORY;
 
     if (!active_hal_pt) hal_pt_init();
 

--- a/kernel/src/mm/vm/distributed/vmm.c
+++ b/kernel/src/mm/vm/distributed/vmm.c
@@ -124,39 +124,11 @@ phys_addr_t vmm_get_kernel_root(void) {
     return kernel_root_pt;
 }
 
-static bool vmm_create_request_obviously_illegal(uint32_t flags)
-{
-    aspace_profile_t profile = aspace_profile_get_current();
-
-    if (!aspace_profile_is_supported(mem_model_get_current(), profile)) {
-        return true;
-    }
-
-    if (flags == 0) {
-        return false;
-    }
-
-    switch (profile) {
-        case ASPACE_PROFILE_FULL:
-        case ASPACE_PROFILE_SPLIT:
-            return false;
-
-        case ASPACE_PROFILE_FLAT:
-        case ASPACE_PROFILE_REGION_ONLY:
-            return true;
-
-        default:
-            return true;
-    }
-}
-
 address_space_t *mm_create_address_space(void) {
     uint32_t create_flags = 0; // Legacy basic creation
-    if (vmm_create_request_obviously_illegal(create_flags)) {
-        return NULL;
-    }
-
     address_space_t *as = NULL;
+
+    // Defer explicit legality checks entirely to the authoritative aspace_create boundary
     if (aspace_create(&as, create_flags) != 0) return NULL;
     return as;
 }

--- a/kernel/src/mm/vmm.c
+++ b/kernel/src/mm/vmm.c
@@ -206,39 +206,11 @@ int vmm_handle_cow_fault(address_space_t* as, virt_addr_t vaddr) {
     return (res == VM_FAULT_RESOLVED) ? 0 : -1;
 }
 
-static bool vmm_create_request_obviously_illegal(uint32_t flags)
-{
-    aspace_profile_t profile = aspace_profile_get_current();
-
-    if (!aspace_profile_is_supported(mem_model_get_current(), profile)) {
-        return true;
-    }
-
-    if (flags == 0) {
-        return false;
-    }
-
-    switch (profile) {
-        case ASPACE_PROFILE_FULL:
-        case ASPACE_PROFILE_SPLIT:
-            return false;
-
-        case ASPACE_PROFILE_FLAT:
-        case ASPACE_PROFILE_REGION_ONLY:
-            return true;
-
-        default:
-            return true;
-    }
-}
-
 address_space_t *mm_create_address_space(void) {
     uint32_t create_flags = 0; // Legacy basic creation
-    if (vmm_create_request_obviously_illegal(create_flags)) {
-        return NULL;
-    }
-
     address_space_t *as = NULL;
+
+    // Defer explicit legality checks entirely to the authoritative aspace_create boundary
     if (aspace_create(&as, create_flags) != 0) return NULL;
     return as;
 }

--- a/tests/test_vmm_aspace.c
+++ b/tests/test_vmm_aspace.c
@@ -262,7 +262,8 @@ TEST(aspace_create_profile_enforcement) {
     // We cannot easily inject FLAT here without changing aspace_profile.h, but we can test
     // that constrained profiles block rich. Since LITE defaults to SPLIT and we left SPLIT permissive,
     // this test for FLAT would need us to be able to mock the profile directly, which is inline.
-    // Let's rely on MPU -> REGION_ONLY test for the rejection path logic.
+    // TODO: Add a test seam to explicitly test FLAT profile behavior once architecture allows easier mocking,
+    // for now, we rely on the MPU -> REGION_ONLY test for the constrained rejection path logic.
 
     printf("Passed aspace_create_profile_enforcement\n");
 }


### PR DESCRIPTION
This pull request tightens central address-space legality checks to explicitly reject unsupported rich/full-VM creation semantics when a constrained address space profile is active, substituting placeholder comments with real validation utilizing `K_ERR_UNSUPPORTED` and `K_ERR_PROFILE_RESTRICTED` kernel status constants.

This acts on the final required piece of PR 3 for constrained profiles, ensuring they explicitly fail when requested to do something beyond their capability matrix (like dynamic virtual memory features on MPU).

- Replaced mock comment return values (`-1`) in `aspace_create()` with `K_ERR_UNSUPPORTED` and `K_ERR_PROFILE_RESTRICTED` constants.
- Avoided repeating the policy logic inside `mm_create_address_space()` for both standard and distributed VM managers, deferring the strict checks entirely back to `aspace_create()`.
- Added a `TODO` inside the `test_vmm_aspace.c` test suite highlighting the exact test coverage limitations for the `FLAT` profile and justifying using the `MPU` coverage for enforcement validation.

---
*PR created automatically by Jules for task [11262381322650502944](https://jules.google.com/task/11262381322650502944) started by @divyang4481*