### PR TITLE
build: add safe stub for execution mode framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ CMakeFiles/
 Testing/
 Makefile
 *.cmake
+!cmake/*.cmake
 !cmake/toolchains/*.cmake
 !cmake/modules/*.cmake
 !tests/host/cmake/*.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,11 @@ set(BHARAT_ISA_FEATURES "" CACHE STRING "Target ISA features as a semicolon-sepa
 set(BHARAT_ACCELERATOR_CLASSES "" CACHE STRING "Target accelerator classes as a semicolon-separated list (e.g., gpu;npu;dsp;crypto;vpu)")
 
 # Execution Mode Framework Integration
-include(cmake/BharatExecutionMode.cmake)
+if(EXISTS "${CMAKE_SOURCE_DIR}/cmake/BharatExecutionMode.cmake")
+    include(cmake/BharatExecutionMode.cmake)
+else()
+    message(WARNING "BharatExecutionMode.cmake not found, using defaults")
+endif()
 
 # Memory Capability Options
 option(BHARAT_ENABLE_MMU "Enable MMU support" ON)

--- a/cmake/BharatExecutionMode.cmake
+++ b/cmake/BharatExecutionMode.cmake
@@ -1,0 +1,18 @@
+# BharatExecutionMode.cmake
+# Stub implementation to unblock build
+# Full execution-mode framework not yet integrated
+
+option(BHARAT_ENABLE_EXECUTION_MODE_FRAMEWORK "Enable execution mode framework" OFF)
+
+set(BHARAT_SYSTEM_PROFILE "GP" CACHE STRING "System profile (RT, GP, MIX)")
+set(BHARAT_EXECUTION_MODE "SMP" CACHE STRING "Execution mode (SMP, AMP, PARTITIONED)")
+
+# Logical CPU count (fallback)
+set(BHARAT_LOGICAL_CPU_COUNT 1 CACHE STRING "Logical CPU count")
+
+# Scheduler class (default fallback)
+set(BHARAT_SCHEDULER_CLASS "DEFAULT" CACHE STRING "Scheduler class")
+
+message(STATUS "[ExecutionMode] Framework: STUB (disabled)")
+message(STATUS "[ExecutionMode] Profile: ${BHARAT_SYSTEM_PROFILE}")
+message(STATUS "[ExecutionMode] Mode: ${BHARAT_EXECUTION_MODE}")


### PR DESCRIPTION
Fixes a CMake configuration failure caused by a missing file `cmake/BharatExecutionMode.cmake`.
This patch introduces a minimal, safe stub for the execution mode framework and makes its inclusion in `CMakeLists.txt` optional to unblock builds without introducing untested "fake architecture". Additionally, `.gitignore` has been updated to ensure the `.cmake` file can be tracked in the repository.

---
*PR created automatically by Jules for task [15751760293415833221](https://jules.google.com/task/15751760293415833221) started by @divyang4481*