### PR TITLE
init: implement profile-aware bootstrap policies and broaden manifest selection

### DIFF
--- a/include/bharat/uapi/init/init_boot_context.h
+++ b/include/bharat/uapi/init/init_boot_context.h
@@ -18,6 +18,10 @@ typedef enum {
     INIT_PROFILE_DESKTOP = 32,
     INIT_PROFILE_DRONE = 64,
     INIT_PROFILE_CLOUD = 128,
+    INIT_PROFILE_AUTOMOTIVE = 256,
+    INIT_PROFILE_TV = 512,
+    INIT_PROFILE_APPLIANCE = 1024,
+    INIT_PROFILE_WATCH = 2048,
 } init_profile_t;
 
 typedef enum {

--- a/lib/include/ipc_user.h
+++ b/lib/include/ipc_user.h
@@ -3,16 +3,17 @@
 
 #include <stdint.h>
 
-#include "unistd.h"
 #include <bharat/uapi/syscall_nr.h>
 #include <bharat/uapi/syscall_args.h>
+
+long bharat_syscall(long sysno, long arg1, long arg2, long arg3, long arg4, long arg5, long arg6);
 
 static inline long ipc_endpoint_create(uint32_t* out_send_cap, uint32_t* out_recv_cap) {
     bharat_sys_endpoint_create_args_t args = {
         .out_send_cap_ptr = (uint64_t)(uintptr_t)out_send_cap,
         .out_recv_cap_ptr = (uint64_t)(uintptr_t)out_recv_cap,
     };
-    return syscall(SYSCALL_ENDPOINT_CREATE, (long)(uintptr_t)&args);
+    return bharat_syscall(SYSCALL_ENDPOINT_CREATE, (long)(uintptr_t)&args, 0, 0, 0, 0, 0);
 }
 
 static inline long ipc_endpoint_send(uint32_t send_cap,
@@ -30,7 +31,7 @@ static inline long ipc_endpoint_send(uint32_t send_cap,
         .cap_send_rights = cap_rights,
         .reserved0 = 0,
     };
-    return syscall(SYSCALL_ENDPOINT_SEND, (long)(uintptr_t)&args);
+    return bharat_syscall(SYSCALL_ENDPOINT_SEND, (long)(uintptr_t)&args, 0, 0, 0, 0, 0);
 }
 
 static inline long ipc_endpoint_receive(uint32_t recv_cap,
@@ -47,7 +48,7 @@ static inline long ipc_endpoint_receive(uint32_t recv_cap,
         .timeout_ticks = timeout_ticks,
         .out_received_cap_ptr = (uint64_t)(uintptr_t)out_received_cap,
     };
-    return syscall(SYSCALL_ENDPOINT_RECEIVE, (long)(uintptr_t)&args);
+    return bharat_syscall(SYSCALL_ENDPOINT_RECEIVE, (long)(uintptr_t)&args, 0, 0, 0, 0, 0);
 }
 
 #endif // BHARAT_USER_IPC_H

--- a/lib/ipc/CMakeLists.txt
+++ b/lib/ipc/CMakeLists.txt
@@ -5,7 +5,7 @@ project(BharatOS_Lib_IPC C ASM)
 add_library(bharat_libipc STATIC src/ipc.c)
 
 # Set the public include directory
-target_include_directories(bharat_libipc PUBLIC include)
+target_include_directories(bharat_libipc PUBLIC include ../include ../posix/include)
 
 # IPC depends on cap headers
 target_link_libraries(bharat_libipc PUBLIC cap bharat_freestanding)

--- a/lib/ipc/src/ipc.c
+++ b/lib/ipc/src/ipc.c
@@ -1,8 +1,10 @@
 #include <bharat/ipc/ipc.h>
 #include <bharat/uapi/ipc/contract.h>
 #include <ipc_user.h>
-#include <string.h>
 #include <stdint.h>
+#include <stddef.h>
+
+#define memcpy __builtin_memcpy
 
 #define BHARAT_IPC_ENDPOINT_PAYLOAD_MAX 128u
 

--- a/services/core/init/init_main.c
+++ b/services/core/init/init_main.c
@@ -27,6 +27,7 @@ int services_init_main(void) {
     // Prepare context
     init_boot_context_t ctx;
     init_profile_get_context(&ctx);
+    const init_profile_policy_t *policy = init_profile_get_policy(ctx.profile);
 
     if (ctx.profile == INIT_PROFILE_TINY) {
         bharat_runtime_log("services/init: Running in TINY profile mode.");
@@ -44,14 +45,16 @@ int services_init_main(void) {
         }
     }
 
-    bharat_runtime_log("services/init: Initialization graph complete. Suspending.");
+    bharat_runtime_log("services/init: Initialization graph complete.");
 
-    // Simulate main event loop or sleep
-    while(1) {
-        bharat_sched_yield();
+    if (policy->quiesce_after_handoff) {
+        bharat_runtime_log("services/init: Entering quiescent mode.");
+        while(1) {
+            bharat_sched_yield();
+        }
     }
 
-    // Unreachable
+    bharat_runtime_log("services/init: Exiting after handoff.");
     bharat_runtime_shutdown();
     return 0;
 }

--- a/services/core/init/init_manifest.c
+++ b/services/core/init/init_manifest.c
@@ -14,6 +14,9 @@ static const init_service_id_t deps_vm_manager[] = { INIT_SVC_NAMESVC, INIT_SVC_
 static const init_service_id_t deps_servicemgr[] = { INIT_SVC_NAMESVC };
 static const init_service_id_t deps_faultmgr[] = { INIT_SVC_NAMESVC };
 static const init_service_id_t deps_boot_displayd[] = { INIT_SVC_NAMESVC };
+static const init_service_id_t deps_telemetrymgr[] = { INIT_SVC_NAMESVC, INIT_SVC_FAULTMGR };
+static const init_service_id_t deps_storagemgr[] = { INIT_SVC_NAMESVC, INIT_SVC_DEVMGR };
+static const init_service_id_t deps_accelmgr[] = { INIT_SVC_NAMESVC };
 
 const init_service_desc_t g_init_manifest[] = {
     {
@@ -29,7 +32,11 @@ const init_service_desc_t g_init_manifest[] = {
         .dep_count = 0,
         .retry_limit = 3,
         .policy = INIT_SERVICE_REQUIRED,
-        .profile_mask = BHARAT_INIT_PROFILE_SMALL | BHARAT_INIT_PROFILE_EMBEDDED_RICH | BHARAT_INIT_PROFILE_MOBILE | BHARAT_INIT_PROFILE_DESKTOP | BHARAT_INIT_PROFILE_DRONE,
+        .profile_mask = BHARAT_INIT_PROFILE_SMALL | BHARAT_INIT_PROFILE_EMBEDDED_RICH |
+                        BHARAT_INIT_PROFILE_MOBILE | BHARAT_INIT_PROFILE_DESKTOP |
+                        BHARAT_INIT_PROFILE_DRONE | BHARAT_INIT_PROFILE_CLOUD |
+                        BHARAT_INIT_PROFILE_AUTOMOTIVE | BHARAT_INIT_PROFILE_TV |
+                        BHARAT_INIT_PROFILE_APPLIANCE | BHARAT_INIT_PROFILE_WATCH,
         .board_mask = BHARAT_INIT_BOARD_ANY,
         .personality_mask = BHARAT_INIT_PERSONALITY_ANY,
         .required_caps = BHARAT_INIT_CAP_NONE,
@@ -47,7 +54,9 @@ const init_service_desc_t g_init_manifest[] = {
         .dep_count = 1,
         .retry_limit = 3,
         .policy = INIT_SERVICE_REQUIRED,
-        .profile_mask = BHARAT_INIT_PROFILE_EMBEDDED_RICH | BHARAT_INIT_PROFILE_MOBILE | BHARAT_INIT_PROFILE_DESKTOP,
+        .profile_mask = BHARAT_INIT_PROFILE_EMBEDDED_RICH | BHARAT_INIT_PROFILE_MOBILE |
+                        BHARAT_INIT_PROFILE_DESKTOP | BHARAT_INIT_PROFILE_AUTOMOTIVE |
+                        BHARAT_INIT_PROFILE_CLOUD,
         .board_mask = BHARAT_INIT_BOARD_ANY,
         .personality_mask = BHARAT_INIT_PERSONALITY_ANY,
         .required_caps = BHARAT_INIT_CAP_NONE,
@@ -65,7 +74,8 @@ const init_service_desc_t g_init_manifest[] = {
         .dep_count = 2,
         .retry_limit = 3,
         .policy = INIT_SERVICE_OPTIONAL,
-        .profile_mask = BHARAT_INIT_PROFILE_EMBEDDED_RICH | BHARAT_INIT_PROFILE_MOBILE | BHARAT_INIT_PROFILE_DESKTOP,
+        .profile_mask = BHARAT_INIT_PROFILE_EMBEDDED_RICH | BHARAT_INIT_PROFILE_MOBILE |
+                        BHARAT_INIT_PROFILE_DESKTOP | BHARAT_INIT_PROFILE_CLOUD,
         .board_mask = BHARAT_INIT_BOARD_ANY,
         .personality_mask = BHARAT_INIT_PERSONALITY_ANY,
         .required_caps = BHARAT_INIT_CAP_MMU,
@@ -83,7 +93,11 @@ const init_service_desc_t g_init_manifest[] = {
         .dep_count = 1,
         .retry_limit = 2,
         .policy = INIT_SERVICE_OPTIONAL,
-        .profile_mask = BHARAT_INIT_PROFILE_SMALL | BHARAT_INIT_PROFILE_EMBEDDED_RICH | BHARAT_INIT_PROFILE_MOBILE | BHARAT_INIT_PROFILE_DESKTOP,
+        .profile_mask = BHARAT_INIT_PROFILE_SMALL | BHARAT_INIT_PROFILE_EMBEDDED_RICH |
+                        BHARAT_INIT_PROFILE_MOBILE | BHARAT_INIT_PROFILE_DESKTOP |
+                        BHARAT_INIT_PROFILE_AUTOMOTIVE | BHARAT_INIT_PROFILE_TV |
+                        BHARAT_INIT_PROFILE_APPLIANCE | BHARAT_INIT_PROFILE_WATCH |
+                        BHARAT_INIT_PROFILE_CLOUD,
         .board_mask = BHARAT_INIT_BOARD_ANY,
         .personality_mask = BHARAT_INIT_PERSONALITY_ANY,
         .required_caps = BHARAT_INIT_CAP_NONE,
@@ -100,8 +114,12 @@ const init_service_desc_t g_init_manifest[] = {
         .deps = deps_faultmgr,
         .dep_count = 1,
         .retry_limit = 1,
-        .policy = INIT_SERVICE_OPTIONAL,
-        .profile_mask = BHARAT_INIT_PROFILE_SMALL | BHARAT_INIT_PROFILE_EMBEDDED_RICH | BHARAT_INIT_PROFILE_DRONE,
+        .policy = INIT_SERVICE_REQUIRED,
+        .profile_mask = BHARAT_INIT_PROFILE_SMALL | BHARAT_INIT_PROFILE_EMBEDDED_RICH |
+                        BHARAT_INIT_PROFILE_DRONE | BHARAT_INIT_PROFILE_AUTOMOTIVE |
+                        BHARAT_INIT_PROFILE_MOBILE | BHARAT_INIT_PROFILE_DESKTOP |
+                        BHARAT_INIT_PROFILE_WATCH | BHARAT_INIT_PROFILE_APPLIANCE |
+                        BHARAT_INIT_PROFILE_CLOUD | BHARAT_INIT_PROFILE_TV,
         .board_mask = BHARAT_INIT_BOARD_ANY,
         .personality_mask = BHARAT_INIT_PERSONALITY_ANY,
         .required_caps = BHARAT_INIT_CAP_NONE,
@@ -119,7 +137,9 @@ const init_service_desc_t g_init_manifest[] = {
         .dep_count = 1,
         .retry_limit = 3,
         .policy = INIT_SERVICE_OPTIONAL,
-        .profile_mask = BHARAT_INIT_PROFILE_EMBEDDED_RICH | BHARAT_INIT_PROFILE_MOBILE | BHARAT_INIT_PROFILE_DESKTOP,
+        .profile_mask = BHARAT_INIT_PROFILE_EMBEDDED_RICH | BHARAT_INIT_PROFILE_MOBILE |
+                        BHARAT_INIT_PROFILE_DESKTOP | BHARAT_INIT_PROFILE_AUTOMOTIVE |
+                        BHARAT_INIT_PROFILE_CLOUD | BHARAT_INIT_PROFILE_TV,
         .board_mask = BHARAT_INIT_BOARD_ANY,
         .personality_mask = BHARAT_INIT_PERSONALITY_ANY,
         .required_caps = BHARAT_INIT_CAP_NONE,
@@ -137,10 +157,70 @@ const init_service_desc_t g_init_manifest[] = {
         .dep_count = 1,
         .retry_limit = 2,
         .policy = INIT_SERVICE_OPTIONAL,
-        .profile_mask = BHARAT_INIT_PROFILE_MOBILE | BHARAT_INIT_PROFILE_DESKTOP,
+        .profile_mask = BHARAT_INIT_PROFILE_MOBILE | BHARAT_INIT_PROFILE_DESKTOP |
+                        BHARAT_INIT_PROFILE_TV | BHARAT_INIT_PROFILE_WATCH,
         .board_mask = BHARAT_INIT_BOARD_ANY,
         .personality_mask = BHARAT_INIT_PERSONALITY_ANY,
         .required_caps = BHARAT_INIT_CAP_DISPLAY,
+    },
+    {
+        .id = INIT_SVC_TELEMETRYMGR,
+        .name = "telemetrymgr",
+        .boot_class = BOOT_CLASS_OPTIONAL,
+        .start_deadline_ms = 1000,
+        .ready_deadline_ms = 5000,
+        .start_fn = stub_start,
+        .probe_fn = NULL,
+        .bootstrap_hint_fn = NULL,
+        .deps = deps_telemetrymgr,
+        .dep_count = 2,
+        .retry_limit = 2,
+        .policy = INIT_SERVICE_OPTIONAL,
+        .profile_mask = BHARAT_INIT_PROFILE_MOBILE | BHARAT_INIT_PROFILE_DESKTOP |
+                        BHARAT_INIT_PROFILE_AUTOMOTIVE | BHARAT_INIT_PROFILE_CLOUD |
+                        BHARAT_INIT_PROFILE_TV | BHARAT_INIT_PROFILE_WATCH,
+        .board_mask = BHARAT_INIT_BOARD_ANY,
+        .personality_mask = BHARAT_INIT_PERSONALITY_ANY,
+        .required_caps = BHARAT_INIT_CAP_NETWORK,
+    },
+    {
+        .id = INIT_SVC_STORAGEMGR,
+        .name = "storagemgr",
+        .boot_class = BOOT_CLASS_INFRA,
+        .start_deadline_ms = 1200,
+        .ready_deadline_ms = 5000,
+        .start_fn = stub_start,
+        .probe_fn = NULL,
+        .bootstrap_hint_fn = NULL,
+        .deps = deps_storagemgr,
+        .dep_count = 2,
+        .retry_limit = 1,
+        .policy = INIT_SERVICE_REQUIRED,
+        .profile_mask = BHARAT_INIT_PROFILE_DESKTOP | BHARAT_INIT_PROFILE_MOBILE |
+                        BHARAT_INIT_PROFILE_TV | BHARAT_INIT_PROFILE_AUTOMOTIVE |
+                        BHARAT_INIT_PROFILE_CLOUD | BHARAT_INIT_PROFILE_APPLIANCE,
+        .board_mask = BHARAT_INIT_BOARD_ANY,
+        .personality_mask = BHARAT_INIT_PERSONALITY_ANY,
+        .required_caps = BHARAT_INIT_CAP_STORAGE,
+    },
+    {
+        .id = INIT_SVC_ACCELMGR,
+        .name = "accelmgr",
+        .boot_class = BOOT_CLASS_LATE,
+        .start_deadline_ms = 800,
+        .ready_deadline_ms = 4000,
+        .start_fn = stub_start,
+        .probe_fn = NULL,
+        .bootstrap_hint_fn = NULL,
+        .deps = deps_accelmgr,
+        .dep_count = 1,
+        .retry_limit = 0,
+        .policy = INIT_SERVICE_OPTIONAL,
+        .profile_mask = BHARAT_INIT_PROFILE_WATCH | BHARAT_INIT_PROFILE_MOBILE |
+                        BHARAT_INIT_PROFILE_TV | BHARAT_INIT_PROFILE_DESKTOP,
+        .board_mask = BHARAT_INIT_BOARD_ANY,
+        .personality_mask = BHARAT_INIT_PERSONALITY_ANY,
+        .required_caps = BHARAT_INIT_CAP_SENSORS,
     },
     {
         .id = INIT_SVC_APP_PAYLOAD,

--- a/services/core/init/init_manifest.h
+++ b/services/core/init/init_manifest.h
@@ -6,15 +6,6 @@
 #include <stddef.h>
 
 typedef enum {
-    BHARAT_INIT_PROFILE_TINY = 1,
-    BHARAT_INIT_PROFILE_SMALL = 2,
-    BHARAT_INIT_PROFILE_EMBEDDED_RICH = 4,
-    BHARAT_INIT_PROFILE_MOBILE = 8,
-    BHARAT_INIT_PROFILE_DESKTOP = 16,
-    BHARAT_INIT_PROFILE_DRONE = 32,
-} bharat_init_profile_t;
-
-typedef enum {
     INIT_SERVICE_DISABLED = 0,
     INIT_SERVICE_OPTIONAL,
     INIT_SERVICE_REQUIRED,
@@ -35,6 +26,20 @@ typedef uint64_t bharat_init_personality_mask_t;
 #define BHARAT_INIT_CAP_DISPLAY         (1 << 2)
 #define BHARAT_INIT_CAP_SENSORS         (1 << 3)
 #define BHARAT_INIT_CAP_MMU             (1 << 4)
+
+// Profile mask flags (mapped to shared uapi profile enum values)
+#define BHARAT_INIT_PROFILE_TINY            ((bharat_init_profile_mask_t)INIT_PROFILE_TINY)
+#define BHARAT_INIT_PROFILE_SMALL           ((bharat_init_profile_mask_t)INIT_PROFILE_SMALL)
+#define BHARAT_INIT_PROFILE_EMBEDDED_RICH   ((bharat_init_profile_mask_t)INIT_PROFILE_EMBEDDED_RICH)
+#define BHARAT_INIT_PROFILE_RT              ((bharat_init_profile_mask_t)INIT_PROFILE_RT)
+#define BHARAT_INIT_PROFILE_MOBILE          ((bharat_init_profile_mask_t)INIT_PROFILE_MOBILE)
+#define BHARAT_INIT_PROFILE_DESKTOP         ((bharat_init_profile_mask_t)INIT_PROFILE_DESKTOP)
+#define BHARAT_INIT_PROFILE_DRONE           ((bharat_init_profile_mask_t)INIT_PROFILE_DRONE)
+#define BHARAT_INIT_PROFILE_CLOUD           ((bharat_init_profile_mask_t)INIT_PROFILE_CLOUD)
+#define BHARAT_INIT_PROFILE_AUTOMOTIVE      ((bharat_init_profile_mask_t)INIT_PROFILE_AUTOMOTIVE)
+#define BHARAT_INIT_PROFILE_TV              ((bharat_init_profile_mask_t)INIT_PROFILE_TV)
+#define BHARAT_INIT_PROFILE_APPLIANCE       ((bharat_init_profile_mask_t)INIT_PROFILE_APPLIANCE)
+#define BHARAT_INIT_PROFILE_WATCH           ((bharat_init_profile_mask_t)INIT_PROFILE_WATCH)
 
 // Platform mask placeholders (example)
 #define BHARAT_INIT_BOARD_ANY           (0xFFFFFFFFU)

--- a/services/core/init/init_profile.c
+++ b/services/core/init/init_profile.c
@@ -11,6 +11,39 @@
 #define BHARAT_INIT_CAP_MMU             (1 << 4)
 #endif
 
+static const init_profile_policy_t g_default_policy = {
+    .name = "unknown",
+    .strict_core_deadlines = false,
+    .quiesce_after_handoff = false,
+    .allow_optional_failure = true,
+};
+
+static const init_profile_policy_t g_profile_policies[] = {
+    [0] = {0},
+    [1] = { .name = "tiny", .strict_core_deadlines = false, .quiesce_after_handoff = false, .allow_optional_failure = true },
+    [2] = { .name = "small", .strict_core_deadlines = false, .quiesce_after_handoff = false, .allow_optional_failure = true },
+    [4] = { .name = "embedded_rich", .strict_core_deadlines = true, .quiesce_after_handoff = true, .allow_optional_failure = true },
+    [8] = { .name = "rt", .strict_core_deadlines = true, .quiesce_after_handoff = false, .allow_optional_failure = true },
+    [16] = { .name = "mobile", .strict_core_deadlines = true, .quiesce_after_handoff = true, .allow_optional_failure = true },
+    [32] = { .name = "desktop", .strict_core_deadlines = false, .quiesce_after_handoff = false, .allow_optional_failure = true },
+    [64] = { .name = "drone", .strict_core_deadlines = true, .quiesce_after_handoff = true, .allow_optional_failure = false },
+    [128] = { .name = "cloud", .strict_core_deadlines = true, .quiesce_after_handoff = true, .allow_optional_failure = true },
+    [256] = { .name = "automotive", .strict_core_deadlines = true, .quiesce_after_handoff = true, .allow_optional_failure = true },
+    [512] = { .name = "tv", .strict_core_deadlines = false, .quiesce_after_handoff = true, .allow_optional_failure = true },
+    [1024] = { .name = "appliance", .strict_core_deadlines = true, .quiesce_after_handoff = true, .allow_optional_failure = false },
+    [2048] = { .name = "watch", .strict_core_deadlines = true, .quiesce_after_handoff = true, .allow_optional_failure = true },
+};
+
+const init_profile_policy_t *init_profile_get_policy(init_profile_t profile) {
+    if (profile > 0 && profile < (init_profile_t)(sizeof(g_profile_policies) / sizeof(g_profile_policies[0]))) {
+        const init_profile_policy_t *policy = &g_profile_policies[profile];
+        if (policy->name != NULL) {
+            return policy;
+        }
+    }
+    return &g_default_policy;
+}
+
 void init_profile_get_context(init_boot_context_t *ctx) {
     if (!ctx) return;
 
@@ -40,6 +73,16 @@ void init_profile_get_context(init_boot_context_t *ctx) {
     ctx->profile = INIT_PROFILE_DESKTOP;
 #elif defined(BHARAT_INIT_PROFILE_DRONE)
     ctx->profile = INIT_PROFILE_DRONE;
+#elif defined(BHARAT_INIT_PROFILE_CLOUD)
+    ctx->profile = INIT_PROFILE_CLOUD;
+#elif defined(BHARAT_INIT_PROFILE_AUTOMOTIVE)
+    ctx->profile = INIT_PROFILE_AUTOMOTIVE;
+#elif defined(BHARAT_INIT_PROFILE_TV)
+    ctx->profile = INIT_PROFILE_TV;
+#elif defined(BHARAT_INIT_PROFILE_APPLIANCE)
+    ctx->profile = INIT_PROFILE_APPLIANCE;
+#elif defined(BHARAT_INIT_PROFILE_WATCH)
+    ctx->profile = INIT_PROFILE_WATCH;
 #elif defined(BHARAT_DEFAULT_INIT_PROFILE)
     // Fallback if built with BHARAT_DEFAULT_INIT_PROFILE string definition
     ctx->profile = INIT_PROFILE_DESKTOP;

--- a/services/core/init/init_profile.h
+++ b/services/core/init/init_profile.h
@@ -2,7 +2,16 @@
 #define BHARAT_INIT_PROFILE_H
 
 #include <bharat/uapi/init/init_boot_context.h>
+#include <stdbool.h>
+
+typedef struct {
+    const char *name;
+    bool strict_core_deadlines;
+    bool quiesce_after_handoff;
+    bool allow_optional_failure;
+} init_profile_policy_t;
 
 void init_profile_get_context(init_boot_context_t *ctx);
+const init_profile_policy_t *init_profile_get_policy(init_profile_t profile);
 
 #endif // BHARAT_INIT_PROFILE_H


### PR DESCRIPTION
### Motivation
- Expose more product profiles in the shared boot contract so `init` can implement profile-specific bootstrap behavior for Automotive/TV/Appliance/Watch device classes.
- Provide a small, explicit profile policy model so build-time/runtime profile choices can control `init` behavior (deadlines, quiesce vs exit, optional-failure tolerance).
- Broaden the service manifest to cover cross-profile expectations and add a few staged services required by profile adapters.
- While validating platform builds, remove fragile host-libc dependencies from the IPC transport path so `lib/ipc` can compile in the freestanding build environment used by headless targets.

### Description
- Added new profile values to the public boot contract in `include/bharat/uapi/init/init_boot_context.h` (`INIT_PROFILE_AUTOMOTIVE`, `INIT_PROFILE_TV`, `INIT_PROFILE_APPLIANCE`, `INIT_PROFILE_WATCH`).
- Introduced a profile policy type and lookup API in `services/core/init`: `init_profile_policy_t` and `init_profile_get_policy()` with a per-profile policy table in `services/core/init/init_profile.{h,c}` and extended `init_profile_get_context()` to recognize the new build-time profile defines.
- Mapped manifest profile masks to the shared UAPI flags in `services/core/init/init_manifest.h` and expanded the manifest in `services/core/init/init_manifest.c` to broaden profile coverage and add staged services `telemetrymgr`, `storagemgr`, and `accelmgr` with basic deps/cap gating.
- Updated `services/core/init/init_main.c` to consult the profile policy and honor `quiesce_after_handoff` (quiesce vs exit) after handoff.
- Fixed freestanding IPC build issues by declaring and using `bharat_syscall` in `lib/include/ipc_user.h`, adding needed include directories to `lib/ipc/CMakeLists.txt`, and removing reliance on host libc headers in `lib/ipc/src/ipc.c` (use `__builtin_memcpy` and `stddef.h`).

### Testing
- Ran headless build matrix commands: `./build.sh build --target x86_64_desktop_headless`, `./build.sh build --target arm64_desktop_headless`, `./build.sh build --target riscv64_desktop_headless`, `./build.sh build --target arm32_mmu_lite_headless`, and `./build.sh build --target riscv32_mmu_lite_headless` as part of validation; all builds exercised the updated files but the matrix did not complete successfully because of pre-existing cross-toolchain/freestanding gaps in other services (missing host libc headers for several targets and undefined `__aeabi_*` symbols on some ARM targets).
- Ran `./build.sh run --target <same targets>` which failed to launch QEMU due to missing kernel boot artifacts produced by earlier build failures.
- The IPC changes allowed `lib/ipc` to compile and link further in the pipeline, but leftover platform/toolchain issues (host header lookup and target-specific runtime symbols) prevented the end-to-end artifacts from being produced in this run.

Automated builds were executed and the results described above reflect the observed pass/fail status for each run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e51dbb738483209d8702f72dfb2420)