### PR TITLE
ui: start P1 display/input class contract

### DIFF
--- a/docs/architecture/ui/ui_execution_roadmap.md
+++ b/docs/architecture/ui/ui_execution_roadmap.md
@@ -3,6 +3,16 @@
 **Status:** Proposed next-task execution plan  
 **Scope:** UI/media architecture as first-class Bharat-OS area, explicitly out of kernel policy space.
 
+## Current Execution Focus (Started)
+
+- **Selected core task:** **P1 — Production-grade display/input class model**.
+- **Why this task first:** it unblocks `devmgr`, `displayd`, `inputd`, and every higher-level UI stack by defining a stable service-visible hardware contract.
+- **Implementation started in this change-set:**
+  - canonical display/input subclasses added to shared device class UAPI
+  - generic display/input capability-bit registry added
+  - canonical display/input capability structs and input event wire shape added
+  - host test added for UI class/capability contract stability
+
 ---
 
 ## 1) Layer Contract (Non-Negotiable)

--- a/include/bharat/uapi/device/device_class.h
+++ b/include/bharat/uapi/device/device_class.h
@@ -29,11 +29,53 @@ typedef enum {
 } bharat_device_class_t;
 
 /**
+ * Canonical display subclasses for UI/media stacks.
+ */
+typedef enum {
+    BHARAT_DISPLAY_SUBCLASS_UNKNOWN = 0,
+    BHARAT_DISPLAY_SUBCLASS_PANEL,
+    BHARAT_DISPLAY_SUBCLASS_FRAMEBUFFER,
+    BHARAT_DISPLAY_SUBCLASS_GPU,
+    BHARAT_DISPLAY_SUBCLASS_VIDEO_OUT
+} bharat_display_subclass_t;
+
+/**
+ * Canonical input subclasses for UI/HMI stacks.
+ */
+typedef enum {
+    BHARAT_INPUT_SUBCLASS_UNKNOWN = 0,
+    BHARAT_INPUT_SUBCLASS_TOUCH,
+    BHARAT_INPUT_SUBCLASS_KEYPAD,
+    BHARAT_INPUT_SUBCLASS_ROTARY,
+    BHARAT_INPUT_SUBCLASS_IR,
+    BHARAT_INPUT_SUBCLASS_CAN_CONTROL
+} bharat_input_subclass_t;
+
+/**
  * Common Device Attributes Flags
  */
 #define BHARAT_DEV_ATTR_REMOVABLE  (1ull << 0)
 #define BHARAT_DEV_ATTR_POWER_MGT  (1ull << 1)
 #define BHARAT_DEV_ATTR_SECURE     (1ull << 2)
+
+/**
+ * Display capability bits used by generic service queries.
+ */
+#define BHARAT_DISPLAY_CAP_OVERLAY            (1ull << 0)
+#define BHARAT_DISPLAY_CAP_DIRECT_SCANOUT     (1ull << 1)
+#define BHARAT_DISPLAY_CAP_SECURE_OVERLAY     (1ull << 2)
+#define BHARAT_DISPLAY_CAP_MODESET            (1ull << 3)
+#define BHARAT_DISPLAY_CAP_VSYNC_SIGNAL       (1ull << 4)
+
+/**
+ * Input capability bits used by generic service queries.
+ */
+#define BHARAT_INPUT_CAP_ABSOLUTE_COORDS      (1ull << 0)
+#define BHARAT_INPUT_CAP_RELATIVE_COORDS      (1ull << 1)
+#define BHARAT_INPUT_CAP_KEYS                 (1ull << 2)
+#define BHARAT_INPUT_CAP_ROTARY_STEPS         (1ull << 3)
+#define BHARAT_INPUT_CAP_IR_CODES             (1ull << 4)
+#define BHARAT_INPUT_CAP_CAN_SIGNALS          (1ull << 5)
 
 /**
  * Normalized Device Descriptor
@@ -42,11 +84,46 @@ typedef enum {
 typedef struct {
     uint32_t device_id;
     bharat_device_class_t dev_class;
+    uint32_t subclass;
     uint32_t vendor_id;
     uint32_t product_id;
     uint64_t attributes;
     char name[32];
 } bharat_device_descriptor_t;
+
+typedef struct {
+    uint32_t min_hz;
+    uint32_t max_hz;
+} bharat_refresh_range_t;
+
+typedef struct {
+    uint32_t width_px;
+    uint32_t height_px;
+    uint32_t min_stride_bytes;
+} bharat_display_mode_caps_t;
+
+typedef struct {
+    uint32_t plane_count;
+    uint32_t pixel_format_count;
+    uint64_t capability_bits;
+    bharat_refresh_range_t refresh_hz;
+    bharat_display_mode_caps_t max_mode;
+} bharat_display_caps_t;
+
+typedef struct {
+    uint32_t source_id;
+    uint32_t coordinate_mode;
+    uint32_t keymap_set_id;
+    uint32_t rotary_resolution;
+    uint64_t capability_bits;
+} bharat_input_caps_t;
+
+typedef struct {
+    uint64_t timestamp_ns;
+    uint16_t type;
+    uint16_t code;
+    int32_t value;
+} bharat_input_event_wire_t;
 
 /**
  * Standard Device Query Metadata Shape

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -161,6 +161,10 @@ target_include_directories(test_capability_misuse PRIVATE ../kernel/include ../l
 target_compile_definitions(test_capability_misuse PRIVATE TESTING=1)
 add_test(NAME test_capability_misuse COMMAND test_capability_misuse)
 
+add_executable(test_ui_device_class_contract test_ui_device_class_contract.c)
+target_include_directories(test_ui_device_class_contract PRIVATE ../include)
+add_test(NAME test_ui_device_class_contract COMMAND test_ui_device_class_contract)
+
 add_executable(test_memory_edgecases test_memory_edgecases.c ../kernel/src/mm/vm/aspace/vm_space.c ../kernel/src/mm/zswap.c $<TARGET_OBJECTS:bharat_test_sched_mocks>)
 target_include_directories(test_memory_edgecases PRIVATE ../kernel/include ../lib/include)
 target_compile_definitions(test_memory_edgecases PRIVATE TESTING=1)

--- a/tests/test_ui_device_class_contract.c
+++ b/tests/test_ui_device_class_contract.c
@@ -1,0 +1,51 @@
+#include <assert.h>
+#include <stdint.h>
+
+#include "bharat/uapi/device/device_class.h"
+
+int main(void) {
+    /* Class identities remain stable for service contracts. */
+    assert(BHARAT_DEV_CLASS_DISPLAY != BHARAT_DEV_CLASS_INPUT);
+    assert(BHARAT_DEV_CLASS_MAX > BHARAT_DEV_CLASS_RADIO);
+
+    /* Subclass registries exist for roadmap task P1. */
+    assert(BHARAT_DISPLAY_SUBCLASS_PANEL > BHARAT_DISPLAY_SUBCLASS_UNKNOWN);
+    assert(BHARAT_DISPLAY_SUBCLASS_VIDEO_OUT > BHARAT_DISPLAY_SUBCLASS_GPU);
+    assert(BHARAT_INPUT_SUBCLASS_TOUCH > BHARAT_INPUT_SUBCLASS_UNKNOWN);
+    assert(BHARAT_INPUT_SUBCLASS_CAN_CONTROL > BHARAT_INPUT_SUBCLASS_IR);
+
+    /* Generic capability bits are distinct and composable. */
+    assert((BHARAT_DISPLAY_CAP_OVERLAY & BHARAT_DISPLAY_CAP_DIRECT_SCANOUT) == 0);
+    assert((BHARAT_INPUT_CAP_KEYS & BHARAT_INPUT_CAP_ROTARY_STEPS) == 0);
+
+    /* Contracts must carry key fields from the UI execution roadmap. */
+    bharat_display_caps_t display_caps = {
+        .plane_count = 2,
+        .pixel_format_count = 3,
+        .capability_bits = BHARAT_DISPLAY_CAP_OVERLAY | BHARAT_DISPLAY_CAP_MODESET,
+        .refresh_hz = {.min_hz = 48, .max_hz = 120},
+        .max_mode = {.width_px = 1920, .height_px = 1080, .min_stride_bytes = 7680},
+    };
+
+    bharat_input_caps_t input_caps = {
+        .source_id = 1,
+        .coordinate_mode = 1,
+        .keymap_set_id = 7,
+        .rotary_resolution = 24,
+        .capability_bits = BHARAT_INPUT_CAP_KEYS,
+    };
+
+    bharat_input_event_wire_t event = {
+        .timestamp_ns = 1234567890ull,
+        .type = 1,
+        .code = 30,
+        .value = 1,
+    };
+
+    assert(display_caps.max_mode.width_px == 1920);
+    assert(display_caps.refresh_hz.max_hz == 120);
+    assert(input_caps.keymap_set_id == 7);
+    assert(event.timestamp_ns > 0);
+
+    return 0;
+}


### PR DESCRIPTION
### Motivation
- Begin execution of roadmap task P1 (Production-grade display/input class model) to provide a stable, service-visible hardware contract that unblocks `devmgr`, `displayd`, `inputd` and higher UI stacks.
- Provide a minimal, reviewable slice focused on the contract surface (types/flags/wire shape) so downstream plumbing can be implemented against a stable UAPI.

### Description
- Added canonical display and input subclass enums, capability bit flags, and richer capability structs to the shared device UAPI in `include/bharat/uapi/device/device_class.h` to express display/input capabilities and wire shapes.
- Extended `bharat_device_descriptor_t` with a `subclass` field and introduced `bharat_display_caps_t`, `bharat_input_caps_t`, `bharat_input_event_wire_t`, and helper types for refresh and mode caps.
- Marked the UI roadmap as actively focusing on P1 and documented what this change implements in `docs/architecture/ui/ui_execution_roadmap.md`.
- Added a host-side contract test `tests/test_ui_device_class_contract.c` validating enum/capability invariants and basic struct behavior, and wired the test into `tests/CMakeLists.txt`.

### Testing
- Built and executed the small host test directly with `cc -Iinclude tests/test_ui_device_class_contract.c -o /tmp/test_ui_device_class_contract && /tmp/test_ui_device_class_contract`, which ran successfully.
- Attempted to build the test via the repository `cmake` test tree with `cmake -S tests -B /tmp/bharat-tests-build && cmake --build /tmp/bharat-tests-build --target test_ui_device_class_contract -j2`, but CMake configure failed due to a pre-existing missing file in the repo (`tests/kernel/src/core/constraints/constraints_common.c`), so the multi-target build did not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e512e382348320a781f6ac853fe48f)