### PR TITLE
Fix headless multi-arch build/run pipeline for QEMU

### DIFF
--- a/kernel/src/mm/iommu/iommu_stub.c
+++ b/kernel/src/mm/iommu/iommu_stub.c
@@ -1,6 +1,17 @@
+#include "mm/iommu.h"
 #include "hal/hal_iommu.h"
 #include "console/console_core.h"
 #include "kernel/status.h"
+
+static const hal_iommu_ops_t *g_stub_iommu_ops = NULL;
+
+void hal_iommu_set_ops(const hal_iommu_ops_t *ops) {
+    g_stub_iommu_ops = ops;
+}
+
+const hal_iommu_ops_t *hal_iommu_get_ops(void) {
+    return g_stub_iommu_ops;
+}
 
 int iommu_init(void) {
     console_write_raw("IOMMU: Subsystem disabled/stubbed via build configuration\n", 58);

--- a/tools/build/legacy_adapter.py
+++ b/tools/build/legacy_adapter.py
@@ -1,4 +1,6 @@
 import json
+import subprocess
+from shutil import which
 from pathlib import Path
 
 from tools.build.models import (
@@ -24,6 +26,24 @@ def load_legacy_config(repo_root: Path) -> dict:
         return json.load(f)
 
 
+def resolve_objcopy_for_cmake() -> str | None:
+    candidates = ("llvm-objcopy", "llvm-objcopy-20", "llvm-objcopy-19", "objcopy")
+    for candidate in candidates:
+        if not which(candidate):
+            continue
+        try:
+            subprocess.run(
+                [candidate, "--version"],
+                check=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            return candidate
+        except Exception:
+            continue
+    return None
+
+
 def resolve_legacy_target(target_name: str, repo_root: Path) -> ResolvedTarget:
     config = load_legacy_config(repo_root)
 
@@ -47,10 +67,20 @@ def resolve_legacy_target(target_name: str, repo_root: Path) -> ResolvedTarget:
     nographic = not gui_enabled
 
     # Fallback boot logic guessing
-    protocol = "linux_arm64" if arch == "arm64" else "multiboot2" if arch == "x86_64" else "opensbi_payload"
-    artifact_format = "raw_bin" if protocol == "linux_arm64" else "elf"
+    protocol = "elf_direct" if arch == "arm64" else "multiboot2" if arch == "x86_64" else "opensbi_payload"
+    artifact_format = "elf"
 
     transforms = []
+    boot_artifact = "kernel/kernel.elf"
+
+    if arch == "x86_64" and protocol == "multiboot2":
+        transforms.append(PackageTransformConfig(
+            type="multiboot_elf_fix",
+            input="kernel/kernel.elf",
+            output="kernel/kernel.elf32",
+        ))
+        boot_artifact = "kernel/kernel.elf32"
+
     if artifact_format == "raw_bin":
         transforms.append(PackageTransformConfig(
             type="elf_to_bin",
@@ -58,10 +88,16 @@ def resolve_legacy_target(target_name: str, repo_root: Path) -> ResolvedTarget:
             output="kernel.bin"
         ))
         boot_artifact = "kernel.bin"
-    else:
-        boot_artifact = "kernel/kernel.elf"
 
     dtb_mode = "qemu_generated"
+    default_cpu = "cortex-a72" if arch == "arm64" else None
+
+    cmake_defs = {
+        "BHARAT_BOOT_GUI": "ON" if gui_enabled else "OFF",
+    }
+    resolved_objcopy = resolve_objcopy_for_cmake()
+    if resolved_objcopy:
+        cmake_defs["CMAKE_OBJCOPY"] = resolved_objcopy
 
     return ResolvedTarget(
         name=target_name,
@@ -73,6 +109,7 @@ def resolve_legacy_target(target_name: str, repo_root: Path) -> ResolvedTarget:
         execution_profile="gp",
         build=BuildConfig(
             cmake_preset=preset,
+            cmake_defs=cmake_defs,
         ),
         kernel=KernelConfig(
             canonical_elf="kernel/kernel.elf",
@@ -88,6 +125,7 @@ def resolve_legacy_target(target_name: str, repo_root: Path) -> ResolvedTarget:
         run=RunConfig(
             backend="qemu",
             machine="virt" if arch in ("arm64", "riscv64", "arm32", "riscv32") else "q35",
+            cpu=default_cpu,
             boot_artifact=boot_artifact,
             nographic=nographic,
             serial=["stdio"],

--- a/tools/build/target_resolver.py
+++ b/tools/build/target_resolver.py
@@ -1,6 +1,4 @@
 import sys
-import yaml
-import jsonschema
 from pathlib import Path
 
 from tools.build.models import (
@@ -19,13 +17,28 @@ from tools.build.models import (
 
 SCHEMA_PATH = Path(__file__).parent.parent / "schemas" / "target.schema.yaml"
 
+
+def _require_yaml_deps():
+    try:
+        import yaml  # type: ignore
+        import jsonschema  # type: ignore
+    except ModuleNotFoundError as exc:
+        raise RuntimeError(
+            "YAML target support requires optional Python dependencies "
+            "(pyyaml and jsonschema). Install them or use --target for legacy "
+            "build_config.json targets."
+        ) from exc
+    return yaml, jsonschema
+
 def load_yaml_target(path: Path) -> dict:
+    yaml, _ = _require_yaml_deps()
     if not path.exists():
         raise FileNotFoundError(f"Target YAML not found: {path}")
     with open(path, "r") as f:
         return yaml.safe_load(f)
 
 def validate_yaml_target(raw: dict) -> None:
+    yaml, jsonschema = _require_yaml_deps()
     if not SCHEMA_PATH.exists():
         print(f"[Warning] Target schema not found at {SCHEMA_PATH}, skipping schema validation.")
         return

--- a/tools/package/transforms/multiboot_elf_fix.py
+++ b/tools/package/transforms/multiboot_elf_fix.py
@@ -1,6 +1,30 @@
 import os
 import subprocess
 from pathlib import Path
+from shutil import which
+
+
+def _resolve_objcopy() -> str:
+    env_objcopy = os.environ.get("OBJCOPY")
+    if env_objcopy:
+        return env_objcopy
+
+    candidates = ("llvm-objcopy", "llvm-objcopy-20", "llvm-objcopy-19", "objcopy")
+    for candidate in candidates:
+        if not which(candidate):
+            continue
+        try:
+            subprocess.run(
+                [candidate, "--version"],
+                check=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            return candidate
+        except Exception:
+            continue
+
+    return "llvm-objcopy"
 
 
 def apply_multiboot_elf_fix(input_path: Path, output_path: Path):
@@ -14,7 +38,7 @@ def apply_multiboot_elf_fix(input_path: Path, output_path: Path):
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
     # Note: We use specific targets for x86_64 conversion
-    objcopy_cmd = os.environ.get("OBJCOPY", "llvm-objcopy")
+    objcopy_cmd = _resolve_objcopy()
     cmd = [
         objcopy_cmd,
         "-I", "elf64-x86-64",

--- a/tools/run/runner_qemu.py
+++ b/tools/run/runner_qemu.py
@@ -74,7 +74,7 @@ def run_qemu(manifest_path: Path) -> int:
 
     # We use discrete flags for better signal handling on Windows/WSL
     # -nographic often hijacks the signal handler
-    cmd.extend(["-display", "none", "-serial", "stdio"])
+    cmd.extend(["-nographic", "-monitor", "none", "-serial", "stdio"])
 
     smp = run_config.get("smp", 1)
     if smp:


### PR DESCRIPTION
### Motivation
- Make the user-facing `./build.sh` workflow robust for legacy `--target` usage without requiring optional YAML Python packages. 
- Ensure headless builds for `x86_64`, `arm64`, and `riscv64` produce QEMU-bootable artifacts and invoke QEMU reliably in CI/headless environments. 
- Avoid brittle toolchain/runtime failures caused by missing or broken `objcopy` shims and unresolved IOMMU stub symbols during cross-arch builds.

### Description
- Make YAML support lazy and optional by deferring import of `pyyaml`/`jsonschema` and raising a clear error when YAML resolution is attempted; change in `tools/build/target_resolver.py`.
- Improve legacy target resolution in `tools/build/legacy_adapter.py` to: set `BHARAT_BOOT_GUI` for headless targets, choose `elf_direct` for ARM64, add a default ARM64 CPU, generate a `multiboot_elf_fix` transform for x86_64 to produce a 32-bit Multiboot ELF, and inject a validated `CMAKE_OBJCOPY` into `cmake_defs` when available.
- Harden `objcopy` discovery and selection in `tools/package/transforms/multiboot_elf_fix.py` so the code probes multiple candidate binaries (`llvm-objcopy`, `llvm-objcopy-20`, `objcopy`, etc.) and skips broken shims before invoking the transform.
- Update QEMU runner invocation in `tools/run/runner_qemu.py` to use headless-friendly flags (`-nographic -monitor none -serial stdio`) and honor default CPU settings so QEMU runs do not conflict with monitors/serial backends.
- Fix build/link failures by restoring IOMMU-related types/includes and exporting stub HAL functions in `kernel/src/mm/iommu/iommu_stub.c` so adapters and link steps succeed when the IOMMU backend is stubbed.

### Testing
- Ran `./build.sh --help` to verify CLI startup and no immediate Python import failure, which succeeded. 
- Installed QEMU packages with `apt-get install -y qemu-system-x86 qemu-system-arm qemu-system-misc` to provide QEMU runners for tests, which completed successfully. 
- Built and exercised headless flows with timed runs: `timeout 45 ./build.sh all --target x86_64_desktop_headless`, `timeout 25 ./build.sh all --target arm64_desktop_headless`, and `timeout 90 ./build.sh all --target riscv64_desktop_headless`; all three targets completed the CMake/build/package stages and launched QEMU (QEMU sessions were observed to start and emit kernel boot logs within the bounded timeouts). 
- Observed runtime kernel diagnostics (self-tests and some kernel panics) during QEMU runs, but the changes achieved the goal of compiling and invoking QEMU headlessly across the three architectures in a CI-style harness.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4a0bde60c8320b4e023cdf4f76e8c)