### PR TITLE
feat(telemetry): Add standard telemetry and diagnostic contract

### DIFF
--- a/docs/architecture/core/uapi-idl-ipc-boundary.md
+++ b/docs/architecture/core/uapi-idl-ipc-boundary.md
@@ -1,0 +1,140 @@
+# UAPI, IDL, and IPC Boundary
+
+This document explicitly defines the separation of concerns between UAPI, IDL, and IPC layers in Bharat-OS. Maintaining strict discipline around these boundaries is critical for a stable ABI, decoupled service interactions, and long-term architectural health.
+
+## Overview
+
+```text
+UAPI  → defines data structures (what data is)
+IDL   → defines interactions (how components talk)
+IPC   → implements transport (how messages move)
+```
+
+Or conceptually:
+
+```text
+[ UAPI structs ]
+       ↓
+[ IDL methods using those structs ]
+       ↓
+[ IPC transports those messages between endpoints ]
+```
+
+## Layer Definitions
+
+### 1. UAPI (User/API boundary)
+
+**Definition:** Stable, versioned, language-agnostic data contracts shared across the kernel, user-space services, and external consumers.
+
+**Scope:** The `uapi/` directory.
+
+**Must Include:**
+* C structs defining exact memory layout.
+* Enums and constants (e.g., event kinds, error codes).
+* ABI-stable types.
+* Capability handles and standardized identifiers.
+
+**Must NOT Include:**
+* Function implementations.
+* RPC method definitions or service logic.
+* Transport-specific mechanisms (e.g., queue pointers).
+
+### 2. IDL (Interface Definition Layer)
+
+**Definition:** Service interface contracts that define *how components interact*, not *what the internal data structures look like*.
+
+**Scope:** The `idl/` directory.
+
+**Must Include:**
+* RPC methods (e.g., `Subscribe`, `Publish`, `ReadSnapshot`).
+* Request and Response schemas that compose or reference UAPI types.
+* Streaming/subscription service contracts.
+
+**Must NOT Include:**
+* Kernel-internal structures.
+* Low-level ABI/memory layout assumptions.
+* Transport or implementation-specific code.
+
+### 3. IPC (Transport / Mechanism)
+
+**Definition:** The runtime mechanism used to move messages defined by IDL, carrying data structures defined in UAPI.
+
+**Scope:** `lib/ipc/`, `lib/urpc/`, or kernel IPC facilities.
+
+**Must Include:**
+* Message passing mechanics.
+* Queue management, buffering, and synchronization.
+* Transport-level framing.
+
+**Must NOT Include:**
+* Business logic or policy.
+* Service-specific schema definitions.
+* Enforcement of application-level invariants.
+
+## Folder Placement Rules
+
+* **`uapi/`**: Contains stable shared contracts (e.g., `uapi/bharat/system/telemetry.h`).
+* **`idl/`**: Contains service interface definitions (e.g., `idl/telemetry_v1.bidl`).
+* **`lib/ipc/` or `lib/urpc/`**: Implements transport mechanisms.
+* **`services/`**: Contains service implementations that provide or consume IDL interfaces.
+* **`kernel/`**: Emits or consumes UAPI types directly and leverages IPC, but typically does not participate in IDL-level RPC policies.
+
+## DOs and DON'Ts
+
+### DO
+* **DO** define shared structures in UAPI.
+* **DO** compose or reference UAPI types inside IDL messages.
+* **DO** keep IDL entirely transport-agnostic.
+* **DO** keep IPC mechanisms generic and strictly policy-free.
+
+### DO NOT
+* **DO NOT** duplicate data structures in IDL if they already exist (or should exist) in UAPI.
+* **DO NOT** embed RPC method definitions or service routing in UAPI headers.
+* **DO NOT** bake transport-specific (e.g., socket or queue) assumptions into IDL contracts.
+* **DO NOT** allow services to invent private, incompatible ad-hoc schemas when a shared semantic concept exists.
+
+## Concrete Examples
+
+### Example 1: Telemetry Event
+
+**UAPI (`uapi/bharat/system/telemetry.h`):**
+```c
+typedef struct {
+    uint64_t timestamp;
+    uint32_t event_type;
+    uint32_t severity;
+    uint32_t source_id;
+} bharat_event_header_t;
+```
+
+**IDL (`idl/telemetry_v1.bidl`):**
+```text
+rpc Subscribe(SubscribeReq) -> SubscribeResp
+rpc GetEventSnapshot(GetEventSnapshotReq) -> GetEventSnapshotResp
+```
+
+**IPC:**
+* A message sent via a uRPC queue, carrying a serialized payload built upon the UAPI struct.
+
+### Example 2: Telemetry Counter
+
+**UAPI (`uapi/bharat/system/telemetry.h`):**
+```c
+typedef struct {
+    uint32_t counter_id;
+    uint64_t value;
+    uint32_t type; /* monotonic vs gauge */
+} bharat_counter_t;
+```
+
+**IDL (`idl/telemetry_v1.bidl`):**
+```text
+rpc ListCounters(ListCountersReq) -> ListCountersResp
+rpc ReadCounterSnapshot(ReadCounterSnapshotReq) -> ReadCounterSnapshotResp
+```
+
+## Versioning Guidance
+
+* **UAPI** requires extreme caution; changes can break the fundamental ABI contract between kernel and user-space or between separately compiled components. Backward compatibility is strictly required.
+* **IDL** can evolve via versioned namespaces (e.g., `service.v1`, `service.v2`) allowing graceful service upgrades.
+* **IPC** remains generic, evolving only to optimize or add new transport backends.

--- a/docs/architecture/folder_structure.md
+++ b/docs/architecture/folder_structure.md
@@ -81,6 +81,7 @@ The `kernel/` directory should only contain:
 
 - **`stacks/`**: For composed subsystems that span multiple layers (e.g., `net/`, `storage/`, `media/`, `vehicle/`, `cloud/`). This prevents these complex systems from being smeared across `services/`, `lib/`, and `drivers/`.
 - **`uapi/`**: The explicit boundary for external contracts. Contains syscall headers, capability invoke contracts, shared IPC structures visible outside the kernel, and stable ABI types.
+  - *Note:* The strict separation between UAPI, IDL, and IPC is defined in [uapi-idl-ipc-boundary.md](core/uapi-idl-ipc-boundary.md).
 
 ### 6. Benchmark and Verification Ownership
 

--- a/docs/architecture/services/system/diag.md
+++ b/docs/architecture/services/system/diag.md
@@ -14,3 +14,4 @@ The `diag` service manages system diagnostics. This includes collecting metrics,
 
 - Hardware interfacing occurs through HAL/Drivers. The `diag` service only provides the policy/logic layer over collected telemetry.
 - IPC is used to expose diagnostic queries to other user-space managers.
+- Telemetry contracts strictly follow the separation between UAPI, IDL, and IPC defined in [uapi-idl-ipc-boundary.md](../../core/uapi-idl-ipc-boundary.md).

--- a/idl/services/telemetry_v1.bidl
+++ b/idl/services/telemetry_v1.bidl
@@ -1,0 +1,76 @@
+service bharat.telemetry.v1 = 10 {
+
+  // Subscription management
+  rpc Subscribe(SubscribeReq) -> SubscribeResp {
+    qos = reliable;
+    timeout_ms = 500;
+  }
+
+  rpc Unsubscribe(UnsubscribeReq) -> UnsubscribeResp {
+    qos = reliable;
+    timeout_ms = 500;
+  }
+
+  // Counter queries
+  rpc ListCounters(ListCountersReq) -> ListCountersResp {
+    qos = reliable;
+    timeout_ms = 500;
+  }
+
+  rpc ReadCounterSnapshot(ReadCounterSnapshotReq) -> ReadCounterSnapshotResp {
+    qos = reliable;
+    timeout_ms = 200;
+  }
+}
+
+// ---------------------------------------------------------
+// Subscriptions
+// ---------------------------------------------------------
+message SubscribeReq {
+  // Client identifier
+  u32 client_id;
+
+  // Filter settings matching UAPI definition
+  u32 event_kind_mask;
+  u32 min_severity;
+  u32 source_id;
+}
+
+message SubscribeResp {
+  u32 subscription_id;
+  u32 status; // 0 = ok
+}
+
+message UnsubscribeReq {
+  u32 subscription_id;
+}
+
+message UnsubscribeResp {
+  u32 status; // 0 = ok
+}
+
+
+// ---------------------------------------------------------
+// Counters
+// ---------------------------------------------------------
+message ListCountersReq {
+  u32 filter_source_id; // 0 for all sources
+}
+
+// In a real BIDL parser this would map to an array of bharat_counter_desc_t.
+// We approximate the layout here or use IDL strings/fields.
+message ListCountersResp {
+  u32 status;
+  u32 num_counters;
+  // Payload contains array of UAPI bharat_counter_desc_t structs
+}
+
+message ReadCounterSnapshotReq {
+  u32 counter_id;
+}
+
+message ReadCounterSnapshotResp {
+  u32 status; // 0 = ok
+  u64 value;
+  u64 timestamp_ns;
+}

--- a/include/bharat/telemetry.h
+++ b/include/bharat/telemetry.h
@@ -1,0 +1,86 @@
+#ifndef BHARAT_KERNEL_TELEMETRY_H
+#define BHARAT_KERNEL_TELEMETRY_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+/* Use relative path or standard path depending on the build system setup.
+ * Often uapi/ headers are included directly via include paths */
+#include "system/telemetry.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @file telemetry.h
+ * @brief Kernel-internal API for exporting telemetry data.
+ *
+ * This API provides hooks for kernel subsystems and drivers to register
+ * counters and emit events. It bridges internal kernel state to the stable
+ * UAPI structures, making them accessible to user-space services (e.g., diag).
+ *
+ * Note: This layer purely manages emission and registration mechanisms.
+ * Policy (such as routing, persistence, and complex filtering) is delegated
+ * entirely to user-space services.
+ */
+
+/* --------------------------------------------------------------------------
+ * Counters
+ * -------------------------------------------------------------------------- */
+
+/**
+ * Register a new telemetry counter.
+ *
+ * @param desc Pointer to the counter description structure.
+ * @return 0 on success, or a negative error code.
+ */
+int kernel_telemetry_register_counter(const bharat_counter_desc_t *desc);
+
+/**
+ * Update the value of a telemetry counter.
+ *
+ * @param counter_id The ID of the counter to update.
+ * @param value The new value for the counter.
+ * @return 0 on success, or a negative error code.
+ */
+int kernel_telemetry_update_counter(uint32_t counter_id, uint64_t value);
+
+/**
+ * Increment a telemetry counter by a specific amount.
+ *
+ * @param counter_id The ID of the counter to increment.
+ * @param amount The amount to increment by.
+ * @return 0 on success, or a negative error code.
+ */
+int kernel_telemetry_inc_counter(uint32_t counter_id, uint64_t amount);
+
+
+/* --------------------------------------------------------------------------
+ * Events
+ * -------------------------------------------------------------------------- */
+
+/**
+ * Emit a telemetry event.
+ *
+ * @param event Pointer to the populated event structure. The timestamp
+ *              will be automatically populated if it is 0.
+ * @return 0 on success, or a negative error code.
+ */
+int kernel_telemetry_emit_event(bharat_telemetry_event_t *event);
+
+/**
+ * Helper to quickly emit a simple event with no payload.
+ *
+ * @param kind Event kind.
+ * @param severity Event severity.
+ * @param source_id Subsystem or domain ID.
+ * @return 0 on success, or a negative error code.
+ */
+int kernel_telemetry_emit_simple_event(uint32_t kind, uint32_t severity, uint32_t source_id);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BHARAT_KERNEL_TELEMETRY_H */

--- a/services/system/diag/CMakeLists.txt
+++ b/services/system/diag/CMakeLists.txt
@@ -8,10 +8,11 @@ if (BHARAT_AUTOMOTIVE_PROFILE)
             store.c
             debounce.c
             freeze_frame.c
+            telemetry.c
         LIBS
             bharat_libruntime
             bharat_libipc
             bharat_libcap
     )
-    target_include_directories(diag_service PRIVATE ${CMAKE_SOURCE_DIR}/services/include)
+    target_include_directories(diag_service PRIVATE ${CMAKE_SOURCE_DIR}/services/include ${CMAKE_SOURCE_DIR}/uapi/bharat)
 endif()

--- a/services/system/diag/main.c
+++ b/services/system/diag/main.c
@@ -1,5 +1,12 @@
 #include <stdio.h>
+
+extern void diag_telemetry_init(void);
+
 int main(void) {
     printf("Diag Service started.\n");
+
+    // Initialize the telemetry subsystem
+    diag_telemetry_init();
+
     return 0;
 }

--- a/services/system/diag/telemetry.c
+++ b/services/system/diag/telemetry.c
@@ -1,0 +1,116 @@
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+
+/* This would typically come from our internal includes, but we'll mock the needed UAPI parts for now. */
+#include "system/telemetry.h"
+
+#define MAX_SUBSCRIPTIONS 32
+
+typedef struct {
+    bool active;
+    uint32_t sub_id;
+    uint32_t client_id;
+    bharat_telemetry_filter_t filter;
+} diag_subscription_t;
+
+static diag_subscription_t s_subscriptions[MAX_SUBSCRIPTIONS];
+static uint32_t s_next_sub_id = 1;
+
+/**
+ * Initialize the subscription subsystem.
+ */
+void diag_telemetry_init(void) {
+    memset(s_subscriptions, 0, sizeof(s_subscriptions));
+}
+
+/**
+ * Handle a Subscribe request.
+ *
+ * @param client_id ID of the subscribing client.
+ * @param filter The filter parameters.
+ * @param out_sub_id Pointer to store the assigned subscription ID.
+ * @return 0 on success, negative error code on failure.
+ */
+int diag_telemetry_subscribe(uint32_t client_id, const bharat_telemetry_filter_t* filter, uint32_t* out_sub_id) {
+    if (!filter || !out_sub_id) {
+        return -1;
+    }
+
+    for (int i = 0; i < MAX_SUBSCRIPTIONS; ++i) {
+        if (!s_subscriptions[i].active) {
+            s_subscriptions[i].active = true;
+            s_subscriptions[i].sub_id = s_next_sub_id++;
+            s_subscriptions[i].client_id = client_id;
+            s_subscriptions[i].filter = *filter;
+            *out_sub_id = s_subscriptions[i].sub_id;
+            return 0; // Success
+        }
+    }
+
+    return -2; // Out of resources
+}
+
+/**
+ * Handle an Unsubscribe request.
+ *
+ * @param sub_id The subscription ID to remove.
+ * @return 0 on success, negative error code on failure.
+ */
+int diag_telemetry_unsubscribe(uint32_t sub_id) {
+    for (int i = 0; i < MAX_SUBSCRIPTIONS; ++i) {
+        if (s_subscriptions[i].active && s_subscriptions[i].sub_id == sub_id) {
+            s_subscriptions[i].active = false;
+            return 0; // Success
+        }
+    }
+    return -1; // Not found
+}
+
+/**
+ * Filter an incoming event against a subscription.
+ *
+ * @param event The event to check.
+ * @param filter The filter to apply.
+ * @return true if the event passes the filter, false otherwise.
+ */
+bool diag_telemetry_filter_event(const bharat_telemetry_event_t* event, const bharat_telemetry_filter_t* filter) {
+    if (!event || !filter) {
+        return false;
+    }
+
+    // Check kind mask
+    if ((filter->event_kind_mask & (1 << event->kind)) == 0 && filter->event_kind_mask != 0xFFFFFFFF) {
+        return false;
+    }
+
+    // Check severity
+    if (event->severity < filter->min_severity) {
+        return false;
+    }
+
+    // Check source
+    if (filter->source_id != 0 && event->source_id != filter->source_id) {
+        return false;
+    }
+
+    return true;
+}
+
+/**
+ * Process an incoming event from the kernel or another subsystem.
+ *
+ * @param event The incoming event.
+ */
+void diag_telemetry_process_event(const bharat_telemetry_event_t* event) {
+    if (!event) return;
+
+    for (int i = 0; i < MAX_SUBSCRIPTIONS; ++i) {
+        if (s_subscriptions[i].active) {
+            if (diag_telemetry_filter_event(event, &s_subscriptions[i].filter)) {
+                // In a real implementation, this would queue a message to the client_id via IPC
+                // e.g., ipc_send_event(s_subscriptions[i].client_id, event);
+            }
+        }
+    }
+}

--- a/uapi/bharat/system/telemetry.h
+++ b/uapi/bharat/system/telemetry.h
@@ -1,0 +1,100 @@
+#ifndef BHARAT_UAPI_SYSTEM_TELEMETRY_H
+#define BHARAT_UAPI_SYSTEM_TELEMETRY_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @file telemetry.h
+ * @brief UAPI for System Telemetry and Diagnostics.
+ *
+ * This file defines the stable, shared data structures for telemetry events,
+ * counters, and diagnostic data across the system. It adheres to the strict
+ * UAPI boundary definition where these structs describe *what* the data is.
+ */
+
+/* --------------------------------------------------------------------------
+ * Event Kinds
+ * -------------------------------------------------------------------------- */
+#define BHARAT_EVENT_KIND_FAULT      1
+#define BHARAT_EVENT_KIND_POWER      2
+#define BHARAT_EVENT_KIND_THERMAL    3
+#define BHARAT_EVENT_KIND_NETWORK    4
+#define BHARAT_EVENT_KIND_HEARTBEAT  5
+#define BHARAT_EVENT_KIND_AUDIT      6
+#define BHARAT_EVENT_KIND_DIAG       7
+
+/* --------------------------------------------------------------------------
+ * Event Severities
+ * -------------------------------------------------------------------------- */
+#define BHARAT_SEVERITY_DEBUG        0
+#define BHARAT_SEVERITY_INFO         1
+#define BHARAT_SEVERITY_WARNING      2
+#define BHARAT_SEVERITY_ERROR        3
+#define BHARAT_SEVERITY_CRITICAL     4
+#define BHARAT_SEVERITY_FATAL        5
+
+/* --------------------------------------------------------------------------
+ * Telemetry Event Structure
+ * -------------------------------------------------------------------------- */
+typedef struct {
+    uint32_t version;         /* Event format version (currently 1) */
+    uint32_t kind;            /* Event kind (e.g., BHARAT_EVENT_KIND_FAULT) */
+    uint64_t timestamp_ns;    /* Monotonic timestamp in nanoseconds */
+    uint32_t severity;        /* Event severity */
+    uint32_t source_id;       /* Domain or subsystem ID originating the event */
+    uint32_t payload_type;    /* Identifies the layout of payload_data */
+    uint32_t payload_len;     /* Length of the payload */
+    uint8_t  payload_data[64]; /* Inline payload data (union or typed extension could go here) */
+} bharat_telemetry_event_t;
+
+
+/* --------------------------------------------------------------------------
+ * Heartbeat Specifics
+ * -------------------------------------------------------------------------- */
+/* When kind == BHARAT_EVENT_KIND_HEARTBEAT, the payload represents this struct */
+typedef struct {
+    uint32_t status_flags;    /* Bitmask indicating component health */
+    uint32_t uptime_seconds;
+} bharat_heartbeat_payload_t;
+
+
+/* --------------------------------------------------------------------------
+ * Counter Definitions
+ * -------------------------------------------------------------------------- */
+#define BHARAT_COUNTER_TYPE_MONOTONIC 0
+#define BHARAT_COUNTER_TYPE_GAUGE     1
+
+typedef struct {
+    uint32_t counter_id;
+    uint32_t source_id;       /* Subsystem or component ID */
+    uint32_t type;            /* BHARAT_COUNTER_TYPE_MONOTONIC or GAUGE */
+    char     name[32];        /* Null-terminated name */
+    char     unit[16];        /* e.g., "bytes", "errors", "celsius" */
+} bharat_counter_desc_t;
+
+typedef struct {
+    uint32_t counter_id;
+    uint64_t value;           /* Current counter value */
+    uint64_t timestamp_ns;    /* When this value was sampled */
+} bharat_counter_snapshot_t;
+
+
+/* --------------------------------------------------------------------------
+ * Subscription Filters
+ * -------------------------------------------------------------------------- */
+typedef struct {
+    uint32_t event_kind_mask; /* Bitmask of event kinds to receive, or 0xFFFFFFFF for all */
+    uint32_t min_severity;    /* Only receive events with severity >= min_severity */
+    uint32_t source_id;       /* Specific source ID to filter, or 0 for all sources */
+} bharat_telemetry_filter_t;
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BHARAT_UAPI_SYSTEM_TELEMETRY_H */


### PR DESCRIPTION
Implemented the system-wide telemetry and diagnostic contract.

- Created `docs/architecture/core/uapi-idl-ipc-boundary.md` to define architectural boundaries.
- Defined UAPI schema in `uapi/bharat/system/telemetry.h`.
- Defined Service IDL in `idl/services/telemetry_v1.bidl`.
- Added kernel hook API in `include/bharat/telemetry.h`.
- Extended `services/system/diag` with `telemetry.c` to manage subscriptions.

---
*PR created automatically by Jules for task [17445596510657911722](https://jules.google.com/task/17445596510657911722) started by @divyang4481*