### PR TITLE
x86_64: keep hw_unmapped_fault out of normal boot path

### DIFF
--- a/kernel/src/tests/ktest_unmapped_fault.c
+++ b/kernel/src/tests/ktest_unmapped_fault.c
@@ -139,4 +139,8 @@ static int test_unmapped_user_fault(void) {
     return test_result;
 }
 
-REGISTER_BOOT_SELFTEST("hw_unmapped_fault", "memory", test_unmapped_user_fault, BOOT_TEST_STAGE_RUNTIME, BOOT_TEST_MANDATORY, 0, false)
+// Keep this probe out of normal boot for now: on some x86_64 QEMU setups the
+// fault-recovery hook is not reliably reached, causing a reboot loop before
+// services/init handoff. It remains available in diagnostic/quick-capable
+// modes where fault-path validation is explicitly requested.
+REGISTER_BOOT_SELFTEST("hw_unmapped_fault", "memory", test_unmapped_user_fault, BOOT_TEST_STAGE_RUNTIME, BOOT_TEST_QUICK, 0, false)


### PR DESCRIPTION
### Motivation
- On some x86_64 QEMU setups the runtime `hw_unmapped_fault` probe can fail to recover via the fault hook and induce a reboot loop before `services/init` handoff, so normal boot should avoid running this test.

### Description
- Change the boot self-test registration for `hw_unmapped_fault` in `kernel/src/tests/ktest_unmapped_fault.c` from `BOOT_TEST_MANDATORY` to `BOOT_TEST_QUICK` and add an inline comment explaining the rationale.

### Testing
- Successfully ran `cmake --preset x86_64-debug` and `cmake --build --preset x86_64-debug`; attempted `tools/ci/run_qemu_check.sh` to validate runtime markers but `qemu-system-x86_64` was not present in this environment so QEMU execution could not be validated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df973c2aa8832088dece46edab43ba)