### PR TITLE
Fix ARM64 headless boot logs on Windows

### DIFF
--- a/run_qemu_e2e.sh
+++ b/run_qemu_e2e.sh
@@ -253,15 +253,6 @@ run_case() {
     fi
     kernel_image="${build_dir}/kernel/kernel32.elf"
     "$oc" -O elf32-i386 "$kernel_elf" "$kernel_image"
-  elif [[ "$arch" == "arm64" ]]; then
-    local oc
-    if ! oc="$(objcopy_bin)"; then
-      echo "    [FAIL] objcopy/llvm-objcopy is required for arm64 Image generation"
-      FAIL_COUNT=$((FAIL_COUNT + 1))
-      return
-    fi
-    kernel_image="${build_dir}/kernel/Image"
-    "$oc" -O binary "$kernel_elf" "$kernel_image"
   fi
 
   : > "$log_file"

--- a/tests/e2e/run_e2e.py
+++ b/tests/e2e/run_e2e.py
@@ -133,13 +133,6 @@ def main():
         sys.exit(1)
 
     kernel_image = kernel_elf
-    if arch == "arm64":
-        objcopy = get_objcopy_bin()
-        if not objcopy:
-            print("[FAIL] objcopy or llvm-objcopy is required for arm64.")
-            sys.exit(1)
-        kernel_image = os.path.join(build_dir, "kernel", "Image")
-        subprocess.run([objcopy, "-O", "binary", kernel_elf, kernel_image], check=True)
 
     print(f"[*] Running QEMU ({qemu_cmd}) with kernel {kernel_image}...")
     qemu_full_args = [qemu_cmd, "-kernel", kernel_image] + qemu_args

--- a/tools/boot/arm64_boot.py
+++ b/tools/boot/arm64_boot.py
@@ -12,50 +12,12 @@ def _run_command(cmd):
     result = subprocess.run(cmd)
     return result.returncode == 0
 
-def _find_objcopy():
-    # Prefer versioned LLVM binaries first; some environments ship an
-    # `llvm-objcopy` wrapper that is present in PATH but not executable.
-    candidates = [
-        'llvm-objcopy-20',
-        '/usr/lib/llvm-20/bin/llvm-objcopy',
-        'llvm-objcopy',
-        'objcopy',
-    ]
-    for tool in candidates:
-        try:
-            probe = subprocess.run(
-                [tool, '--version'],
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-            )
-            if probe.returncode == 0:
-                return tool
-        except FileNotFoundError:
-            continue
-    return None
-
-def _build_arm64_image(kernel_path):
-    kernel_dir = os.path.dirname(kernel_path)
-    image_path = os.path.join(kernel_dir, 'Image')
-
-    objcopy = _find_objcopy()
-    if objcopy and _run_command([objcopy, '-O', 'binary', kernel_path, image_path]):
-        return image_path
-
-    raise Exception(
-        "ARM64 boot image conversion failed. Install llvm-objcopy or objcopy."
-    )
-
 def get_boot_config(kernel_path):
     check_fdt_ready()
     if not os.path.exists(kernel_path):
         raise Exception(f"ARM64 kernel ELF not found: {kernel_path}")
 
-    image_path = _build_arm64_image(kernel_path)
     return {
-        # Use a raw ARM64 Linux-style kernel image for QEMU `-kernel`.
-        # This keeps the 64-byte ARM64 image header at offset 0 and avoids
-        # host/QEMU differences in ELF loading behavior.
-        "kernel_path": image_path,
+        "kernel_path": kernel_path,
         "qemu_flags": []
     }

--- a/tools/runners/runner_qemu.py
+++ b/tools/runners/runner_qemu.py
@@ -53,20 +53,6 @@ def run(manifest):
     artifacts = manifest.get('artifacts', {})
     kernel_path = artifacts.get('kernel')
     machine = machine_cfg.get('machine', '')
-    if arch == 'arm64' and 'virt' in machine and kernel_path:
-        normalized = kernel_path.replace('\\', '/')
-        if normalized.lower().endswith('.elf'):
-            print(
-                "Error: ARM64 virt requires a raw kernel image (Image), "
-                f"not ELF: {kernel_path}"
-            )
-            sys.exit(1)
-        if not normalized.endswith('/Image'):
-            print(
-                "Error: ARM64 virt expects kernel artifact named 'Image'. "
-                f"Found: {kernel_path}. Re-run build to regenerate manifest."
-            )
-            sys.exit(1)
 
     if kernel_path:
         cmd.extend(['-kernel', kernel_path])


### PR DESCRIPTION
The user reported an issue where ARM64 builds run headlessly on Windows with QEMU were not producing console logs, although it was silently running in the background. Testing confirmed that removing the strict rule that forces using a raw `Image` payload and allowing `kernel.elf` to be booted directly resolves the console output issue across different OSes. This PR removes the `llvm-objcopy` steps that convert the ELF to a raw `Image` format and stops rejecting the ELF format in `runner_qemu.py`.

---
*PR created automatically by Jules for task [17902909817946056784](https://jules.google.com/task/17902909817946056784) started by @divyang4481*