### PR TITLE
ipc/urpc: add profile-aware routing policy and host matrix tests

### DIFF
--- a/kernel/include/bharat/urpc.h
+++ b/kernel/include/bharat/urpc.h
@@ -4,6 +4,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include "urpc/urpc_bootstrap.h"
+#include "ipc/ipc_profile_policy.h"
 
 // Define standard URPC message types
 typedef enum {
@@ -69,5 +70,6 @@ int urpc_channel_bind(uint32_t target_core);
 int urpc_channel_accept(uint32_t source_core);
 int urpc_channel_close(uint32_t target_core);
 urpc_channel_state_t urpc_channel_get_state(uint32_t target_core);
+int urpc_channel_can_route(ipc_traffic_type_t traffic, uint32_t payload_len, bool cross_core);
 
 #endif // BHARAT_URPC_H

--- a/kernel/include/ipc/ipc_profile_policy.h
+++ b/kernel/include/ipc/ipc_profile_policy.h
@@ -1,0 +1,32 @@
+#ifndef BHARAT_IPC_PROFILE_POLICY_H
+#define BHARAT_IPC_PROFILE_POLICY_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "ipc_endpoint.h"
+#include "mm/mem_model.h"
+#include "profile/profile.h"
+#include "urpc/urpc_bootstrap.h"
+
+typedef enum {
+    IPC_TRANSPORT_ENDPOINT = 0,
+    IPC_TRANSPORT_URPC = 1,
+} ipc_transport_t;
+
+typedef struct {
+    uint16_t endpoint_payload_max;
+    uint16_t max_endpoints;
+    uint16_t urpc_ring_size;
+    uint16_t max_cross_core_payload;
+    bool prefer_urpc_for_control;
+    bool allow_bulk_ipc;
+} ipc_profile_policy_t;
+
+ipc_profile_policy_t ipc_profile_policy_current(void);
+ipc_transport_t ipc_profile_select_transport(ipc_traffic_type_t traffic, bool cross_core);
+bool ipc_profile_payload_supported(ipc_traffic_type_t traffic,
+                                   uint32_t payload_len,
+                                   bool cross_core);
+
+#endif // BHARAT_IPC_PROFILE_POLICY_H

--- a/kernel/src/ipc/CMakeLists.txt
+++ b/kernel/src/ipc/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(k_ipc OBJECT
     ../../src/ipc/endpoint_ipc.c
     ../../src/ipc/ipc_traffic.c
+    ../../src/ipc/ipc_profile_policy.c
     ../../src/ipc/async_ipc.c
     ../../src/ipc/ipc_timeout.c
     ../../src/ipc/multikernel.c

--- a/kernel/src/ipc/ipc_profile_policy.c
+++ b/kernel/src/ipc/ipc_profile_policy.c
@@ -1,0 +1,77 @@
+#include "ipc/ipc_profile_policy.h"
+
+static uint16_t urpc_max_payload_for_mem_model(mem_model_t model) {
+    switch (model) {
+        case MEM_MODEL_MPU:
+            return 32U;
+        case MEM_MODEL_MMU_LITE:
+            return 64U;
+        case MEM_MODEL_MMU_FULL:
+            return 256U;
+        default:
+            return 32U;
+    }
+}
+
+ipc_profile_policy_t ipc_profile_policy_current(void) {
+    const mem_model_t model = mem_model_get_current();
+    const KernelExecutionProfile exec = get_kernel_execution_profile();
+
+    ipc_profile_policy_t p = {
+        .endpoint_payload_max = (uint16_t)BHARAT_IPC_ENDPOINT_PAYLOAD_MAX,
+        .max_endpoints = (uint16_t)BHARAT_IPC_MAX_ENDPOINTS,
+        .urpc_ring_size = (uint16_t)URPC_RING_SIZE,
+        .max_cross_core_payload = urpc_max_payload_for_mem_model(model),
+        .prefer_urpc_for_control = (exec != PROFILE_KERNEL_GP),
+        .allow_bulk_ipc = (exec != PROFILE_KERNEL_RT),
+    };
+
+#if defined(Profile_RTOS)
+    p.prefer_urpc_for_control = true;
+    p.allow_bulk_ipc = false;
+#endif
+
+    if (!mem_model_has_cap(MEM_CAP_TLB_INVALIDATE)) {
+        p.max_cross_core_payload = 32U;
+    }
+
+    return p;
+}
+
+ipc_transport_t ipc_profile_select_transport(ipc_traffic_type_t traffic, bool cross_core) {
+    ipc_profile_policy_t p = ipc_profile_policy_current();
+
+    if (!cross_core) {
+        return IPC_TRANSPORT_ENDPOINT;
+    }
+
+    switch (traffic) {
+        case IPC_TRAFFIC_CONTROL:
+        case IPC_TRAFFIC_EVENT:
+            return p.prefer_urpc_for_control ? IPC_TRANSPORT_URPC : IPC_TRANSPORT_ENDPOINT;
+        case IPC_TRAFFIC_BULK:
+            return p.allow_bulk_ipc ? IPC_TRANSPORT_ENDPOINT : IPC_TRANSPORT_URPC;
+        case IPC_TRAFFIC_TELEMETRY:
+        case IPC_TRAFFIC_SERVICE:
+        case IPC_TRAFFIC_DEFERRED:
+        case IPC_TRAFFIC_UNSPECIFIED:
+        default:
+            return IPC_TRANSPORT_ENDPOINT;
+    }
+}
+
+bool ipc_profile_payload_supported(ipc_traffic_type_t traffic,
+                                   uint32_t payload_len,
+                                   bool cross_core) {
+    ipc_profile_policy_t p = ipc_profile_policy_current();
+
+    if (payload_len == 0U) {
+        return false;
+    }
+
+    if (cross_core && ipc_profile_select_transport(traffic, true) == IPC_TRANSPORT_URPC) {
+        return payload_len <= p.max_cross_core_payload;
+    }
+
+    return payload_len <= p.endpoint_payload_max;
+}

--- a/kernel/src/urpc/urpc_channel.c
+++ b/kernel/src/urpc/urpc_channel.c
@@ -57,3 +57,8 @@ urpc_channel_state_t urpc_channel_get_state(uint32_t target_core) {
     if (target_core >= BHARAT_MAX_CPUS) return URPC_CHANNEL_ERROR;
     return g_urpc_states[target_core];
 }
+
+int urpc_channel_can_route(ipc_traffic_type_t traffic, uint32_t payload_len, bool cross_core) {
+    return ipc_profile_select_transport(traffic, cross_core) == IPC_TRANSPORT_URPC &&
+           ipc_profile_payload_supported(traffic, payload_len, cross_core);
+}

--- a/tests/host/CMakeLists.txt
+++ b/tests/host/CMakeLists.txt
@@ -133,6 +133,21 @@ add_executable(test_ipc_profile test_ipc_profile.c ../../kernel/src/profile/prof
 target_include_directories(test_ipc_profile PRIVATE ../../kernel/include ../../include ../../lib/include)
 add_test(NAME host_test_ipc_profile COMMAND test_ipc_profile)
 
+add_executable(test_ipc_urpc_policy_rt_mpu test_ipc_urpc_policy_matrix.c ../../kernel/src/ipc/ipc_profile_policy.c ../../kernel/src/mm/mem_model.c ../../kernel/src/profile/profile.c)
+target_include_directories(test_ipc_urpc_policy_rt_mpu PRIVATE ../../kernel/include ../../include ../../lib/include)
+target_compile_definitions(test_ipc_urpc_policy_rt_mpu PRIVATE CONFIG_PROFILE_AUTOMOBILE=1 CONFIG_MEM_MODEL_MPU=1 BHARAT_KERNEL_PROFILE_RT=1 EXPECT_PREFER_URPC=1 EXPECT_ALLOW_BULK_IPC=0 EXPECT_URPC_MAX=32 EXPECT_CONTROL_TRANSPORT=IPC_TRANSPORT_URPC EXPECT_BULK_TRANSPORT=IPC_TRANSPORT_URPC)
+add_test(NAME host_test_ipc_urpc_policy_rt_mpu COMMAND test_ipc_urpc_policy_rt_mpu)
+
+add_executable(test_ipc_urpc_policy_gp_mmu_lite test_ipc_urpc_policy_matrix.c ../../kernel/src/ipc/ipc_profile_policy.c ../../kernel/src/mm/mem_model.c ../../kernel/src/profile/profile.c)
+target_include_directories(test_ipc_urpc_policy_gp_mmu_lite PRIVATE ../../kernel/include ../../include ../../lib/include)
+target_compile_definitions(test_ipc_urpc_policy_gp_mmu_lite PRIVATE CONFIG_MEM_MODEL_MMU_LITE=1 EXPECT_PREFER_URPC=0 EXPECT_ALLOW_BULK_IPC=1 EXPECT_URPC_MAX=64 EXPECT_CONTROL_TRANSPORT=IPC_TRANSPORT_ENDPOINT EXPECT_BULK_TRANSPORT=IPC_TRANSPORT_ENDPOINT)
+add_test(NAME host_test_ipc_urpc_policy_gp_mmu_lite COMMAND test_ipc_urpc_policy_gp_mmu_lite)
+
+add_executable(test_ipc_urpc_policy_mix_mmu_full test_ipc_urpc_policy_matrix.c ../../kernel/src/ipc/ipc_profile_policy.c ../../kernel/src/mm/mem_model.c ../../kernel/src/profile/profile.c)
+target_include_directories(test_ipc_urpc_policy_mix_mmu_full PRIVATE ../../kernel/include ../../include ../../lib/include)
+target_compile_definitions(test_ipc_urpc_policy_mix_mmu_full PRIVATE BHARAT_KERNEL_PROFILE_MIX=1 EXPECT_PREFER_URPC=1 EXPECT_ALLOW_BULK_IPC=1 EXPECT_URPC_MAX=256 EXPECT_CONTROL_TRANSPORT=IPC_TRANSPORT_URPC EXPECT_BULK_TRANSPORT=IPC_TRANSPORT_ENDPOINT)
+add_test(NAME host_test_ipc_urpc_policy_mix_mmu_full COMMAND test_ipc_urpc_policy_mix_mmu_full)
+
 # Phase 3: Crypto Tests
 add_executable(test_secure_mem test_secure_mem.c)
 target_include_directories(test_secure_mem PRIVATE ../../kernel/include)

--- a/tests/host/test_ipc_urpc_policy_matrix.c
+++ b/tests/host/test_ipc_urpc_policy_matrix.c
@@ -1,0 +1,60 @@
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include "../../kernel/include/ipc/ipc_profile_policy.h"
+
+#ifndef EXPECT_PREFER_URPC
+#error "EXPECT_PREFER_URPC must be defined"
+#endif
+#ifndef EXPECT_ALLOW_BULK_IPC
+#error "EXPECT_ALLOW_BULK_IPC must be defined"
+#endif
+#ifndef EXPECT_URPC_MAX
+#error "EXPECT_URPC_MAX must be defined"
+#endif
+#ifndef EXPECT_CONTROL_TRANSPORT
+#error "EXPECT_CONTROL_TRANSPORT must be defined"
+#endif
+#ifndef EXPECT_BULK_TRANSPORT
+#error "EXPECT_BULK_TRANSPORT must be defined"
+#endif
+
+static void test_policy_basics(void) {
+    ipc_profile_policy_t policy = ipc_profile_policy_current();
+
+    assert(policy.endpoint_payload_max == BHARAT_IPC_ENDPOINT_PAYLOAD_MAX);
+    assert(policy.max_endpoints == BHARAT_IPC_MAX_ENDPOINTS);
+    assert(policy.urpc_ring_size == URPC_RING_SIZE);
+    assert(policy.prefer_urpc_for_control == (EXPECT_PREFER_URPC != 0));
+    assert(policy.allow_bulk_ipc == (EXPECT_ALLOW_BULK_IPC != 0));
+    assert(policy.max_cross_core_payload == EXPECT_URPC_MAX);
+}
+
+static void test_transport_selection(void) {
+    assert(ipc_profile_select_transport(IPC_TRAFFIC_CONTROL, true) == EXPECT_CONTROL_TRANSPORT);
+    assert(ipc_profile_select_transport(IPC_TRAFFIC_BULK, true) == EXPECT_BULK_TRANSPORT);
+    assert(ipc_profile_select_transport(IPC_TRAFFIC_SERVICE, false) == IPC_TRANSPORT_ENDPOINT);
+}
+
+static void test_payload_rules(void) {
+    assert(ipc_profile_payload_supported(IPC_TRAFFIC_CONTROL, 1U, true));
+    assert(!ipc_profile_payload_supported(IPC_TRAFFIC_CONTROL, 0U, true));
+
+    if (EXPECT_CONTROL_TRANSPORT == IPC_TRANSPORT_URPC) {
+        assert(ipc_profile_payload_supported(IPC_TRAFFIC_CONTROL, EXPECT_URPC_MAX, true));
+        assert(!ipc_profile_payload_supported(IPC_TRAFFIC_CONTROL, (uint32_t)EXPECT_URPC_MAX + 1U, true));
+    } else {
+        assert(ipc_profile_payload_supported(IPC_TRAFFIC_CONTROL, BHARAT_IPC_ENDPOINT_PAYLOAD_MAX, true));
+    }
+}
+
+int main(void) {
+    test_policy_basics();
+    test_transport_selection();
+    test_payload_rules();
+
+    printf("test_ipc_urpc_policy_matrix passed\n");
+    return 0;
+}


### PR DESCRIPTION
### Motivation
- Provide a compact, static policy layer to choose IPC transport (endpoint vs uRPC) and payload limits based on kernel execution profile and memory model so cross-core routing is predictable for devices from MPU-based RTOS to MMU-full datacenter kernels.
- Avoid bloating runtime code paths by centralizing decision logic in a lightweight policy API that can be consulted by URPC call sites and build-time profile switches.
- Ensure the policy is testable on host with a small matrix of representative profiles to catch regressions early.

### Description
- Added a new public header `kernel/include/ipc/ipc_profile_policy.h` and implementation `kernel/src/ipc/ipc_profile_policy.c` providing `ipc_profile_policy_current()`, `ipc_profile_select_transport()`, and `ipc_profile_payload_supported()` which derive limits from `mem_model_get_current()` and `get_kernel_execution_profile()`.
- Wired the policy into uRPC by including the header in `kernel/include/bharat/urpc.h` and exposing `urpc_channel_can_route(...)`, and by implementing `urpc_channel_can_route` in `kernel/src/urpc/urpc_channel.c` to allow call sites to gate cross-core messages.
- Added the new policy source to the kernel IPC object library in `kernel/src/ipc/CMakeLists.txt` so it builds with the kernel IPC subsystem.
- Added a host-side matrix test `tests/host/test_ipc_urpc_policy_matrix.c` and registered three configurations in `tests/host/CMakeLists.txt` to validate behavior for RT+MPU, GP+MMU-Lite, and MIX+MMU-Full profiles.

### Testing
- Configured host build with tests enabled via `cmake -S /workspace/Bharat-OS -B /workspace/Bharat-OS/build-host -DBHARAT_BUILD_HOST_TESTS=ON` and generation completed successfully.
- Built the three matrix tests with `cmake --build /workspace/Bharat-OS/build-host --target test_ipc_urpc_policy_rt_mpu test_ipc_urpc_policy_gp_mmu_lite test_ipc_urpc_policy_mix_mmu_full` and linking succeeded for all targets.
- Executed `./test_ipc_urpc_policy_rt_mpu`, `./test_ipc_urpc_policy_gp_mmu_lite`, and `./test_ipc_urpc_policy_mix_mmu_full` and all printed success (`test_ipc_urpc_policy_matrix passed`).
- Rebuilt and ran the existing `test_ipc_profile` checks and they completed successfully with no regressions detected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4f470ee948320897583ecbdeb96f7)