### PR TITLE
cmake: honor userspace PIE setting and remove -nostartfiles from freestanding flags

### DIFF
--- a/cmake/modules/BharatCommon.cmake
+++ b/cmake/modules/BharatCommon.cmake
@@ -89,7 +89,6 @@ target_compile_options(bharat_freestanding INTERFACE
 
 target_link_options(bharat_freestanding INTERFACE
     -nostdlib
-    -nostartfiles
 )
 
 
@@ -169,12 +168,14 @@ function(bharat_configure_userspace_binary TARGET_NAME)
     if(BHARAT_USERSPACE_PIE)
         set_target_properties(${TARGET_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
         target_compile_options(${TARGET_NAME} PRIVATE -fPIE)
-        target_link_options(${TARGET_NAME} PRIVATE -nostdlib -nostartfiles -pie)
+        target_link_options(${TARGET_NAME} PRIVATE -nostdlib -pie)
     else()
         set_target_properties(${TARGET_NAME} PROPERTIES POSITION_INDEPENDENT_CODE OFF)
         target_compile_options(${TARGET_NAME} PRIVATE -fno-pie -fno-PIC)
-        target_link_options(${TARGET_NAME} PRIVATE -nostdlib -nostartfiles "LINKER:-no-pie")
+        target_link_options(${TARGET_NAME} PRIVATE -nostdlib "LINKER:-no-pie")
     endif()
 endfunction()
 
-set(BHARAT_USERSPACE_PIE ON CACHE BOOL "Build user-space services as Position Independent Executables" FORCE)
+# Respect caller/toolchain-selected userspace PIE policy instead of forcing it on.
+# Default remains OFF unless explicitly enabled via cache/preset.
+set(BHARAT_USERSPACE_PIE "${BHARAT_USERSPACE_PIE}" CACHE BOOL "Build user-space services as Position Independent Executables" FORCE)


### PR DESCRIPTION
### Motivation
- The arm64 desktop/headless build printed noisy Clang linker-driver warnings about unused `-pie`/`-nostartfiles` when userspace flags were forced by the CMake policy. 
- Userspace PIE should be selectable by toolchain/preset/cache instead of being hard-forced in the common CMake logic.

### Description
- Stop forcing `BHARAT_USERSPACE_PIE=ON` in `cmake/modules/BharatCommon.cmake` and make the option respect the configured cache/preset value. 
- Remove global `-nostartfiles` from the `bharat_freestanding` link options so the freestanding baseline no longer injects that flag. 
- Remove duplicated `-nostartfiles` from `bharat_configure_userspace_binary()` while preserving `-nostdlib` and PIE/non-PIE semantics.

### Testing
- Ran configuration with `cmake --preset=arm64-edge -DBHARAT_ARCH_FAMILY=ARM64 -DBHARAT_DEVICE_PROFILE=DESKTOP -DBHARAT_PERSONALITY_PROFILE=LINUX -DBHARAT_TARGET_BOARD=virt -DBHARAT_BOOT_GUI=OFF`, which completed successfully. 
- Ran build with `cmake --build --preset=arm64-edge`, which completed successfully and no longer emitted the prior linker-driver warning spam related to `-pie`/`-nostartfiles`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df61254c008320b7921ebd99b7feea)