### PR TITLE
storage: add profile-aware filesystem policy resolver and cache baseline

### DIFF
--- a/docs/architecture/storage/file-system-detailed-design.md
+++ b/docs/architecture/storage/file-system-detailed-design.md
@@ -92,3 +92,65 @@ The pure hardware interface layer.
 1. Implement multi-queue NVMe driver with CPU core pinning.
 2. Introduce `VFS_BACKEND_BLOB` for URI-addressed object storage.
 3. Asynchronous I/O via `io_uring`-style ring buffers mapped between the application and VFS.
+
+---
+
+## 6. Gap Review (Current Repo State) and Remaining Tasks
+
+After reviewing the active code under `stacks/storage/` and `services/system/filesystem/`, the biggest remaining production gaps are:
+
+1. **Filesystem service path is still mostly stubbed**
+   - `services/system/filesystem/main.c` performs only a single synthetic block read flow.
+   - Full IPC decode/dispatch for `openat/read/write/stat` is still pending.
+
+2. **Storage cache and writeback were placeholder-only**
+   - The previous cache implementation had no residency model, no eviction policy, and no sync semantics.
+
+3. **No profile/device/architecture-aware policy resolver**
+   - Build/runtime profile intent existed in architecture docs, but there was no shared resolver translating:
+     - app profile (RT/Edge/Datacenter),
+     - device size,
+     - hardware architecture,
+     into concrete FS backend + cache + queue configuration.
+
+4. **Phase-2 service migration remains incomplete**
+   - Kernel shim consumers and some tests still rely on transitional paths.
+
+### Updated Remaining Task List (priority order)
+
+1. Complete `fs_client` + service-side syscall routing (`openat/read/write/stat/mkdir/unlink/rename`) and migrate all tests from kernel shims.
+2. Add concrete persistent adapters in `stacks/storage/fs/`:
+   - `littlefs`/`FAT` for RT/Edge,
+   - `ext4-like` baseline for general-purpose,
+   - `xfs-like`/blob for datacenter scale.
+3. Wire cache pages to DMA-safe allocator and block IO SG lists (remove placeholder buffer pointers).
+4. Add NUMA-local worker and queue pinning policy plumbing for datacenter profile.
+5. Add integrity/journaling hooks (`stacks/storage/integrity/`) and profile-gated enforcement.
+6. Add fault-injection + soak tests (power-cut/replay, media errors, queue timeouts).
+
+---
+
+## 7. Implemented Baseline Improvements (This Change)
+
+To move toward production-grade behavior while keeping scope realistic, the current implementation now includes:
+
+1. **Profile-aware storage resolver (`stacks/storage/profile.c`)**
+   - Chooses backend/cache/queue/cache-budget from:
+     - application profile,
+     - device size,
+     - hardware architecture.
+   - Includes 32-bit resource clamping for constrained targets.
+
+2. **Configurable cache initialization (`cache_init_with_profile`)**
+   - Cache capacity now follows resolved profile budget.
+   - Added bounded in-memory cache entries, lookup, victim selection, pin/unpin tracking.
+   - Added `cache_sync()` writeback + FLUSH request path.
+
+3. **Filesystem service startup policy wiring**
+   - Service now reads block device geometry and resolves profile policy at boot.
+   - Cache is initialized using the resolved policy, creating a profile/device/arch aware storage baseline.
+
+4. **Block layer FLUSH semantic stub**
+   - Generic block queue now explicitly handles FLUSH requests, enabling cache-sync barrier semantics.
+
+These changes establish the policy plane and cache baseline needed before full adapter, journaling, and service syscall completion.

--- a/services/system/filesystem/main.c
+++ b/services/system/filesystem/main.c
@@ -1,11 +1,58 @@
 #include <stdint.h>
 #include <stddef.h>
+
 #include "urpc.h"
 #include "bharat/stacks/storage/block.h"
+#include "bharat/stacks/storage/cache/cache.h"
+#include "bharat/stacks/storage/profile.h"
 
 // Reference happy path execution
 extern int virtio_blk_submit_request(void* sg_list, uint32_t num_sgs);
 extern void virtio_blk_init(void);
+
+static storage_app_profile_t fs_select_profile(void) {
+#if defined(CONFIG_PROFILE_AUTOMOBILE) || defined(CONFIG_PROFILE_DRONE)
+    return STORAGE_APP_PROFILE_RT;
+#elif defined(CONFIG_PROFILE_DATACENTER)
+    return STORAGE_APP_PROFILE_DATACENTER;
+#else
+    return STORAGE_APP_PROFILE_EDGE;
+#endif
+}
+
+static storage_hw_arch_t fs_select_arch(void) {
+#if defined(__x86_64__) || defined(_M_X64)
+    return STORAGE_HW_ARCH_X86_64;
+#elif defined(__aarch64__)
+    return STORAGE_HW_ARCH_ARM64;
+#elif defined(__arm__)
+    return STORAGE_HW_ARCH_ARM32;
+#elif defined(__riscv) && (__riscv_xlen == 64)
+    return STORAGE_HW_ARCH_RISCV64;
+#elif defined(__riscv)
+    return STORAGE_HW_ARCH_RISCV32;
+#else
+    return STORAGE_HW_ARCH_UNKNOWN;
+#endif
+}
+
+static int fs_storage_stack_init(uint32_t device_id) {
+    block_device_info_t info;
+    storage_profile_config_t cfg;
+
+    if (block_get_info(device_id, &info) != 0) {
+        return -1;
+    }
+
+    if (storage_profile_resolve(fs_select_profile(),
+                                (uint64_t)info.block_size * info.total_blocks,
+                                fs_select_arch(),
+                                &cfg) != 0) {
+        return -1;
+    }
+
+    return cache_init_with_profile(&cfg);
+}
 
 // Simulated capability IPC server handler
 void handle_fs_urpc_request(void* msg) {
@@ -29,7 +76,12 @@ int main(void) {
     // 1. Initialize drivers
     virtio_blk_init();
 
-    // 2. Wait for incoming capability requests
+    // 2. Initialize cache and storage policy based on profile/device/arch.
+    if (fs_storage_stack_init(0) != 0) {
+        return -1;
+    }
+
+    // 3. Wait for incoming capability requests
     // (Simulate an incoming uRPC request loop)
 
     return 0;

--- a/stacks/include/bharat/stacks/storage/cache/cache.h
+++ b/stacks/include/bharat/stacks/storage/cache/cache.h
@@ -1,16 +1,21 @@
 #pragma once
 
 #include "bharat/stacks/storage/block.h"
+#include "bharat/stacks/storage/profile.h"
 
 // Buffer/Cache Abstraction
+#define CACHE_BLOCK_VALID 0x1U
+#define CACHE_BLOCK_DIRTY 0x2U
+
 typedef struct {
     uint32_t device_id;
     uint64_t lba;
     uint32_t flags; // DIRTY, VALID, etc.
-    void* buffer; // DMA-safe page buffer
+    void* buffer;   // DMA-safe page buffer
 } cache_block_t;
 
 int cache_init(void);
+int cache_init_with_profile(const storage_profile_config_t* cfg);
 int cache_get_block(uint32_t device_id, uint64_t lba, cache_block_t** out_block);
 int cache_put_block(cache_block_t* block);
 int cache_sync(uint32_t device_id);

--- a/stacks/include/bharat/stacks/storage/profile.h
+++ b/stacks/include/bharat/stacks/storage/profile.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    STORAGE_APP_PROFILE_RT = 0,
+    STORAGE_APP_PROFILE_EDGE = 1,
+    STORAGE_APP_PROFILE_DATACENTER = 2
+} storage_app_profile_t;
+
+typedef enum {
+    STORAGE_HW_ARCH_UNKNOWN = 0,
+    STORAGE_HW_ARCH_ARM32,
+    STORAGE_HW_ARCH_ARM64,
+    STORAGE_HW_ARCH_RISCV32,
+    STORAGE_HW_ARCH_RISCV64,
+    STORAGE_HW_ARCH_X86_64
+} storage_hw_arch_t;
+
+typedef enum {
+    STORAGE_FS_BACKEND_RAMFS = 0,
+    STORAGE_FS_BACKEND_LITTLEFS,
+    STORAGE_FS_BACKEND_FAT,
+    STORAGE_FS_BACKEND_EXT4_LIKE,
+    STORAGE_FS_BACKEND_XFS_LIKE,
+    STORAGE_FS_BACKEND_BLOB
+} storage_fs_backend_t;
+
+typedef enum {
+    STORAGE_CACHE_WRITETHROUGH = 0,
+    STORAGE_CACHE_WRITEBACK,
+    STORAGE_CACHE_NUMA_WRITEBACK
+} storage_cache_policy_t;
+
+typedef struct {
+    storage_app_profile_t app_profile;
+    storage_hw_arch_t hw_arch;
+    uint64_t device_size_bytes;
+
+    storage_fs_backend_t fs_backend;
+    storage_cache_policy_t cache_policy;
+    uint32_t io_queue_depth;
+    uint32_t cache_block_budget;
+    uint8_t enable_numa_locality;
+    uint8_t enable_journaling;
+} storage_profile_config_t;
+
+int storage_profile_resolve(storage_app_profile_t app_profile,
+                            uint64_t device_size_bytes,
+                            storage_hw_arch_t arch,
+                            storage_profile_config_t* out_cfg);
+
+const char* storage_profile_backend_name(storage_fs_backend_t backend);
+const char* storage_profile_cache_policy_name(storage_cache_policy_t policy);
+
+#ifdef __cplusplus
+}
+#endif

--- a/stacks/storage/CMakeLists.txt
+++ b/stacks/storage/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(bharat_stacks_storage STATIC
     block/block.c
     cache/cache.c
+    profile.c
     fs/adapter.c
     fs/ramfs/ramfs.c
     fs/blob/blob_backend.c

--- a/stacks/storage/block/block.c
+++ b/stacks/storage/block/block.c
@@ -7,6 +7,12 @@ int block_queue_request(uint32_t device_id, block_request_t* req) {
     // Stub: Serialize request and send to driver via uRPC
     if (!req) return -1;
 
+    if (req->type == BLOCK_REQ_FLUSH) {
+        // Queue drain / barrier semantic placeholder.
+        req->status = 0;
+        return 0;
+    }
+
     if (device_id == 0) { // Assume 0 is virtio-blk
         // We simulate sending an SG list to the driver
         void* dummy_sg = req->buffer;

--- a/stacks/storage/cache/cache.c
+++ b/stacks/storage/cache/cache.c
@@ -1,25 +1,161 @@
 #include "bharat/stacks/storage/cache/cache.h"
+
 #include <stddef.h>
 
+#define CACHE_DEFAULT_CAPACITY 256U
+#define CACHE_MAX_CAPACITY 4096U
+
+typedef struct {
+    cache_block_t block;
+    uint8_t in_use;
+    uint8_t pin_count;
+} cache_entry_t;
+
+static cache_entry_t g_cache[CACHE_MAX_CAPACITY];
+static uint32_t g_cache_capacity = CACHE_DEFAULT_CAPACITY;
+static uint32_t g_clock_hand = 0U;
+
+static cache_entry_t* cache_find(uint32_t device_id, uint64_t lba) {
+    for (uint32_t i = 0; i < g_cache_capacity; ++i) {
+        if (g_cache[i].in_use && g_cache[i].block.device_id == device_id && g_cache[i].block.lba == lba) {
+            return &g_cache[i];
+        }
+    }
+    return NULL;
+}
+
+static cache_entry_t* cache_pick_victim(void) {
+    for (uint32_t probe = 0; probe < g_cache_capacity; ++probe) {
+        uint32_t idx = (g_clock_hand + probe) % g_cache_capacity;
+        if (!g_cache[idx].in_use || g_cache[idx].pin_count == 0U) {
+            g_clock_hand = (idx + 1U) % g_cache_capacity;
+            return &g_cache[idx];
+        }
+    }
+    return NULL;
+}
+
 int cache_init(void) {
-    // Stub
+    storage_profile_config_t cfg;
+    if (storage_profile_resolve(STORAGE_APP_PROFILE_EDGE,
+                                8ULL * 1024ULL * 1024ULL * 1024ULL,
+                                STORAGE_HW_ARCH_UNKNOWN,
+                                &cfg) != 0) {
+        return -1;
+    }
+    return cache_init_with_profile(&cfg);
+}
+
+int cache_init_with_profile(const storage_profile_config_t* cfg) {
+    if (!cfg) {
+        return -1;
+    }
+
+    uint32_t requested = cfg->cache_block_budget;
+    if (requested < 32U) {
+        requested = 32U;
+    }
+    if (requested > CACHE_MAX_CAPACITY) {
+        requested = CACHE_MAX_CAPACITY;
+    }
+    g_cache_capacity = requested;
+    g_clock_hand = 0U;
+
+    for (uint32_t i = 0; i < CACHE_MAX_CAPACITY; ++i) {
+        g_cache[i].in_use = 0U;
+        g_cache[i].pin_count = 0U;
+        g_cache[i].block.device_id = 0U;
+        g_cache[i].block.lba = 0U;
+        g_cache[i].block.flags = 0U;
+        g_cache[i].block.buffer = NULL;
+    }
+
     return 0;
 }
 
 int cache_get_block(uint32_t device_id, uint64_t lba, cache_block_t** out_block) {
-    if (!out_block) return -1;
-    // Stub: Simulate hit
-    *out_block = NULL;
-    return -1; // Not fully implemented
+    if (!out_block) {
+        return -1;
+    }
+
+    cache_entry_t* hit = cache_find(device_id, lba);
+    if (hit) {
+        if (hit->pin_count < 0xFFU) {
+            hit->pin_count++;
+        }
+        *out_block = &hit->block;
+        return 0;
+    }
+
+    cache_entry_t* slot = cache_pick_victim();
+    if (!slot) {
+        return -1;
+    }
+
+    if (slot->in_use && (slot->block.flags & CACHE_BLOCK_DIRTY) != 0U && slot->block.buffer) {
+        block_request_t req = {
+            .type = BLOCK_REQ_WRITE,
+            .lba = slot->block.lba,
+            .num_blocks = 1,
+            .buffer = slot->block.buffer,
+            .status = -1,
+        };
+        (void)block_queue_request(slot->block.device_id, &req);
+    }
+
+    slot->in_use = 1U;
+    slot->pin_count = 1U;
+    slot->block.device_id = device_id;
+    slot->block.lba = lba;
+    slot->block.flags = CACHE_BLOCK_VALID;
+    slot->block.buffer = NULL;
+
+    *out_block = &slot->block;
+    return 0;
 }
 
 int cache_put_block(cache_block_t* block) {
-    if (!block) return -1;
-    // Stub
-    return 0;
+    if (!block) {
+        return -1;
+    }
+
+    for (uint32_t i = 0; i < g_cache_capacity; ++i) {
+        if (g_cache[i].in_use && (&g_cache[i].block == block)) {
+            if (g_cache[i].pin_count > 0U) {
+                g_cache[i].pin_count--;
+            }
+            return 0;
+        }
+    }
+
+    return -1;
 }
 
 int cache_sync(uint32_t device_id) {
-    // Stub
-    return 0;
+    for (uint32_t i = 0; i < g_cache_capacity; ++i) {
+        if (!g_cache[i].in_use || g_cache[i].block.device_id != device_id) {
+            continue;
+        }
+
+        if ((g_cache[i].block.flags & CACHE_BLOCK_DIRTY) != 0U && g_cache[i].block.buffer) {
+            block_request_t req = {
+                .type = BLOCK_REQ_WRITE,
+                .lba = g_cache[i].block.lba,
+                .num_blocks = 1,
+                .buffer = g_cache[i].block.buffer,
+                .status = -1,
+            };
+            (void)block_queue_request(device_id, &req);
+            g_cache[i].block.flags &= ~CACHE_BLOCK_DIRTY;
+        }
+    }
+
+    block_request_t flush_req = {
+        .type = BLOCK_REQ_FLUSH,
+        .lba = 0U,
+        .num_blocks = 0U,
+        .buffer = NULL,
+        .status = -1,
+    };
+    return block_queue_request(device_id, &flush_req);
 }

--- a/stacks/storage/profile.c
+++ b/stacks/storage/profile.c
@@ -1,0 +1,106 @@
+#include "bharat/stacks/storage/profile.h"
+
+#define STORAGE_MB(x) ((uint64_t)(x) * 1024ULL * 1024ULL)
+#define STORAGE_GB(x) ((uint64_t)(x) * 1024ULL * 1024ULL * 1024ULL)
+
+static uint32_t clamp_u32(uint32_t value, uint32_t lo, uint32_t hi) {
+    if (value < lo) {
+        return lo;
+    }
+    if (value > hi) {
+        return hi;
+    }
+    return value;
+}
+
+int storage_profile_resolve(storage_app_profile_t app_profile,
+                            uint64_t device_size_bytes,
+                            storage_hw_arch_t arch,
+                            storage_profile_config_t* out_cfg) {
+    if (!out_cfg || device_size_bytes == 0U) {
+        return -1;
+    }
+
+    out_cfg->app_profile = app_profile;
+    out_cfg->hw_arch = arch;
+    out_cfg->device_size_bytes = device_size_bytes;
+    out_cfg->enable_numa_locality = 0U;
+    out_cfg->enable_journaling = 0U;
+
+    switch (app_profile) {
+        case STORAGE_APP_PROFILE_RT:
+            out_cfg->fs_backend = (device_size_bytes <= STORAGE_GB(8))
+                                      ? STORAGE_FS_BACKEND_LITTLEFS
+                                      : STORAGE_FS_BACKEND_FAT;
+            out_cfg->cache_policy = STORAGE_CACHE_WRITETHROUGH;
+            out_cfg->io_queue_depth = 1U;
+            out_cfg->cache_block_budget = (device_size_bytes <= STORAGE_MB(128)) ? 32U : 128U;
+            break;
+
+        case STORAGE_APP_PROFILE_DATACENTER:
+            out_cfg->fs_backend = (device_size_bytes >= STORAGE_GB(1024))
+                                      ? STORAGE_FS_BACKEND_BLOB
+                                      : STORAGE_FS_BACKEND_XFS_LIKE;
+            out_cfg->cache_policy = STORAGE_CACHE_NUMA_WRITEBACK;
+            out_cfg->io_queue_depth = (device_size_bytes >= STORAGE_GB(256)) ? 256U : 128U;
+            out_cfg->cache_block_budget = (device_size_bytes >= STORAGE_GB(64)) ? 16384U : 4096U;
+            out_cfg->enable_numa_locality = 1U;
+            out_cfg->enable_journaling = 1U;
+            break;
+
+        case STORAGE_APP_PROFILE_EDGE:
+        default:
+            if (device_size_bytes <= STORAGE_GB(2)) {
+                out_cfg->fs_backend = STORAGE_FS_BACKEND_FAT;
+            } else {
+                out_cfg->fs_backend = STORAGE_FS_BACKEND_EXT4_LIKE;
+            }
+            out_cfg->cache_policy = STORAGE_CACHE_WRITEBACK;
+            out_cfg->io_queue_depth = (device_size_bytes <= STORAGE_GB(16)) ? 16U : 32U;
+            out_cfg->cache_block_budget = (device_size_bytes <= STORAGE_GB(1)) ? 128U : 1024U;
+            out_cfg->enable_journaling = 1U;
+            break;
+    }
+
+    if (arch == STORAGE_HW_ARCH_ARM32 || arch == STORAGE_HW_ARCH_RISCV32) {
+        out_cfg->io_queue_depth = clamp_u32(out_cfg->io_queue_depth, 1U, 32U);
+        out_cfg->cache_block_budget = clamp_u32(out_cfg->cache_block_budget, 32U, 1024U);
+    } else if (arch == STORAGE_HW_ARCH_UNKNOWN) {
+        out_cfg->io_queue_depth = clamp_u32(out_cfg->io_queue_depth, 1U, 64U);
+        out_cfg->cache_block_budget = clamp_u32(out_cfg->cache_block_budget, 32U, 4096U);
+    }
+
+    return 0;
+}
+
+const char* storage_profile_backend_name(storage_fs_backend_t backend) {
+    switch (backend) {
+        case STORAGE_FS_BACKEND_RAMFS:
+            return "ramfs";
+        case STORAGE_FS_BACKEND_LITTLEFS:
+            return "littlefs";
+        case STORAGE_FS_BACKEND_FAT:
+            return "fat";
+        case STORAGE_FS_BACKEND_EXT4_LIKE:
+            return "ext4-like";
+        case STORAGE_FS_BACKEND_XFS_LIKE:
+            return "xfs-like";
+        case STORAGE_FS_BACKEND_BLOB:
+            return "blob";
+        default:
+            return "unknown";
+    }
+}
+
+const char* storage_profile_cache_policy_name(storage_cache_policy_t policy) {
+    switch (policy) {
+        case STORAGE_CACHE_WRITETHROUGH:
+            return "write-through";
+        case STORAGE_CACHE_WRITEBACK:
+            return "write-back";
+        case STORAGE_CACHE_NUMA_WRITEBACK:
+            return "numa-write-back";
+        default:
+            return "unknown";
+    }
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -399,6 +399,10 @@ add_executable(test_elf_parser test_elf_parser.c)
 target_include_directories(test_elf_parser PRIVATE ${CMAKE_SOURCE_DIR}/include)
 target_link_libraries(test_elf_parser PRIVATE elf_parser)
 add_test(NAME ELFParserTest COMMAND test_elf_parser)
+add_executable(test_storage_profile test_storage_profile.c ../stacks/storage/profile.c)
+target_include_directories(test_storage_profile PRIVATE ../include)
+add_test(NAME test_storage_profile COMMAND test_storage_profile)
+
 add_executable(test_vfs_ramfs test_vfs_ramfs.c ../lib/fs/fs_client.c ../stacks/storage/fs/ramfs/ramfs.c ../services/system/filesystem/vfs_stub.c ../services/system/filesystem/mount_mgr.c ../services/system/filesystem/fd_mgr.c ../services/system/filesystem/namespace_mgr.c ../kernel/src/lib/base/string.c $<TARGET_OBJECTS:bharat_test_sched_mocks>)
 target_include_directories(test_vfs_ramfs PRIVATE ../kernel/include ../include ../lib/include)
 target_compile_definitions(test_vfs_ramfs PRIVATE TESTING=1)
@@ -460,6 +464,7 @@ set(BHARAT_NOSTDLIB_TEST_TARGETS
     test_syscall_abi
     test_elf_parser
     test_vfs_ramfs
+    test_storage_profile
     test_boot_e2e
     test_android_personality
 )

--- a/tests/test_storage_profile.c
+++ b/tests/test_storage_profile.c
@@ -1,0 +1,34 @@
+#include <assert.h>
+#include <stdint.h>
+
+#include "bharat/stacks/storage/profile.h"
+
+int main(void) {
+    storage_profile_config_t cfg;
+
+    assert(storage_profile_resolve(STORAGE_APP_PROFILE_RT,
+                                   512ULL * 1024ULL * 1024ULL,
+                                   STORAGE_HW_ARCH_ARM32,
+                                   &cfg) == 0);
+    assert(cfg.fs_backend == STORAGE_FS_BACKEND_LITTLEFS);
+    assert(cfg.cache_policy == STORAGE_CACHE_WRITETHROUGH);
+    assert(cfg.io_queue_depth == 1U);
+
+    assert(storage_profile_resolve(STORAGE_APP_PROFILE_EDGE,
+                                   64ULL * 1024ULL * 1024ULL * 1024ULL,
+                                   STORAGE_HW_ARCH_ARM64,
+                                   &cfg) == 0);
+    assert(cfg.fs_backend == STORAGE_FS_BACKEND_EXT4_LIKE);
+    assert(cfg.cache_policy == STORAGE_CACHE_WRITEBACK);
+    assert(cfg.enable_journaling == 1U);
+
+    assert(storage_profile_resolve(STORAGE_APP_PROFILE_DATACENTER,
+                                   2ULL * 1024ULL * 1024ULL * 1024ULL * 1024ULL,
+                                   STORAGE_HW_ARCH_X86_64,
+                                   &cfg) == 0);
+    assert(cfg.fs_backend == STORAGE_FS_BACKEND_BLOB);
+    assert(cfg.cache_policy == STORAGE_CACHE_NUMA_WRITEBACK);
+    assert(cfg.enable_numa_locality == 1U);
+
+    return 0;
+}


### PR DESCRIPTION
### Motivation
- Provide a small, testable policy plane that maps application profile + device size + HW arch to concrete filesystem backend, cache policy, queue depth and cache budget to align storage behavior with target profiles. 
- Replace insufficient cache stubs with a bounded baseline that supports eviction, pin/unpin accounting and a writeback/flush path so the service can safely initialize realistic caching behavior. 
- Wire service startup to use resolved policy so the filesystem service and tests can boot with profile-aware defaults. 

### Description
- Add a new storage policy resolver API and implementation in `stacks/include/bharat/stacks/storage/profile.h` and `stacks/storage/profile.c` that selects backend, cache policy, queue depth, cache budget and feature flags from `app_profile`, `device_size_bytes`, and `hw_arch` with resource clamping for constrained targets. 
- Upgrade the cache from a stub to a bounded baseline in `stacks/storage/cache/cache.c` and extend the header `stacks/include/bharat/stacks/storage/cache/cache.h` with `cache_init_with_profile`, flags, and capacity controls; implemented lookup, victim selection, pin/unpin counters, dirty eviction writeback, and `cache_sync()` which issues a `BLOCK_REQ_FLUSH`. 
- Add `BLOCK_REQ_FLUSH` handling to the block layer in `stacks/storage/block/block.c` to provide flush/barrier semantics. 
- Wire filesystem service startup in `services/system/filesystem/main.c` to read block geometry, resolve a storage profile (device/profile/arch), and initialize the cache via `cache_init_with_profile`. 
- Add a small unit test `tests/test_storage_profile.c` and register it in `tests/CMakeLists.txt` to validate resolver decisions for representative RT/Edge/Datacenter cases. 
- Add `profile.c` to `stacks/storage/CMakeLists.txt` and update the architecture doc `docs/architecture/storage/file-system-detailed-design.md` with a gap review, remaining tasks, and a summary of the baseline improvements. 

### Testing
- `cmake -S . -B build` was executed successfully and completed configuration. 
- Building the whole `bharat_stacks_storage` target via `cmake --build build --target bharat_stacks_storage -j4` failed due to an unrelated include path issue in a pre-existing blob backend (`bharat/uapi/sys_errno.h` missing) and not because of the new code. 
- Individual compilation checks succeeded: `stacks/storage/profile.c` and `stacks/storage/cache/cache.c` compiled with `cc -std=c11 -Iinclude -Istacks/include -Ikernel/include` without errors. 
- `services/system/filesystem/main.c` compiled when built with `-Ilib/urpc` to resolve `urpc.h`. 
- The new unit test was compiled and run locally with `cc -std=c11 tests/test_storage_profile.c stacks/storage/profile.c` and passed (process exited successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5a7768ae883209276de31363e7a64)