### PR TITLE
fix(arm64): pin QEMU `virt` machine to `gic-version=2` for desktop targets

### DIFF
--- a/targets/target_matrix.json
+++ b/targets/target_matrix.json
@@ -51,7 +51,7 @@
     "arch": "arm64",
     "profile": "desktop",
     "execution_class": "qemu",
-    "machine": "virt",
+    "machine": "virt,gic-version=2",
     "boot_contract": {
       "entry": "kernel_elf",
       "requires_fdt": true,
@@ -78,7 +78,7 @@
     "arch": "arm64",
     "profile": "desktop",
     "execution_class": "qemu",
-    "machine": "virt",
+    "machine": "virt,gic-version=2",
     "boot_contract": {
       "entry": "kernel_elf",
       "requires_fdt": true,
@@ -181,7 +181,7 @@
     "arch": "arm64",
     "profile": "desktop",
     "execution_class": "qemu",
-    "machine": "virt",
+    "machine": "virt,gic-version=2",
     "boot_contract": {
       "entry": "kernel_elf",
       "requires_fdt": true,


### PR DESCRIPTION
### Motivation
- ARM64 desktop QEMU boots were hanging due to an interrupt-controller mismatch between the QEMU `virt` machine (which may default to GICv3) and the kernel HAL which currently uses GICv2-style access.
- Provide a deterministic QEMU machine configuration so early interrupt/boot bring-up behaves consistently and avoids headless hangs.

### Description
- Updated `targets/target_matrix.json` to set `"machine": "virt,gic-version=2"` for the ARM64 desktop targets `arm64_desktop_gui`, `arm64_desktop_headless`, and `arm64_desktop_qemu_virt`.
- This change causes the QEMU command line synthesized by the runner to include `-machine virt,gic-version=2` for those targets, producing e.g. `qemu-system-aarch64 -machine virt,gic-version=2 ... -serial stdio -nographic`.
- The change is scoped to ARM64 desktop targets only and leaves x86_64 and RISC-V machine settings unchanged.

### Testing
- JSON validation was run with `python3 -m json.tool targets/target_matrix.json` and succeeded.
- A Python inspection verified the `machine` values for `arm64_desktop_headless`, `arm64_desktop_gui`, and `arm64_desktop_qemu_virt` now map to `virt,gic-version=2` and `riscv64_desktop_gui` remains `virt`.
- The `tools.runners.runner_qemu.run` path was exercised with a synthetic manifest and `subprocess.run` was stubbed to capture the constructed QEMU command, confirming `-machine virt,gic-version=2` appears as expected and the runner synthesis succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df9be307e48320b2ca56e8f23f956d)