### PR TITLE
docs(test): clarify x86_64 unmapped fault probe reboot risk

### DIFF
--- a/kernel/src/tests/ktest_unmapped_fault.c
+++ b/kernel/src/tests/ktest_unmapped_fault.c
@@ -140,7 +140,9 @@ static int test_unmapped_user_fault(void) {
 }
 
 // Keep this probe out of normal boot for now: on some x86_64 QEMU setups the
-// fault-recovery hook is not reliably reached, causing a reboot loop before
-// services/init handoff. It remains available in diagnostic/quick-capable
-// modes where fault-path validation is explicitly requested.
+// intentional kernel-mode #PF used by this test can still bypass the intended
+// recovery path and fall through to panic/reboot before services/init handoff.
+// arm64/riscv64 do not show the same instability in current CI runs. Keep this
+// as a diagnostic/quick-only probe until x86_64 trap-frame/return handling for
+// in-kernel fault injection is fully hardened.
 REGISTER_BOOT_SELFTEST("hw_unmapped_fault", "memory", test_unmapped_user_fault, BOOT_TEST_STAGE_RUNTIME, BOOT_TEST_QUICK, 0, false)


### PR DESCRIPTION
### Motivation
- Make the architecture-specific risk profile for the `hw_unmapped_fault` runtime selftest explicit so engineers understand that the x86_64 path can provoke a panic/reboot during intentional in-kernel page-fault injection while ARM64/RISC-V do not show the same instability.

### Description
- Updated the explanatory comment in `kernel/src/tests/ktest_unmapped_fault.c` to call out that the intentional kernel-mode `#PF` used by this probe can bypass the intended recovery path on x86_64 and therefore the test remains diagnostic/quick-only until x86_64 trap-frame/return handling for in-kernel fault injection is hardened.

### Testing
- Verified the source change via a file diff and ran whitespace/patch validation (`git diff -- kernel/src/tests/ktest_unmapped_fault.c` and `git diff --check`) with no formatting issues detected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df997cba048320a2313e2a1a470fd9)