### PR TITLE
test: Harden crypto protocol and dispatch with host tests

### DIFF
--- a/services/security/crypto/crypto_service.h
+++ b/services/security/crypto/crypto_service.h
@@ -1,6 +1,7 @@
 #ifndef CRYPTO_SERVICE_H
 #define CRYPTO_SERVICE_H
 
+#include <stddef.h>
 #include "crypto/crypto_uapi.h"
 
 /* Protocol and validation */

--- a/services/security/crypto/dispatch.c
+++ b/services/security/crypto/dispatch.c
@@ -1,6 +1,10 @@
 #include "crypto_service.h"
 
 crypto_status_t crypto_dispatch_request(const crypto_request_msg_t *req, crypto_resp_common_t *resp) {
+    if (req == NULL || resp == NULL) {
+        return CRYPTO_STATUS_ERR_BAD_PARAM;
+    }
+
     switch (req->header.opcode) {
         case CRYPTO_OP_GET_RANDOM:
             return handle_get_random(&req->payload.get_random, resp);

--- a/services/security/crypto/protocol.c
+++ b/services/security/crypto/protocol.c
@@ -1,6 +1,10 @@
 #include "crypto_service.h"
 
 crypto_status_t crypto_protocol_validate(const crypto_request_msg_t *req, uint32_t len) {
+    if (req == NULL) {
+        return CRYPTO_STATUS_ERR_BAD_PARAM;
+    }
+
     if (len < sizeof(crypto_msg_header_t)) {
         return CRYPTO_STATUS_ERR_BAD_PARAM;
     }

--- a/tests/host/CMakeLists.txt
+++ b/tests/host/CMakeLists.txt
@@ -138,6 +138,11 @@ add_executable(test_secure_mem test_secure_mem.c)
 target_include_directories(test_secure_mem PRIVATE ../../kernel/include)
 
 add_test(NAME host_test_secure_mem COMMAND test_secure_mem)
+
+add_executable(test_crypto_protocol_dispatch services/test_crypto_protocol_dispatch.c ../../services/security/crypto/protocol.c ../../services/security/crypto/dispatch.c)
+target_include_directories(test_crypto_protocol_dispatch PRIVATE ../../services/security/crypto ../../kernel/include)
+add_test(NAME host_test_crypto_protocol_dispatch COMMAND test_crypto_protocol_dispatch)
+
 # Phase 3: NetMgr Tests
 add_executable(test_netmgr_address_table services/test_netmgr_address_table.c ../../services/netmgr/src/address_table.c ../../lib/runtime/src/freestanding_string.c)
 target_include_directories(test_netmgr_address_table PRIVATE ../../services/netmgr/src ../../services/netmgr/include ../../services/core/subsysmgr/include ../../lib/net/include ../../lib/runtime/include)

--- a/tests/host/services/test_crypto_protocol_dispatch.c
+++ b/tests/host/services/test_crypto_protocol_dispatch.c
@@ -1,0 +1,91 @@
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include "../../../services/security/crypto/crypto_service.h"
+
+static void test_crypto_protocol_validate(void) {
+    printf("Running test_crypto_protocol_validate...\n");
+
+    crypto_request_msg_t req;
+    memset(&req, 0, sizeof(req));
+    req.header.version = CRYPTO_UAPI_VERSION;
+    req.header.opcode = CRYPTO_OP_GET_RANDOM;
+    uint32_t valid_len = sizeof(crypto_msg_header_t) + sizeof(crypto_req_get_random_t);
+
+    // 1. NULL pointer
+    assert(crypto_protocol_validate(NULL, valid_len) == CRYPTO_STATUS_ERR_BAD_PARAM);
+
+    // 2. Short length
+    assert(crypto_protocol_validate(&req, sizeof(crypto_msg_header_t) - 1) == CRYPTO_STATUS_ERR_BAD_PARAM);
+
+    // 3. Wrong version
+    req.header.version = CRYPTO_UAPI_VERSION + 1;
+    assert(crypto_protocol_validate(&req, valid_len) == CRYPTO_STATUS_ERR_BAD_PARAM);
+    req.header.version = CRYPTO_UAPI_VERSION; // Restore
+
+    // 4. Invalid opcode (too low)
+    req.header.opcode = CRYPTO_OP_INVALID;
+    assert(crypto_protocol_validate(&req, valid_len) == CRYPTO_STATUS_ERR_BAD_PARAM);
+
+    // 5. Invalid opcode (too high)
+    req.header.opcode = CRYPTO_OP_ENCRYPT_DUMP + 1;
+    assert(crypto_protocol_validate(&req, valid_len) == CRYPTO_STATUS_ERR_BAD_PARAM);
+
+    // 6. Valid header
+    req.header.opcode = CRYPTO_OP_GET_RANDOM;
+    assert(crypto_protocol_validate(&req, valid_len) == CRYPTO_STATUS_OK);
+
+    printf("test_crypto_protocol_validate passed.\n");
+}
+
+static void test_crypto_dispatch_request(void) {
+    printf("Running test_crypto_dispatch_request...\n");
+
+    crypto_request_msg_t req;
+    crypto_resp_common_t resp;
+    memset(&req, 0, sizeof(req));
+    memset(&resp, 0, sizeof(resp));
+
+    req.header.version = CRYPTO_UAPI_VERSION;
+
+    // 1. NULL pointers
+    assert(crypto_dispatch_request(NULL, &resp) == CRYPTO_STATUS_ERR_BAD_PARAM);
+    assert(crypto_dispatch_request(&req, NULL) == CRYPTO_STATUS_ERR_BAD_PARAM);
+    assert(crypto_dispatch_request(NULL, NULL) == CRYPTO_STATUS_ERR_BAD_PARAM);
+
+    // 2. Each known opcode returns the expected current phase behavior (NOT_IMPL for all currently)
+    crypto_opcode_t known_ops[] = {
+        CRYPTO_OP_GET_RANDOM,
+        CRYPTO_OP_HASH_INIT,
+        CRYPTO_OP_HASH_UPDATE,
+        CRYPTO_OP_HASH_FINAL,
+        CRYPTO_OP_AEAD_SEAL,
+        CRYPTO_OP_AEAD_OPEN,
+        CRYPTO_OP_SIGN,
+        CRYPTO_OP_VERIFY,
+        CRYPTO_OP_KEY_CREATE,
+        CRYPTO_OP_KEY_DESTROY,
+        CRYPTO_OP_ENCRYPT_DUMP
+    };
+
+    for (size_t i = 0; i < sizeof(known_ops) / sizeof(known_ops[0]); i++) {
+        req.header.opcode = known_ops[i];
+        assert(crypto_dispatch_request(&req, &resp) == CRYPTO_STATUS_ERR_NOT_IMPL);
+    }
+
+    // 3. Unknown opcode returns CRYPTO_STATUS_ERR_NOT_IMPL
+    req.header.opcode = CRYPTO_OP_ENCRYPT_DUMP + 1;
+    assert(crypto_dispatch_request(&req, &resp) == CRYPTO_STATUS_ERR_NOT_IMPL);
+
+    printf("test_crypto_dispatch_request passed.\n");
+}
+
+int main(void) {
+    printf("Starting Crypto Protocol and Dispatch tests...\n");
+
+    test_crypto_protocol_validate();
+    test_crypto_dispatch_request();
+
+    printf("All tests passed.\n");
+    return 0;
+}


### PR DESCRIPTION
**PR3.1-X9 — Crypto protocol validation and deny-path test hardening**

This commit addresses the crypto service protocol/dispatch hardening task:
- Adds basic defensive programming (`NULL` checks for request and response pointers) to `protocol.c` and `dispatch.c`.
- Introduces `tests/host/services/test_crypto_protocol_dispatch.c` to test the internal validation and dispatch seam.
- Tests verify short lengths, bad versions, invalid opcodes, valid headers, known opcodes, and unknown opcodes against the expected status returns (`ERR_BAD_PARAM`, `ERR_NOT_IMPL`, `OK`).
- Wires the new test program into `tests/host/CMakeLists.txt` following the existing host testing patterns, pulling in `protocol.c` and `dispatch.c` directly.
- Keeps transport stubbed and isolated without pulling in additional architecture or subsystems.

---
*PR created automatically by Jules for task [10697375716492659129](https://jules.google.com/task/10697375716492659129) started by @divyang4481*