### PR TITLE
Improve ARM64 image creation and harden QEMU runner behavior

### DIFF
--- a/tools/boot/arm64_boot.py
+++ b/tools/boot/arm64_boot.py
@@ -12,13 +12,34 @@ def _run_command(cmd):
     result = subprocess.run(cmd)
     return result.returncode == 0
 
-def _build_arm64_image(kernel_path):
-    image_path = kernel_path.replace('kernel.elf', 'kernel.img')
+def _find_objcopy():
+    # Prefer versioned LLVM binaries first; some environments ship an
+    # `llvm-objcopy` wrapper that is present in PATH but not executable.
+    candidates = [
+        'llvm-objcopy-20',
+        '/usr/lib/llvm-20/bin/llvm-objcopy',
+        'llvm-objcopy',
+        'objcopy',
+    ]
+    for tool in candidates:
+        try:
+            probe = subprocess.run(
+                [tool, '--version'],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            if probe.returncode == 0:
+                return tool
+        except FileNotFoundError:
+            continue
+    return None
 
-    # Prefer llvm-objcopy (used elsewhere in this repo), fallback to objcopy.
-    if _run_command(['llvm-objcopy', '-O', 'binary', kernel_path, image_path]):
-        return image_path
-    if _run_command(['objcopy', '-O', 'binary', kernel_path, image_path]):
+def _build_arm64_image(kernel_path):
+    kernel_dir = os.path.dirname(kernel_path)
+    image_path = os.path.join(kernel_dir, 'Image')
+
+    objcopy = _find_objcopy()
+    if objcopy and _run_command([objcopy, '-O', 'binary', kernel_path, image_path]):
         return image_path
 
     raise Exception(

--- a/tools/runners/runner_qemu.py
+++ b/tools/runners/runner_qemu.py
@@ -43,12 +43,6 @@ def run(manifest):
     if machine_cfg.get('cpu'):
         cmd.extend(['-cpu', machine_cfg['cpu']])
 
-    # For ARM64 direct kernel boot, force firmware-less path to avoid host
-    # firmware variance (e.g., EDK2 grabbing control and appearing as a hang
-    # on serial-only runs).
-    if arch == 'arm64':
-        cmd.extend(['-bios', 'none'])
-
     cmd.extend(['-m', str(machine_cfg.get('memory', '512M'))])
 
     smp = machine_cfg.get('smp')
@@ -56,8 +50,25 @@ def run(manifest):
         cmd.extend(['-smp', str(smp)])
 
     artifacts = manifest.get('artifacts', {})
-    if artifacts.get('kernel'):
-        cmd.extend(['-kernel', artifacts['kernel']])
+    kernel_path = artifacts.get('kernel')
+    machine = machine_cfg.get('machine', '')
+    if arch == 'arm64' and 'virt' in machine and kernel_path:
+        normalized = kernel_path.replace('\\', '/')
+        if normalized.lower().endswith('.elf'):
+            print(
+                "Error: ARM64 virt requires a raw kernel image (Image), "
+                f"not ELF: {kernel_path}"
+            )
+            sys.exit(1)
+        if not normalized.endswith('/Image'):
+            print(
+                "Error: ARM64 virt expects kernel artifact named 'Image'. "
+                f"Found: {kernel_path}. Re-run build to regenerate manifest."
+            )
+            sys.exit(1)
+
+    if kernel_path:
+        cmd.extend(['-kernel', kernel_path])
 
     serial_routing = manifest.get('serial_routing', {})
     dual_serial = manifest.get('dual_serial_requested', False)
@@ -70,6 +81,8 @@ def run(manifest):
     if dual_serial:
         cmd.extend(['-serial', 'vc'])
 
+    is_windows = sys.platform.startswith('win')
+
     if not display_routing.get('requested'):
         # Headless routing:
         # - Prefer -nographic when serial is routed to stdio. This works across
@@ -77,7 +90,13 @@ def run(manifest):
         #   and keeps boot logs visible in the terminal.
         # - Fallback to -display none when no stdio serial sink is requested.
         if serial_routing.get('stdio'):
-            cmd.append('-nographic')
+            # On some native Windows QEMU builds, `-serial stdio` + `-nographic`
+            # can yield no visible guest output in PowerShell sessions.
+            # Prefer `-display none` there and keep explicit serial routing.
+            if is_windows:
+                cmd.extend(['-display', 'none'])
+            else:
+                cmd.append('-nographic')
         else:
             cmd.extend(['-display', 'none'])
     else:
@@ -102,5 +121,9 @@ def run(manifest):
     # Try to execute if qemu is installed, otherwise just print
     try:
         subprocess.run(cmd)
+    except KeyboardInterrupt:
+        print("\n[QEMU Runner] Interrupted by user (Ctrl+C).")
+        print("[QEMU Runner] QEMU process terminated.")
+        sys.exit(130)
     except FileNotFoundError:
         print(f"Warning: {qemu_cmd} not found. Simulated execution successful.")


### PR DESCRIPTION
### Motivation
- Ensure ARM64 kernel artifacts are produced as raw `Image` files and use a reliable `objcopy` binary selection to avoid failures in diverse environments.
- Prevent running ELF kernels with QEMU `-machine virt` and fail early with clear messages to avoid confusing runtime hangs.
- Make QEMU runner more robust on Windows and during user interrupts by adjusting display flags and handling `Ctrl+C` cleanly.

### Description
- Add `_find_objcopy` to `tools/boot/arm64_boot.py` to probe for `llvm-objcopy-20`, `/usr/lib/llvm-20/bin/llvm-objcopy`, `llvm-objcopy`, and `objcopy`, and use the discovered tool when converting ELF to a raw `Image` artifact.  Replace previous `kernel.elf`->`kernel.img` logic so `_build_arm64_image` emits `Image` next to the kernel. 
- In `tools/runners/runner_qemu.py` normalize kernel handling and only append `-kernel` after validating that an ARM64 `virt` target is not an ELF and that the artifact name is `Image`, emitting clear errors and exiting if expectations are not met. 
- Remove the forced `-bios none` override for ARM64 and add Windows-specific logic to prefer `-display none` instead of `-nographic` when `-serial stdio` is used, to preserve visible guest output in some PowerShell environments. 
- Add `KeyboardInterrupt` handling around the `subprocess.run` invocation to print a friendly message and exit with code `130` when interrupted by the user. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfb6821f9c8320abeffb414fb8a817)