### PR TITLE
Add virtio-input driver scaffold with bounded queues and host tests

### DIFF
--- a/drivers/input/CMakeLists.txt
+++ b/drivers/input/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(i2c_hid)
+add_subdirectory(virtio_input)
 
 set(BHARAT_DRIVER_INPUT_SOURCES)
 if(BHARAT_ENABLE_INPUT_GPIO_KEYS)
@@ -19,6 +20,7 @@ target_compile_options(bharatos_driver_input_static PRIVATE -ffreestanding -nost
 add_library(bharatos_driver_input INTERFACE)
 target_link_libraries(bharatos_driver_input INTERFACE
   bharatos_driver_input_i2c_hid
+  bharatos_driver_input_virtio_input
   bharatos_driver_input_static
 )
-target_include_directories(bharatos_driver_input INTERFACE i2c_hid)
+target_include_directories(bharatos_driver_input INTERFACE i2c_hid virtio_input)

--- a/drivers/input/virtio_input/CMakeLists.txt
+++ b/drivers/input/virtio_input/CMakeLists.txt
@@ -1,0 +1,14 @@
+set(BHARAT_DRIVER_VIRTIO_INPUT_SOURCES)
+if(BHARAT_ENABLE_DRIVER_VIRTIO_INPUT)
+    list(APPEND BHARAT_DRIVER_VIRTIO_INPUT_SOURCES virtio_input.c)
+endif()
+
+if(NOT BHARAT_DRIVER_VIRTIO_INPUT_SOURCES)
+    file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/dummy_virtio_input.c "")
+    list(APPEND BHARAT_DRIVER_VIRTIO_INPUT_SOURCES ${CMAKE_CURRENT_BINARY_DIR}/dummy_virtio_input.c)
+endif()
+
+add_library(bharatos_driver_input_virtio_input STATIC ${BHARAT_DRIVER_VIRTIO_INPUT_SOURCES})
+target_include_directories(bharatos_driver_input_virtio_input PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(bharatos_driver_input_virtio_input PRIVATE ${CMAKE_SOURCE_DIR}/drivers/input/include)
+target_compile_options(bharatos_driver_input_virtio_input PRIVATE -ffreestanding -nostdlib -Wall)

--- a/drivers/input/virtio_input/virtio_input.c
+++ b/drivers/input/virtio_input/virtio_input.c
@@ -1,0 +1,248 @@
+#include "virtio_input.h"
+
+#include <string.h>
+
+#ifndef REL_X
+#define REL_X 0x00
+#endif
+#ifndef REL_Y
+#define REL_Y 0x01
+#endif
+#ifndef REL_WHEEL
+#define REL_WHEEL 0x08
+#endif
+#ifndef BTN_LEFT
+#define BTN_LEFT 0x110
+#endif
+#ifndef BTN_RIGHT
+#define BTN_RIGHT 0x111
+#endif
+#ifndef BTN_MIDDLE
+#define BTN_MIDDLE 0x112
+#endif
+
+#define VIRTIO_INPUT_EV_SYN 0x00
+#define VIRTIO_INPUT_EV_KEY 0x01
+#define VIRTIO_INPUT_EV_REL 0x02
+#define VIRTIO_INPUT_EV_ABS 0x03
+
+#define VIRTIO_INPUT_OK 0
+#define VIRTIO_INPUT_EINVAL -1
+#define VIRTIO_INPUT_ESTATE -2
+#define VIRTIO_INPUT_ENOSPC -3
+
+__attribute__((weak)) int bharat_input_register(bharat_input_device_t *dev) {
+    (void)dev;
+    return 0;
+}
+
+__attribute__((weak)) void bharat_input_report_event(bharat_input_device_t *dev, uint16_t type, uint16_t code, int32_t value) {
+    (void)dev;
+    (void)type;
+    (void)code;
+    (void)value;
+}
+
+__attribute__((weak)) void bharat_input_sync(bharat_input_device_t *dev) {
+    (void)dev;
+}
+
+static bool virtio_input_supported_code(const virtio_input_device_t *dev, uint16_t type, uint16_t code) {
+    if (!dev) {
+        return false;
+    }
+
+    switch (type) {
+        case VIRTIO_INPUT_EV_KEY:
+            if (code >= BTN_LEFT) {
+                return dev->supports_buttons;
+            }
+            return dev->supports_keys;
+        case VIRTIO_INPUT_EV_REL:
+            if (code == REL_WHEEL) {
+                return dev->supports_wheel;
+            }
+            return dev->supports_rel && (code == REL_X || code == REL_Y);
+        case VIRTIO_INPUT_EV_ABS:
+            return dev->supports_abs;
+        case VIRTIO_INPUT_EV_SYN:
+            return true;
+        default:
+            return false;
+    }
+}
+
+int virtio_input_init(virtio_input_device_t *dev,
+                      virtio_input_raw_event_t *queue_buf,
+                      size_t queue_depth) {
+    if (!dev || !queue_buf || queue_depth == 0u) {
+        return VIRTIO_INPUT_EINVAL;
+    }
+
+    memset(dev, 0, sizeof(*dev));
+    dev->queue = queue_buf;
+    dev->queue_depth = queue_depth;
+
+    dev->input_dev.name = "virtio-input";
+    dev->input_dev.priv_data = dev;
+
+    return VIRTIO_INPUT_OK;
+}
+
+int virtio_input_probe(virtio_input_device_t *dev, void *device_handle) {
+    if (!dev || !device_handle) {
+        return VIRTIO_INPUT_EINVAL;
+    }
+    return VIRTIO_INPUT_OK;
+}
+
+int virtio_input_bind(virtio_input_device_t *dev, const virtio_input_caps_t *caps) {
+    int rc;
+    if (!dev || !caps) {
+        return VIRTIO_INPUT_EINVAL;
+    }
+
+    dev->supports_keys = caps->supports_keys;
+    dev->supports_rel = caps->supports_rel;
+    dev->supports_buttons = caps->supports_buttons;
+    dev->supports_wheel = caps->supports_wheel;
+    dev->supports_abs = caps->supports_abs;
+
+    rc = bharat_input_register(&dev->input_dev);
+    if (rc != 0) {
+        return rc;
+    }
+
+    return VIRTIO_INPUT_OK;
+}
+
+int virtio_input_start(virtio_input_device_t *dev) {
+    if (!dev) {
+        return VIRTIO_INPUT_EINVAL;
+    }
+    dev->started = true;
+    return VIRTIO_INPUT_OK;
+}
+
+int virtio_input_stop(virtio_input_device_t *dev) {
+    if (!dev) {
+        return VIRTIO_INPUT_EINVAL;
+    }
+
+    dev->started = false;
+    dev->irq_enabled = false;
+    dev->queue_head = 0;
+    dev->queue_tail = 0;
+    dev->queue_used = 0;
+    return VIRTIO_INPUT_OK;
+}
+
+int virtio_input_reset(virtio_input_device_t *dev) {
+    int rc;
+    if (!dev) {
+        return VIRTIO_INPUT_EINVAL;
+    }
+
+    dev->counters.resets++;
+    rc = virtio_input_stop(dev);
+    if (rc != 0) {
+        return rc;
+    }
+
+    return virtio_input_start(dev);
+}
+
+int virtio_input_enqueue_raw_event(virtio_input_device_t *dev,
+                                   const virtio_input_raw_event_t *ev) {
+    if (!dev || !ev) {
+        return VIRTIO_INPUT_EINVAL;
+    }
+
+    if (dev->queue_used >= dev->queue_depth) {
+        dev->counters.events_dropped++;
+        return VIRTIO_INPUT_ENOSPC;
+    }
+
+    dev->queue[dev->queue_tail] = *ev;
+    dev->queue_tail = (dev->queue_tail + 1u) % dev->queue_depth;
+    dev->queue_used++;
+    dev->counters.queue_refills++;
+    return VIRTIO_INPUT_OK;
+}
+
+static int virtio_input_process_one(virtio_input_device_t *dev) {
+    virtio_input_raw_event_t ev;
+
+    if (!dev || !dev->started) {
+        return VIRTIO_INPUT_ESTATE;
+    }
+
+    if (dev->queue_used == 0u) {
+        return 0;
+    }
+
+    ev = dev->queue[dev->queue_head];
+    dev->queue_head = (dev->queue_head + 1u) % dev->queue_depth;
+    dev->queue_used--;
+
+    if (!virtio_input_supported_code(dev, ev.type, ev.code)) {
+        dev->counters.malformed_events++;
+        dev->counters.events_dropped++;
+        return 1;
+    }
+
+    if (ev.type == VIRTIO_INPUT_EV_REL && ev.value == 0) {
+        dev->counters.events_dropped++;
+        return 1;
+    }
+
+    bharat_input_report_event(&dev->input_dev, ev.type, ev.code, ev.value);
+    if (ev.type != VIRTIO_INPUT_EV_SYN) {
+        bharat_input_sync(&dev->input_dev);
+    }
+    dev->counters.events_rx++;
+    return 1;
+}
+
+int virtio_input_poll(virtio_input_device_t *dev, size_t budget) {
+    size_t processed = 0;
+    int rc;
+
+    if (!dev || budget == 0u) {
+        return VIRTIO_INPUT_EINVAL;
+    }
+
+    while (processed < budget) {
+        rc = virtio_input_process_one(dev);
+        if (rc <= 0) {
+            if (rc == 0) {
+                break;
+            }
+            return rc;
+        }
+        processed++;
+    }
+
+    return (int)processed;
+}
+
+int virtio_input_handle_irq(virtio_input_device_t *dev, size_t budget) {
+    if (!dev) {
+        return VIRTIO_INPUT_EINVAL;
+    }
+
+    if (!dev->started) {
+        return VIRTIO_INPUT_ESTATE;
+    }
+
+    dev->irq_enabled = true;
+    dev->counters.irq_count++;
+    return virtio_input_poll(dev, budget);
+}
+
+const virtio_input_counters_t *virtio_input_get_counters(const virtio_input_device_t *dev) {
+    if (!dev) {
+        return NULL;
+    }
+    return &dev->counters;
+}

--- a/drivers/input/virtio_input/virtio_input.h
+++ b/drivers/input/virtio_input/virtio_input.h
@@ -1,0 +1,67 @@
+#ifndef BHARAT_VIRTIO_INPUT_H
+#define BHARAT_VIRTIO_INPUT_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <bharat/input/input_driver.h>
+
+typedef struct {
+    uint16_t type;
+    uint16_t code;
+    int32_t value;
+} virtio_input_raw_event_t;
+
+typedef struct {
+    uint64_t events_rx;
+    uint64_t events_dropped;
+    uint64_t malformed_events;
+    uint64_t queue_refills;
+    uint64_t irq_count;
+    uint64_t resets;
+} virtio_input_counters_t;
+
+typedef struct {
+    bool supports_keys;
+    bool supports_rel;
+    bool supports_buttons;
+    bool supports_wheel;
+    bool supports_abs;
+} virtio_input_caps_t;
+
+typedef struct {
+    bool started;
+    bool irq_enabled;
+    bool supports_keys;
+    bool supports_rel;
+    bool supports_buttons;
+    bool supports_wheel;
+    bool supports_abs;
+
+    size_t queue_depth;
+    size_t queue_head;
+    size_t queue_tail;
+    size_t queue_used;
+    virtio_input_raw_event_t *queue;
+
+    bharat_input_device_t input_dev;
+    virtio_input_counters_t counters;
+} virtio_input_device_t;
+
+int virtio_input_init(virtio_input_device_t *dev,
+                      virtio_input_raw_event_t *queue_buf,
+                      size_t queue_depth);
+int virtio_input_probe(virtio_input_device_t *dev, void *device_handle);
+int virtio_input_bind(virtio_input_device_t *dev, const virtio_input_caps_t *caps);
+int virtio_input_start(virtio_input_device_t *dev);
+int virtio_input_stop(virtio_input_device_t *dev);
+int virtio_input_reset(virtio_input_device_t *dev);
+
+int virtio_input_enqueue_raw_event(virtio_input_device_t *dev,
+                                   const virtio_input_raw_event_t *ev);
+int virtio_input_poll(virtio_input_device_t *dev, size_t budget);
+int virtio_input_handle_irq(virtio_input_device_t *dev, size_t budget);
+
+const virtio_input_counters_t *virtio_input_get_counters(const virtio_input_device_t *dev);
+
+#endif

--- a/tests/host/CMakeLists.txt
+++ b/tests/host/CMakeLists.txt
@@ -268,6 +268,11 @@ if(BHARAT_BUILD_HOST_TESTS)
     add_executable(test_i2c_hid_failures ${CMAKE_SOURCE_DIR}/tests/host/drivers/test_i2c_hid_failures.c ${CMAKE_SOURCE_DIR}/drivers/input/i2c_hid/i2c_hid.c ${CMAKE_SOURCE_DIR}/drivers/bus/i2c/i2c_core.c ${CMAKE_SOURCE_DIR}/drivers/bus/i2c/i2c_registry.c)
     target_include_directories(test_i2c_hid_failures PRIVATE ${CMAKE_SOURCE_DIR}/drivers/input/i2c_hid ${CMAKE_SOURCE_DIR}/drivers/bus/i2c)
     add_test(NAME host_test_i2c_hid_failures COMMAND test_i2c_hid_failures)
+
+    # VirtIO Input Host Tests
+    add_executable(test_virtio_input ${CMAKE_SOURCE_DIR}/tests/host/drivers/test_virtio_input.c ${CMAKE_SOURCE_DIR}/drivers/input/virtio_input/virtio_input.c)
+    target_include_directories(test_virtio_input PRIVATE ${CMAKE_SOURCE_DIR}/drivers/input/virtio_input ${CMAKE_SOURCE_DIR}/drivers/input/include ${CMAKE_SOURCE_DIR}/uapi)
+    add_test(NAME host_test_virtio_input COMMAND test_virtio_input)
 endif()
 add_executable(test_fdt_parser test_fdt_parser.c ../../hal/common/fdt_parser.c)
 target_include_directories(test_fdt_parser PRIVATE ../../include ../../kernel/include ../../boot/include)

--- a/tests/host/drivers/test_virtio_input.c
+++ b/tests/host/drivers/test_virtio_input.c
@@ -1,0 +1,97 @@
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include "../../../drivers/input/virtio_input/virtio_input.h"
+#include "../../../uapi/bharat/input/input.h"
+
+#ifndef REL_X
+#define REL_X 0x00
+#endif
+#ifndef BTN_LEFT
+#define BTN_LEFT 0x110
+#endif
+
+static int g_report_count = 0;
+static int g_sync_count = 0;
+static uint16_t g_last_type = 0;
+static uint16_t g_last_code = 0;
+static int32_t g_last_value = 0;
+
+int bharat_input_register(bharat_input_device_t *dev) {
+    (void)dev;
+    return 0;
+}
+
+void bharat_input_report_event(bharat_input_device_t *dev, uint16_t type, uint16_t code, int32_t value) {
+    (void)dev;
+    g_report_count++;
+    g_last_type = type;
+    g_last_code = code;
+    g_last_value = value;
+}
+
+void bharat_input_sync(bharat_input_device_t *dev) {
+    (void)dev;
+    g_sync_count++;
+}
+
+static void reset_capture(void) {
+    g_report_count = 0;
+    g_sync_count = 0;
+    g_last_type = 0;
+    g_last_code = 0;
+    g_last_value = 0;
+}
+
+int main(void) {
+    virtio_input_device_t dev;
+    virtio_input_raw_event_t queue[2];
+    virtio_input_caps_t caps = {
+        .supports_keys = true,
+        .supports_rel = true,
+        .supports_buttons = true,
+        .supports_wheel = true,
+        .supports_abs = false,
+    };
+
+    assert(virtio_input_init(&dev, queue, 2) == 0);
+    assert(virtio_input_probe(&dev, &dev) == 0);
+    assert(virtio_input_bind(&dev, &caps) == 0);
+    assert(virtio_input_start(&dev) == 0);
+
+    /* feature negotiation + event decode */
+    assert(virtio_input_enqueue_raw_event(&(dev), &(virtio_input_raw_event_t){.type = EV_KEY, .code = KEY_A, .value = 1}) == 0);
+    assert(virtio_input_poll(&dev, 4) == 1);
+    assert(g_report_count == 1);
+    assert(g_sync_count == 1);
+    assert(g_last_type == EV_KEY);
+    assert(g_last_code == KEY_A);
+
+    reset_capture();
+    assert(virtio_input_enqueue_raw_event(&(dev), &(virtio_input_raw_event_t){.type = EV_REL, .code = REL_X, .value = 5}) == 0);
+    assert(virtio_input_handle_irq(&dev, 4) == 1);
+    assert(g_report_count == 1);
+    assert(g_sync_count == 1);
+    assert(virtio_input_get_counters(&dev)->irq_count == 1);
+
+    /* malformed drop */
+    assert(virtio_input_enqueue_raw_event(&(dev), &(virtio_input_raw_event_t){.type = 0x99, .code = 0, .value = 0}) == 0);
+    assert(virtio_input_poll(&dev, 1) == 1);
+    assert(virtio_input_get_counters(&dev)->malformed_events == 1);
+
+    /* queue exhaustion */
+    assert(virtio_input_enqueue_raw_event(&(dev), &(virtio_input_raw_event_t){.type = EV_KEY, .code = KEY_B, .value = 1}) == 0);
+    assert(virtio_input_enqueue_raw_event(&(dev), &(virtio_input_raw_event_t){.type = EV_KEY, .code = KEY_C, .value = 1}) == 0);
+    assert(virtio_input_enqueue_raw_event(&(dev), &(virtio_input_raw_event_t){.type = EV_KEY, .code = KEY_D, .value = 1}) != 0);
+
+    /* stop/reset path */
+    assert(virtio_input_stop(&dev) == 0);
+    assert(virtio_input_poll(&dev, 1) < 0);
+    assert(virtio_input_reset(&dev) == 0);
+    assert(dev.started);
+    assert(virtio_input_get_counters(&dev)->resets == 1);
+
+    puts("virtio_input host tests passed");
+    return 0;
+}


### PR DESCRIPTION
### Motivation
- Provide a first PR for Ticket 1 by adding a production-ready scaffold for a VirtIO input driver under `drivers/input/virtio_input` so future work can implement real virtqueues and QEMU smoke tests. 
- Integrate the component into the existing input build path while preserving the existing component toggle and dummy-fallback behavior when the driver is disabled. 

### Description
- Add new driver sources `drivers/input/virtio_input/virtio_input.c` and `drivers/input/virtio_input/virtio_input.h` implementing bounded event queue state, capability flags, lifecycle APIs (`init/probe/bind/start/stop/reset`), poll and IRQ entry points, and counters. 
- Add `drivers/input/virtio_input/CMakeLists.txt` and wire the new static target into the input aggregate by updating `drivers/input/CMakeLists.txt` so the component is built only when `BHARAT_ENABLE_DRIVER_VIRTIO_INPUT` is enabled and otherwise provides a dummy object. 
- Add a host unit test `tests/host/drivers/test_virtio_input.c` that exercises feature negotiation, event decode, malformed-event drop, queue exhaustion, IRQ handling, and stop/reset paths, and register it in `tests/host/CMakeLists.txt`. 
- Provide weak `bharat_input_*` stubs for host test integration so the driver can be exercised in the host test harness without pulling in full inputmgr service code. 

### Testing
- Built and ran host tests with `BHARAT_BUILD_HOST_TESTS=ON` and executed `ctest` for the virtio input host test with: `cmake -S . -B build-host -DBHARAT_BUILD_HOST_TESTS=ON && cmake --build build-host --target test_virtio_input -j4 && ctest --test-dir build-host -R host_test_virtio_input --output-on-failure`, and `host_test_virtio_input` passed. 
- Verified the input targets produce a dummy object when `BHARAT_ENABLE_DRIVER_VIRTIO_INPUT=OFF` by configuring and building the input sub-target libraries in the off configuration. 
- Verified the virtio input static target builds when `BHARAT_ENABLE_DRIVER_VIRTIO_INPUT=ON` by configuring and building the `bharatos_driver_input_virtio_input` target; final builds and host test runs succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e520c53d4c83209b8c9c3b8e9425a7)