### PR TITLE
Fix QEMU runner shutdown on Ctrl+C

### DIFF
--- a/tools/runners/runner_qemu.py
+++ b/tools/runners/runner_qemu.py
@@ -126,16 +126,12 @@ def run(manifest):
             sys.exit(return_code)
     except KeyboardInterrupt:
         print("\n[QEMU Runner] Interrupted by user (Ctrl+C).")
-        try:
-            if proc is not None:
-                if is_windows and hasattr(signal, "CTRL_BREAK_EVENT"):
-                    proc.send_signal(signal.CTRL_BREAK_EVENT)
-                else:
-                    proc.terminate()
-                proc.wait(timeout=5)
-        except Exception:
-            if proc is not None:
+        if proc is not None:
+            try:
                 proc.kill()
+                proc.wait(timeout=2)
+            except Exception:
+                pass
         print("[QEMU Runner] QEMU process terminated.")
         sys.exit(130)
     except FileNotFoundError:


### PR DESCRIPTION
This PR fixes an issue where pressing `Ctrl+C` while running a headless QEMU instance via `runner_qemu.py` fails to stop the QEMU process, leaving it hanging in the background.

The previous logic attempted graceful termination (`proc.terminate()` or `CTRL_BREAK_EVENT`), which was unreliable across Windows, WSL, and Linux, particularly when `KeyboardInterrupt` was triggered during the timeout wait. This update assertively calls `proc.kill()` to ensure immediate and reliable termination of QEMU.

---
*PR created automatically by Jules for task [915742560208935454](https://jules.google.com/task/915742560208935454) started by @divyang4481*