### PR TITLE
Use -nographic for headless QEMU runs to fix ARM64 headless hang

### DIFF
--- a/tools/build.py
+++ b/tools/build.py
@@ -299,8 +299,10 @@ def do_run(build_cfg, dual_serial, run_tests=False, cpus=1, target_name=None):
                 # virtio-gpu for ARM64/RISC-V64 (modern standard)
                 qemu_opts.extend(['-device', 'virtio-gpu-pci'])
         else:
-            # Headless mode: No window
-            qemu_opts.extend(['-display', 'none'])
+            # Headless mode: prefer -nographic for robust serial routing.
+            # This is especially important on some aarch64 host/QEMU builds
+            # where -display none can result in a silent terminal session.
+            qemu_opts.extend(['-nographic'])
 
         runner = run_config.get("runner")
 

--- a/tools/runners/runner_qemu.py
+++ b/tools/runners/runner_qemu.py
@@ -65,7 +65,11 @@ def run(manifest):
         cmd.extend(['-serial', 'vc'])
 
     if not display_routing.get('requested'):
-        cmd.extend(['-display', 'none'])
+        # For headless boots, prefer -nographic over -display none.
+        # On some QEMU builds (notably Windows aarch64 setups), -nographic
+        # is the most reliable way to route PL011/NS16550 boot logs to the
+        # terminal and avoid apparent "hangs" with a blank console.
+        cmd.append('-nographic')
     else:
          cmd.extend(['-display', 'gtk'])
          device = display_routing.get('device')


### PR DESCRIPTION
### Motivation
- ARM64 headless QEMU runs could silently appear to hang with no boot serial output when `-display none` was used, particularly on some aarch64/Windows QEMU builds. 
- The goal is to ensure boot serial (PL011/NS16550) logs reliably reach the host terminal for headless runs. 

### Description
- Replace `-display none` with `-nographic` in the manifest-driven runner at `tools/runners/runner_qemu.py` to route serial to the terminal. 
- Apply the same change to the legacy run path in `tools/build.py` so both execution paths use `-nographic` for headless boots. 
- Added comments explaining the rationale and left GUI paths (`-display gtk`, device handling) unchanged. 

### Testing
- Ran `python3 -m py_compile tools/build.py tools/runners/runner_qemu.py` and the files compiled successfully. 
- Committed the changes and validated the modified files are syntactically correct via the compile step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df99bcdf788320bd0fb68b8c86291e)