### PR TITLE
Fix ARM64 QEMU FDT handoff by converting kernel artifact to raw binary

### DIFF
--- a/tools/boot/arm64_boot.py
+++ b/tools/boot/arm64_boot.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 
 def check_fdt_ready():
     # In a real environment, QEMU passes the FDT via `-machine virt` and places it in RAM.
@@ -8,7 +9,12 @@ def check_fdt_ready():
 
 def get_boot_config(kernel_path):
     check_fdt_ready()
+
+    bin_path = kernel_path.replace('.elf', '.bin')
+    if os.path.exists(kernel_path):
+        subprocess.run(['llvm-objcopy', '-O', 'binary', kernel_path, bin_path], check=True)
+
     return {
-        "kernel_path": kernel_path,
+        "kernel_path": bin_path,
         "qemu_flags": []
     }

--- a/tools/build.py
+++ b/tools/build.py
@@ -152,9 +152,8 @@ def do_build(build_cfg, target_name=None):
         #    architecture-specific artifacts before execution.
         # 3. Runners (like runner_qemu.py) do not perform implicit kernel artifact
         #    conversion; they consume the manifest as-is.
-        if arch == 'x86_64':
-            boot_config = boot.get_bootloader(arch)(kernel_path)
-            kernel_path = boot_config.get('kernel_path', kernel_path)
+        boot_config = boot.get_bootloader(arch)(kernel_path)
+        kernel_path = boot_config.get('kernel_path', kernel_path)
 
         manifest = {
             'target_name': target_name,


### PR DESCRIPTION
### Description

This PR fixes a bug where `arm64_desktop_headless` would crash with an early kernel panic on boot (`FDT not provided by bootloader and fallback failed`).

**Root Cause:**
The build script (`tools/build.py`) only processed the kernel artifact through the bootloader configuration for `x86_64`. For `arm64`, it passed `kernel.elf` directly to the `run_manifest.json` file. When QEMU is given an ELF file on `arm64`, it bypasses the Linux boot protocol and does not load the generated device tree blob (FDT) pointer into the `x0` register.

**Fix:**
* Modified `tools/build.py` to invoke `boot.get_bootloader(arch)(kernel_path)` for all architectures, not exclusively `x86_64`.
* Updated `tools/boot/arm64_boot.py` to use `llvm-objcopy -O binary` to convert `kernel.elf` into `kernel.bin` and return that as the manifest artifact.
* The QEMU runner (`runner_qemu.py`) remains agnostic and properly passes `-kernel kernel.bin`. QEMU now treats the image correctly as a Linux kernel, auto-generating and passing the `FDT` via the `x0` register.

---
*PR created automatically by Jules for task [2671974498818146402](https://jules.google.com/task/2671974498818146402) started by @divyang4481*