### PR TITLE
arm64: convert kernel ELF to raw image and set QEMU virt GIC to v2

### DIFF
--- a/targets/target_matrix.json
+++ b/targets/target_matrix.json
@@ -51,7 +51,7 @@
     "arch": "arm64",
     "profile": "desktop",
     "execution_class": "qemu",
-    "machine": "virt",
+    "machine": "virt,gic-version=2",
     "boot_contract": {
       "entry": "kernel_elf",
       "requires_fdt": true,
@@ -78,7 +78,7 @@
     "arch": "arm64",
     "profile": "desktop",
     "execution_class": "qemu",
-    "machine": "virt",
+    "machine": "virt,gic-version=2",
     "boot_contract": {
       "entry": "kernel_elf",
       "requires_fdt": true,
@@ -181,7 +181,7 @@
     "arch": "arm64",
     "profile": "desktop",
     "execution_class": "qemu",
-    "machine": "virt",
+    "machine": "virt,gic-version=2",
     "boot_contract": {
       "entry": "kernel_elf",
       "requires_fdt": true,

--- a/tools/boot/arm64_boot.py
+++ b/tools/boot/arm64_boot.py
@@ -1,15 +1,40 @@
+import os
+import subprocess
+
 def check_fdt_ready():
     # In a real environment, QEMU passes the FDT via `-machine virt` and places it in RAM.
     # The kernel needs to validate it with a magic check in boot.S.
     # Here we assert the correct QEMU arguments are returned.
     print("ARM64: Expecting valid FDT pointer in x0 via QEMU.")
 
+def _run_command(cmd):
+    print(f"Running: {' '.join(cmd)}")
+    result = subprocess.run(cmd)
+    return result.returncode == 0
+
+def _build_arm64_image(kernel_path):
+    image_path = kernel_path.replace('kernel.elf', 'kernel.img')
+
+    # Prefer llvm-objcopy (used elsewhere in this repo), fallback to objcopy.
+    if _run_command(['llvm-objcopy', '-O', 'binary', kernel_path, image_path]):
+        return image_path
+    if _run_command(['objcopy', '-O', 'binary', kernel_path, image_path]):
+        return image_path
+
+    raise Exception(
+        "ARM64 boot image conversion failed. Install llvm-objcopy or objcopy."
+    )
+
 def get_boot_config(kernel_path):
     check_fdt_ready()
+    if not os.path.exists(kernel_path):
+        raise Exception(f"ARM64 kernel ELF not found: {kernel_path}")
+
+    image_path = _build_arm64_image(kernel_path)
     return {
-        # Keep the ELF image for QEMU `-kernel` on `-machine virt`.
-        # Converting to a flat binary can strip ELF entry/loading metadata and
-        # may lead to a silent boot/hang before early serial output.
-        "kernel_path": kernel_path,
+        # Use a raw ARM64 Linux-style kernel image for QEMU `-kernel`.
+        # This keeps the 64-byte ARM64 image header at offset 0 and avoids
+        # host/QEMU differences in ELF loading behavior.
+        "kernel_path": image_path,
         "qemu_flags": []
     }


### PR DESCRIPTION
### Motivation
- Ensure QEMU boots ARM64 kernels reliably by producing a raw Linux-style kernel image and failing early if conversion is unavailable. 
- Make the QEMU `virt` machine explicit about the Generic Interrupt Controller version to avoid platform/interrupt mismatches. 

### Description
- Add an ARM64 boot helper `tools/boot/arm64_boot.py` that converts `kernel.elf` to a flat binary via `_build_arm64_image` and `_run_command`, and updates `get_boot_config` to point `kernel_path` at the generated image. 
- Validate the input ELF exists and propagate a clear exception when `llvm-objcopy`/`objcopy` are not present. 
- Update `targets/target_matrix.json` to change the `machine` field from `virt` to `virt,gic-version=2` for ARM64 `virt` targets to force GIC v2 selection. 

### Testing
- No automated tests were added for the change and no automated test suite was executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df9be307e48320b2ca56e8f23f956d)