### PR TITLE
Fix boot logs QEMU runner

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -33,6 +33,9 @@ Before building Bharat-OS, you need to set up your development environment.
 - Ninja or Make
 - Clang & LLD (`llvm`, `clang`, `lld`)
 - QEMU (for running the kernel)
+
+Note: `build.ps1` and `build.sh` are thin wrappers. The real implementation path for builds and runners is driven by `tools/build.py`.
+
 Please see the comprehensive **[Environment Preparation Guide](docs/build/ENV_PREP.md)** for platform-specific instructions.
 
 ### QEMU runtime prerequisites (Linux)
@@ -115,7 +118,7 @@ E2E_MATRIX_MODE=explicit E2E_MATRIX="arm64:mmu:desktop:linux" ./run_qemu_e2e.sh
 E2E_MATRIX_MODE=explicit E2E_MATRIX="riscv64:mmu:desktop:linux" ./run_qemu_e2e.sh
 ```
 
-### GUI profiles with host-visible boot logs (`--run`)
+### How to run desktop GUI builds
 
 `--run` now routes primary serial to host stdio and disables monitor-on-stdio conflicts, so these GUI profiles should print boot logs in your host terminal while the QEMU window is open:
 
@@ -131,12 +134,27 @@ E2E_MATRIX_MODE=explicit E2E_MATRIX="riscv64:mmu:desktop:linux" ./run_qemu_e2e.s
 ./build.sh riscv64_desktop_gui --run
 ```
 
-If your local terminal still does not display serial output reliably, use one of these fallback modes:
+### How to run headless builds
 
-- `--run-tests` (headless/CI-style, strongest host-log path)
-- `--run --dual-serial` (keeps GUI and mirrors a second serial channel to QEMU VC)
+For a pure terminal-based experience without a QEMU graphical window (e.g., CI or remote SSH environments), use the `headless` targets:
 
-> Use `--dual-serial` (hyphen), **not** `--dual_serial`.
+```powershell
+.\build.ps1 x86_64_desktop_headless --run
+.\build.ps1 arm64_desktop_headless --run
+.\build.ps1 riscv64_desktop_headless --run
+```
+
+```bash
+./build.sh x86_64_desktop_headless --run
+./build.sh arm64_desktop_headless --run
+./build.sh riscv64_desktop_headless --run
+```
+
+### Expected behavior & Dual serial usage
+
+- Host terminal **must show boot logs** in both headless and GUI modes. The QEMU graphical window does not replace the host terminal serial logging.
+- `--dual-serial` (hyphen) may additionally show serial output in the QEMU window by adding a secondary `-serial vc` sink.
+- Note: **Use `--dual-serial`, NOT `--dual_serial`.**
 
 Examples with GUI + mirrored serial (`--dual-serial`):
 
@@ -163,6 +181,15 @@ Examples with GUI + mirrored serial (`--dual-serial`):
 - **Wrong image format / objcopy issue**
   - Symptom: x86_64/arm64 runs fail before boot with image format errors.
   - Fix: install `llvm-objcopy` (or equivalent `objcopy`) and verify it is callable in PATH.
+- **Legacy execution path warning**
+  - Symptom: "Warning: Running legacy execution path (no target matrix entry found)."
+  - Fix: Use one of the first-class targets that appear in `targets/target_matrix.json` (e.g., `x86_64_desktop_gui`).
+- **Wrong flag spelling**
+  - Symptom: Script rejects `--dual_serial`.
+  - Fix: Always use `--dual-serial` (with a hyphen).
+- **GUI window appears but host terminal is silent**
+  - Symptom: QEMU starts, the GUI window loads, but the host terminal receives no logs.
+  - Fix: Make sure you're using a first-class manifest target, which correctly routes primary serial to `stdio`.
 - **No boot markers in host terminal**
   - Symptom: QEMU starts but none of the required markers appear.
   - Fix: use `--run-tests` for headless serial-first validation, or use `--run --dual-serial` for GUI+VC mirroring; then inspect `e2e_logs/`.

--- a/kernel/src/console/console_discovery.c
+++ b/kernel/src/console/console_discovery.c
@@ -6,8 +6,11 @@ size_t console_discover_devices(console_device_desc_t *out, size_t max_count) {
         return 0;
     }
 
+    extern void hal_serial_write(const char *s);
+
     platform_boot_console_desc_t boot_console;
     if (!platform_get_boot_console_desc(&boot_console) || !boot_console.valid || !boot_console.uart) {
+        hal_serial_write("BOOT ERROR: no boot console resolved or invalid UART descriptor.\n");
         return 0;
     }
 
@@ -21,6 +24,24 @@ size_t console_discover_devices(console_device_desc_t *out, size_t max_count) {
     out[0].caps = boot_console.caps;
     out[0].name = boot_console.name;
     out[0].opaque = (void *)boot_console.uart;
+
+    hal_serial_write("BOOT DIAGNOSTICS: Boot console discovered successfully.\n");
+    hal_serial_write("BOOT DIAGNOSTICS: Selected backend: ");
+    hal_serial_write(boot_console.name ? boot_console.name : "unknown");
+    hal_serial_write("\n");
+
+    // We cannot easily format hex with basic hal_serial_write, but we can print the fact it's configured
+    hal_serial_write("BOOT DIAGNOSTICS: UART Base/Config resolved.\n");
+
+    if (boot_console.early_ok) {
+        hal_serial_write("BOOT DIAGNOSTICS: Early console is ACTIVE.\n");
+    }
+    if (boot_console.caps & CON_CAP_RUNTIME) {
+        hal_serial_write("BOOT DIAGNOSTICS: Runtime console is ACTIVE.\n");
+    }
+    if (boot_console.panic_ok) {
+        hal_serial_write("BOOT DIAGNOSTICS: Panic console is ACTIVE.\n");
+    }
 
     return 1;
 }

--- a/targets/target_matrix.json
+++ b/targets/target_matrix.json
@@ -1,4 +1,137 @@
 {
+  "x86_64_desktop_gui": {
+    "name": "x86_64_desktop_gui",
+    "arch": "x86_64",
+    "profile": "desktop",
+    "execution_class": "qemu",
+    "machine": "q35",
+    "boot_contract": {
+      "entry": "kernel_elf",
+      "requires_fdt": false
+    },
+    "discovery_contract": "acpi",
+    "console_contract": {
+      "mode": "serial+display",
+      "primary_uart": "uart.ns16550",
+      "display": "display.vga"
+    },
+    "device_contracts": {
+      "interrupt": "intc.ioapic",
+      "timer": "timer.hpet",
+      "bus": ["bus.pci"]
+    }
+  },
+  "x86_64_desktop_headless": {
+    "name": "x86_64_desktop_headless",
+    "arch": "x86_64",
+    "profile": "desktop",
+    "execution_class": "qemu",
+    "machine": "q35",
+    "boot_contract": {
+      "entry": "kernel_elf",
+      "requires_fdt": false
+    },
+    "discovery_contract": "acpi",
+    "console_contract": {
+      "mode": "serial",
+      "primary_uart": "uart.ns16550"
+    },
+    "device_contracts": {
+      "interrupt": "intc.ioapic",
+      "timer": "timer.hpet",
+      "bus": ["bus.pci"]
+    }
+  },
+  "arm64_desktop_gui": {
+    "name": "arm64_desktop_gui",
+    "arch": "arm64",
+    "profile": "desktop",
+    "execution_class": "qemu",
+    "machine": "virt",
+    "boot_contract": {
+      "entry": "kernel_elf",
+      "requires_fdt": true,
+      "fdt_source": "emulator"
+    },
+    "discovery_contract": "fdt",
+    "console_contract": {
+      "mode": "serial+display",
+      "primary_uart": "uart.pl011",
+      "display": "display.virtio_gpu"
+    },
+    "device_contracts": {
+      "interrupt": "intc.gicv3",
+      "timer": "timer.arm_generic",
+      "bus": ["bus.platform_mmio", "bus.pci"]
+    }
+  },
+  "arm64_desktop_headless": {
+    "name": "arm64_desktop_headless",
+    "arch": "arm64",
+    "profile": "desktop",
+    "execution_class": "qemu",
+    "machine": "virt",
+    "boot_contract": {
+      "entry": "kernel_elf",
+      "requires_fdt": true,
+      "fdt_source": "emulator"
+    },
+    "discovery_contract": "fdt",
+    "console_contract": {
+      "mode": "serial",
+      "primary_uart": "uart.pl011"
+    },
+    "device_contracts": {
+      "interrupt": "intc.gicv3",
+      "timer": "timer.arm_generic",
+      "bus": ["bus.platform_mmio", "bus.pci"]
+    }
+  },
+  "riscv64_desktop_gui": {
+    "name": "riscv64_desktop_gui",
+    "arch": "riscv64",
+    "profile": "desktop",
+    "execution_class": "qemu",
+    "machine": "virt",
+    "boot_contract": {
+      "entry": "kernel_elf",
+      "requires_fdt": true,
+      "fdt_source": "emulator"
+    },
+    "discovery_contract": "fdt",
+    "console_contract": {
+      "mode": "serial+display",
+      "primary_uart": "uart.ns16550",
+      "display": "display.virtio_gpu"
+    },
+    "device_contracts": {
+      "interrupt": "intc.plic",
+      "timer": "timer.systick",
+      "bus": ["bus.platform_mmio", "bus.pci"]
+    }
+  },
+  "riscv64_desktop_headless": {
+    "name": "riscv64_desktop_headless",
+    "arch": "riscv64",
+    "profile": "desktop",
+    "execution_class": "qemu",
+    "machine": "virt",
+    "boot_contract": {
+      "entry": "kernel_elf",
+      "requires_fdt": true,
+      "fdt_source": "emulator"
+    },
+    "discovery_contract": "fdt",
+    "console_contract": {
+      "mode": "serial",
+      "primary_uart": "uart.ns16550"
+    },
+    "device_contracts": {
+      "interrupt": "intc.plic",
+      "timer": "timer.systick",
+      "bus": ["bus.platform_mmio", "bus.pci"]
+    }
+  },
   "arm32_small_qemu_virt": {
     "name": "arm32_small_qemu_virt",
     "arch": "arm32",

--- a/tools/build.py
+++ b/tools/build.py
@@ -224,9 +224,13 @@ def do_run(build_cfg, dual_serial, run_tests=False, cpus=1, target_name=None):
     if target_name and os.path.exists(manifest_path):
         with open(manifest_path, 'r') as f:
             manifest = json.load(f)
+
+        # Push dual_serial state into the manifest for the runner
+        manifest['dual_serial_requested'] = dual_serial
     else:
         # Fallback to legacy execution logic for builds without a target matrix entry
         print("Warning: Running legacy execution path (no target matrix entry found).")
+        print("Hint: To fix this, add proper target matrix / manifest-backed run entries to targets/target_matrix.json.")
         arch = build_cfg.get('arch')
         board = build_cfg.get('board', '')
 
@@ -368,7 +372,7 @@ def do_matrix(manifest):
             try:
                 get_target(build_name, silent=True)
                 target_name = build_name
-            except SystemExit:
+            except (SystemExit, KeyError):
                 pass
 
             do_configure(build_cfg)
@@ -397,6 +401,12 @@ def main():
     # Detect legacy flags and provide a friendly migration error
     legacy_flags = {'-arch', '-clean', '-run', '-bootgui', '-dualserial', '-profile', '-e2e', '-serialtarget', '-preset'}
     used_legacy = [arg for arg in sys.argv[1:] if arg.lower() in legacy_flags]
+
+    # Check for invalid dual_serial flag spelling
+    if '--dual_serial' in sys.argv:
+        print("Error: The flag is --dual-serial (with a hyphen), not --dual_serial.")
+        sys.exit(1)
+
     if used_legacy:
         print(f"Error: Legacy flags detected: {', '.join(used_legacy)}")
         print("\nThe build system has been unified around tools/build.py with a canonical interface.")
@@ -451,7 +461,7 @@ def main():
     try:
         target = get_target(args.build_name, silent=True)
         target_name = args.build_name
-    except SystemExit:
+    except (SystemExit, KeyError, Exception):
         pass
 
     if args.build_name not in manifest.get('builds', {}):

--- a/tools/runners/runner_qemu.py
+++ b/tools/runners/runner_qemu.py
@@ -54,18 +54,34 @@ def run(manifest):
         cmd.extend(['-kernel', artifacts['kernel']])
 
     serial_routing = manifest.get('serial_routing', {})
+    dual_serial = manifest.get('dual_serial_requested', False)
+
     if serial_routing.get('stdio'):
         # Prevent monitor/serial stdio contention when routing boot logs to host terminal.
         cmd.extend(['-monitor', 'none'])
         cmd.extend(['-serial', 'stdio'])
 
+    if dual_serial:
+        cmd.extend(['-serial', 'vc'])
+
     if not display_routing.get('requested'):
         cmd.extend(['-display', 'none'])
     else:
-         # Need real device mapping in full implementation, simple string for now
+         cmd.extend(['-display', 'gtk'])
          device = display_routing.get('device')
          if device == 'display.virtio_gpu':
              cmd.extend(['-device', 'virtio-gpu-pci'])
+         elif device == 'display.vga':
+             cmd.extend(['-vga', 'std'])
+
+    print("\n--- Final QEMU Routing Summary ---")
+    print(f"Host serial: {'enabled' if serial_routing.get('stdio') else 'disabled'}")
+    print(f"Secondary serial sink: {'enabled' if dual_serial else 'disabled'}")
+    print(f"GUI: {'enabled' if display_routing.get('requested') else 'disabled'}")
+    print(f"Runner: {qemu_cmd}")
+    print(f"Machine: {machine_cfg.get('machine', 'default')}")
+    print(f"Board: {manifest.get('arch', 'unknown')} / {manifest.get('profile', 'unknown')}")
+    print("----------------------------------\n")
 
     print(f"[QEMU Runner] Executing: {' '.join(cmd)}")
 

--- a/tools/targets/loader.py
+++ b/tools/targets/loader.py
@@ -18,5 +18,8 @@ def get_target(target_name, matrix=None, silent=False):
     if target_name not in matrix:
         if not silent:
             print(f"Error: Target '{target_name}' not found in target matrix.")
+        # If silent, raise KeyError instead of exiting, so caller can catch it without killing the process
+        if silent:
+            raise KeyError(target_name)
         sys.exit(1)
     return matrix[target_name]


### PR DESCRIPTION
This task fixes QEMU host-visible boot logs, corrects the serial logic in `runner_qemu.py`, fixes the legacy runner fallback logic, adds proper diagnostic boot prints, and updates `BUILD.md` accordingly.

---
*PR created automatically by Jules for task [15732403818235040849](https://jules.google.com/task/15732403818235040849) started by @divyang4481*