### PR TITLE
ARM64: objcopy selection, require raw Image for virt, and QEMU runner robustness

### DIFF
--- a/tools/boot/arm64_boot.py
+++ b/tools/boot/arm64_boot.py
@@ -12,13 +12,34 @@ def _run_command(cmd):
     result = subprocess.run(cmd)
     return result.returncode == 0
 
-def _build_arm64_image(kernel_path):
-    image_path = kernel_path.replace('kernel.elf', 'kernel.img')
+def _find_objcopy():
+    # Prefer versioned LLVM binaries first; some environments ship an
+    # `llvm-objcopy` wrapper that is present in PATH but not executable.
+    candidates = [
+        'llvm-objcopy-20',
+        '/usr/lib/llvm-20/bin/llvm-objcopy',
+        'llvm-objcopy',
+        'objcopy',
+    ]
+    for tool in candidates:
+        try:
+            probe = subprocess.run(
+                [tool, '--version'],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            if probe.returncode == 0:
+                return tool
+        except FileNotFoundError:
+            continue
+    return None
 
-    # Prefer llvm-objcopy (used elsewhere in this repo), fallback to objcopy.
-    if _run_command(['llvm-objcopy', '-O', 'binary', kernel_path, image_path]):
-        return image_path
-    if _run_command(['objcopy', '-O', 'binary', kernel_path, image_path]):
+def _build_arm64_image(kernel_path):
+    kernel_dir = os.path.dirname(kernel_path)
+    image_path = os.path.join(kernel_dir, 'Image')
+
+    objcopy = _find_objcopy()
+    if objcopy and _run_command([objcopy, '-O', 'binary', kernel_path, image_path]):
         return image_path
 
     raise Exception(

--- a/tools/runners/runner_qemu.py
+++ b/tools/runners/runner_qemu.py
@@ -43,12 +43,6 @@ def run(manifest):
     if machine_cfg.get('cpu'):
         cmd.extend(['-cpu', machine_cfg['cpu']])
 
-    # For ARM64 direct kernel boot, force firmware-less path to avoid host
-    # firmware variance (e.g., EDK2 grabbing control and appearing as a hang
-    # on serial-only runs).
-    if arch == 'arm64':
-        cmd.extend(['-bios', 'none'])
-
     cmd.extend(['-m', str(machine_cfg.get('memory', '512M'))])
 
     smp = machine_cfg.get('smp')
@@ -56,8 +50,25 @@ def run(manifest):
         cmd.extend(['-smp', str(smp)])
 
     artifacts = manifest.get('artifacts', {})
-    if artifacts.get('kernel'):
-        cmd.extend(['-kernel', artifacts['kernel']])
+    kernel_path = artifacts.get('kernel')
+    machine = machine_cfg.get('machine', '')
+    if arch == 'arm64' and 'virt' in machine and kernel_path:
+        normalized = kernel_path.replace('\\', '/')
+        if normalized.lower().endswith('.elf'):
+            print(
+                "Error: ARM64 virt requires a raw kernel image (Image), "
+                f"not ELF: {kernel_path}"
+            )
+            sys.exit(1)
+        if not normalized.endswith('/Image'):
+            print(
+                "Error: ARM64 virt expects kernel artifact named 'Image'. "
+                f"Found: {kernel_path}. Re-run build to regenerate manifest."
+            )
+            sys.exit(1)
+
+    if kernel_path:
+        cmd.extend(['-kernel', kernel_path])
 
     serial_routing = manifest.get('serial_routing', {})
     dual_serial = manifest.get('dual_serial_requested', False)
@@ -102,5 +113,9 @@ def run(manifest):
     # Try to execute if qemu is installed, otherwise just print
     try:
         subprocess.run(cmd)
+    except KeyboardInterrupt:
+        print("\n[QEMU Runner] Interrupted by user (Ctrl+C).")
+        print("[QEMU Runner] QEMU process terminated.")
+        sys.exit(130)
     except FileNotFoundError:
         print(f"Warning: {qemu_cmd} not found. Simulated execution successful.")


### PR DESCRIPTION
### Motivation
- Ensure the ARM64 boot image conversion uses a usable `objcopy` binary across environments and produces the expected raw `Image` artifact.
- Prevent running QEMU with an ELF kernel when the `virt` machine expects a raw `Image`, to avoid confusing boot behavior.
- Improve the QEMU runner's robustness by handling user interrupts cleanly.

### Description
- Added `_find_objcopy()` to prefer versioned LLVM `llvm-objcopy-20` and fall back to `llvm-objcopy` or `objcopy`, and used it from `_build_arm64_image()` which now writes `Image` into the kernel directory. 
- Updated `runner_qemu.py` to validate ARM64 + `virt` kernels and error out if the artifact is an ELF or not named `/Image`, and preserved the general `-kernel` handling for other cases. 
- Removed the unconditional `-bios none` insertion for ARM64 and added a `KeyboardInterrupt` handler around the `subprocess.run()` call so Ctrl+C prints a message and exits with code `130`.

### Testing
- No automated tests were executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfb6821f9c8320abeffb414fb8a817)