### PR TITLE
feat(architecture): Establish platformization and personality contracts

### DIFF
--- a/docs/architecture/personalities/android-compat-personality.md
+++ b/docs/architecture/personalities/android-compat-personality.md
@@ -1,0 +1,46 @@
+---
+title: Android Compatibility Personality
+status: active
+owner: Architecture Team
+version: 1.0
+---
+
+# Android Compatibility Personality
+
+The Android Compatibility Personality is designed to provide application ecosystem leverage for mobile, embedded, and consumer profile use cases. It aims to host Android application frameworks and runtimes above the Bharat-OS native core.
+
+## 1. Scope and Purpose
+
+*   **Goal:** Enable running Android apps (APK/AAB) and reusing Android ecosystem components (like SurfaceFlinger equivalents or media stacks) with minimal modification.
+*   **Target Workloads:** GUI-heavy consumer apps, mobile middleware, and embedded Android use cases.
+
+## 2. ART and Runtime Expectations
+
+*   The personality hosts the Android Runtime (ART).
+*   It provides the required native memory mappings, threading behaviors (e.g., standard Bionic libc expectations), and JNI environments required by ART.
+*   This relies heavily on the shared **Runtime Hosting Layer** (`uapi/runtime/`) for standard process and memory hooks.
+
+## 3. Binder IPC Strategy
+
+*   **No In-Kernel Binder:** Bharat-OS will not implement Binder in the kernel.
+*   **User-Space Translation:** The personality must implement a user-space Binder emulation layer or an adapter that translates Binder transactions into Bharat-OS native URPC messages.
+*   Android services (e.g., ActivityManager) will run as isolated user-space processes communicating over this emulated Binder/URPC bridge.
+
+## 4. HAL Adaptation (Display, Input, Audio, Sensors)
+
+*   The Android HAL (Hardware Abstraction Layer) will not communicate directly with Bharat-OS kernel drivers.
+*   The personality provides an **Adapter HAL**:
+    *   **Graphics (Gralloc/Surface):** Maps to the Bharat-OS native display server and shared memory arenas.
+    *   **Audio/Input:** Translates Android AudioFlinger and InputManager requests into native Bharat-OS service IPC.
+    *   **Sensors:** Bridges Android sensor events from the native sensor service.
+
+## 5. Packaging and Deployment Flow
+
+*   Android APKs remain the deployment unit.
+*   The `bharat-pkg` tool (or a dedicated Android personality installer) parses the `AndroidManifest.xml` and translates its permissions into Bharat-OS capabilities.
+*   The application runs inside a native Bharat-OS sandbox, meaning Android permissions are strictly enforced by the native capability subsystem.
+
+## 6. Compatibility Limits
+
+*   We do not aim to support full custom Android ROM features or deep system-level Android modifications.
+*   Root apps or apps expecting to drop into a raw Linux shell will not work.

--- a/docs/architecture/personalities/linux-compat-personality.md
+++ b/docs/architecture/personalities/linux-compat-personality.md
@@ -1,0 +1,46 @@
+---
+title: Linux Compatibility Personality
+status: active
+owner: Architecture Team
+version: 1.0
+---
+
+# Linux Compatibility Personality
+
+The Linux Compatibility Personality provides a POSIX-like user space to accelerate ecosystem unlock for developer tools, existing C/C++ projects, and headless server workloads (e.g., Python, Node.js).
+
+## 1. Scope and Purpose
+
+*   **Goal:** Enable rapid porting of POSIX software with zero or minimal source modifications.
+*   **Target Workloads:** CLI tools, server applications, language runtimes (Python, Node.js, early Java/CoreCLR), and build systems.
+
+## 2. ELF Loading Model
+
+*   The personality intercepts execution of statically or dynamically linked Linux ELF binaries.
+*   It implements a custom `ld.so` or traps the entry point to inject the libc shim layer.
+
+## 3. POSIX and Syscall Coverage Scope
+
+*   **File I/O:** `open`, `read`, `write`, `close`, `seek`, `stat`.
+*   **Memory:** `mmap`, `munmap`, `mprotect` (translated to Bharat-OS VM abstractions).
+*   **Sockets:** Baseline IPv4/IPv6 TCP and UDP sockets.
+*   **Threading:** Standard `pthread` expectations (creation, mutexes, condition variables) mapped to Bharat-OS native threads.
+*   **Signals:** A restricted, mostly synchronous subset of signals (e.g., `SIGINT`, `SIGTERM`, `SIGSEGV`).
+
+## 4. What is Explicitly NOT Supported
+
+This personality does **not** aim for 100% bug-for-bug Linux compatibility.
+*   **No full `fork()`:** Applications relying on complex `fork()`+`exec()` states with deep copy-on-write assumptions may fail or require porting to `posix_spawn()`.
+*   **No `ptrace` or deep kernel tracing:** Linux specific debug APIs are not supported. Debugging goes through the Bharat-OS diagnostic SDK.
+*   **No `cgroups` or `namespaces`:** Linux container models are not emulated. Isolation is handled natively via Bharat-OS capabilities.
+*   **No raw device nodes:** `/dev/sda` or raw `ioctl` pass-through to hardware is forbidden.
+
+## 5. libc Strategy
+
+*   The personality relies on a custom or heavily patched libc (e.g., musl libc ported to the Bharat-OS UAPI) acting as a bridge.
+*   System calls are intercepted in user space and translated to Bharat-OS Native IPC messages to the VFS or Network services.
+
+## 6. Filesystem and Networking Expectations
+
+*   **VFS Bridge:** The personality presents a fake global filesystem hierarchy (like `/etc`, `/usr`, `/tmp`) backed by a chroot-like capability granted by the Native OS.
+*   **Networking:** Standard BSD sockets are supported via a library translation layer communicating with the Native network service.

--- a/docs/architecture/personalities/native-personality.md
+++ b/docs/architecture/personalities/native-personality.md
@@ -1,0 +1,73 @@
+---
+title: Native Personality
+status: active
+owner: Architecture Team
+version: 1.0
+---
+
+# Native Personality (Bharat-OS Reference)
+
+The Native Personality is the reference platform for Bharat-OS. It is not an emulation or compatibility layer; it is the raw, unrestricted (save for capability constraints) application platform. It defines the true OS contract.
+
+## 1. App Model (Process & Lifecycle)
+
+*   **No `fork()`:** Applications are created using explicit `spawn` primitives. Address spaces are populated based on the app manifest before thread execution begins.
+*   **Lifecycle:** Applications receive explicit capability-mediated messages for `START`, `PAUSE`, `RESUME`, and `STOP`.
+*   **Background Jobs:** Native apps do not fork to daemonize. They register background service components in their manifest, which the OS scheduler and service manager invoke based on system policy.
+
+## 2. Manifest Schema
+
+Every Native application is deployed with a strict manifest.
+```json
+{
+  "app_id": "com.bharatos.native.demo",
+  "version": "1.0.0",
+  "entry": "bin/demo_app",
+  "capabilities": {
+    "required": [
+      "sys.display.window.create",
+      "net.socket.bind:8080"
+    ],
+    "optional": [
+      "hw.camera.access"
+    ]
+  },
+  "services": [
+    {
+      "name": "demo_worker",
+      "ipc_contract": "bidl/demo_v1"
+    }
+  ]
+}
+```
+
+## 3. IPC and Service Access Model
+
+*   **URPC Native:** All cross-process communication uses the Bharat-OS URPC (Unified RPC) layer over capability-secured endpoints.
+*   **Service Discovery:** Apps query a local namespace manager for service endpoints. Endpoints are strictly isolated.
+*   **No Global PIDs:** Apps do not send signals to process IDs. They send messages to capability handles representing a target.
+
+## 4. Capability Model Usage
+
+The Native personality is the purest expression of the Bharat-OS capability model.
+*   Handles are 64-bit opaque references managed by the kernel.
+*   Every UAPI call (map memory, send message, create thread) requires an explicit handle.
+*   Capabilities are granted at spawn via the manifest and can be delegated dynamically via IPC.
+
+## 5. Filesystem and Config Conventions
+
+*   **VFS is a Service:** The filesystem is not in the kernel. It is a service accessed via URPC.
+*   **Namespaces over Paths:** Global `/` does not exist for apps. An app is granted a capability to a virtual root directory (e.g., its private data directory and a read-only view of its package).
+*   **Config:** Configuration is exposed via a structured capability-based key-value service, not flat files in `/etc`.
+
+## 6. Packaging Model
+
+*   Packages are read-only, verifiable bundles (e.g., similar to Flatpak or APEX) signed by a trusted authority.
+*   Installed via the `bharat-pkg` tool.
+*   Updates are atomic.
+
+## 7. SDK Contract
+
+*   **Languages:** C, C++, and Rust are first-class native languages.
+*   **Headers:** Found in `sdk/native/include/`.
+*   **Libraries:** Link against `libbharat_native`, which provides safe wrappers around raw `uapi/` syscalls.

--- a/docs/architecture/personalities/personality-contract.md
+++ b/docs/architecture/personalities/personality-contract.md
@@ -1,0 +1,47 @@
+---
+title: Personality Contract
+status: active
+owner: Architecture Team
+version: 1.0
+---
+
+# Personality Contract
+
+This document is the root governance contract for all personality implementations within Bharat-OS. It defines the strict boundaries of what a personality is allowed to do, what it must delegate, and how it interacts with the underlying capability-oriented microkernel and services.
+
+## 1. What a Personality Owns
+
+A personality is an adapter layer responsible for translating an external Application Binary Interface (ABI) or runtime expectation into Bharat-OS native primitives. A personality owns:
+*   **Application Lifecycle Translation:** Translating foreign process concepts (e.g., `fork`, Android Activity transitions) into Bharat-OS `spawn` and lifecycle messages.
+*   **ABI/Syscall Emulation:** Implementing traps, syscall entries, or libc bridges that foreign binaries expect.
+*   **Resource Mapping:** Mapping foreign identifiers (e.g., file descriptors, Android Binders) to Bharat-OS capability handles.
+*   **Toolchain/Packaging Abstraction:** Defining how a foreign binary is packaged, deployed, and identified within its own ecosystem.
+
+## 2. What a Personality Cannot Bypass
+
+Personalities are strictly user-space components (or user-space service extensions). They **must not**:
+*   **Bypass Capability Security:** A personality cannot access resources for which it (or its client process) does not hold a valid capability handle.
+*   **Fork Kernel Architecture:** A personality cannot add architecture-specific drivers, kernel traps, or modify the core scheduler to achieve compatibility.
+*   **Bypass the Driver Model:** Hardware access must always go through the unified device manager and service layer. Personalities cannot directly drive hardware (e.g., no raw memory mapping of device registers unless explicitly granted via a capability for an adapter service).
+*   **Implement Monolithic Filesystems:** A personality must translate file operations to the Bharat-OS VFS IPC contracts. It cannot write its own raw block drivers.
+
+## 3. Kernel and Service Interaction Rules
+
+*   **Mechanism vs. Policy:** The kernel provides mechanisms (memory, threads, capabilities, IPC). Services provide policy (access control, routing, naming). Personalities are strictly clients to services.
+*   **IPC Mapping:** Personalities must translate their native IPC (e.g., POSIX signals, D-Bus, Binder) into Bharat-OS URPC messages or local shared memory arenas coordinated via capabilities.
+*   **Sandboxing:** Every personality runs within a standard Bharat-OS namespace and sandbox, constrained by the capability grant at launch.
+
+## 4. Capability Enforcement Rules
+
+*   **No Ambient Authority:** A personality cannot assume "root" or ambient file system access.
+*   **Translation, Not Escalation:** If a Linux binary requests `open("/etc/passwd", O_RDONLY)`, the Linux personality must have been granted a namespace capability that includes the `/etc` equivalent, and must perform the lookup against the native VFS service.
+
+## 5. ABI/API Stability Levels
+
+*   **Native UAPI:** Strictly versioned and stable. Personalities rely on this.
+*   **Personality Internal ABI:** Owned by the personality. The Linux personality may upgrade its `glibc` shim independently of the Native personality, provided it continues to map to the stable Native UAPI.
+*   **Runtime Hosting:** Personalities interact with language runtimes via the Runtime Hosting layer, which provides a stable intermediate contract.
+
+## 6. Runtime Hosting Dependency
+
+All personalities must eventually target the shared **Runtime Hosting Layer** (`uapi/runtime/`, `lib/runtime/host/`) when integrating major managed runtimes (Java, Python, .NET, Node.js). Personalities should not implement bespoke bare-metal hooks for these runtimes if a shared abstraction exists.

--- a/docs/architecture/personalities/personality-performance-contract.md
+++ b/docs/architecture/personalities/personality-performance-contract.md
@@ -1,0 +1,70 @@
+---
+title: Personality Performance Contract
+status: active
+owner: Architecture Team
+version: 1.0
+---
+
+# Personality Performance Contract
+
+Compatibility is not enough. Personality support on Bharat-OS must be performance-grade. If the Linux or Android personality acts as a slow translation layer, it will only be tolerated for demos. Our goal is **near-native semantics, near-native performance, and native-grade observability** for each personality.
+
+## 1. The Core Rule
+
+Do **not** build personalities as heavy emulation first. Instead, build them as:
+*   Thin ABI/runtime personalities.
+*   Running on top of high-performance shared kernel mechanisms.
+*   Using zero-copy and direct fast paths where possible.
+*   Enforcing policy separation only where it does not hurt hot paths.
+
+## 2. 3 Execution Tiers
+
+We enforce a tiered execution model to preserve performance parity.
+
+### Tier 1 — Native Fast Path
+For Bharat Native apps and services:
+*   Direct ABI and IPC.
+*   Direct graphics/network/storage contracts.
+*   No compatibility tax.
+*   **Must be the best-performing path.**
+
+### Tier 2 — Personality-Optimized Path
+For Linux and Android personalities:
+*   ABI-compatible front end.
+*   Shared kernel primitives underneath.
+*   Compatibility shim *only* at the contract boundary.
+*   No repeated translations across layers.
+
+### Tier 3 — Fallback/Emulation Path
+For unsupported or rare features:
+*   Slow path via userspace helpers or complex translation.
+*   Clearly marked and measurable.
+*   **Must never dominate common workloads.**
+
+## 3. Hot-Path First Design
+
+For every personality, we separate operations into hot, warm, and cold paths. Hot paths must avoid extra service hops, dynamic allocation, format translation, and repeated validation.
+
+### Hot Path Examples
+*   **Linux:** `read`/`write`, `send`/`recv`, `epoll` wait/wakeup, futex-like primitives, `mmap`/page fault.
+*   **Android:** Binder transact/reply, UI buffer queue, input event dispatch, audio callbacks, surface composition signaling.
+*   **Native:** Service IPC, async runtime wakeups, graphics command submission, storage/network stream path.
+
+## 4. Personality-Aware Optimizations
+
+Performance parity requires tuning the shared kernel mechanisms to cater to personality semantics without rewriting them:
+
+*   **Scheduler:** Per-personality hooks for wakeup latency, UI/render affinity, server throughput classes, and futex/park efficiency.
+*   **IPC:** Different IPC classes: tiny control messages, large shared buffer handoff, and zero-copy async streams.
+*   **VM:** COW performance, page fault fast paths, and personality-specific memory hints.
+
+## 5. Performance Budgets
+
+Every personality adapter operates under a strict budget compared to native benchmarks on identical hardware:
+
+*   **Linux Personality Budget:** Tight overhead bounds on syscall adapter, VFS translation, socket translation, and thread/TLS overhead. Target is parity with native Linux for server/CLI workloads.
+*   **Android Personality Budget:** Tight overhead bounds on Binder wrapper, graphics queue, and audio bridge overhead. Target is parity with native Android for UI/media workloads.
+
+## 6. Observability Parity
+
+To hit these budgets, the Bharat-OS SDK must provide tracing, perf counters, IPC latency histograms, frame timing, and page fault profiling equal to or better than native Linux/Android ecosystems.

--- a/idl/runtime/runtime_v1.bidl
+++ b/idl/runtime/runtime_v1.bidl
@@ -1,0 +1,43 @@
+// Runtime Hosting Service Contract v1
+// This interface defines the contract between a runtime environment
+// (e.g., Java ART, Node.js v8, Python) and the Bharat-OS Service Manager.
+
+namespace bharat.runtime.v1;
+
+/// Represents the current execution state of a hosted runtime.
+enum RuntimeState {
+    INIT = 0,
+    RUNNING = 1,
+    PAUSED = 2,
+    STOPPING = 3,
+    CRASHED = 4
+}
+
+/// A request to spawn a new isolate or process within the current runtime capability domain.
+struct SpawnRequest {
+    string package_id;
+    string entry_point;
+    list<string> args;
+}
+
+/// The result of a spawn operation.
+struct SpawnResponse {
+    uint64 process_handle;
+    int32 status_code;
+}
+
+/// Service interface for the runtime host to communicate with the OS.
+interface RuntimeHostController {
+
+    /// Reports the current state of the runtime to the OS lifecycle manager.
+    /// This is used for suspending/resuming apps or tracking background jobs.
+    method ReportState(RuntimeState state) -> ();
+
+    /// Requests to spawn a new child process bounded by the current app's capabilities.
+    method SpawnChild(SpawnRequest req) -> (SpawnResponse res);
+
+    /// Looks up an OS service capability handle by name.
+    /// The OS will only return a handle if the app's manifest permits it.
+    method LookupService(string service_name) -> (uint64 endpoint_handle);
+
+}

--- a/lib/android/README.md
+++ b/lib/android/README.md
@@ -1,0 +1,15 @@
+# Bharat-OS Android Compatibility Library Layer
+
+This directory (`lib/android/`) contains the user-space portability library for the Android Compatibility Personality.
+
+## Purpose
+
+It implements the Binder adapters, HAL translation layers (Gralloc, AudioFlinger shims), and ART runtime expectations required to host the Android application framework.
+
+## Scope
+* Bionic libc ABI compatibility stubs.
+* User-space Binder to Bharat-OS URPC translation.
+* Graphic and sensor adapter libraries.
+
+## Boundary
+Code here is strictly an adapter. It must map down into the `uapi/runtime/` hosting layer or communicate via IPC to native Bharat-OS display/sensor services. It does not introduce Android-specific code into the core kernel or driver model.

--- a/lib/android/stub.c
+++ b/lib/android/stub.c
@@ -1,0 +1,5 @@
+/* Stub for Android Compatibility Library */
+
+void bharat_android_compat_init(void) {
+    // Initialization for Android compatibility shims (e.g., Binder translator)
+}

--- a/lib/linux_compat/README.md
+++ b/lib/linux_compat/README.md
@@ -1,0 +1,16 @@
+# Bharat-OS Linux Compatibility Library Layer
+
+This directory (`lib/linux_compat/`) contains the user-space portability library for the Linux Compatibility Personality.
+
+## Purpose
+
+It implements the libc shims, ELF loading stubs, and syscall translation mechanisms required to host unaltered Linux binaries.
+
+## Scope
+* Syscall trap handlers.
+* Translation from Linux file descriptors (FDs) to Bharat-OS Capabilities.
+* Signal translation logic.
+* Threading/pthread emulation backed by `lib/runtime/host/`.
+
+## Boundary
+Code in this folder must *not* leak into `lib/posix/` or core `lib/`. It is strictly tied to the `BHARAT_ENABLE_COMPAT_LINUX` personality path.

--- a/lib/linux_compat/stub.c
+++ b/lib/linux_compat/stub.c
@@ -1,0 +1,5 @@
+/* Stub for Linux Compatibility Library */
+
+void bharat_linux_compat_init(void) {
+    // Initialization for Linux compatibility shims
+}

--- a/lib/posix/README.md
+++ b/lib/posix/README.md
@@ -1,0 +1,6 @@
+# Bharat-OS POSIX Portability Layer
+
+This directory contains the core POSIX abstraction layer for Bharat-OS.
+It is designed to provide minimal, capability-aware POSIX equivalents for basic C/C++ runtimes.
+
+This is a **portability layer** meant to map standard C library functions (like open/read/write) down to Bharat-OS `uapi/` and `uapi/runtime/` calls. It is distinct from the full `linux_compat` personality layer, though the personality layer may rely heavily on this.

--- a/lib/runtime/CMakeLists.txt
+++ b/lib/runtime/CMakeLists.txt
@@ -7,10 +7,10 @@ target_include_directories(bharat_crt0 PUBLIC include)
 target_link_libraries(bharat_crt0 PUBLIC bharat_freestanding bharat_syscall)
 
 # Add the lib/runtime static library
-add_library(bharat_libruntime STATIC src/runtime.c src/freestanding_string.c)
+add_library(bharat_libruntime STATIC src/runtime.c src/freestanding_string.c host/runtime_host.c)
 
 # Set the public include directory
-target_include_directories(bharat_libruntime PUBLIC include)
+target_include_directories(bharat_libruntime PUBLIC include ${CMAKE_SOURCE_DIR}/uapi/runtime)
 
 # Runtime depends on cap and ipc headers
 target_link_libraries(bharat_libruntime PUBLIC cap ipc bharat_syscall bharat_freestanding)

--- a/lib/runtime/host/runtime_host.c
+++ b/lib/runtime/host/runtime_host.c
@@ -1,0 +1,88 @@
+#include "runtime_host.h"
+
+/*
+ * Skeleton implementation of the Runtime Hosting Layer.
+ *
+ * This layer will eventually translate these stable ABI calls into
+ * underlying Bharat-OS native capabilities and URPC messages.
+ * Personalities (Linux, Android) and directly-hosted runtimes (Java, Python)
+ * link against this library.
+ */
+
+int bharat_runtime_init(void) {
+    // TODO: Initialize capability arena and establish URPC connection to service manager.
+    return 0;
+}
+
+int bharat_runtime_spawn(bharat_runtime_handle_t executable_handle, const char* const args[], bharat_runtime_handle_t* out_process_handle) {
+    if (!out_process_handle) return -1;
+    // TODO: Construct SpawnRequest over URPC to lifecycle manager.
+    *out_process_handle = BHARAT_RUNTIME_INVALID_HANDLE;
+    return -1; // Unimplemented
+}
+
+void bharat_runtime_report_state(bharat_runtime_state_t state) {
+    // TODO: Send state update over URPC to lifecycle manager.
+    (void)state;
+}
+
+int bharat_runtime_thread_create(bharat_runtime_handle_t* out_thread_handle, bharat_thread_func_t func, void* arg) {
+    if (!out_thread_handle || !func) return -1;
+    // TODO: Map to underlying kernel thread creation capability.
+    *out_thread_handle = BHARAT_RUNTIME_INVALID_HANDLE;
+    return -1; // Unimplemented
+}
+
+int bharat_runtime_thread_join(bharat_runtime_handle_t thread_handle, void** out_result) {
+    // TODO: Wait on thread capability handle.
+    (void)thread_handle;
+    if (out_result) *out_result = NULL;
+    return -1; // Unimplemented
+}
+
+int bharat_runtime_service_lookup(const char* service_name, bharat_runtime_handle_t* out_endpoint_handle) {
+    if (!service_name || !out_endpoint_handle) return -1;
+    // TODO: Perform URPC lookup against local namespace manager.
+    *out_endpoint_handle = BHARAT_RUNTIME_INVALID_HANDLE;
+    return -1; // Unimplemented
+}
+
+int bharat_runtime_ipc_call(bharat_runtime_handle_t endpoint_handle, const void* req_buf, size_t req_len, void* res_buf, size_t res_len, size_t* out_res_len) {
+    // TODO: Perform URPC synchronous send/receive.
+    (void)endpoint_handle;
+    (void)req_buf;
+    (void)req_len;
+    (void)res_buf;
+    (void)res_len;
+    if (out_res_len) *out_res_len = 0;
+    return -1; // Unimplemented
+}
+
+int bharat_runtime_file_open(const char* path, int flags, bharat_runtime_handle_t* out_file_handle) {
+    if (!path || !out_file_handle) return -1;
+    // TODO: Resolve path against VFS capability root via URPC.
+    *out_file_handle = BHARAT_RUNTIME_INVALID_HANDLE;
+    return -1; // Unimplemented
+}
+
+int64_t bharat_runtime_read(bharat_runtime_handle_t handle, void* buf, size_t count) {
+    // TODO: URPC read request to the capability handle.
+    (void)handle;
+    (void)buf;
+    (void)count;
+    return -1; // Unimplemented
+}
+
+int64_t bharat_runtime_write(bharat_runtime_handle_t handle, const void* buf, size_t count) {
+    // TODO: URPC write request to the capability handle.
+    (void)handle;
+    (void)buf;
+    (void)count;
+    return -1; // Unimplemented
+}
+
+int bharat_runtime_close(bharat_runtime_handle_t handle) {
+    // TODO: Drop capability handle.
+    (void)handle;
+    return -1; // Unimplemented
+}

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -1,0 +1,14 @@
+# Bharat-OS SDK Structure
+
+This repository contains the SDK surface for Bharat-OS, establishing the contract for platformization across Native, Linux, and Android personalities.
+
+## Layout
+
+* `core/`: Core SDK components for all app developers (manifest schema, generic IPC clients).
+* `native/`: The true OS definition SDK (UI/window APIs, service registration, full capability-aware APIs).
+* `compat/`: SDKs for bridging legacy code.
+  * `linux/`: Syscall mapping docs, compatibility headers, unsupported API matrices.
+  * `android/`: Stubbed Android HAL headers, ART bridging config.
+* `runtime-host/`: SDK for runtime maintainers (embedding contract for Java, Python, Node, etc.).
+* `bindings/`: Language specific SDK wrappers for interacting with the `native` SDK or `runtime-host`.
+* `tools/`: Build and packaging tools (`bharat-pkg`, `bharat-run`, build targets).

--- a/sdk/bindings/README.md
+++ b/sdk/bindings/README.md
@@ -1,0 +1,7 @@
+# SDK Bindings
+
+Language-specific idiomatic wrappers over the `sdk/native` and `sdk/core` APIs.
+
+## Supported Languages
+* `c/`, `cpp/`, `rust/`: Primary system languages.
+* `java/`, `python/`, `dotnet/`, `node/`: Managed languages communicating via the runtime host layer.

--- a/sdk/compat/android/README.md
+++ b/sdk/compat/android/README.md
@@ -1,0 +1,8 @@
+# SDK Android Compat
+
+SDK for bridging Android ecosystem components to Bharat-OS.
+
+## Scope
+* Android SDK/NDK translation guides.
+* Bridge headers for Android graphics and media HALs.
+* Documentation on runtime constraints when executing APKs inside the Bharat-OS Android personality.

--- a/sdk/compat/linux/README.md
+++ b/sdk/compat/linux/README.md
@@ -1,0 +1,9 @@
+# SDK Linux Compat
+
+SDK providing the portability contract for bringing Linux code to Bharat-OS.
+
+## Scope
+* Syscall and ABI mapping documentation.
+* `libc` compatibility glue headers.
+* Porting guides.
+* Matrix of unsupported or strictly-stubbed POSIX APIs (e.g., `fork()`).

--- a/sdk/core/README.md
+++ b/sdk/core/README.md
@@ -1,0 +1,9 @@
+# SDK Core
+
+Contains universal definitions required by all applications running on Bharat-OS, regardless of their personality.
+
+## Scope
+* Application Manifest Schema definitions (`.json` or YAML specs).
+* Basic IPC/Service client API wrappers generic to all personalities.
+* Common capability request models.
+* Generic logging and telemetry interfaces.

--- a/sdk/native/README.md
+++ b/sdk/native/README.md
@@ -1,0 +1,10 @@
+# SDK Native
+
+The first-class Native Application Framework SDK for Bharat-OS.
+
+## Scope
+* Bharat app framework entry points.
+* UI, windowing, and event loop APIs (strictly capability-based).
+* Service registration and capability-delegation APIs.
+* Background job and task lifecycles.
+* Full access to native storage, media, and networking abstractions without POSIX overhead.

--- a/sdk/runtime-host/README.md
+++ b/sdk/runtime-host/README.md
@@ -1,0 +1,8 @@
+# SDK Runtime Host
+
+The stable contract designed for Language Runtime Maintainers (e.g., OpenJDK, CPython, Node.js).
+
+## Scope
+* Embedding contract definitions referencing `uapi/runtime/`.
+* Guidelines on GC-safe thread hooks and async event-loop integration.
+* Package and runtime deployment models.

--- a/sdk/tools/README.md
+++ b/sdk/tools/README.md
@@ -1,0 +1,13 @@
+# SDK Tools
+
+Build, packaging, and diagnostic tools for Bharat-OS development.
+
+## Core Tooling Concepts
+
+* `bharat`: The main CLI entry point for interacting with a connected Bharat-OS device or emulator.
+* `bharat-pkg`: Tooling for packing applications based on their manifest. Translates manifest capabilities into deployable bundles.
+* `bharat-run`: Emulation runner/launcher.
+* `bharat-debug`: Diagnostic bridge for GDB/LLDB or language-specific profilers.
+
+## Build Target Model
+Defines cross-compilation toolchains, sysroots, and target triples per architecture and personality (e.g., `x86_64-bharat-native`, `aarch64-bharat-linuxcompat`).

--- a/uapi/runtime/runtime_host.h
+++ b/uapi/runtime/runtime_host.h
@@ -1,0 +1,144 @@
+#ifndef BHARAT_UAPI_RUNTIME_HOST_H
+#define BHARAT_UAPI_RUNTIME_HOST_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+/**
+ * @file runtime_host.h
+ * @brief Stable Application Binary Interface (ABI) for the Runtime Hosting Layer.
+ *
+ * This contract provides a unified, capability-driven abstraction for
+ * complex managed runtimes (Java, Python, .NET, Node.js). Personalities
+ * (e.g., Linux Compat, Android Compat) and direct native execution environments
+ * must rely on this abstraction instead of interacting with kernel primitives directly.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* =====================================================================
+ * Opaque Handles & Capabilities
+ * ===================================================================== */
+
+/**
+ * @brief Opaque handle representing a capability or resource managed by the runtime.
+ */
+typedef uint64_t bharat_runtime_handle_t;
+
+#define BHARAT_RUNTIME_INVALID_HANDLE ((bharat_runtime_handle_t)0)
+
+/* =====================================================================
+ * Process & Lifecycle Hooks
+ * ===================================================================== */
+
+typedef enum {
+    RUNTIME_STATE_INIT,
+    RUNTIME_STATE_RUNNING,
+    RUNTIME_STATE_PAUSED,
+    RUNTIME_STATE_STOPPING
+} bharat_runtime_state_t;
+
+/**
+ * @brief Initialize the runtime hosting environment.
+ * @return 0 on success, negative error code on failure.
+ */
+int bharat_runtime_init(void);
+
+/**
+ * @brief Spawn a new child process/task bounded by a capability.
+ * @param executable_handle Handle to the executable package/binary.
+ * @param args Null-terminated array of arguments.
+ * @param out_process_handle Pointer to store the spawned process handle.
+ * @return 0 on success.
+ */
+int bharat_runtime_spawn(bharat_runtime_handle_t executable_handle, const char* const args[], bharat_runtime_handle_t* out_process_handle);
+
+/**
+ * @brief Report current runtime state to the OS lifecycle manager.
+ */
+void bharat_runtime_report_state(bharat_runtime_state_t state);
+
+/* =====================================================================
+ * Threading & Synchronization Hooks
+ * ===================================================================== */
+
+typedef void* (*bharat_thread_func_t)(void* arg);
+
+/**
+ * @brief Create a native thread managed by the runtime host.
+ * @param out_thread_handle Pointer to store the created thread handle.
+ * @param func Entry point function.
+ * @param arg Argument passed to the entry point.
+ * @return 0 on success.
+ */
+int bharat_runtime_thread_create(bharat_runtime_handle_t* out_thread_handle, bharat_thread_func_t func, void* arg);
+
+/**
+ * @brief Wait for a thread to exit.
+ * @param thread_handle Handle of the thread to join.
+ * @param out_result Pointer to store the thread's return value.
+ * @return 0 on success.
+ */
+int bharat_runtime_thread_join(bharat_runtime_handle_t thread_handle, void** out_result);
+
+/* =====================================================================
+ * IPC & Service Access
+ * ===================================================================== */
+
+/**
+ * @brief Look up a service endpoint by name in the local namespace.
+ * @param service_name Name of the requested service.
+ * @param out_endpoint_handle Pointer to store the capability handle for the endpoint.
+ * @return 0 on success.
+ */
+int bharat_runtime_service_lookup(const char* service_name, bharat_runtime_handle_t* out_endpoint_handle);
+
+/**
+ * @brief Send a synchronous message to a service endpoint.
+ * @param endpoint_handle Handle of the target service endpoint.
+ * @param req_buf Request buffer.
+ * @param req_len Request buffer length.
+ * @param res_buf Response buffer.
+ * @param res_len Max response buffer length.
+ * @param out_res_len Actual length of the response.
+ * @return 0 on success.
+ */
+int bharat_runtime_ipc_call(bharat_runtime_handle_t endpoint_handle, const void* req_buf, size_t req_len, void* res_buf, size_t res_len, size_t* out_res_len);
+
+/* =====================================================================
+ * File & Network Abstraction (VFS/Net URPC Proxies)
+ * ===================================================================== */
+
+/**
+ * @brief Open a capability-bounded file/resource.
+ * @param path Abstract path within the permitted namespace.
+ * @param flags Open flags.
+ * @param out_file_handle Pointer to store the opened file handle.
+ * @return 0 on success.
+ */
+int bharat_runtime_file_open(const char* path, int flags, bharat_runtime_handle_t* out_file_handle);
+
+/**
+ * @brief Read data from a runtime handle (file/socket).
+ * @return Number of bytes read, or negative on error.
+ */
+int64_t bharat_runtime_read(bharat_runtime_handle_t handle, void* buf, size_t count);
+
+/**
+ * @brief Write data to a runtime handle (file/socket).
+ * @return Number of bytes written, or negative on error.
+ */
+int64_t bharat_runtime_write(bharat_runtime_handle_t handle, const void* buf, size_t count);
+
+/**
+ * @brief Close a runtime handle.
+ */
+int bharat_runtime_close(bharat_runtime_handle_t handle);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BHARAT_UAPI_RUNTIME_HOST_H */


### PR DESCRIPTION
This PR introduces the required contracts and directory skeletons for the Bharat-OS platformization push, creating a firm architectural boundary between the kernel, personalities, and shared runtime layers.

Key additions:
1.  **Architecture Contracts:** Added `personality-contract.md`, `native-personality.md`, `linux-compat-personality.md`, `android-compat-personality.md`, and `personality-performance-contract.md` to define what a personality owns, capability constraints, performance budgets, and IPC translations.
2.  **Runtime Hosting Layer:** Defined the stable ABI for managed language runtimes (Java, Python, etc.) via `uapi/runtime/runtime_host.h`, a baseline BIDL file (`idl/runtime/runtime_v1.bidl`), and a C stub in `lib/runtime/host/runtime_host.c` properly integrated into CMake.
3.  **Portability Layers:** Stubbed out `lib/posix/`, `lib/linux_compat/`, and `lib/android/` at the root as mandated.
4.  **SDK Scaffold:** Created the `sdk/` repository layout with `README.md` documents clarifying the scope of Native, Compat, Bindings, and Core SDKs.

---
*PR created automatically by Jules for task [10242406410545206202](https://jules.google.com/task/10242406410545206202) started by @divyang4481*