### PR TITLE
Make subsystem CPU masks topology-aware and revalidate context-switch review

### DIFF
--- a/docs/reviews/context-switching-hw-optimization-review.md
+++ b/docs/reviews/context-switching-hw-optimization-review.md
@@ -1,33 +1,46 @@
-# Context Switching Review: Kernel + Subsystem
+# Context Switching Review: Kernel + Subsystem (revalidated)
 
 ## Scope
-- Kernel scheduler context-switch path (`sched.c`) and architecture-facing selection hooks.
-- Subsystem CPU allocation model (`subsys/src/*.c`).
+- Kernel scheduler runqueue selection and context-switch path.
+- Subsystem CPU allocation mask handling in `services/core/subsysmgr`.
+- HAL topology query surface used by scheduling/allocation policy.
 
-## Findings (Gaps)
-1. **L1 scheduler path claimed bitmap optimization but still performed full linear scans.**
-   - Existing code comments mentioned `__builtin_clz`-style bitmask selection, but implementation still iterated all priorities.
-2. **Redundant context-switch churn when scheduler re-selected the currently running thread.**
-   - This inflated software switch counters and wasted preemption path work.
-3. **No hardware-informed dynamic slice adaptation in runtime path.**
-   - Telemetry was collected but not used to tune slice length.
-4. **Subsystem CPU masks were not normalized against platform-supported core range.**
-   - A subsystem could carry an all-zero or out-of-range mask until runtime use.
+## Alignment Check Against Current Code
 
-## Improvement Plan
-1. Add and maintain a per-core active-priority bitmask in runqueue state.
-2. Use highest-set-bit selection (`clz`) in L1 pick-next path for O(1) priority discovery.
-3. Avoid no-op switch accounting when next == current.
-4. Feed AI complexity telemetry back into bounded time-slice tuning.
-5. Normalize subsystem CPU masks at creation/start so execution domains always map to valid cores.
+### 1) Priority selection and bitmap path
+**Status: aligned (implemented).**
+- Runqueue selection uses a priority bitmap and bit-scan helpers via `sched_pick_priority_from_bitmap()`.
+- Highest-priority and lowest-priority paths are selected with `__builtin_clz` / `__builtin_ctz` (policy dependent), not linear priority scans.
 
-## Implemented in this change
-- Added `active_priority_mask` maintenance on enqueue/dequeue and used it in L1 scheduler selection.
-- Added self-switch fast path in `sched_switch_to`.
-- Added bounded dynamic time-slice shaping based on predicted complexity.
-- Added subsystem CPU mask normalization helper and enforcement at subsystem creation/start.
+### 2) Redundant self-switch accounting
+**Status: aligned (implemented).**
+- `sched_switch_to()` early-returns when `current == next`, so no context-switch counters or arch save/restore path are executed for a no-op switch.
 
-## Next candidates (not yet implemented)
-- Save/restore SIMD/FPU/vector context lazily by arch (x86 XSAVE/XRSTOR, ARM64 FP/SIMD, RISC-V V extension).
-- Add explicit CPU count query in HAL (instead of fixed max assumption in multiple modules).
-- Introduce per-core runqueue locking + remote wakeups/IPI balancing for true SMP concurrency.
+### 3) Hardware-/telemetry-informed slice shaping
+**Status: partially aligned.**
+- AI telemetry and complexity signals are integrated in scheduler AI paths.
+- Runtime usage exists, but end-to-end policy remains heuristic and not yet tied to deeper per-arch hardware pressure signals (cache miss, memory stalls, etc.).
+
+### 4) Subsystem CPU mask normalization
+**Status: aligned and improved.**
+- Subsystem CPU masks are normalized in create/start paths.
+- Updated to use HAL CPU-topology query so normalization is based on discovered CPU count rather than a fixed compile-time core cap in this module.
+
+## Current Gaps (remaining)
+1. **Lazy extended-context switching is still not implemented.**
+   - Save/restore hooks exist, but no clear arch-specific lazy ownership strategy (e.g., XSAVE ownership tracking / trap-on-first-use model).
+2. **Topology shape is still coarse for policy.**
+   - Query returns discovered CPU count and basic SMP indicator, but no cluster/perf-class data for heterogeneous scheduling decisions.
+3. **SMP scalability work remains open.**
+   - Per-core queue locking exists, but full remote balancing/coalescing and explicit cross-core work-stealing policy is still an ongoing area.
+
+## Next Code Task (selected)
+### Task: **Topology-aware subsystem placement follow-through**
+After replacing the fixed subsystem core limit with HAL topology query, the next task is:
+1. Add per-subsystem allocation policy modes (packed/spread).
+2. Use topology metadata (once extended) to map masks to performance or efficiency clusters.
+3. Add tests for edge masks (`0`, out-of-range, full-mask) under different discovered CPU counts.
+
+## Work started in this update
+- Added `hal_cpu_topology_query()` implementation backed by discovered platform topology.
+- Switched subsystem CPU mask normalization to use `hal_cpu_topology_query()` instead of local fixed `MAX_SUPPORTED_CORES`.

--- a/hal/common/discovery.c
+++ b/hal/common/discovery.c
@@ -1,4 +1,5 @@
 #include "hal/hal_discovery.h"
+#include "hal/hal_cpu_topology.h"
 #include "arch/arch_cpu_caps.h"
 #include "boot/boot_info.h"
 #include <stddef.h>
@@ -10,6 +11,23 @@ static system_discovery_t g_system_discovery;
 
 system_discovery_t* hal_get_system_discovery(void) {
     return &g_system_discovery;
+}
+
+bool hal_cpu_topology_query(hal_cpu_topology_info_t *out) {
+    if (!out) {
+        return false;
+    }
+
+    const system_discovery_t *discovery = hal_get_system_discovery();
+    uint32_t discovered = 1U;
+    if (discovery && discovery->topology.cpu_count > 0U) {
+        discovered = discovery->topology.cpu_count;
+    }
+
+    out->discovered_cpu_count = discovered;
+    out->smp_available = (discovered > 1U);
+    out->homogeneous_cores = true;
+    return true;
 }
 
 void hal_discovery_init(const boot_info_t *boot) {

--- a/services/core/subsysmgr/manager.c
+++ b/services/core/subsysmgr/manager.c
@@ -1,17 +1,27 @@
 #include "subsys.h"
 #include "bharat/subsys_test.h"
+#include "hal/hal_cpu_topology.h"
 #include "../../../personalities/compat/linux/linux_compat.h"
 #include "../../../personalities/compat/windows/win_compat.h"
 
-#ifndef MAX_SUPPORTED_CORES
-#define MAX_SUPPORTED_CORES 8U
-#endif
+static uint32_t subsys_allowed_cpu_mask(void) {
+    hal_cpu_topology_info_t topology = {0};
+    uint32_t discovered = 1U;
+    if (hal_cpu_topology_query(&topology) && topology.discovered_cpu_count > 0U) {
+        discovered = topology.discovered_cpu_count;
+    }
+    if (discovered > 32U) {
+        discovered = 32U;
+    }
+
+    if (discovered == 32U) {
+        return UINT32_MAX;
+    }
+    return (1U << discovered) - 1U;
+}
 
 static uint32_t subsys_effective_cpu_mask(uint32_t requested_mask) {
-    uint32_t allowed_mask = 0U;
-    for (uint32_t i = 0; i < MAX_SUPPORTED_CORES && i < 32U; ++i) {
-        allowed_mask |= (1U << i);
-    }
+    uint32_t allowed_mask = subsys_allowed_cpu_mask();
 
     uint32_t effective = requested_mask & allowed_mask;
     if (effective == 0U) {


### PR DESCRIPTION
### Motivation
- Align subsystem CPU allocation and the review doc with discovered hardware topology instead of a local fixed core cap.
- Provide a small HAL topology query surface so scheduling and placement code can make topology-informed decisions.

### Description
- Rewrote and revalidated `docs/reviews/context-switching-hw-optimization-review.md` to reflect current scheduler behavior, remaining gaps, and the next task.
- Added `hal_cpu_topology_query()` in `hal/common/discovery.c` that reports `discovered_cpu_count`, `smp_available`, and `homogeneous_cores` with a sane fallback when discovery is missing.
- Replaced the compile-time `MAX_SUPPORTED_CORES` assumption in `services/core/subsysmgr/manager.c` with `subsys_allowed_cpu_mask()` backed by the HAL query and updated `subsys_effective_cpu_mask()` to normalize and clamp requested masks to the discovered CPU range.
- Applied topology-aware mask normalization in subsystem creation/start paths so subsystems never carry an out-of-range or empty mask.

### Testing
- Ran `git diff --check` with no issues reported.
- Ran `cmake -S . -B build` which configured and generated build files successfully.
- Attempted `cmake --build build -j2 --target hal_common` which failed because that target is not present in the generated build files.
- Built `test_sched_reap` with `cmake --build build --target test_sched_reap`, which completed; host tests are disabled in the current configuration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6cb82475c83209f2853aaa2e90029)