### PR TITLE
build: Default-off scaffold services in normal developer builds

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -56,8 +56,11 @@ Edit `build_config.json` to define your target composition (e.g. arch, UI on/off
 
 ```bash
 # Linux/Mac/WSL
-# Build the default_dev profile
+# Build the default_dev profile (conservative, disables scaffold-heavy service groups)
 ./build.sh default_dev
+
+# Build the experimental services profile (enables scaffold-heavy experimental services)
+./build.sh experimental_services
 
 # Build and run immediately in QEMU
 ./build.sh default_dev --run

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -657,6 +657,22 @@
         "BHARAT_TARGET_BOARD": "virt",
         "BHARAT_BOOT_GUI": "OFF"
       }
+    },
+    {
+      "name": "experimental-services",
+      "displayName": "Experimental Services Build (Debug)",
+      "description": "Build with all scaffold-heavy experimental service groups enabled",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/experimental-services",
+      "toolchainFile": "${sourceDir}/cmake/toolchains/x86_64-elf-clang.cmake",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "BHARAT_DEVICE_PROFILE": "DESKTOP",
+        "BHARAT_TARGET_BOARD": "qemu-virt",
+        "BHARAT_BUILD_USER_SERVICES_STUBS": "ON",
+        "BHARAT_BUILD_CORE_SERVICES": "ON",
+        "BHARAT_BUILD_NETWORK_STUBS": "ON"
+      }
     }
   ],
   "buildPresets": [
@@ -831,6 +847,10 @@
     {
       "name": "riscv32-iot-release",
       "configurePreset": "riscv32-iot-release"
+    },
+    {
+      "name": "experimental-services",
+      "configurePreset": "experimental-services"
     }
   ],
   "testPresets": [

--- a/build_config.json
+++ b/build_config.json
@@ -1,5 +1,14 @@
 {
   "builds": {
+    "experimental_services": {
+      "preset": "experimental-services",
+      "arch": "x86_64",
+      "profile": "DESKTOP",
+      "personality": "NATIVE",
+      "board": "qemu-virt",
+      "gui": false,
+      "run": false
+    },
     "default_dev": {
       "preset": "x86_64-debug",
       "arch": "x86_64",

--- a/docs/dev/current-code-status.md
+++ b/docs/dev/current-code-status.md
@@ -30,9 +30,9 @@ Use these labels consistently across status docs and roadmap updates:
 
 ### Service composition
 - Always built: `process_manager`, `vm_manager`, `file_system`, `drivers`, `crypto`, `console`, `boot_displayd`, legacy `net`.
-- Default-on option groups:
+- Default-off option groups (enabled in experimental presets):
   - `BHARAT_BUILD_USER_SERVICES_STUBS=ON`: `init`, `namesvc`, `servicemgr`.
-  - `BHARAT_BUILD_CORE_SERVICES=ON`: `coremgr`, `memmgr`, `schedmgr`, `devmgr`, `accelmgr`, `storagemgr`, `faultmgr`, `telemetrymgr`.
+  - `BHARAT_BUILD_CORE_SERVICES=ON`: `coremgr`, `memmgr`, `schedmgr`, `devmgr`, `storagemgr`, `faultmgr`, `telemetrymgr`.
   - `BHARAT_BUILD_NETWORK_STUBS=ON`: `netmgr`, `netstack`, `netfast`.
 
 ---

--- a/services/CMakeLists.txt
+++ b/services/CMakeLists.txt
@@ -5,7 +5,7 @@ add_subdirectory(process_manager)
 add_subdirectory(vm_manager)
 
 # Phase 1: Native Service Skeletons
-option(BHARAT_BUILD_USER_SERVICES_STUBS "Build foundational user-space service stubs" ON)
+option(BHARAT_BUILD_USER_SERVICES_STUBS "Build foundational user-space service stubs" OFF)
 if(BHARAT_BUILD_USER_SERVICES_STUBS)
     add_subdirectory(init)
     add_subdirectory(namesvc)
@@ -13,7 +13,7 @@ if(BHARAT_BUILD_USER_SERVICES_STUBS)
 endif()
 
 # Core System Services (Multi-kernel / Distributed OS)
-option(BHARAT_BUILD_CORE_SERVICES "Build core multi-kernel distributed OS services" ON)
+option(BHARAT_BUILD_CORE_SERVICES "Build core multi-kernel distributed OS services" OFF)
 if(BHARAT_BUILD_CORE_SERVICES)
     add_subdirectory(coremgr)
     add_subdirectory(memmgr)
@@ -43,7 +43,7 @@ if(BHARAT_ENABLE_SERVICE_NETWORK)
 endif()
 
 # Profile-driven network stack and manager
-option(BHARAT_BUILD_NETWORK_STUBS "Build network manager and stack user-space stubs" ON)
+option(BHARAT_BUILD_NETWORK_STUBS "Build network manager and stack user-space stubs" OFF)
 if(BHARAT_BUILD_NETWORK_STUBS AND BHARAT_ENABLE_SERVICE_NETWORK)
     add_subdirectory(netmgr)
     add_subdirectory(netstack)


### PR DESCRIPTION
Addresses PR3.1-X1: Default-off scaffold-only services in normal developer builds.

This PR makes the normal developer build more conservative by disabling groups of services that are largely scaffold logic. It adds an `experimental_services` build profile that enables these groups for developers who want to work on them or run experimental systems. Documentation is updated to reflect this reality.

---
*PR created automatically by Jules for task [3535023187035168140](https://jules.google.com/task/3535023187035168140) started by @divyang4481*