### PR TITLE
Fix ARM64 headless QEMU boot to use ELF kernel image

### DIFF
--- a/tools/boot/arm64_boot.py
+++ b/tools/boot/arm64_boot.py
@@ -1,6 +1,3 @@
-import os
-import subprocess
-
 def check_fdt_ready():
     # In a real environment, QEMU passes the FDT via `-machine virt` and places it in RAM.
     # The kernel needs to validate it with a magic check in boot.S.
@@ -9,12 +6,10 @@ def check_fdt_ready():
 
 def get_boot_config(kernel_path):
     check_fdt_ready()
-
-    bin_path = kernel_path.replace('.elf', '.bin')
-    if os.path.exists(kernel_path):
-        subprocess.run(['llvm-objcopy', '-O', 'binary', kernel_path, bin_path], check=True)
-
     return {
-        "kernel_path": bin_path,
+        # Keep the ELF image for QEMU `-kernel` on `-machine virt`.
+        # Converting to a flat binary can strip ELF entry/loading metadata and
+        # may lead to a silent boot/hang before early serial output.
+        "kernel_path": kernel_path,
         "qemu_flags": []
     }


### PR DESCRIPTION
### Motivation
- Avoid silent boot/hangs and missing early serial logs when running ARM64 `virt` in QEMU by not stripping ELF entry/load metadata via conversion to a flat binary.

### Description
- Removed the `llvm-objcopy` conversion from `tools/boot/arm64_boot.py` and keep `kernel_path` pointing to the original `kernel.elf`, with an inline comment documenting the rationale.

### Testing
- Verified `python -m py_compile tools/boot/arm64_boot.py` succeeded and `get_boot_config('build/arm64-edge/kernel/kernel.elf')` returns a manifest with `kernel_path` still set to the `.elf` (invoked via a short Python snippet).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df921da1a0832082987e9bb1f1a946)