### PR TITLE
init: prevent bootstrap panic when userspace init loader is deferred

### DIFF
--- a/kernel/src/init/init_bootstrap.c
+++ b/kernel/src/init/init_bootstrap.c
@@ -2,7 +2,13 @@
 #include "console/console_core.h"
 #include "sched/sched.h"
 
-// Minimal placeholder for the ELF/initramfs bootloader until implemented
+// Minimal placeholder for the ELF/initramfs bootloader until implemented.
+//
+// NOTE:
+// The previous stub unconditionally returned failure, which forced a kernel
+// panic on every boot once runtime reached the bootstrap handoff stage.
+// Until the userspace ELF loader is wired in, treat bootstrap as "deferred"
+// and keep the system alive in degraded mode.
 static int bootstrap_launch_first_service(void) {
     // A future change will implement:
     // create_process("init");
@@ -13,7 +19,8 @@ static int bootstrap_launch_first_service(void) {
     // grant bootstrap caps/handles
     // sched_enqueue();
 
-    return -1; // -ENOSYS
+    console_write_raw("  [BOOTSTRAP] userspace loader not wired yet; deferring services/init launch\n", 76);
+    return 0;
 }
 
 static void bootstrap_thread_entry(void) {
@@ -24,6 +31,8 @@ static void bootstrap_thread_entry(void) {
         console_write_raw("  [BOOTSTRAP] Failed to launch services/init\n", 45);
         kernel_panic("bootstrap: first service launch failed");
     }
+
+    console_write_raw("  [BOOTSTRAP] services/init launch deferred (degraded boot)\n", 59);
 
     thread_destroy(sched_current_thread());
     kthread_yield();


### PR DESCRIPTION
### Motivation
- The bootstrap stub previously returned failure unconditionally which caused a deterministic kernel panic when the kernel attempted to launch the first userspace service (`services/init`).
- Until the ELF/initramfs userspace loader is implemented, the kernel should continue running in a degraded mode instead of hard-failing the boot.

### Description
- Updated `kernel/src/init/init_bootstrap.c` to treat the missing userspace loader as a deferred condition and avoid returning an error from `bootstrap_launch_first_service`.
- Added explanatory comments and a diagnostic log in `bootstrap_launch_first_service` to indicate the loader is not wired and the launch is being deferred.
- Added an extra diagnostic log in `bootstrap_thread_entry` to report that the `services/init` launch was deferred and that the system is in degraded boot mode.
- Preserved the existing bootstrap thread teardown flow (`thread_destroy` and `kthread_yield`) so the kernel continues without panicking.

### Testing
- Ran `cmake --list-presets` to enumerate available build presets and it completed successfully.
- Ran `cmake --preset=riscv64-edge` which configured and generated build files successfully.
- Ran `cmake --build --preset=riscv64-edge` which progressed through compilation and linking, and stopped during OpenSBI payload generation due to a missing host tool (`llvm-objcopy`), which is an environment/tooling issue rather than a code regression.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df937a58c883208b07ecf01e00b5fd)