### PR TITLE
Improve ARM64 QEMU boot resilience and legacy CLI tolerance

### DIFF
--- a/arch/arm/arm64/boot/entry.c
+++ b/arch/arm/arm64/boot/entry.c
@@ -7,6 +7,15 @@
 #include <stddef.h>
 #include <stdint.h>
 
+static uintptr_t arm64_find_fdt_fallback(uintptr_t start, uintptr_t end, uintptr_t step) {
+    for (uintptr_t p = start; p < end; p += step) {
+        if (fdt_is_valid((void*)p)) {
+            return p;
+        }
+    }
+    return 0;
+}
+
 // Early boot entry for ARM64
 void kernel_main(uintptr_t fdt_ptr) {
     boot_info_t boot;
@@ -19,14 +28,27 @@ void kernel_main(uintptr_t fdt_ptr) {
     hal_serial_write("\n");
 
     if (fdt_ptr == 0 || !fdt_is_valid((void*)fdt_ptr)) {
-        // Probe common locations for QEMU virt
-        fdt_ptr = 0x40000000;
-        hal_serial_write("Probing FDT at fallback: ");
+        // Probe common locations for QEMU virt.
+        // Some host/QEMU combinations may fail to preserve x0 handoff.
+        const uintptr_t fdt_scan_start = 0x40000000ULL;
+        const uintptr_t fdt_scan_end = 0x50000000ULL;
+        const uintptr_t fdt_scan_step = 0x1000ULL;
+
+        hal_serial_write("Probing FDT fallback range: ");
+        hal_serial_write_hex(fdt_scan_start);
+        hal_serial_write("..");
+        hal_serial_write_hex(fdt_scan_end);
+        hal_serial_write("\n");
+
+        uintptr_t discovered = arm64_find_fdt_fallback(fdt_scan_start, fdt_scan_end, fdt_scan_step);
+        if (discovered == 0) {
+            kernel_panic("FDT not provided by bootloader and fallback scan failed");
+        }
+
+        fdt_ptr = discovered;
+        hal_serial_write("FDT fallback discovered at: ");
         hal_serial_write_hex(fdt_ptr);
         hal_serial_write("\n");
-        if (!fdt_is_valid((void*)fdt_ptr)) {
-            kernel_panic("FDT not provided by bootloader and fallback failed");
-        }
     }
 
     extern void arm_fdt_parse_common(boot_info_t *boot, const void *fdt_ptr);

--- a/tools/build/cli.py
+++ b/tools/build/cli.py
@@ -41,8 +41,25 @@ def parse_args():
             file=sys.stderr,
         )
 
+        normalized_args = list(sys.argv[2:])
+        normalized_flags = set(normalized_args)
+        filtered_args = []
+
+        # Be tolerant of users typing "-- run" / "-- all" in legacy mode.
+        i = 0
+        while i < len(normalized_args):
+            arg = normalized_args[i]
+            if arg == "--" and i + 1 < len(normalized_args):
+                maybe_flag = f"--{normalized_args[i + 1]}"
+                if maybe_flag in ("--run", "--build", "--all"):
+                    normalized_flags.add(maybe_flag)
+                    i += 2
+                    continue
+            filtered_args.append(arg)
+            i += 1
+
         # We'll create a dummy 'all' or 'build' command internally
-        mock_argv = ["all" if "--run" in sys.argv or "--all" in sys.argv else "build"]
+        mock_argv = ["all" if "--run" in normalized_flags or "--all" in normalized_flags else "build"]
         # Add target spec
         if sys.argv[1].endswith(".yaml"):
             mock_argv.extend(["--target-yaml", sys.argv[1]])
@@ -50,7 +67,7 @@ def parse_args():
             mock_argv.extend(["--target", sys.argv[1]])
 
         # Keep other flags
-        for arg in sys.argv[2:]:
+        for arg in filtered_args:
             if arg not in ("--run", "--build", "--all"):
                 mock_argv.append(arg)
 


### PR DESCRIPTION
### Motivation
- Fix an ARM64 kernel panic seen when QEMU does not preserve the DTB pointer in `x0` by improving fallback discovery logic. 
- Make the legacy positional CLI wrappers tolerant of the common `"-- run"` / `"-- all"` (split) invocation pattern so wrappers behave as users expect.

### Description
- Add `arm64_find_fdt_fallback()` and a scanning fallback in `kernel_main()` to probe a QEMU virt RAM range for a valid FDT instead of testing a single hardcoded address, and emit serial diagnostics for the scan and discovered location (`arch/arm/arm64/boot/entry.c`).
- Normalize legacy CLI arguments in `tools/build/cli.py` by collecting `normalized_args`, detecting split flags produced as `-- run` / `-- all`, filtering them into `filtered_args`, and building `mock_argv` from normalized flags so legacy invocations map to the intended subcommand.
- Keep existing explicit subcommand parsing unchanged; only the legacy-positional path is made more forgiving.

### Testing
- `python3 -m py_compile tools/build/cli.py` was run and completed successfully. 
- Exercised `tools.build.cli.parse_args()` with legacy argv cases (`target.yaml -- run`, `target.yaml -- all`, `target.yaml --run`) and verified they normalize to the expected subcommand (`all`).
- An automated `python3 -m py_compile arch/arm/arm64/boot/entry.c` was attempted and failed because that command attempts to byte-compile a C source file with the Python compiler; no automated C toolchain build was performed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5c5c4dfe08320a489efbd34d2ab07)