### PR TITLE
feat: Unified Multi-Arch SMP Run Matrix

### DIFF
--- a/build_config.json
+++ b/build_config.json
@@ -18,6 +18,15 @@
       "gui": false,
       "run": false
     },
+    "arm32_virt_mmu": {
+      "preset": "arm32-edge",
+      "arch": "arm32",
+      "profile": "EDGE",
+      "personality": "NATIVE",
+      "board": "virt",
+      "gui": false,
+      "run": false
+    },
     "arm64_desktop_mmu": {
       "preset": "arm64-edge",
       "arch": "arm64",

--- a/docs/testing/run-matrix.md
+++ b/docs/testing/run-matrix.md
@@ -1,0 +1,47 @@
+# Unified Multi-Arch SMP Run Matrix
+
+Bharat-OS supports a systematic execution matrix to test Single-core (UP) and Multi-core (SMP) operations across varying architectures and execution profiles.
+
+## Architecture & Board Support
+
+The runtime behavior and SMP capability differ based on the target architecture and the underlying machine/board selected:
+
+| Arch    | Board           | Runner                | SMP Supported | Notes                                      |
+| ------- | --------------- | --------------------- | ------------- | ------------------------------------------ |
+| x86_64  | qemu-virt       | `qemu-system-x86_64`  | ✅           | Stable SMP. Uses `q35` machine.            |
+| arm64   | virt            | `qemu-system-aarch64` | ✅           | Stable SMP. Uses `virt` machine.           |
+| riscv64 | virt            | `qemu-system-riscv64` | ✅           | Stable SMP. Uses `virt` machine.           |
+| arm32   | virt            | `qemu-system-arm`     | ✅           | Cortex-A15 SMP via QEMU virt.              |
+| arm32   | avh-corstone310 | `VHT_Corstone_SSE-310`| ❌           | Cortex-M single-core board. No SMP support.|
+| riscv32 | virt            | `qemu-system-riscv32` | ⚠️           | Experimental.                              |
+
+## Usage
+
+The centralized runner is `tools/build.py` (which powers the wrappers `./build.sh` and `.\build.ps1`).
+
+### Specify CPUs
+
+To test an SMP configuration, you can pass the `--cpus` option alongside the run flags. Note that SMP must be supported by the run target as defined in the matrix above.
+
+```bash
+# Run on 1 CPU
+./build.sh x86_64_desktop_mmu --run --cpus 1
+
+# Run on 4 CPUs
+./build.sh x86_64_desktop_mmu --run --cpus 4
+
+# Run ARM32 with SMP (virt path)
+./build.sh arm32_virt_mmu --run --cpus 2
+```
+
+If you specify `--cpus N` (where N > 1) for a board without SMP support (like `avh-corstone310`), the runner will intentionally fail rather than pretending to provide SMP capabilities.
+
+### Matrix Mode
+
+For a powerful, automated approach, you can run a pre-curated test matrix using the `--matrix` option:
+
+```bash
+./build.sh --matrix
+```
+
+This sequentially configures, builds, and runs headless tests against a curated list of build configurations and CPU counts, including single-core and multi-core configurations across architectures. At the conclusion of the matrix execution, a summary is provided showing the pass/fail status of each configuration.

--- a/tools/build.py
+++ b/tools/build.py
@@ -132,11 +132,29 @@ def do_clean(build_cfg):
     if os.path.exists(build_dir):
         run_command(['cmake', '--build', f'--preset={preset}', '--target', 'clean'])
 
-def do_run(build_cfg, dual_serial, run_tests=False):
+RUN_MATRIX = {
+    ("x86_64", "qemu-virt"): {"runner": "qemu-system-x86_64", "machine": "q35", "smp_supported": True},
+    ("arm64", "virt"): {"runner": "qemu-system-aarch64", "machine": "virt", "cpu": "cortex-a57", "smp_supported": True},
+    ("riscv64", "virt"): {"runner": "qemu-system-riscv64", "machine": "virt", "smp_supported": True},
+    ("arm32", "avh-corstone310"): {"runner": "VHT_Corstone_SSE-310", "smp_supported": False},
+    ("arm32", "virt"): {"runner": "qemu-system-arm", "machine": "virt", "cpu": "cortex-a15", "smp_supported": True},
+    ("riscv32", "virt"): {"runner": "qemu-system-riscv32", "machine": "virt", "smp_supported": True},
+}
+
+def do_run(build_cfg, dual_serial, run_tests=False, cpus=1):
     arch = build_cfg.get('arch')
     board = build_cfg.get('board', '')
     gui = build_cfg.get('gui', False)
     preset = build_cfg.get('preset')
+
+    target_key = (arch, board)
+    run_config = RUN_MATRIX.get(target_key)
+    if not run_config:
+        print(f"Unsupported run configuration for arch {arch} board {board}")
+        sys.exit(1)
+
+    if cpus > 1 and not run_config.get("smp_supported", False):
+        raise Exception(f"SMP not supported on this target (arch: {arch}, board: {board})")
 
     kernel_path = os.path.join('build', preset, 'kernel', 'kernel.elf')
     if not os.path.exists(kernel_path):
@@ -173,19 +191,73 @@ def do_run(build_cfg, dual_serial, run_tests=False):
     else:
         qemu_opts.extend(['-serial', 'stdio', '-display', 'none'])
 
-    if arch == 'x86_64':
-        cmd = ['qemu-system-x86_64', '-kernel', run_kernel, '-m', '512'] + qemu_opts
-    elif arch == 'arm64':
-        cmd = ['qemu-system-aarch64', '-kernel', run_kernel, '-m', '512'] + qemu_opts
-    elif arch == 'riscv64':
-        cmd = ['qemu-system-riscv64', '-kernel', run_kernel, '-m', '512'] + qemu_opts
-    elif arch == 'arm32' and board == 'avh-corstone310':
-        cmd = ['VHT_Corstone_SSE-310', '-a', run_kernel] + qemu_opts
-    else:
-        print(f"Unsupported run configuration for arch {arch} board {board}")
-        sys.exit(1)
+    runner = run_config.get("runner")
 
+    if runner == 'VHT_Corstone_SSE-310':
+        cmd = [runner, '-a', run_kernel] + qemu_opts
+    else:
+        cmd = [runner, '-kernel', run_kernel, '-m', '512']
+        if "machine" in run_config:
+            cmd.extend(['-machine', run_config["machine"]])
+        if "cpu" in run_config:
+            cmd.extend(['-cpu', run_config["cpu"]])
+        if run_config.get("smp_supported", False) and cpus > 1:
+            cmd.extend(['-smp', str(cpus)])
+        cmd.extend(qemu_opts)
+
+    print(f"[RUN] Arch: {arch} | CPUs: {cpus} | Board: {board}")
     run_command(cmd)
+
+def do_matrix(manifest):
+    matrix_targets = [
+        ("x86_64_desktop_mmu", 1),
+        ("x86_64_desktop_mmu", 4),
+        ("arm64_desktop_mmu", 1),
+        ("arm64_desktop_mmu", 4),
+        ("riscv64_desktop_mmu", 1),
+        ("riscv64_desktop_mmu", 4),
+        ("arm32_edge_mpu", 1),
+        ("arm32_virt_mmu", 1),
+        ("arm32_virt_mmu", 2),
+        ("riscv32_edge_mmu_lite", 1),
+    ]
+
+    results = []
+
+    for build_name, cpus in matrix_targets:
+        print(f"\n{'='*60}")
+        print(f"MATRIX RUN: {build_name} with {cpus} CPU(s)")
+        print(f"{'='*60}\n")
+
+        if build_name not in manifest.get('builds', {}):
+            print(f"Warning: Build '{build_name}' not found in manifest. Skipping.")
+            results.append((build_name, cpus, "SKIPPED"))
+            continue
+
+        build_cfg = manifest['builds'][build_name]
+
+        try:
+            do_configure(build_cfg)
+            do_build(build_cfg)
+            do_run(build_cfg, dual_serial=False, run_tests=True, cpus=cpus)
+            results.append((build_name, cpus, "PASS"))
+        except SystemExit as e:
+            if e.code == 0:
+                results.append((build_name, cpus, "PASS"))
+            else:
+                results.append((build_name, cpus, "FAIL"))
+        except Exception as e:
+            print(f"Error during matrix run for {build_name}: {e}")
+            results.append((build_name, cpus, "FAIL"))
+
+    print("\n" + "="*60)
+    print("MATRIX SUMMARY")
+    print("="*60)
+    print(f"{'Build Name':<30} | {'CPUs':<4} | {'Status'}")
+    print("-" * 60)
+    for build_name, cpus, status in results:
+        print(f"{build_name:<30} | {cpus:<4} | {status}")
+    print("="*60 + "\n")
 
 def main():
     # Detect legacy flags and provide a friendly migration error
@@ -221,6 +293,8 @@ def main():
     parser.add_argument('--test', action='store_true', help='Run tests (host)')
     parser.add_argument('--run-tests', action='store_true', help='Run user-space and kernel tests in emulator (headless)')
     parser.add_argument('--dual-serial', action='store_true', help='Use dual serial ports in emulator')
+    parser.add_argument('--cpus', type=int, default=1, help='Number of CPUs for SMP run (if supported)')
+    parser.add_argument('--matrix', action='store_true', help='Run the execution matrix sequentially')
 
     args = parser.parse_args()
 
@@ -232,6 +306,10 @@ def main():
 
     if args.list:
         print_list(manifest)
+        return
+
+    if args.matrix:
+        do_matrix(manifest)
         return
 
     if args.build_name not in manifest.get('builds', {}):
@@ -261,7 +339,7 @@ def main():
         do_test(build_cfg)
 
     if args.run or args.run_tests:
-        do_run(build_cfg, args.dual_serial, args.run_tests)
+        do_run(build_cfg, args.dual_serial, args.run_tests, args.cpus)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
This PR implements the requested board-aware multi-architecture SMP execution matrix for `tools/build.py`. 

**Features Included:**
* `arm32_virt_mmu` configuration added to `build_config.json` enabling the `qemu-system-arm` `virt` board path for Cortex-A15 SMP emulation without clashing with the existing Cortex-M `avh-corstone310` target.
* `RUN_MATRIX` dictionary inside `tools/build.py` keys targets by `(arch, board)` directly defining their QEMU runners, specific `-machine`/`-cpu` flags, and a hard boolean `smp_supported` check.
* CLI arguments extended to include `--cpus N` and `--matrix`.
* Safety validation checks user-defined `--cpus` against the `RUN_MATRIX` ensuring QEMU is only given `-smp N` if the target is explicitly permitted.
* `--matrix` sequentially loops a curated list of build configurations, triggering `do_configure`, `do_build`, and headless `do_run(run_tests=True)` logic per item, terminating with an easy-to-read PASS/FAIL/SKIPPED summary table.
* Added `docs/testing/run-matrix.md` documentation explaining matrix usage and constraints.

---
*PR created automatically by Jules for task [8615742224678487267](https://jules.google.com/task/8615742224678487267) started by @divyang4481*