### PR TITLE
uapi: add unified policy-plane contracts and SLO gate vocabulary

### DIFF
--- a/docs/dev/unified-policy-uapi-contracts.md
+++ b/docs/dev/unified-policy-uapi-contracts.md
@@ -1,0 +1,69 @@
+# Unified Policy UAPI Contracts (uapi/policy)
+
+## Scope
+
+This document defines the baseline **Unified Policy UAPI** contracts that centralize profile/capability policy resolution and measurable SLO gate evaluation without moving policy logic into the kernel.
+
+Layer ownership remains aligned with Bharat-OS principles:
+
+- Kernel: mechanism only (scheduler primitives, IPC primitives, memory classes, power/fault hooks).
+- Services: policy and orchestration (`policymgr`, `telemetrymgr`, `schedmgr`, `powermgr`, `safetymgr`).
+- UAPI: stable shared contracts so policy decisions are explicit and auditable.
+
+## New UAPI headers
+
+- `include/bharat/uapi/policy/contract.h`
+  - policy opcodes for boot snapshot resolution, runtime updates, and SLO gate workflows
+  - snapshot schema capturing profile/hardware/tier/subsystem state
+  - first-class SLO domains and enforcement action vocabulary
+- `include/bharat/uapi/policy/status.h`
+  - policy-level status aliases and policy-specific failures (profile mismatch, unsupported tier, SLO gate failure)
+
+## Contract model
+
+### 1) Boot-time policy snapshot
+
+`BHARAT_POLICY_OP_RESOLVE_BOOT_SNAPSHOT` returns a `bharat_policy_snapshot_t` containing:
+
+- `profile_mask`
+- `hw_capability_flags`
+- protection model (`MPU_ONLY`, `MMU_LITE`, `MMU_FULL`)
+- realization tier (`STATIC`, `LIGHTWEIGHT`, `FULL`)
+- enabled subsystem bitmask
+- generation + effective timestamp
+
+This allows one canonical policy realization at boot instead of independent scheduler/IPC/memory fragments.
+
+### 2) Runtime updates (tier-scaled)
+
+`BHARAT_POLICY_OP_APPLY_RUNTIME_UPDATE` introduces generation-checked updates:
+
+- caller provides `expected_generation`
+- policymgr either applies a new snapshot or rejects stale/unsupported updates
+
+Tiny targets can keep this path dormant (Tier A), while Tier B/C systems can use it for controlled runtime adaptation.
+
+### 3) SLO gate flow
+
+SLO contracts are explicit and measurable:
+
+- `BHARAT_POLICY_OP_REPORT_SLO_SAMPLE`
+- `BHARAT_POLICY_OP_EVAL_SLO_GATES`
+- standardized domains for initial rollout:
+  - scheduler latency
+  - IPC queue pressure
+  - memory pressure
+  - watchdog heartbeat health
+  - thermal violations
+
+Evaluation responses carry both gate status and enforcement action, allowing deterministic orchestration by peer services.
+
+## Why this shape
+
+This avoids duplicate policy models while keeping implementation scalable:
+
+- Tier A (static): compile/boot-resolved snapshot, minimal runtime churn
+- Tier B (lightweight): event-driven updates and threshold gates
+- Tier C (full): telemetry-integrated dynamic policy plane
+
+The UAPI surface is shared across tiers; only operational richness changes.

--- a/include/bharat/uapi/policy/contract.h
+++ b/include/bharat/uapi/policy/contract.h
@@ -1,0 +1,134 @@
+#ifndef BHARAT_UAPI_POLICY_CONTRACT_H
+#define BHARAT_UAPI_POLICY_CONTRACT_H
+
+#include <stdint.h>
+
+#include <bharat/uapi/ipc/contract.h>
+#include <bharat/uapi/policy/status.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @file contract.h
+ * @brief Unified policy-plane UAPI contract shared by policymgr and peer managers.
+ */
+
+#define POLICYMGR_SERVICE_ID 0x00010010u
+
+enum {
+    BHARAT_POLICY_CONTRACT_VERSION_V1 = 1u,
+};
+
+typedef enum {
+    BHARAT_POLICY_TIER_STATIC = 1u,      /* Tier A: build/boot-resolved policy */
+    BHARAT_POLICY_TIER_LIGHTWEIGHT = 2u, /* Tier B: event-driven lightweight runtime policy */
+    BHARAT_POLICY_TIER_FULL = 3u,        /* Tier C: full dynamic runtime policy plane */
+} bharat_policy_realization_tier_t;
+
+typedef enum {
+    BHARAT_POLICY_PROTECTION_UNKNOWN = 0u,
+    BHARAT_POLICY_PROTECTION_MPU_ONLY = 1u,
+    BHARAT_POLICY_PROTECTION_MMU_LITE = 2u,
+    BHARAT_POLICY_PROTECTION_MMU_FULL = 3u,
+} bharat_policy_protection_model_t;
+
+typedef enum {
+    BHARAT_POLICY_OP_RESOLVE_BOOT_SNAPSHOT = 1u,
+    BHARAT_POLICY_OP_GET_ACTIVE_SNAPSHOT = 2u,
+    BHARAT_POLICY_OP_APPLY_RUNTIME_UPDATE = 3u,
+    BHARAT_POLICY_OP_REPORT_SLO_SAMPLE = 4u,
+    BHARAT_POLICY_OP_EVAL_SLO_GATES = 5u,
+    BHARAT_POLICY_OP_GET_ENFORCEMENT = 6u,
+} bharat_policy_opcode_t;
+
+enum {
+    BHARAT_POLICY_SUBSYS_SCHED      = (1u << 0),
+    BHARAT_POLICY_SUBSYS_IPC        = (1u << 1),
+    BHARAT_POLICY_SUBSYS_MEMORY     = (1u << 2),
+    BHARAT_POLICY_SUBSYS_POWER      = (1u << 3),
+    BHARAT_POLICY_SUBSYS_TELEMETRY  = (1u << 4),
+    BHARAT_POLICY_SUBSYS_SAFETY     = (1u << 5),
+    BHARAT_POLICY_SUBSYS_DEVICE     = (1u << 6),
+    BHARAT_POLICY_SUBSYS_NETWORK    = (1u << 7),
+    BHARAT_POLICY_SUBSYS_STORAGE    = (1u << 8),
+};
+
+enum {
+    BHARAT_POLICY_SLO_DOMAIN_SCHED_LATENCY = 1u,
+    BHARAT_POLICY_SLO_DOMAIN_IPC_QUEUE = 2u,
+    BHARAT_POLICY_SLO_DOMAIN_MEMORY_PRESSURE = 3u,
+    BHARAT_POLICY_SLO_DOMAIN_WATCHDOG_HEARTBEAT = 4u,
+    BHARAT_POLICY_SLO_DOMAIN_THERMAL = 5u,
+};
+
+enum {
+    BHARAT_POLICY_ACTION_NONE = 0u,
+    BHARAT_POLICY_ACTION_THROTTLE_BEST_EFFORT = 1u,
+    BHARAT_POLICY_ACTION_REJECT_NEW_WORK = 2u,
+    BHARAT_POLICY_ACTION_RECLAIM_MEMORY = 3u,
+    BHARAT_POLICY_ACTION_ENTER_SAFE_MODE = 4u,
+    BHARAT_POLICY_ACTION_RESTART_FAULT_DOMAIN = 5u,
+};
+
+typedef struct {
+    uint32_t contract_version;
+    uint32_t profile_mask;
+    uint32_t hw_capability_flags;
+    uint32_t protection_model;
+    uint32_t realization_tier;
+    uint32_t enabled_subsystems;
+    bharat_policy_status_t status;
+    uint32_t generation;
+    uint64_t effective_since_ticks;
+} bharat_policy_snapshot_t;
+
+typedef struct {
+    uint32_t requested_profile_mask;
+    uint32_t hw_capability_flags;
+    uint32_t protection_model;
+    uint32_t requested_subsystems;
+} bharat_policy_req_resolve_boot_snapshot_t;
+
+typedef struct {
+    bharat_policy_snapshot_t snapshot;
+} bharat_policy_resp_boot_snapshot_t;
+
+typedef struct {
+    uint32_t expected_generation;
+    bharat_policy_snapshot_t proposed_snapshot;
+} bharat_policy_req_apply_runtime_update_t;
+
+typedef struct {
+    bharat_policy_status_t status;
+    uint32_t new_generation;
+} bharat_policy_resp_apply_runtime_update_t;
+
+typedef struct {
+    uint32_t slo_domain;
+    uint32_t signal_id;
+    uint64_t observed_value;
+    uint64_t target_value;
+    uint64_t sample_timestamp_ticks;
+} bharat_policy_req_report_slo_sample_t;
+
+typedef struct {
+    uint32_t slo_domain;
+    uint32_t evaluation_window_ms;
+    uint32_t max_breach_count;
+    uint32_t reserved;
+} bharat_policy_req_eval_slo_gate_t;
+
+typedef struct {
+    bharat_policy_status_t gate_status;
+    uint32_t breach_count;
+    uint32_t enforcement_action;
+    uint32_t enforcement_scope_subsystems;
+} bharat_policy_resp_eval_slo_gate_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BHARAT_UAPI_POLICY_CONTRACT_H */

--- a/include/bharat/uapi/policy/status.h
+++ b/include/bharat/uapi/policy/status.h
@@ -1,0 +1,39 @@
+#ifndef BHARAT_UAPI_POLICY_STATUS_H
+#define BHARAT_UAPI_POLICY_STATUS_H
+
+#include <bharat/uapi/service_status.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @file status.h
+ * @brief Canonical status codes for unified policy-plane contracts.
+ */
+typedef int32_t bharat_policy_status_t;
+
+#define BHARAT_POLICY_STATUS_OK                BHARAT_STATUS_OK
+#define BHARAT_POLICY_STATUS_ERR_DECODE        BHARAT_STATUS_ERR_DECODE
+#define BHARAT_POLICY_STATUS_ERR_VERSION       BHARAT_STATUS_ERR_VERSION
+#define BHARAT_POLICY_STATUS_ERR_OPCODE        BHARAT_STATUS_ERR_OPCODE
+#define BHARAT_POLICY_STATUS_ERR_PERMISSION    BHARAT_STATUS_ERR_PERMISSION
+#define BHARAT_POLICY_STATUS_ERR_NOT_FOUND     BHARAT_STATUS_ERR_NOT_FOUND
+#define BHARAT_POLICY_STATUS_ERR_UNSUPPORTED   BHARAT_STATUS_ERR_UNSUPPORTED
+#define BHARAT_POLICY_STATUS_ERR_INTERNAL      BHARAT_STATUS_ERR_INTERNAL
+#define BHARAT_POLICY_STATUS_ERR_TRUNCATED     BHARAT_STATUS_ERR_TRUNCATED
+#define BHARAT_POLICY_STATUS_ERR_LENGTH        BHARAT_STATUS_ERR_LENGTH
+#define BHARAT_POLICY_STATUS_ERR_FLAGS         BHARAT_STATUS_ERR_FLAGS
+
+/* Policy-plane specific failures. */
+#define BHARAT_POLICY_STATUS_ERR_PROFILE_MISMATCH   ((bharat_policy_status_t)-64)
+#define BHARAT_POLICY_STATUS_ERR_HW_UNSUPPORTED     ((bharat_policy_status_t)-65)
+#define BHARAT_POLICY_STATUS_ERR_TIER_UNSUPPORTED   ((bharat_policy_status_t)-66)
+#define BHARAT_POLICY_STATUS_ERR_SLO_GATE_FAILED    ((bharat_policy_status_t)-67)
+#define BHARAT_POLICY_STATUS_ERR_BUDGET_EXHAUSTED   ((bharat_policy_status_t)-68)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BHARAT_UAPI_POLICY_STATUS_H */


### PR DESCRIPTION
### Motivation

- Profile and hardware capability policy is currently fragmented across scheduler, IPC, and memory paths and needs a single, auditable UAPI surface for boot-time resolution and runtime enforcement.
- The platform requires measurable SLO gates and a shared vocabulary so services (not the kernel) can evaluate and act on policy breaches deterministically. 
- The implementation must scale across device capability classes (static boot-resolved policy up to a full runtime policy plane) while keeping kernel responsibilities as mechanisms only.

### Description

- Add `include/bharat/uapi/policy/contract.h` which defines `POLICYMGR_SERVICE_ID`, contract versioning, realization tiers (`STATIC`/`LIGHTWEIGHT`/`FULL`), protection-model enums (`MPU_ONLY`/`MMU_LITE`/`MMU_FULL`), policy opcodes for snapshot/update/SLO workflows, subsystem bitmask, SLO domain enums, enforcement actions, and snapshot/request/response structs used by `policymgr` and peer managers. 
- Add `include/bharat/uapi/policy/status.h` which maps common service-status codes and introduces policy-specific failure codes such as `ERR_PROFILE_MISMATCH`, `ERR_HW_UNSUPPORTED`, `ERR_TIER_UNSUPPORTED`, `ERR_SLO_GATE_FAILED`, and `ERR_BUDGET_EXHAUSTED`. 
- Add developer documentation at `docs/dev/unified-policy-uapi-contracts.md` describing intent, layer ownership, boot snapshot semantics, generation-checked runtime updates, SLO reporting/evaluation flows, and the tier-scaled realization model. 
- The change is additive to existing IPC/uAPI surfaces and preserves the principle that policy logic remains in user-space services while providing a stable, shared contract for enforcement and telemetry integration.

### Testing

- Ran `git diff --check` to validate whitespace/patch hygiene, which completed with no issues. 
- Ran `cmake -S . -B /tmp/bharat-build` to validate header integration and project configuration, which completed successfully and wrote build files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e52609670483209fec9760fe4241a8)