### PR TITLE
Fix userspace entrypoint by introducing deterministic crt0 linking

### DIFF
--- a/cmake/modules/BharatCommon.cmake
+++ b/cmake/modules/BharatCommon.cmake
@@ -119,14 +119,21 @@ function(bharat_configure_userspace_library TARGET_NAME)
 endfunction()
 
 function(bharat_configure_userspace_binary TARGET_NAME)
+    # Inject the runtime crt0 object directly into the binary
+    if (TARGET bharat_crt0)
+        target_sources(${TARGET_NAME} PRIVATE $<TARGET_OBJECTS:bharat_crt0>)
+        # Make sure every binary implicitly links the syscalls needed by crt0 (bharat_exit)
+        target_link_libraries(${TARGET_NAME} PRIVATE bharat_syscall)
+    endif()
+
     if(BHARAT_USERSPACE_PIE)
         set_target_properties(${TARGET_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
         target_compile_options(${TARGET_NAME} PRIVATE -fPIE)
-        target_link_options(${TARGET_NAME} PRIVATE -nostdlib -pie)
+        target_link_options(${TARGET_NAME} PRIVATE -nostdlib -nostartfiles -pie)
     else()
         set_target_properties(${TARGET_NAME} PROPERTIES POSITION_INDEPENDENT_CODE OFF)
         target_compile_options(${TARGET_NAME} PRIVATE -fno-pie -fno-PIC)
-        target_link_options(${TARGET_NAME} PRIVATE -nostdlib "LINKER:-no-pie")
+        target_link_options(${TARGET_NAME} PRIVATE -nostdlib -nostartfiles "LINKER:-no-pie")
     endif()
 endfunction()
 

--- a/lib/runtime/CMakeLists.txt
+++ b/lib/runtime/CMakeLists.txt
@@ -1,6 +1,11 @@
 cmake_minimum_required(VERSION 3.20)
 project(BharatOS_Lib_Runtime C ASM)
 
+# Create crt0 as an OBJECT library so it can be explicitly linked into every binary
+add_library(bharat_crt0 OBJECT src/crt0.c)
+target_include_directories(bharat_crt0 PUBLIC include)
+target_link_libraries(bharat_crt0 PUBLIC bharat_freestanding bharat_syscall)
+
 # Add the lib/runtime static library
 add_library(bharat_libruntime STATIC src/runtime.c src/freestanding_string.c)
 
@@ -8,7 +13,7 @@ add_library(bharat_libruntime STATIC src/runtime.c src/freestanding_string.c)
 target_include_directories(bharat_libruntime PUBLIC include)
 
 # Runtime depends on cap and ipc headers
-target_link_libraries(bharat_libruntime PUBLIC cap ipc bharat_freestanding)
+target_link_libraries(bharat_libruntime PUBLIC cap ipc bharat_syscall bharat_freestanding)
 bharat_configure_userspace_library(bharat_libruntime)
 
 # Alias for compatibility

--- a/lib/runtime/src/crt0.c
+++ b/lib/runtime/src/crt0.c
@@ -1,0 +1,12 @@
+#include <stdint.h>
+
+extern int main(int argc, char** argv);
+extern void bharat_exit(int status);
+
+__attribute__((used))
+void _start(void) {
+    // For now, simple _start for freestanding C
+    int ret = main(0, 0);
+    bharat_exit(ret);
+    while (1) {}
+}

--- a/user/sdk/CMakeLists.txt
+++ b/user/sdk/CMakeLists.txt
@@ -51,13 +51,13 @@ endif()
 
 # Sample Application
 add_executable(sample_app sample_app/main.c)
-target_link_libraries(sample_app PRIVATE bharat bharat_user_buildopts bharat_freestanding)
 
-# If building standalone, we need to ensure the executable is built without host stdlib
-if (NOT TARGET bharat_user_buildopts)
-    target_compile_options(sample_app PRIVATE -ffreestanding -nostdlib -fPIC)
-    target_link_options(sample_app PRIVATE -nostdlib -pie)
+# Note: In an integrated build, we should just use the global function
+if (TARGET bharat_crt0)
+    bharat_configure_userspace_binary(sample_app)
+    target_link_libraries(sample_app PRIVATE bharat bharat_user_buildopts bharat_freestanding)
 else()
-    target_compile_options(sample_app PRIVATE -fPIC)
+    target_link_libraries(sample_app PRIVATE bharat)
+    target_compile_options(sample_app PRIVATE -ffreestanding -nostdlib -fPIC)
     target_link_options(sample_app PRIVATE -nostdlib -pie)
 endif()

--- a/user/sdk/sample_app/main.c
+++ b/user/sdk/sample_app/main.c
@@ -2,7 +2,6 @@
 #include <stddef.h>
 
 extern int bharat_write(int fd, const void* buf, size_t count);
-extern void bharat_exit(int status);
 
 // Minimal print for demo
 void print(const char *msg) {
@@ -11,13 +10,7 @@ void print(const char *msg) {
     bharat_write(1, msg, len);
 }
 
-// The entry point for the sample app
-void _start_app() {
-    print("Hello from Bharat-OS SDK Sample App!\n");
-    bharat_exit(0);
-}
-
 int main() {
-    _start_app();
+    print("Hello from Bharat-OS SDK Sample App!\n");
     return 0;
 }


### PR DESCRIPTION
Fixes linker warnings for `cannot find entry symbol _start` when building userspace binaries by explicitly injecting a `crt0` object library into all userspace executables.

---
*PR created automatically by Jules for task [6406079144673685103](https://jules.google.com/task/6406079144673685103) started by @divyang4481*