### PR TITLE
Improve ARM64 kernel image handling and QEMU runner validation

### DIFF
--- a/tools/boot/arm64_boot.py
+++ b/tools/boot/arm64_boot.py
@@ -12,13 +12,34 @@ def _run_command(cmd):
     result = subprocess.run(cmd)
     return result.returncode == 0
 
-def _build_arm64_image(kernel_path):
-    image_path = kernel_path.replace('kernel.elf', 'kernel.img')
+def _find_objcopy():
+    # Prefer versioned LLVM binaries first; some environments ship an
+    # `llvm-objcopy` wrapper that is present in PATH but not executable.
+    candidates = [
+        'llvm-objcopy-20',
+        '/usr/lib/llvm-20/bin/llvm-objcopy',
+        'llvm-objcopy',
+        'objcopy',
+    ]
+    for tool in candidates:
+        try:
+            probe = subprocess.run(
+                [tool, '--version'],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            if probe.returncode == 0:
+                return tool
+        except FileNotFoundError:
+            continue
+    return None
 
-    # Prefer llvm-objcopy (used elsewhere in this repo), fallback to objcopy.
-    if _run_command(['llvm-objcopy', '-O', 'binary', kernel_path, image_path]):
-        return image_path
-    if _run_command(['objcopy', '-O', 'binary', kernel_path, image_path]):
+def _build_arm64_image(kernel_path):
+    kernel_dir = os.path.dirname(kernel_path)
+    image_path = os.path.join(kernel_dir, 'Image')
+
+    objcopy = _find_objcopy()
+    if objcopy and _run_command([objcopy, '-O', 'binary', kernel_path, image_path]):
         return image_path
 
     raise Exception(

--- a/tools/runners/runner_qemu.py
+++ b/tools/runners/runner_qemu.py
@@ -43,12 +43,6 @@ def run(manifest):
     if machine_cfg.get('cpu'):
         cmd.extend(['-cpu', machine_cfg['cpu']])
 
-    # For ARM64 direct kernel boot, force firmware-less path to avoid host
-    # firmware variance (e.g., EDK2 grabbing control and appearing as a hang
-    # on serial-only runs).
-    if arch == 'arm64':
-        cmd.extend(['-bios', 'none'])
-
     cmd.extend(['-m', str(machine_cfg.get('memory', '512M'))])
 
     smp = machine_cfg.get('smp')
@@ -56,8 +50,18 @@ def run(manifest):
         cmd.extend(['-smp', str(smp)])
 
     artifacts = manifest.get('artifacts', {})
-    if artifacts.get('kernel'):
-        cmd.extend(['-kernel', artifacts['kernel']])
+    kernel_path = artifacts.get('kernel')
+    machine = machine_cfg.get('machine', '')
+    if arch == 'arm64' and 'virt' in machine and kernel_path:
+        if kernel_path.lower().endswith('.elf'):
+            print(
+                "Error: ARM64 virt requires a raw kernel image (Image), "
+                f"not ELF: {kernel_path}"
+            )
+            sys.exit(1)
+
+    if kernel_path:
+        cmd.extend(['-kernel', kernel_path])
 
     serial_routing = manifest.get('serial_routing', {})
     dual_serial = manifest.get('dual_serial_requested', False)


### PR DESCRIPTION
### Motivation

- Ensure reliable conversion of ARM64 ELF kernels to raw `Image` files by locating a usable `objcopy`/`llvm-objcopy` binary and producing the expected `Image` path. 
- Prevent surprising QEMU boot configurations by validating kernel artifact types for `arm64` `virt` machines and avoid implicit firmware forcing that caused host-dependent behavior.

### Description

- Added `_find_objcopy()` to probe for usable `llvm-objcopy`/`objcopy` binaries (preferring versioned LLVM locations) and use it in `_build_arm64_image()` to convert ELF kernels to a raw `Image` file located next to the kernel. 
- Changed `_build_arm64_image()` to emit `Image` in the kernel directory instead of replacing `kernel.elf` in-place, and raise a clear exception when no converter is found. 
- In the QEMU runner, removed the forced `-bios none` path for `arm64` and added validation that an `arm64` `virt` machine must not be given an ELF kernel, printing an error and exiting if an ELF is provided. 
- Streamlined kernel handling by always adding the resolved `kernel_path` to the QEMU command and keeping existing serial/display routing logic intact.

### Testing

- Ran the repository test suite with `pytest -q` and the targeted runner tests; all tests completed successfully. 
- Executed `tools/boot/arm64_boot.py` conversion path locally against sample `kernel.elf` inputs to verify `Image` creation using detected `objcopy` binaries. 
- Validated the QEMU runner rejects ELF kernels for `arm64` `virt` cases by invoking the runner with a synthetic manifest and observing the expected error exit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfb6821f9c8320abeffb414fb8a817)