### PR TITLE
docs(architecture): define Linux personality and performance contracts

### DIFF
--- a/docs/architecture/personalities/linux-personality-benchmark-plan.md
+++ b/docs/architecture/personalities/linux-personality-benchmark-plan.md
@@ -1,0 +1,38 @@
+---
+title: Linux Personality Benchmark Plan
+status: active
+owner: Architecture Team
+version: 1.0
+---
+
+# Linux Personality Benchmark Plan
+
+This document outlines the mandatory microbenchmarks and validation methodology for evaluating the performance of the Bharat-OS Linux personality. The goal is to enforce the "no translation tax" rule and prove that Linux compatibility hot paths run at near-native speeds.
+
+## 1. Mandatory Benchmarks
+
+The following operations define the latency profile of the compatibility layer. They must be continuously monitored against native baselines.
+
+*   **Null Syscall Latency (`getpid`, `prctl`):** Measures the absolute overhead of the syscall trap, context switch, dispatch table lookup, and return path.
+*   **Memory Mapping (`mmap`, `munmap`, `mprotect`):** Measures the efficiency of the single-authority VM layer handling standard Linux anonymous and file-backed mappings.
+*   **Futex Wait/Wake Latency:** Measures the performance of user-space synchronization primitives. The wait/wake path must not hit global kernel locks and must scale across cores.
+*   **Event Polling (`epoll` latency):** Measures readiness notification overhead. The test must validate that `epoll` maps directly to the kernel event system without per-event translation loops.
+*   **Time Retrieval (`clock_gettime`):** Measures the VDSO fast-path vs. trap implementation for monotonic and realtime clock reads.
+*   **Process/Thread Spawning (Thread Ping-Pong):** Measures `clone` overhead, TLS initialization, and cross-thread wakeups to validate the thread personality descriptor setup.
+
+## 2. Comparison Methodology
+
+To guarantee a fair comparison, all benchmarks must adhere to the following conditions:
+
+*   **Environment:** Identical hardware (same CPU model, stepping, and cache layout). If running in QEMU/KVM for CI, the exact same machine configuration must be used.
+*   **Toolchain:** Same compiler class (e.g., Clang 16+) and optimization flags (`-O3`, `-flto`) used to compile the benchmark payloads.
+*   **Workload:** Identical benchmark source code (e.g., standard microbenchmarks or custom bare-metal equivalent tests) executed on both platforms.
+*   **Baseline Definition:** The performance delta is calculated as: `(Bharat Linux Personality Result / Native Linux Result) - 1`.
+
+## 3. Pass Criteria (Definition of Done)
+
+A benchmark suite is considered successful only if it meets these strict criteria:
+
+*   **Latency Overhead:** Hot-path syscall overhead must fall within a strict tight delta (e.g., < 5% variance) compared to native Linux.
+*   **Zero-Copy IPC:** Shared-memory IPC, `mmap` handoffs, and event notifications must demonstrate zero extra memory copies within the kernel boundary.
+*   **Architecture Validation:** The tracing output must prove there is no "double-fault" handling path for VM operations and no fallback emulation engaged during fast-path operations.

--- a/docs/architecture/personalities/linux-personality-contract.md
+++ b/docs/architecture/personalities/linux-personality-contract.md
@@ -1,0 +1,38 @@
+---
+title: Linux Personality Contract
+status: active
+owner: Architecture Team
+version: 1.0
+---
+
+# Linux Personality Contract
+
+This document defines the ABI boundary and performance contract for the Linux personality on Bharat-OS. The Linux personality is an external ABI compatibility layer; it maps Linux concepts to Bharat-OS core mechanisms without leaking policy into the kernel.
+
+## A. ABI Scope
+
+The Linux personality will not support the full Linux syscall table immediately. It will be built upon a minimal, performance-grade slice:
+*   **Syscall Coverage Strategy:** Focus initially on a minimal runnable slice (e.g., `read`, `write`, `close`, `mmap`, `munmap`, `mprotect`, `futex`, `clock_gettime`, `epoll` subset, `exit`, and thread `clone`). Full compatibility will expand outward only after performance targets are validated.
+*   **ELF Expectations:** The system must efficiently handle ELF interpreter contracts, correct aux vector (`auxv`) population, and standard stack layouts.
+*   **Thread & Signals:** Robust handling of TLS initialization (via standard ABI conventions), thread creation, and a lightweight signal mapping model that routes directly to the kernel's notification core.
+
+## B. Performance Rules
+
+The goal is **near-native semantics and performance**.
+*   **Direct Syscall Mapping:** Syscalls classified as hot paths (e.g., `mmap`, `futex`, `read`, `write`, `epoll`) must use direct mapping or zero-copy translation into kernel mechanisms. Emulation is reserved strictly for slow paths and legacy compatibility.
+*   **Near-Native Hot Paths:** `mmap`, `futex`, and `epoll` implementations must achieve latency parity with native Linux. This includes using shared kernel primitives (like user-memory wait/wake primitives) without a translation tax.
+*   **No Overhead on Internal Operations:** Avoid per-syscall object translation loops or repeated personality/string lookups. The process/thread descriptors must carry the personality ID and relevant ABI/TLS configurations to allow immediate dispatch.
+
+## C. Constraints (What NOT to do)
+
+*   **No Kernel Policy Leakage:** The Linux personality lives in the ABI compatibility layer. Policy decisions (like complex namespaces or cgroups emulation) belong in user-space services, not the kernel core.
+*   **No Double-Layer VM Handling:** The VM mapping path must be single-authority. Do not maintain a separate "Linux VMA list" that mirrors a "Bharat VMA list." A single kernel VM mechanism must serve both with zero-cost abstraction.
+*   **No Object Translation Loops:** Avoid mapping integer FDs to internal object references on every hot path operation with expensive lock-contended hash lookups. Use direct pointer handles securely or highly optimized, lockless, per-process FD tables.
+
+## D. Layering Alignment
+
+The Linux personality must respect the established repository structure and architectural boundaries:
+*   **Kernel (`kernel/`):** Mechanism only. Contains generic trap entry, scheduling, VM, IPC, and primitive wait/wake.
+*   **Services (`services/`):** Policy orchestration. Manages permissions, lifecycle, and higher-level OS constructs.
+*   **Personalities (`personalities/compat/linux/`):** ABI mapping only. Adapts Linux userland calls to the core kernel and service mechanisms without bringing its own parallel OS logic.
+*   **Android Relationship:** The Android personality is strictly defined as "Linux personality + Android Delta" (e.g., Binder, Ashmem, Bionic differences). It does not duplicate Linux functionality.

--- a/docs/architecture/personalities/personality-performance-contract.md
+++ b/docs/architecture/personalities/personality-performance-contract.md
@@ -68,3 +68,24 @@ Every personality adapter operates under a strict budget compared to native benc
 ## 6. Observability Parity
 
 To hit these budgets, the Bharat-OS SDK must provide tracing, perf counters, IPC latency histograms, frame timing, and page fault profiling equal to or better than native Linux/Android ecosystems.
+
+## 7. Hard KPIs and Latency Targets
+
+To ensure the "no translation tax" rule is upheld, the following hard KPIs are enforced for personality hot paths:
+
+*   **Null Syscall Latency:** Must be within a tight delta (e.g., < 5%) of the equivalent native Linux `getpid` or `prctl` latency.
+*   **Memory Mapping (`mmap`/`munmap`/`mprotect`):** Must match native speeds. The VM path must use a single authority without a double-layer translation.
+*   **Futex Wait/Wake Latency:** Must bypass global locks and remain highly concurrent, matching Linux/Android native performance.
+*   **Event Polling (`epoll`/`poll`/`select`):** Readiness mapping must not involve per-event translation churn; it must map directly to the kernel's readiness object model.
+*   **Process / Thread Spawn Overhead:** Clone/fork-like operations must not be heavily penalized by personality setup.
+*   **Shared-Memory IPC Throughput:** Must achieve zero-copy throughput parity for large buffers (critical for Binder and Ashmem-like behavior).
+
+## 8. Benchmark Methodology
+
+All performance validations must follow a strict comparison method:
+*   **Environment:** Same hardware target (or accurate QEMU configuration for preliminary checks).
+*   **Toolchain:** Same compiler class and optimization levels.
+*   **Workload:** Identical benchmark source code (e.g., standard microbenchmarks for syscall, epoll, mmap).
+*   **Baseline:** Native Linux result vs. Bharat Linux personality result.
+
+Pass bands require that hot syscalls fall within the defined latency deltas, IPC fast paths perform zero extra memory copies, and no repeated personality/string lookups occur on internal kernel state transitions.

--- a/uapi/compat/personality.h
+++ b/uapi/compat/personality.h
@@ -1,0 +1,74 @@
+#ifndef BHARAT_UAPI_COMPAT_PERSONALITY_H
+#define BHARAT_UAPI_COMPAT_PERSONALITY_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Core personality identification.
+ * Defines the OS personality bound to a process or thread.
+ */
+typedef enum {
+    BHARAT_PERSONALITY_NATIVE = 0,
+    BHARAT_PERSONALITY_LINUX,
+    BHARAT_PERSONALITY_ANDROID,
+} bharat_personality_id_t;
+
+/**
+ * @brief Classification of system calls for performance routing.
+ */
+typedef enum {
+    SYSCALL_CLASS_FAST,
+    SYSCALL_CLASS_VM,
+    SYSCALL_CLASS_SYNC,
+    SYSCALL_CLASS_IO,
+    SYSCALL_CLASS_SIGNAL,
+    SYSCALL_CLASS_SLOW,
+} syscall_class_t;
+
+/**
+ * @brief Fast-path eligibility rules for a syscall.
+ */
+typedef enum {
+    SYSCALL_MAP_DIRECT,
+    SYSCALL_MAP_TRANSLATED,
+    SYSCALL_MAP_EMULATED,
+} syscall_map_type_t;
+
+/**
+ * @brief Process-level personality descriptor.
+ * Attached to the process/task creation path to avoid scattering ABI assumptions.
+ */
+typedef struct {
+    bharat_personality_id_t personality;
+    uint8_t abi_bits;       /* e.g., 32 or 64 */
+    uint8_t signal_model;   /* Specifies how signals are routed/delivered */
+    uint8_t tls_model;      /* TLS initialization and layout semantics */
+} personality_process_desc_t;
+
+/**
+ * @brief Thread-level personality descriptor.
+ * Carries thread-specific ABI and compat logic (e.g., futex semantics).
+ */
+typedef struct {
+    uint64_t tls_base;
+    uint32_t futex_compat;  /* Futex semantics version or mapping flag */
+} personality_thread_desc_t;
+
+/**
+ * @brief Memory Management (VM) personality descriptor.
+ * Maps Linux-style mmap semantics and copy-on-write models securely.
+ */
+typedef struct {
+    uint8_t mmap_semantics; /* Handles private/shared/anon behaviors */
+    uint8_t cow_model;      /* Copy-on-write mapping logic */
+} personality_mm_desc_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BHARAT_UAPI_COMPAT_PERSONALITY_H */


### PR DESCRIPTION
This submission implements the architecture baseline necessary for carving out the personality compatibility layers (Linux and Android) with a "performance-first" mindset. It establishes enforceable contracts rather than rushing into building a slow emulation tier.

Key deliverables:
1. **Performance Contract Update**: Explicitly limits translation overheads and enforces zero-copy IPC and fast-path mapping.
2. **Linux Contract**: Documents exactly what to build (minimal syscall slice, ELF expectations) and what NOT to build (no policy leakage, no double VM layer).
3. **UAPI Descriptor Model**: Introduces `uapi/compat/personality.h` providing the structs to tag processes, threads, and memory models with personality data to avoid per-syscall lookups.
4. **Benchmark Plan**: Sets exact standards for what success looks like (null syscall delta, futex scaling, epoll direct mapping) before actual code is written.

---
*PR created automatically by Jules for task [6688018590418988936](https://jules.google.com/task/6688018590418988936) started by @divyang4481*