### PR TITLE
docs: rewrite build/tooling guides for Windows, WSL/Linux, and macOS workflows

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,142 +1,195 @@
-# Building Bharat-OS
+# Bharat-OS Build, Package, Run, and Debug Guide
 
-Bharat-OS utilizes a modern CMake Presets (`CMakePresets.json`) based workflow, allowing identical configuration and compilation paths on Windows, WSL, Linux, macOS, and BSD. We build entirely with **LLVM/Clang** + **LLD** for cross-arch reproducibility.
+This document is the **single user guide** for using Bharat-OS build tooling on:
 
-```mermaid
-flowchart TD
-    subgraph BuildSystem["Build System (CMake Presets)"]
-        A[Source Code] -->|CMake| B(Build Generator)
-    end
+- Windows (PowerShell)
+- WSL/Linux
+- macOS
 
-    subgraph Toolchains["Cross-Platform Toolchains"]
-        B -->|host-linux-clang.cmake| HostL[Host Linux Clang]
-        B -->|host-windows-clang.cmake| HostW[Host Windows Clang]
-        B -->|x86_64-elf-clang.cmake| X86[LLVM/Clang x86_64]
-        B -->|riscv64-elf-clang.cmake| RV[LLVM/Clang riscv64]
-        B -->|aarch64-elf-clang.cmake| ARM[LLVM/Clang arm64]
-    end
+It covers:
 
-    subgraph Output["Output Artifacts"]
-        X86 --> O1[kernel.elf + bharat_image]
-        RV --> O2[kernel.elf + bharat_image]
-        ARM --> O3[kernel.elf + bharat_image]
-    end
-```
+- what to install,
+- how `build.ps1` / `build.sh` work,
+- how to build/package/run/debug,
+- QEMU workflows,
+- board flashing workflows,
+- preset command recipes (especially headless).
 
 ---
 
-## Prerequisites & Environment Preparation
+## 1) Tool entrypoints and command model
 
-Before building Bharat-OS, you need to set up your development environment.
+Bharat-OS provides two user-facing wrappers:
 
-- CMake 3.20+
-- Ninja or Make
-- Clang & LLD (`llvm`, `clang`, `lld`)
-- QEMU (for running the kernel)
+- `./build.sh` (Linux/macOS/WSL)
+- `.\build.ps1` (Windows PowerShell)
 
-Note: `build.ps1` and `build.sh` are thin wrappers. The real implementation path for builds and runners is driven by `tools/build.py`.
+Both wrappers forward directly to `tools/build.py`. The Python CLI is authoritative and supports these subcommands:
 
-Please see the comprehensive **[Environment Preparation Guide](docs/build/ENV_PREP.md)** for platform-specific instructions.
+- `configure`
+- `build`
+- `package`
+- `run`
+- `flash`
+- `debug`
+- `all`
 
-### QEMU runtime prerequisites (Linux)
+Each subcommand requires exactly one target selector:
 
-For validated QEMU runtime bring-up (host-visible serial logs), install:
+- `--target <name>` (legacy targets from `build_config.json`)
+- `--target-yaml <path>` (explicit target YAML in `tools/targets/`)
 
-- Core build tools: `cmake`, `ninja-build`, `clang`, `lld`, `llvm`, `python3`
-- QEMU system emulators:
-  - `qemu-system-x86_64`
-  - `qemu-system-aarch64`
-  - `qemu-system-riscv64`
-- `llvm-objcopy` (or compatible `objcopy`) for x86_64/arm64 image conversion paths used by the harness
-- OpenSBI (`opensbi`) when your RISC-V QEMU flow requires explicit firmware handoff in your environment
+Examples:
 
-On Debian/Ubuntu-family hosts, this usually maps to packages such as:
+```powershell
+# Windows PowerShell
+.\build.ps1 build --target x86_64_desktop_headless
+.\build.ps1 all --target x86_64_desktop_headless
+.\build.ps1 run --target-yaml tools/targets/qemu/x86_64_desktop_headless.yaml
+```
+
+```bash
+# Linux/macOS/WSL
+./build.sh build --target x86_64_desktop_headless
+./build.sh all --target x86_64_desktop_headless
+./build.sh run --target-yaml tools/targets/qemu/x86_64_desktop_headless.yaml
+```
+
+> Legacy positional syntax still works (for example `.\build.ps1 x86_64_desktop_headless --run`), but it is compatibility-only and emits a warning. Prefer explicit subcommands.
+
+---
+
+## 2) Host prerequisites by platform
+
+### Windows host (PowerShell)
+
+Install:
+
+- Python 3
+- CMake (3.20+)
+- Ninja
+- LLVM/Clang + LLD (and `llvm-objcopy`)
+- QEMU
+- (optional for board flashing) OpenOCD
+- (optional for debug) GDB (`gdb` or `gdb-multiarch`)
+
+Typical installs (examples):
+
+```powershell
+# Winget examples
+winget install Python.Python.3
+winget install Kitware.CMake
+winget install Ninja-build.Ninja
+winget install LLVM.LLVM
+winget install SoftwareFreedomConservancy.QEMU
+```
+
+Ensure these commands are in `PATH`: `python`, `cmake`, `ninja`, `clang`, `ld.lld`, and the needed `qemu-system-*` binary.
+
+### WSL / Linux host
+
+Install:
+
+- `python3`
+- `cmake`
+- `ninja-build`
+- `clang`, `lld`, `llvm` (for `llvm-objcopy`)
+- `qemu-system-x86`, `qemu-system-arm`, `qemu-system-misc`
+- (optional) `opensbi` for RISC-V environments
+- (optional) `openocd` for board flashing
+- (optional) `gdb-multiarch`
 
 ```bash
 sudo apt update
 sudo apt install -y \
-  cmake ninja-build clang lld llvm python3 \
+  python3 cmake ninja-build clang lld llvm \
   qemu-system-x86 qemu-system-arm qemu-system-misc \
-  opensbi
+  opensbi openocd gdb-multiarch
 ```
 
-> Boot validation is serial-first: expected boot markers must appear in the **host terminal**.
+### macOS host
+
+Install with Homebrew:
+
+- `python`
+- `cmake`
+- `ninja`
+- `llvm`
+- `qemu`
+- (optional) `openocd`
+- (optional) `gdb`
+
+```bash
+brew install python cmake ninja llvm qemu openocd gdb
+```
+
+If Homebrew LLVM is not default, export PATH:
+
+```bash
+export PATH="$(brew --prefix llvm)/bin:$PATH"
+```
 
 ---
 
-## QEMU build/run flow (x86_64, arm64, riscv64)
+## 3) Build pipeline stages (what each command does)
 
-This is the canonical developer flow for the currently validated runtime targets: **x86_64**, **arm64**, and **riscv64**.
+### `configure`
+Runs CMake configure preset and writes build manifest metadata.
 
-### How boot logs are surfaced
+### `build`
+Runs configure + compile for the selected preset.
 
-- The serial console is the authoritative early-boot/runtime sink.
-- QEMU runs in `-nographic -serial stdio` style for validation.
-- A graphical framebuffer window is **not required** for the validated path.
-- Success criteria are marker-driven from host terminal output.
+### `package`
+Generates packaging artifacts/manifests (run/flash/debug manifests + footprint report).
 
-### Expected boot markers in host terminal
+### `run`
+Packages (if needed) and launches QEMU for the target.
 
-The current harness validates these markers:
+### `all`
+Build + package + run in one command.
 
-- `BOOT: kernel_main reached`
-- `BOOT: pmm initialized`
-- `BOOT: vmm initialized`
-- `[BOOT] Runtime mode:`
+### `flash`
+Packages and runs flashing backend (currently OpenOCD backend path).
 
-If these markers do not appear, treat the run as failed even if QEMU launched.
+### `debug`
+Generates/validates debug path, but current workflow reports that full debug automation is not yet implemented.
 
-### Build examples (repo-canonical commands)
+Output layout uses CMake preset name:
 
-```bash
-# x86_64
-./build.sh build --target default_dev
+- `build/<preset>/...`
+- `build/<preset>/manifests/run-manifest.json`
+- `build/<preset>/manifests/flash-manifest.json`
+- `build/<preset>/manifests/debug-manifest.json`
 
-# arm64
-./build.sh build --target arm64_desktop_headless
+---
 
-# riscv64
-./build.sh build --target riscv64_desktop_headless
-```
+## 4) QEMU usage (desktop/headless/emulator targets)
 
-### Run examples (recommended: QEMU E2E harness)
-
-Recommended path is `run_qemu_e2e.sh` with explicit matrix entries:
-
-```bash
-# x86_64 + arm64 + riscv64 runtime matrix
-E2E_MATRIX_MODE=explicit \
-E2E_MATRIX="x86_64:mmu:desktop:linux arm64:mmu:desktop:linux riscv64:mmu:desktop:linux" \
-./run_qemu_e2e.sh
-```
-
-You can also execute per-arch runs one-by-one:
-
-```bash
-E2E_MATRIX_MODE=explicit E2E_MATRIX="x86_64:mmu:desktop:linux" ./run_qemu_e2e.sh
-E2E_MATRIX_MODE=explicit E2E_MATRIX="arm64:mmu:desktop:linux" ./run_qemu_e2e.sh
-E2E_MATRIX_MODE=explicit E2E_MATRIX="riscv64:mmu:desktop:linux" ./run_qemu_e2e.sh
-```
-
-### How to run desktop GUI builds
-
-`--run` now routes primary serial to host stdio and disables monitor-on-stdio conflicts, so these GUI profiles should print boot logs in your host terminal while the QEMU window is open:
+### Recommended quick workflow
 
 ```powershell
-.\build.ps1 all --target x86_64_desktop_gui
-.\build.ps1 all --target arm64_desktop_gui
-.\build.ps1 all --target riscv64_desktop_gui
+.\build.ps1 all --target x86_64_desktop_headless
 ```
 
 ```bash
-./build.sh all --target x86_64_desktop_gui
-./build.sh all --target arm64_desktop_gui
-./build.sh all --target riscv64_desktop_gui
+./build.sh all --target x86_64_desktop_headless
 ```
 
-### How to run headless builds
+### Supported QEMU runners by architecture
 
-For a pure terminal-based experience without a QEMU graphical window (e.g., CI or remote SSH environments), use the `headless` targets:
+- `x86_64` -> `qemu-system-x86_64`
+- `arm64` -> `qemu-system-aarch64`
+- `riscv64` -> `qemu-system-riscv64`
+- `arm32` -> `qemu-system-arm`
+- `riscv32` -> `qemu-system-riscv32`
+
+Runtime command includes serial-first bring-up (`-nographic -monitor none -serial stdio`) so headless logs stream to your terminal.
+
+---
+
+## 5) Preset command cookbook
+
+## 5.1 Canonical headless run commands (PowerShell)
 
 ```powershell
 .\build.ps1 all --target x86_64_desktop_headless
@@ -144,7 +197,45 @@ For a pure terminal-based experience without a QEMU graphical window (e.g., CI o
 .\build.ps1 all --target riscv64_desktop_headless
 .\build.ps1 all --target arm32_mmu_lite_headless
 .\build.ps1 all --target riscv32_mmu_lite_headless
+
+.\build.ps1 all --target x86_64_desktop_headless_gp
+.\build.ps1 all --target x86_64_desktop_headless_rt
+.\build.ps1 all --target x86_64_desktop_headless_mix
+
+.\build.ps1 all --target arm64_desktop_headless_gp
+.\build.ps1 all --target arm64_desktop_headless_rt
+.\build.ps1 all --target arm64_desktop_headless_mix
+
+.\build.ps1 all --target riscv64_desktop_headless_gp
+.\build.ps1 all --target riscv64_desktop_headless_rt
+.\build.ps1 all --target riscv64_desktop_headless_mix
+
+.\build.ps1 all --target arm32_mmu_lite_headless_gp
+.\build.ps1 all --target arm32_mmu_lite_headless_rt
+.\build.ps1 all --target arm32_mmu_lite_headless_mix
+
+.\build.ps1 all --target riscv32_mmu_lite_headless_gp
+.\build.ps1 all --target riscv32_mmu_lite_headless_rt
+.\build.ps1 all --target riscv32_mmu_lite_headless_mix
+
+.\build.ps1 all --target x86_64_gp_headless
+.\build.ps1 all --target x86_64_rt_headless
+.\build.ps1 all --target x86_64_mix_headless
+.\build.ps1 all --target arm64_gp_headless
+.\build.ps1 all --target arm64_rt_headless
+.\build.ps1 all --target arm64_mix_headless
+.\build.ps1 all --target riscv64_gp_headless
+.\build.ps1 all --target riscv64_rt_headless
+.\build.ps1 all --target riscv64_mix_headless
+.\build.ps1 all --target arm32_gp_headless
+.\build.ps1 all --target arm32_rt_headless
+.\build.ps1 all --target arm32_mix_headless
+.\build.ps1 all --target riscv32_gp_headless
+.\build.ps1 all --target riscv32_rt_headless
+.\build.ps1 all --target riscv32_mix_headless
 ```
+
+## 5.2 Canonical headless run commands (WSL/Linux/macOS)
 
 ```bash
 ./build.sh all --target x86_64_desktop_headless
@@ -152,15 +243,45 @@ For a pure terminal-based experience without a QEMU graphical window (e.g., CI o
 ./build.sh all --target riscv64_desktop_headless
 ./build.sh all --target arm32_mmu_lite_headless
 ./build.sh all --target riscv32_mmu_lite_headless
+
+./build.sh all --target x86_64_desktop_headless_gp
+./build.sh all --target x86_64_desktop_headless_rt
+./build.sh all --target x86_64_desktop_headless_mix
+
+./build.sh all --target arm64_desktop_headless_gp
+./build.sh all --target arm64_desktop_headless_rt
+./build.sh all --target arm64_desktop_headless_mix
+
+./build.sh all --target riscv64_desktop_headless_gp
+./build.sh all --target riscv64_desktop_headless_rt
+./build.sh all --target riscv64_desktop_headless_mix
+
+./build.sh all --target arm32_mmu_lite_headless_gp
+./build.sh all --target arm32_mmu_lite_headless_rt
+./build.sh all --target arm32_mmu_lite_headless_mix
+
+./build.sh all --target riscv32_mmu_lite_headless_gp
+./build.sh all --target riscv32_mmu_lite_headless_rt
+./build.sh all --target riscv32_mmu_lite_headless_mix
+
+./build.sh all --target x86_64_gp_headless
+./build.sh all --target x86_64_rt_headless
+./build.sh all --target x86_64_mix_headless
+./build.sh all --target arm64_gp_headless
+./build.sh all --target arm64_rt_headless
+./build.sh all --target arm64_mix_headless
+./build.sh all --target riscv64_gp_headless
+./build.sh all --target riscv64_rt_headless
+./build.sh all --target riscv64_mix_headless
+./build.sh all --target arm32_gp_headless
+./build.sh all --target arm32_rt_headless
+./build.sh all --target arm32_mix_headless
+./build.sh all --target riscv32_gp_headless
+./build.sh all --target riscv32_rt_headless
+./build.sh all --target riscv32_mix_headless
 ```
 
-### Expected behavior & Dual serial usage
-
-- Host terminal **must show boot logs** in both headless and GUI modes. The QEMU graphical window does not replace the host terminal serial logging.
-- `--dual-serial` (hyphen) may additionally show serial output in the QEMU window by adding a secondary `-serial vc` sink.
-- Note: **Use `--dual-serial`, NOT `--dual_serial`.**
-
-Examples with GUI + mirrored serial (`--dual-serial`):
+## 5.3 GUI presets (examples)
 
 ```powershell
 .\build.ps1 all --target x86_64_desktop_gui
@@ -174,394 +295,108 @@ Examples with GUI + mirrored serial (`--dual-serial`):
 ./build.sh all --target riscv64_desktop_gui
 ```
 
-### Troubleshooting (QEMU runtime)
-
-- **Missing QEMU binary**
-  - Symptom: log contains skip/fail indicating `qemu-system-* not found`.
-  - Fix: install corresponding system emulator package(s) and confirm with `command -v qemu-system-<arch>`.
-- **Missing OpenSBI (RISC-V environments that require it)**
-  - Symptom: RISC-V fails before expected markers; firmware handoff errors may appear.
-  - Fix: install OpenSBI and ensure your local run configuration points to valid firmware.
-- **Wrong image format / objcopy issue**
-  - Symptom: x86_64/arm64 runs fail before boot with image format errors.
-  - Fix: install `llvm-objcopy` (or equivalent `objcopy`) and verify it is callable in PATH.
-- **Legacy execution path warning**
-  - Symptom: "Warning: Running legacy execution path (no target matrix entry found)."
-  - Fix: Use one of the first-class targets that appear in `targets/target_matrix.json` (e.g., `x86_64_desktop_gui`).
-- **Wrong flag spelling**
-  - Symptom: Script rejects `--dual_serial`.
-  - Fix: Always use `--dual-serial` (with a hyphen).
-- **GUI window appears but host terminal is silent**
-  - Symptom: QEMU starts, the GUI window loads, but the host terminal receives no logs.
-  - Fix: Make sure you're using a first-class manifest target, which correctly routes primary serial to `stdio`.
-- **No boot markers in host terminal**
-  - Symptom: QEMU starts but none of the required markers appear.
-  - Fix: use `--run-tests` for headless serial-first validation, or use `--run --dual-serial` for GUI+VC mirroring; then inspect `e2e_logs/`.
-- **Timeout without panic**
-  - Symptom: process times out but panic markers are absent.
-  - Fix: inspect the last emitted marker in logs to identify stall stage (early boot, PMM, VMM, runtime transition).
-- **Panic marker found**
-  - Symptom: `[PANIC]` or fatal self-test text appears.
-  - Fix: treat as runtime failure; capture full log and debug by failing stage.
-
-### Current validated QEMU runtime status
-
-- ✅ x86_64: validated
-- ✅ arm64: validated
-- ✅ riscv64: validated
-- ✅ arm32: headless build + QEMU target wiring available
-- ✅ riscv32: headless build + QEMU target wiring available
-
-Follow-up implementation tasks are tracked in `docs/dev/boot-console-milestone-and-followups.md`.
-
----
-
-## How the Build System Works
-
-All compiler and linker settings are isolated in **CMake toolchain files** under `cmake/toolchains/`. Target generation is mapped out via profiles in `CMakePresets.json`.
-
-We provide simple wrapper scripts (`build.sh` and `build.ps1`) that pass configuration from the target `build_config.json` configuration and execute the underlying `cmake --preset` engine using `tools/build.py`.
-
-At configure time, component selection is enforced by `cmake/modules/BharatComponentPolicy.cmake`.
-The central script `tools/build.py` reads the desired configuration from `build_config.json` and injects variables like:
-
-- `BHARAT_DEVICE_PROFILE`
-- `BHARAT_PERSONALITY_PROFILE`
-- `BHARAT_TARGET_BOARD`
-
-### Helper Scripts (Recommended)
-
-Edit `build_config.json` to define your target composition (e.g. arch, UI on/off, profile mapping). Then use the wrapper:
-
-```bash
-# Linux/Mac/WSL
-# Build the default_dev profile (conservative, disables scaffold-heavy service groups)
-./build.sh build --target default_dev
-
-# Build the experimental services profile (enables scaffold-heavy experimental services)
-./build.sh build --target experimental_services
-
-# Build and run immediately in QEMU
-./build.sh all --target default_dev
-```
+## 5.4 Legacy positional example requested by users
 
 ```powershell
-# Windows
-
-# --- x86_64 ---
-# Build and run x86_64 with GUI
-.\build.ps1 all --target default_dev
-# Build and run x86_64 without GUI (Headless)
-.\build.ps1 all --target default_dev
-
-# --- ARM64 ---
-# Build and run ARM64 with GUI
-.\build.ps1 all --target arm64_desktop_gui
-# Build and run ARM64 without GUI (Headless)
-.\build.ps1 all --target-yaml tools/targets/qemu/arm64_desktop_headless.yaml
-
-# --- RISCV64 ---
-# Build and run RISCV64 with GUI
-.\build.ps1 all --target riscv64_desktop_gui
-# Build and run RISCV64 without GUI (Headless)
-.\build.ps1 all --target-yaml tools/targets/qemu/riscv64_desktop_headless.yaml
-
-# --- ARM32 ---
-# Build and run ARM32 without GUI (Edge profile)
-.\build.ps1 build --target arm32_edge_mpu
+.\build.ps1 x86_64_desktop_headless --run
 ```
 
-### 🚨 Migration Guide: Legacy Flags Removed
-
-The build system has been unified around `tools/build.py` using canonical `argparse` arguments. **Legacy PowerShell and shell flags (like `-Arch`, `-Run`, `-Clean`, `-BootGui`, `-DualSerial`) are no longer supported.** The wrappers do not translate flags; they strictly forward to `build.py`.
-
-| Old Syntax (Deprecated) | New Syntax (Canonical) | Notes |
-| :--- | :--- | :--- |
-| `.\build.ps1 all --target x86_64` | `.\build.ps1 all --target default_dev` | Arch, board, and profile are now bundled into named configurations in `build_config.json`. |
-| `.\build.ps1 all --target riscv64` | `.\build.ps1 build --target riscv64_desktop_headless` | |
-| `.\build.ps1 build --target arm64_medical_debug` | `.\build.ps1 build --target arm64_medical_debug` | |
-| `.\build.ps1 build --target x86_64_laptop_debug` | `.\build.ps1 all --target x86_64_laptop_debug` | Use a configuration that specifies `"gui": true` in the JSON manifest. |
-| `.\build.ps1 build --target x86_64` | `.\build.ps1 all --target default_dev` | |
-| `./build.sh build --target x86_64` | `./build.sh build --target default_dev` | |
-
-If you need a specific combination of architecture, profile, and features that does not exist in `build_config.json`, simply add a new block to the JSON file.
-
-### Manual CMake Presets
-
-You can bypass the YAML wrapper and invoke the raw presets directly:
-
-```bash
-# View available presets
-cmake --list-presets
-
-# Configure for x86_64 dev target on Linux host
-cmake --preset linux-x86_64-dev-debug
-
-# Build the target image and dependencies
-cmake --build --preset linux-x86_64-dev-debug
-
-# Configure for ARM64 GUI target
-cmake --preset arm64-gui
-cmake --build --preset arm64-gui
-
-# Configure for RISC-V GUI target
-cmake --preset riscv64-gui
-cmake --build --preset riscv64-gui
-```
-
----
-
-## Testing & SDK Development
-
-### Validating Host-Side Tests (Windows & WSL/Linux)
-
-Bharat-OS separates purely host-isolated unit tests from kernel self-tests. The host tests execute natively on your host machine (Windows or Linux) without QEMU, making them fast and suitable for CI.
-
-**Running host tests from the preset:**
-```bash
-# Configure the host profile (Linux example)
-cmake --preset linux-host-debug
-cmake --build --preset linux-host-debug
-
-# Run all test runners
-ctest --preset linux-host-debug
-```
-
-For Windows:
-```powershell
-cmake --preset windows-hosttools-debug
-cmake --build --preset windows-hosttools-debug
-ctest --preset windows-hosttools-debug
-```
-
-To run just the CMake component-policy host check:
-```bash
-ctest --preset linux-host-debug -R test_component_policy_matrix
-```
-
-### Profile and Image Bundling
-
-During build execution, CMake groups your selected targets into bundles:
-- `bharat_services_bundle`: All compiled user-space daemon libraries.
-- `bharat_apps_bundle`: Leaf applications selected by your current `profiles/*.cmake` file.
-- `bharat_initramfs`: A mock tar packaging the root filesystem payloads.
-- `bharat_image`: The overarching target tying `kernel.elf` to the final bundled manifest.
-
-
-## Build Output
-
-| File                      | Description                                 |
-| ------------------------- | ------------------------------------------- |
-| `build/<arch>/kernel.elf` | Bare-metal ELF image, loadable by GRUB/QEMU |
-
----
-
-## Supported Architectures
-
-| Arch      | Status                                     | QEMU Machine                        |
-| --------- | ------------------------------------------ | ----------------------------------- |
-| `x86_64`  | ✅ Active                                  | `qemu-system-x86_64 -machine q35`   |
-| `arm64`   | ✅ Active                                  | `qemu-system-aarch64 -machine virt` |
-| `riscv64` | ✅ Active                                  | `qemu-system-riscv64 -machine virt` |
-| `arm32`   | ⚠️ Incomplete runtime markers              | `qemu-system-arm -machine virt`     |
-| `riscv32` | ⚠️ Incomplete link/runtime bring-up        | `qemu-system-riscv32 -machine virt` |
-
-
----
-
-## Portability Matrix
-
-Bharat-OS exclusively relies on LLVM/Clang and LLD (version 16+) for bare-metal compilation. This strategy ensures cross-compilation stability and avoids conflicts seen with standard C libraries.
-
-| Architecture | Target Triple         | Compiler | Linker | Status      |
-| ------------ | --------------------- | -------- | ------ | ----------- |
-| `x86_64`     | `x86_64-elf`          | Clang 16+| LLD 16+| Active      |
-| `arm64`      | `aarch64-elf`         | Clang 16+| LLD 16+| Active      |
-| `riscv64`    | `riscv64-elf`         | Clang 16+| LLD 16+| Active      |
-| `arm32`      | `armv7a-none-eabi`    | Clang 16+| LLD 16+| Partial (runtime gap) |
-| `riscv32`    | `riscv32-elf`         | Clang 16+| LLD 16+| Partial (link/runtime gap) |
-
----
-
-## Running the AI Governor in User Space
-
-During early bring-up, the AI Governor operates as an isolated user-space process. It uses the capability-based IPC model (specifically the Lockless URPC messaging spine or Synchronous Endpoint IPC) to analyze telemetry from the microkernel and suggest configuration tuning.
-
-To run the AI governor in user space during development or testing:
-
-1. **Build the subsystem:** The governor is located in `subsys/src/ai_governor.c`. Ensure it is built using the same bare-metal toolchain provided in `cmake/toolchains/`. (Note: A testing wrapper can also be built as a standalone binary on the host to simulate telemetry).
-2. **Execute integration tests:** Run the tests located in the `tests/` directory (e.g., `test_ai_governor`) to verify IPC message formatting and URPC ring behavior before booting the full kernel image in QEMU.
-3. **Boot in Emulator:** Once built into the root filesystem image (pending storage subsystem availability), the microkernel will spawn the AI governor as a capability-restricted task upon boot.
-
-
----
-
-
-
-## Troubleshooting
-
-**`clang not found` (CMake error)**
-→ Install LLVM (see above). On macOS, also run `export PATH="$(brew --prefix llvm)/bin:$PATH"`.
-
-**`ld.lld not found`**
-→ Install `lld`. On Ubuntu: `sudo apt install lld`. On macOS: included with Homebrew LLVM.
-
-**QEMU: `-nographic` freezes**
-→ Press Ctrl+A then X to exit. Or use `-serial stdio` without `-nographic` to open a separate window.
-
-**Windows: `ninja` not found by CMake**
-→ Install Ninja via winget (see above) or set path: `$env:Path += ";C:\path\to\ninja"`.
-
-
-## Boot-time configuration
-
-You can tune early boot behavior without source edits:
-
-- `BHARAT_BOOT_GUI` (`ON`/`OFF`): enables boot-to-GUI handoff metadata.
-- `BHARAT_BOOT_HW_PROFILE` (`generic`, `desktop`, `server`, `vm`, `laptop`): picks hardware profile compile definitions for boot policy and defaults.
-
-These are wired through both build scripts and raw CMake cache entries.
-
-### Building for Device Profiles (Automobile, Drone, Medical, Edge)
-
-Bharat-OS supports various device profiles natively. The build scripts (`build.sh` and `build.ps1`) automatically inject the correct QEMU flags to emulate hardware-specific peripherals (like CAN buses or watchdog timers) depending on the selected profile configured in `build_config.json`.
-
-**1. Automobile & EV Testing**
-The CAN subsystem is enabled automatically for Automotive profiles. QEMU will be launched with a virtual Kvaser PCI CAN bus.
-```bash
-# Bash
-./build.sh all --target arm64_automobile_debug
-
-# PowerShell
-.\build.ps1 all --target arm64_automobile_debug
-```
-
-**2. Drone (UAV) Testing**
-Drone firmware usually relies on specific ARM processors. Using the `DRONE` profile on `arm64` or `arm32` defaults to emulating a Cortex-A15.
-```bash
-# Bash
-./build.sh all --target arm32_drone_debug
-
-# PowerShell
-.\build.ps1 all --target arm32_drone_debug
-```
-
-**3. Medical Device Validation**
-Medical environments require strict V&V. The `MEDICAL` profile injects a watchdog device (`i6300esb`) configured to pause on trigger, allowing you to simulate and test fault injection and safe failure states.
-```bash
-# Bash
-./build.sh all --target arm64_medical_debug
-```
-
-**4. Robotics & Edge Devices**
-The `ROBOT` and `EDGE` profiles inject basic virtio networking to represent generic IoT or edge deployments.
-```bash
-./build.sh all --target riscv32_robot_debug
-```
-
-**5. Laptops & Workstations**
-The `LAPTOP` profile targets traditional PC or workstation form factors. It injects a virtio network device, as well as a virtio-tablet and virtio-keyboard to emulate typical human interface devices. For `x86_64` targets, it automatically switches the QEMU machine to `q35` and expands the memory to 1G to support ACPI and modern PC buses.
-```bash
-# Bash
-./build.sh all --target x86_64_laptop_debug
-
-# PowerShell
-.\build.ps1 all --target x86_64_laptop_debug
-```
-
-### End-to-End (E2E) Test Support
-
-For Continuous Integration (CI) and automated validation, you can pass the `--run-tests` flag.
-
-When enabled:
-1. It forces the system to boot in headless mode.
-2. It runs tests in the emulator environment.
-3. It prevents the emulator from rebooting on a crash.
-
-```bash
-# Bash example for automated testing
-./build.sh build --target arm64_automobile_debug
-```
-
-For a full multi-arch and multi-profile QEMU harness, use `run_qemu_e2e.sh`.
-
-```bash
-# Default matrix (x86_64 desktop/laptop, riscv64 edge, arm64 drone)
-./run_qemu_e2e.sh
-
-# Custom matrix format: arch:profile:personality
-E2E_MATRIX="x86_64:desktop:none riscv64:automobile:none" ./run_qemu_e2e.sh
-
-# Fail if any case is skipped (useful in CI)
-STRICT_QEMU=1 ./run_qemu_e2e.sh
-```
-
-Notes:
-- Logs are written to `e2e_logs/` per test case.
-- The harness validates boot markers (`BOOT: pmm initialized`, `BOOT: vmm initialized`, runtime mode) and fails on panic logs.
-
-### GUI and Serial Console Output
-
-When a build configuration has `"gui": true` in `build_config.json`, QEMU is launched with a graphical window.
-
-To ensure early kernel logs are visible during UI development, you can use the `--dual-serial` flag to automatically route QEMU serial output to both your host terminal and a Virtual Console (`vc`) inside the QEMU GUI using the `-serial stdio -serial vc` flags.
-
-**Architecture specific behaviors with GUI enabled:**
-- **`x86_64`:** Uses standard VGA (`-vga std`). The serial `vc` output appears natively.
-- **`riscv64` & `arm64`:** These `virt` machines do not support legacy VGA. The build scripts use VirtIO GPU (`-device virtio-gpu-device` or `-device virtio-gpu-pci`). Serial boot logs are routed to the host terminal; optional `--dual-serial` also mirrors serial to a QEMU Virtual Console tab (`View -> serial0` / `Ctrl-Alt-2` in GTK/SDL).
+Equivalent modern command:
 
 ```powershell
-# Build and run a GUI-enabled config
-.\build.ps1 all --target arm64_automobile_debug
-
-# Build and run with dual serial (Both GUI and Terminal)
-.\build.ps1 all --target arm64_automobile_debug
-```
-
-### Troubleshooting: `qemu_add_wait_object: failed`
-If you see the error `could not connect serial device to character backend 'mon:stdio'` on Windows, it is likely due to terminal limitations. 
-
-**Solution:** Use the QEMU virtual console natively if GUI is enabled.
-
-**Example Build Commands:**
-```powershell
-# Windows (PowerShell)
-# Build and run x86_64 with GUI enabled
-.\build.ps1 all --target x86_64_laptop_debug
+.\build.ps1 all --target x86_64_desktop_headless
 ```
 
 ---
 
-## Multi-Architecture Build & Test Execution Plan
-
-Use the validated runtime matrix as the baseline:
-
-| Architecture | Preferred Build Name | Runtime validation status |
-| :--- | :--- | :--- |
-| **x86_64** | `default_dev` | ✅ Validated |
-| **arm64** | `arm64_desktop_headless` (or `arm64_desktop_gui`) | ✅ Validated |
-| **riscv64** | `riscv64_desktop_headless` (or `riscv64_desktop_gui`) | ✅ Validated |
-| **arm32** | `arm32_edge_mpu` | ⚠️ Not runtime-complete |
-| **riscv32** | `riscv32_edge_mmu_lite` | ⚠️ Not link/runtime-complete |
-
-### Recommended execution strategy
-
-1. Build with `build.sh` / `build.ps1` using a config from `build_config.json`.
-2. Validate boot markers in host-terminal serial logs.
-3. Prefer explicit-matrix runs via `run_qemu_e2e.sh` for regression checks.
-
-### Quick Start Commands (Windows PowerShell)
+## 6) Package-only and run-only workflows
 
 ```powershell
-# x86_64 (using YAML target)
-.\build.ps1 all --target-yaml tools/targets/qemu/x86_64_desktop_headless.yaml
-
-# arm64 (using YAML target)
-.\build.ps1 all --target-yaml tools/targets/qemu/arm64_desktop_headless.yaml
-
-# riscv64 (using YAML target)
-.\build.ps1 all --target-yaml tools/targets/qemu/riscv64_desktop_headless.yaml
-
-# x86_64 legacy (using build_config.json)
-.\build.ps1 all --target default_dev
+.\build.ps1 build --target x86_64_desktop_headless
+.\build.ps1 package --target x86_64_desktop_headless
+.\build.ps1 run --target x86_64_desktop_headless
 ```
+
+```bash
+./build.sh build --target x86_64_desktop_headless
+./build.sh package --target x86_64_desktop_headless
+./build.sh run --target x86_64_desktop_headless
+```
+
+YAML target path equivalent:
+
+```bash
+./build.sh all --target-yaml tools/targets/qemu/x86_64_desktop_headless.yaml
+```
+
+---
+
+## 7) Debug workflow
+
+Current state:
+
+- `build.py debug` exists in CLI.
+- The main debug stage prints `Debug workflow not fully implemented yet.`
+- You can still use helper debugger attach scripts:
+  - `tools/debug.sh`
+  - `tools/debug.ps1`
+
+Typical pattern:
+
+1. launch QEMU with gdb stub enabled from target extra args (if configured),
+2. attach with debug helper script.
+
+---
+
+## 8) Board and hardware flashing workflow
+
+For hardware/board flows, use `flash` with a target that includes flash configuration.
+
+```powershell
+.\build.ps1 flash --target <board_target>
+.\build.ps1 flash --target <board_target> --dry-run
+```
+
+```bash
+./build.sh flash --target <board_target>
+./build.sh flash --target <board_target> --dry-run
+```
+
+Flash backend currently implemented: **OpenOCD**.
+
+Install OpenOCD first (`openocd` command in PATH).
+
+---
+
+## 9) Discovering available presets and targets
+
+List CLI usage:
+
+```bash
+./build.sh --help
+./build.sh build --help
+```
+
+Print all legacy target names from `build_config.json`:
+
+```bash
+python3 - <<'PY'
+import json
+cfg = json.load(open('build_config.json'))['builds']
+for name in cfg:
+    print(name)
+PY
+```
+
+See YAML targets under:
+
+- `tools/targets/qemu/`
+
+---
+
+## 10) Wrapper script summary (`build.ps1` and `build.sh`)
+
+- Root wrappers (`/build.sh`, `/build.ps1`) are the stable commands users should run.
+- `tools/build.sh` and `tools/build.ps1` are compatibility shims.
+- New build/run feature behavior must be implemented in `tools/build.py`.
+

--- a/README.md
+++ b/README.md
@@ -471,83 +471,53 @@ See:
 
 ## Build quick start
 
-### Prerequisites
+For complete setup on **Windows, WSL/Linux, and macOS** (including QEMU/OpenOCD/GDB install and full preset command cookbook), read [`BUILD.md`](BUILD.md).
 
-- `cmake` (3.20+)
-- Ninja or Make
-- A supported LLVM/Clang cross toolchain
+### Daily commands
 
-### Build examples
-
-Bharat-OS uses a declarative target pipeline driven by YAML files located in `tools/targets/`. The legacy `build_config.json` is still supported for backward compatibility, but target YAML specs are the primary source of truth. You can invoke the build pipeline through the root wrappers `build.sh` and `build.ps1`.
-
-To list all available targets (YAML and legacy):
-```bash
-./build.sh configure --help
-```
-
-**Common build commands (Linux/macOS):**
-```bash
-# Build and run the x86_64 headless YAML target
-./build.sh build --target-yaml tools/targets/qemu/x86_64_desktop_headless.yaml
-
-# Clean, build, and run an arm64 edge device profile using a YAML target
-./build.sh build --target-yaml tools/targets/qemu/arm64_desktop_headless.yaml
-
-# Run a legacy target from build_config.json
-./build.sh build --target default_dev
-```
-
-**Common build commands (Windows):**
 ```powershell
-# Build and run the x86_64 headless YAML target
+# PowerShell
 .\build.ps1 all --target x86_64_desktop_headless
-
-# Clean, build, and run an arm64 edge device profile using a YAML target
 .\build.ps1 all --target arm64_desktop_headless
-
-# Run a legacy target from build_config.json
-.\build.ps1 all --target default_dev
+.\build.ps1 all --target riscv64_desktop_headless
 ```
-
-### 🚨 Migration Guide: Legacy Flags Removed
-
-The build system has been unified around `tools/build.py` using canonical `argparse` arguments. **Legacy PowerShell and shell flags are no longer supported.** The wrappers do not translate flags; they strictly forward to `build.py`.
-
-| Old Syntax (Deprecated) | New Syntax (Canonical) | Notes |
-| :--- | :--- | :--- |
-| `.\build.ps1 all --target x86_64` | `.\build.ps1 all --target default_dev` | Arch, board, and profile are now bundled into named configurations in `build_config.json`. |
-| `.\build.ps1 all --target riscv64` | `.\build.ps1 all --target riscv64_desktop_mmu` | |
-| `.\build.ps1 build --target arm64_medical_debug` | `.\build.ps1 build --target arm64_medical_debug` | |
-| `.\build.ps1 build --target x86_64_laptop_debug` | `.\build.ps1 all --target x86_64_laptop_debug` | Use a configuration that specifies `"gui": true` in the JSON manifest. |
-| `.\build.ps1 build --target x86_64` | `.\build.ps1 all --target default_dev` | |
-| `./build.sh build --target x86_64` | `./build.sh build --target default_dev-tests` | |
-
-If you need a specific combination of architecture, profile, and features, you should create a declarative YAML target specification file in `tools/targets/qemu/` or `tools/targets/boards/`. The legacy `build_config.json` is deprecated and no longer accepts new features.
-
-### Profile/personality/board-aware CMake configuration
-
-Build composition is now resolved through centralized component policy in
-`cmake/modules/BharatComponentPolicy.cmake`. Configure-time decisions use:
-
-- `BHARAT_DEVICE_PROFILE` (for example `DESKTOP`, `AUTOMOTIVE_ECU`, `AUTOMOTIVE_INFOTAINMENT`)
-- `BHARAT_PERSONALITY_PROFILE` (`NATIVE`, `LINUX`, `WINDOWS`, `MAC`)
-- `BHARAT_TARGET_BOARD` (for example `qemu-virt-riscv64`, `shakti-c`)
-
-Both wrapper scripts (`build.sh`, `build.ps1`) pass these canonical cache variables to CMake.
-If a config value contains multiple comma-separated entries, only the first entry is used so
-configure-time policy remains deterministic.
-
-For manual configure:
 
 ```bash
-cmake --preset linux-x86_64-dev-debug \
-  -DBHARAT_DEVICE_PROFILE=AUTOMOTIVE_INFOTAINMENT \
-  -DBHARAT_PERSONALITY_PROFILE=LINUX \
-  -DBHARAT_TARGET_BOARD=qemu-virt-riscv64
+# WSL/Linux/macOS
+./build.sh all --target x86_64_desktop_headless
+./build.sh all --target arm64_desktop_headless
+./build.sh all --target riscv64_desktop_headless
 ```
 
-Please see **[BUILD.md](BUILD.md)** for exhaustive details on presets and cross-compilation toolchains.
+### Stage-oriented usage
+
+```bash
+./build.sh build   --target x86_64_desktop_headless
+./build.sh package --target x86_64_desktop_headless
+./build.sh run     --target x86_64_desktop_headless
+./build.sh flash   --target <board_target> --dry-run
+```
+
+PowerShell equivalents:
+
+```powershell
+.\build.ps1 build   --target x86_64_desktop_headless
+.\build.ps1 package --target x86_64_desktop_headless
+.\build.ps1 run     --target x86_64_desktop_headless
+.\build.ps1 flash   --target <board_target> --dry-run
+```
+
+Legacy positional compatibility example:
+
+```powershell
+.\build.ps1 x86_64_desktop_headless --run
+```
+
+Equivalent modern command:
+
+```powershell
+.\build.ps1 all --target x86_64_desktop_headless
+```
 
 ## Repository layout
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,24 +1,96 @@
-# Bharat-OS Tools Directory
+# Bharat-OS `tools/` Guide
 
-This directory contains the essential build, test, and emulation scripts for Bharat-OS development.
+This directory contains the implementation for the Bharat-OS build delivery pipeline.
 
-## Core Tooling
-- `build.sh` / `build.ps1`: The primary entry points for building the entire kernel and launching it in QEMU.
-- `debug.sh` / `debug.ps1`: Scripts to attach a debugger (GDB/LLDB) to running QEMU instances.
-- `sign_release.py`: Handles payload and image signing.
+## What lives here
 
-## Usage Overview
-To configure, compile, and optionally run the kernel for a specific architecture:
+- `build.py` - authoritative CLI for build/package/run/flash/debug.
+- `build.sh` / `build.ps1` - compatibility wrappers that forward to `build.py`.
+- `build/` - Python modules for target resolve, validation, CMake execution, manifests.
+- `package/` - packaging/transforms and manifest generation.
+- `run/` - QEMU launcher.
+- `flash/` - flashing backend integration (OpenOCD path).
+- `targets/` - explicit YAML targets (QEMU profiles).
+- `debug.sh` / `debug.ps1` - helper debugger attach scripts.
+
+---
+
+## Canonical usage
+
+Use root wrappers from repository root:
 
 ```bash
-# Linux / macOS
-./build.sh all --target x86_64
-
-# Windows (PowerShell)
-.\build.ps1 all --target x86_64
+./build.sh <subcommand> --target <name>
+./build.sh <subcommand> --target-yaml <path>
 ```
 
-For advanced usage (like profiling, hardware targeting, or dual serial output), use `--help` or see the corresponding scripts.
+```powershell
+.\build.ps1 <subcommand> --target <name>
+.\build.ps1 <subcommand> --target-yaml <path>
+```
 
-## Relationship to SDK
-The `tools/` directory is concerned with building the *kernel* and running the *emulation environment*. To build user-space applications, look inside `user/sdk/`.
+Subcommands: `configure`, `build`, `package`, `run`, `flash`, `debug`, `all`.
+
+---
+
+## Common workflows
+
+### Build and run in one command
+
+```powershell
+.\build.ps1 all --target x86_64_desktop_headless
+```
+
+```bash
+./build.sh all --target x86_64_desktop_headless
+```
+
+### Package only
+
+```powershell
+.\build.ps1 package --target x86_64_desktop_headless
+```
+
+```bash
+./build.sh package --target x86_64_desktop_headless
+```
+
+### Run only (after prior build/package)
+
+```powershell
+.\build.ps1 run --target x86_64_desktop_headless
+```
+
+```bash
+./build.sh run --target x86_64_desktop_headless
+```
+
+### Flash (board target)
+
+```powershell
+.\build.ps1 flash --target <board_target> --dry-run
+```
+
+```bash
+./build.sh flash --target <board_target> --dry-run
+```
+
+### Legacy positional compatibility example
+
+```powershell
+.\build.ps1 x86_64_desktop_headless --run
+```
+
+Equivalent modern command:
+
+```powershell
+.\build.ps1 all --target x86_64_desktop_headless
+```
+
+---
+
+## Where to read full docs
+
+- Full build/install/preset guide: `../BUILD.md`
+- High-level project quick start: `../README.md`
+


### PR DESCRIPTION
### Motivation

- Provide a single, comprehensive cross-platform user guide that explains how to install prerequisites and use the Bharat-OS build tooling on Windows (PowerShell), WSL/Linux, and macOS. 
- Clarify how to build, package, run, debug (QEMU and board flashing) and which emulators/tools to install, and supply a canonical preset command cookbook (including headless PowerShell and bash examples). 

### Description

- Rewrote `BUILD.md` into a full Build/Package/Run/Debug guide that documents prerequisites, the `tools/build.py` CLI model, subcommands (`configure`, `build`, `package`, `run`, `flash`, `debug`, `all`), and manifest/output layout. 
- Added an explicit preset cookbook with canonical headless and GUI run commands for PowerShell and WSL/Linux/macOS, plus the legacy positional example (`.\build.ps1 x86_64_desktop_headless --run`) and its modern equivalent. 
- Updated `tools/README.md` to describe the `tools/` layout, canonical usage of the wrappers (`build.sh`/`build.ps1`), common workflows (build/package/run/flash), and links to `BUILD.md`. 
- Adjusted the root `README.md` quick-start to point to `BUILD.md` and include aligned daily and stage-oriented command examples.

### Testing

- Verified wrapper CLI help invocations succeeded: `./build.sh --help` returned success. 
- Verified build help succeeded: `./build.sh build --help` returned success. 
- This change is documentation-only and no runtime/build logic was modified, so no compile or CI build tests were required for validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4ffe6fa18832092026f8f5750c181)