### PR TITLE
hal: silence unused-parameter warnings in IOMMU adapter stubs

### DIFF
--- a/hal/common/iommu_adapter.c
+++ b/hal/common/iommu_adapter.c
@@ -49,6 +49,7 @@ static void adapter_domain_destroy(iommu_domain_t *dom) {
 
 static int adapter_map(iommu_domain_t *dom, uintptr_t iova, uint64_t pa,
                 size_t len, uint64_t prot, uint64_t flags) {
+    (void)flags;
     if (g_legacy_ops && g_legacy_ops->map && dom) {
         return g_legacy_ops->map((hal_iommu_domain_t*)dom->hal_priv, iova, pa, len, prot);
     }
@@ -63,23 +64,32 @@ static int adapter_unmap(iommu_domain_t *dom, uintptr_t iova, size_t len) {
 }
 
 static int adapter_attach_device(iommu_domain_t *dom, iommu_device_t *dev) {
+    (void)dom;
+    (void)dev;
     // Legacy relies on groups, new API does not immediately. Return unsupported for now.
     return -1;
 }
 
 static int adapter_detach_device(iommu_device_t *dev) {
+    (void)dev;
     return -1;
 }
 
 static int adapter_invalidate_domain(iommu_domain_t *dom) {
+    (void)dom;
     return -1;
 }
 
 static int adapter_invalidate_range(iommu_domain_t *dom, uintptr_t iova, size_t len) {
+    (void)dom;
+    (void)iova;
+    (void)len;
     return -1;
 }
 
 static int adapter_query_device_caps(iommu_device_t *dev, iommu_device_caps_t *caps) {
+    (void)dev;
+    (void)caps;
     return -1;
 }
 


### PR DESCRIPTION
### Motivation
- Reduce noisy `-Wunused-parameter` warnings emitted during `riscv64-edge` builds from IOMMU adapter stub functions so build logs are cleaner.
- Preserve existing behavior of the adapter stubs (unsupported paths still return `-1`) while making the intent explicit in code.

### Description
- Add explicit `(void)` casts for currently-unused parameters in `hal/common/iommu_adapter.c` adapter stubs, covering `flags` in `adapter_map(...)` and all unused args in `adapter_attach_device`, `adapter_detach_device`, `adapter_invalidate_domain`, `adapter_invalidate_range`, and `adapter_query_device_caps`.
- No functional changes to return values or legacy-op forwarding logic were made; the stubs still return `-1` for unsupported operations.

### Testing
- Ran `cmake --preset=riscv64-edge -DBHARAT_ARCH_FAMILY=RISCV64 -DBHARAT_DEVICE_PROFILE=DESKTOP -DBHARAT_PERSONALITY_PROFILE=NATIVE -DBHARAT_TARGET_BOARD=virt -DBHARAT_BOOT_GUI=False` which configured successfully.
- Built the kernel with `cmake --build --preset=riscv64-edge --target kernel.elf` and the build/link completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5c26357cc83209d94939205d93f60)