### PR TITLE
Add scheduler invariants and router contract headers and docs

### DIFF
--- a/docs/architecture/kernel/scheduler/README.md
+++ b/docs/architecture/kernel/scheduler/README.md
@@ -18,3 +18,4 @@ The `scheduler` cluster details how the Bharat-OS kernel distributes CPU time am
 - [Preemption](preemption.md) - Kernel preemption points, IRQ-safe regions, and voluntary yielding.
 - [Real-Time Support](realtime.md) - The RT task model and EDF (Earliest Deadline First) scheduling.
 - [Roadmap](roadmap.md) - Current status and future goals for the scheduler.
+- [Invariants & Router Contract](invariants-and-router-contract.md) - Scheduler ownership invariants and the class-router mechanism boundary for refactors.

--- a/docs/architecture/kernel/scheduler/invariants-and-router-contract.md
+++ b/docs/architecture/kernel/scheduler/invariants-and-router-contract.md
@@ -1,0 +1,72 @@
+# Scheduler Invariants and Router Contract
+
+## Purpose
+
+This document defines the non-negotiable scheduler invariants and the router-layer API contract that must remain valid during and after the `sched.c` decomposition.
+
+It is intentionally mechanism-focused: policy tuning and orchestration should remain outside of the kernel scheduler core whenever possible.
+
+## Core Invariants
+
+### I1. Single runnable ownership
+A runnable thread must belong to exactly one active scheduling ownership domain at a time:
+- one core,
+- one scheduling class queue,
+- one enqueue representation.
+
+A thread must never be present in multiple runqueues or class queues simultaneously.
+
+### I2. Single-writer hot path
+State mutations for runnable ownership (`enqueue`, `dequeue`, state transitions involving runnable placement) must follow a single-writer rule on the hot path.
+
+Cross-core operations must not mutate a foreign core's runnable structures directly except through approved handoff/inbox mechanisms.
+
+### I3. Explicit remote path
+Remote enqueue, migration, and handoff must occur only through explicit cross-core mechanisms (inbox/message path) with clear ownership transfer points.
+
+### I4. Core lifecycle authority
+The scheduler core owns lifecycle state safety for runnable transitions and must remain authoritative for:
+- legal thread-state transitions,
+- enqueue/dequeue consistency,
+- cross-class mutation boundaries.
+
+Class modules may maintain class-local accounting but cannot bypass core state/lifecycle invariants.
+
+### I5. Bounded AI actions
+AI-originated actions are advisory hints and must be validated before mutation. They must not bypass normal enqueue/dequeue/state ownership rules.
+
+Rejected AI actions must produce an observable reason code for auditability.
+
+### I6. Strict RT mode isolation
+Strict RT composition must not be forced into GP fairness behavior by global starvation logic. Any starvation guard must be a mixed-mode parameter, not a universal rule.
+
+## Router Contract Surface
+
+The router API is defined in `kernel/include/sched/sched_router_contract.h` and is the only cross-class mutation gateway.
+
+Required operations:
+- `sched_router_enqueue(...)`
+- `sched_router_dequeue(...)`
+- `sched_router_pick_next(...)`
+- `sched_router_on_tick(...)`
+- `sched_router_on_block(...)`
+- `sched_router_on_wake(...)`
+- `sched_router_on_migrate(...)`
+
+## Contract Rules
+
+1. **No hidden side effects:** each API must document permitted state mutation.
+2. **Ownership preconditions:** each API must state lock/IRQ/ownership assumptions.
+3. **Cross-core discipline:** cross-core mutation must delegate to explicit remote paths.
+4. **Class boundary safety:** class logic cannot directly mutate foreign-class internals.
+5. **Deterministic fallback:** router behavior must be deterministic when a class declines an operation.
+
+## Review Gate for Refactor PRs
+
+A scheduler decomposition PR is acceptable only if it preserves these invariants and does not weaken the contract boundary.
+
+At minimum, each PR in the split sequence should include:
+- invariants impact section,
+- router contract impact section,
+- ownership/cross-core path validation notes,
+- tests that exercise affected invariants.

--- a/kernel/include/sched/sched_invariants.h
+++ b/kernel/include/sched/sched_invariants.h
@@ -1,0 +1,20 @@
+#ifndef BHARAT_SCHED_INVARIANTS_H
+#define BHARAT_SCHED_INVARIANTS_H
+
+/*
+ * Scheduler invariant identifiers for documentation, tracing, and test mapping.
+ *
+ * Keeping these symbols centralized helps tests and diagnostics stay aligned with
+ * architecture docs while refactor phases progressively split scheduler code.
+ */
+typedef enum {
+    SCHED_INV_SINGLE_RUNNABLE_OWNERSHIP = 0,
+    SCHED_INV_SINGLE_WRITER_HOT_PATH,
+    SCHED_INV_EXPLICIT_REMOTE_PATH,
+    SCHED_INV_CORE_LIFECYCLE_AUTHORITY,
+    SCHED_INV_BOUNDED_AI_ACTIONS,
+    SCHED_INV_STRICT_RT_ISOLATION,
+    SCHED_INV_COUNT
+} sched_invariant_id_t;
+
+#endif /* BHARAT_SCHED_INVARIANTS_H */

--- a/kernel/include/sched/sched_router_contract.h
+++ b/kernel/include/sched/sched_router_contract.h
@@ -1,0 +1,69 @@
+#ifndef BHARAT_SCHED_ROUTER_CONTRACT_H
+#define BHARAT_SCHED_ROUTER_CONTRACT_H
+
+#include <stdint.h>
+#include "sched/sched.h"
+
+/*
+ * Scheduler Router Contract
+ *
+ * This interface defines the narrow mechanism boundary between scheduler core
+ * lifecycle/state ownership and scheduling-class specific implementations.
+ *
+ * Contract intent:
+ * - keep core lifecycle and ownership invariants centralized,
+ * - keep class-specific accounting local,
+ * - avoid policy sprawl in core paths.
+ */
+
+/* Operation context hints for enqueue/dequeue/migrate pathways. */
+typedef enum {
+    SCHED_ROUTE_REASON_UNKNOWN = 0,
+    SCHED_ROUTE_REASON_CREATE,
+    SCHED_ROUTE_REASON_WAKE,
+    SCHED_ROUTE_REASON_PREEMPT,
+    SCHED_ROUTE_REASON_MIGRATE,
+    SCHED_ROUTE_REASON_REMOTE_INBOX,
+    SCHED_ROUTE_REASON_POLICY_CHANGE,
+    SCHED_ROUTE_REASON_AI_HINT,
+} sched_route_reason_t;
+
+/*
+ * Enqueue a thread through router-approved class/core paths.
+ * Returns 0 on success, negative error code on rejection/failure.
+ */
+int sched_router_enqueue(kthread_t *thread, uint32_t core_id, sched_route_reason_t reason);
+
+/*
+ * Dequeue a thread through router-approved class/core paths.
+ * Returns 0 on success, negative error code on rejection/failure.
+ */
+int sched_router_dequeue(kthread_t *thread, uint32_t core_id, sched_route_reason_t reason);
+
+/*
+ * Pick next runnable thread for the given core according to active composition.
+ * Returns NULL when no runnable candidate exists (idle fallback expected).
+ */
+kthread_t *sched_router_pick_next(uint32_t core_id);
+
+/*
+ * Per-tick hook for router/class accounting updates.
+ */
+void sched_router_on_tick(uint32_t core_id, uint64_t now_ticks);
+
+/*
+ * Thread state transition hooks that preserve core lifecycle authority.
+ */
+void sched_router_on_block(kthread_t *thread, uint32_t core_id);
+void sched_router_on_wake(kthread_t *thread, uint32_t core_id);
+
+/*
+ * Notify router about ownership transfer across cores.
+ * Returns 0 on success, negative error code otherwise.
+ */
+int sched_router_on_migrate(kthread_t *thread,
+                            uint32_t src_core,
+                            uint32_t dst_core,
+                            sched_route_reason_t reason);
+
+#endif /* BHARAT_SCHED_ROUTER_CONTRACT_H */


### PR DESCRIPTION
### Motivation
- Provide a stable, mechanism-focused contract and invariant set to guide the `sched.c` decomposition and scheduler refactors.
- Centralize scheduler invariants so diagnostics, tests, and refactors can reference a consistent set of identifiers.
- Define a narrow router-layer API to enforce ownership, single-writer hot-paths, and explicit cross-core mutation discipline.

### Description
- Add `docs/architecture/kernel/scheduler/invariants-and-router-contract.md` documenting core invariants (I1..I6), router API surface, and review gate requirements. 
- Add `kernel/include/sched/sched_invariants.h` with the `sched_invariant_id_t` enum mapping invariant identifiers for tracing and tests. 
- Add `kernel/include/sched/sched_router_contract.h` defining `sched_route_reason_t` and router API prototypes including `sched_router_enqueue`, `sched_router_dequeue`, `sched_router_pick_next`, `sched_router_on_tick`, `sched_router_on_block`, `sched_router_on_wake`, and `sched_router_on_migrate`. 
- Update `docs/architecture/kernel/scheduler/README.md` to reference the new `Roadmap` and `Invariants & Router Contract` document links.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4ceeb69908320af0badd53830f902)