### PR TITLE
Harden crypto provider registry, add zeroize dispatch, update docs and build wiring

### DIFF
--- a/docs/architecture/security/crypto/kernel-contract.md
+++ b/docs/architecture/security/crypto/kernel-contract.md
@@ -11,6 +11,16 @@ tags: [security, crypto, kernel, contract]
 
 This document strictly defines the boundary between what the Bharat-OS kernel implements directly regarding cryptography and security, and what it delegates to user-space services. The core philosophy is to keep cryptography mechanisms in the kernel only where the kernel must enforce trust, isolation, boot integrity, or hardware binding.
 
+## Current code-backed status (2026-04-21)
+
+The kernel now includes a concrete, test-backed baseline for:
+* Provider registration and lookup.
+* Capability-gated provider invocation.
+* Convenience RNG dispatch to the first registered RNG backend.
+* Key-buffer zeroization dispatch through provider hooks.
+
+These pieces are implemented but not yet fully production-hardened for concurrency, formal capability object routing, and complete secure-element orchestration.
+
 ## What the Kernel Owns (Mechanisms)
 
 The kernel is responsible for the absolute minimum required to securely boot the system, establish trust, protect key material in memory, and safely expose hardware cryptographic features to authorized user-space services.

--- a/docs/architecture/security/crypto/roadmap.md
+++ b/docs/architecture/security/crypto/roadmap.md
@@ -11,25 +11,36 @@ tags: [security, crypto, roadmap]
 
 This roadmap outlines the phased implementation plan for the Bharat-OS Cryptography and Security subsystem. It is designed to establish a solid foundation in the kernel first (mechanisms), followed by the user-space services (policies and algorithms), and finally integration with the rest of the operating system.
 
+## Implementation snapshot (as of 2026-04-21)
+
+The architecture remains target-state oriented, but the following items now have concrete kernel code:
+
+* Provider registry and invocation entry points are implemented in `kernel/src/security/crypto_registry.c`.
+* Capability-gated crypto stubs are implemented in `kernel/src/security/crypto_caps.c`.
+* Secure memory zeroization and secure page wrappers are implemented in `kernel/src/crypto/secure_mem.c`.
+* Kernel self-tests exist for provider registration, capability checks, unsupported op handling, RNG convenience API, and key zeroization dispatch in `kernel/src/tests/security/test_crypto_registry.c`.
+
+The largest remaining gaps are formal capability-object integration (beyond stubs), full secure-element backends, and service-level production wiring.
+
 ## Phase A: Contracts & Architecture (Current)
 
 The goal of this phase is to establish the structural boundaries and the ABI contracts between the kernel and user-space services.
 
 *   [x] Define the 4-Layer Security Architecture model.
 *   [x] Document the boundary between kernel mechanisms and user-space policies.
-*   [ ] Define the internal kernel crypto capability types (`CAP_TYPE_CRYPTO_PROVIDER`, `CAP_TYPE_CRYPTO_KEY`, `CAP_TYPE_RNG`, `CAP_TYPE_SEALER`).
-*   [ ] Define the kernel-side crypto provider interface and the operations it must support (`CRYPTO_OP_GET_RANDOM`, `CRYPTO_OP_HASH_BUFFER`, etc.).
-*   [ ] Define the user-space (UAPI) contract for interacting with the kernel's crypto providers.
+*   [x] Define the internal kernel crypto capability types (`CAP_TYPE_CRYPTO_PROVIDER`, `CAP_TYPE_CRYPTO_KEY`, `CAP_TYPE_RNG`, `CAP_TYPE_SEALER`).
+*   [x] Define the kernel-side crypto provider interface and the operations it must support (`CRYPTO_OP_GET_RANDOM`, `CRYPTO_OP_HASH_BUFFER`, etc.).
+*   [x] Define the user-space (UAPI) contract for interacting with the kernel's crypto providers.
 
 ## Phase B: Kernel Primitives
 
 This phase implements the core, low-level mechanisms within the kernel, strictly adhering to the contracts defined in Phase A.
 
-*   [ ] **Provider Registry:** Implement the central registry where hardware-specific drivers (accelerators, secure elements, RNGs) can register themselves.
-*   [ ] **Capability-Checked Invocation:** Implement the unified API for user-space to request cryptographic operations, enforcing the required capabilities before routing the request to the registered provider.
-*   [ ] **Zeroization Helpers:** Implement compiler-safe primitives (e.g., `memset_explicit()`) for clearing sensitive memory buffers.
+*   [x] **Provider Registry:** Implement the central registry where hardware-specific drivers (accelerators, secure elements, RNGs) can register themselves.
+*   [x] **Capability-Checked Invocation:** Implement the unified API for user-space to request cryptographic operations, enforcing the required capabilities before routing the request to the registered provider.
+*   [x] **Zeroization Helpers:** Implement compiler-safe primitives (e.g., `memset_explicit()`) for clearing sensitive memory buffers.
 *   [ ] **Secure Memory Allocation:** Implement memory allocation tags or classes to guarantee buffers are not swapped, dumped, or accessed by unauthorized DMA.
-*   [ ] **Entropy API:** Implement a unified API for exposing hardware RNGs to user-space and kernel subsystems.
+*   [x] **Entropy API:** Implement a unified API for exposing hardware RNGs to user-space and kernel subsystems.
 
 ## Phase C: Hardware Backends
 

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(bharat_kernel_includes INTERFACE)
 target_include_directories(bharat_kernel_includes INTERFACE
     ${CMAKE_CURRENT_SOURCE_DIR}/include
     ${CMAKE_CURRENT_SOURCE_DIR}/include/generated
+    ${CMAKE_SOURCE_DIR}/hal/include
     ${CMAKE_SOURCE_DIR}/include
     ${CMAKE_SOURCE_DIR}/lib/include
     ${CMAKE_SOURCE_DIR}/boot/include

--- a/kernel/src/security/crypto_registry.c
+++ b/kernel/src/security/crypto_registry.c
@@ -34,6 +34,25 @@ int crypto_provider_register(const crypto_provider_info_t *info, const crypto_pr
     if (!info || !ops) {
         return -SYS_EINVAL;
     }
+    if (info->backend_class != CRYPTO_BACKEND_CPU_ACCEL &&
+        info->backend_class != CRYPTO_BACKEND_SECURE_ELEMENT_TPM &&
+        info->backend_class != CRYPTO_BACKEND_RNG_PROVIDER) {
+        return -SYS_EINVAL;
+    }
+    if (info->supported_ops_mask == 0U) {
+        return -SYS_EINVAL;
+    }
+    if (info->name[0] == '\0') {
+        return -SYS_EINVAL;
+    }
+
+    /* Ensure backend contract completeness for RNG providers. */
+    if (info->backend_class == CRYPTO_BACKEND_RNG_PROVIDER && !ops->get_random) {
+        return -SYS_EINVAL;
+    }
+    if (!ops->invoke && !ops->zeroize && !ops->get_random) {
+        return -SYS_EINVAL;
+    }
 
     crypto_provider_node_t *node = (crypto_provider_node_t *)kmalloc(sizeof(crypto_provider_node_t));
     if (!node) {
@@ -134,7 +153,18 @@ int crypto_provider_invoke(uint32_t provider_id, crypto_op_args_t *args)
         return -SYS_ENOSYS;
     }
 
-    /* 4. Invoke the provider */
+    /* 4. Dispatch the provider operation */
+    if (args->op == CRYPTO_OP_ZEROIZE_KEY) {
+        if (!args->input_buf || args->input_len == 0) {
+            return -SYS_EINVAL;
+        }
+        if (node->ops && node->ops->zeroize) {
+            node->ops->zeroize(args->input_buf, args->input_len);
+            return 0;
+        }
+        return -SYS_ENOSYS;
+    }
+
     if (node->ops && node->ops->invoke) {
         return node->ops->invoke(args);
     }

--- a/kernel/src/tests/security/test_crypto_registry.c
+++ b/kernel/src/tests/security/test_crypto_registry.c
@@ -151,11 +151,54 @@ static int test_get_random_convenience(void) {
     return 0;
 }
 
+static int test_zeroize_dispatch(void) {
+    crypto_registry_init();
+
+    int provider_id = crypto_provider_register(&mock_info, &mock_ops);
+    if (provider_id <= 0) return -1;
+
+    uint8_t keybuf[8];
+    memset(keybuf, 0xA5, sizeof(keybuf));
+
+    crypto_op_args_t args = {
+        .op = CRYPTO_OP_ZEROIZE_KEY,
+        .input_buf = keybuf,
+        .input_len = sizeof(keybuf),
+    };
+
+    crypto_cap_grant(CAP_TYPE_CRYPTO_KEY);
+    int err = crypto_provider_invoke(provider_id, &args);
+    if (err != 0) return -2;
+    if (keybuf[0] != 0x00) return -3;
+
+    crypto_provider_unregister(provider_id);
+    return 0;
+}
+
+static int test_invalid_provider_registration(void) {
+    crypto_registry_init();
+
+    crypto_provider_info_t invalid = mock_info;
+    invalid.backend_class = 0;
+
+    int err = crypto_provider_register(&invalid, &mock_ops);
+    if (err != -SYS_EINVAL) return -1;
+
+    invalid = mock_info;
+    invalid.name[0] = '\0';
+    err = crypto_provider_register(&invalid, &mock_ops);
+    if (err != -SYS_EINVAL) return -2;
+
+    return 0;
+}
+
 static int ktest_crypto_registry_run(void) {
     if (test_provider_registration() != 0) return -1;
     if (test_capability_checks() != 0) return -1;
     if (test_unsupported_operation() != 0) return -1;
     if (test_get_random_convenience() != 0) return -1;
+    if (test_zeroize_dispatch() != 0) return -1;
+    if (test_invalid_provider_registration() != 0) return -1;
     return 0;
 }
 

--- a/services/core/subsysmgr/CMakeLists.txt
+++ b/services/core/subsysmgr/CMakeLists.txt
@@ -9,6 +9,7 @@ target_include_directories(subsys_manager PUBLIC
     ${CMAKE_SOURCE_DIR}/kernel/include
     ${CMAKE_SOURCE_DIR}/lib/include
     ${CMAKE_SOURCE_DIR}/lib/packet/include
+    ${CMAKE_SOURCE_DIR}/hal/include
     ${CMAKE_SOURCE_DIR}/include
     ${CMAKE_SOURCE_DIR}/stacks/network/include
 )


### PR DESCRIPTION
### Motivation

- Align architecture docs with the repository's concrete kernel work and mark progress on implemented primitives. 
- Reject malformed or incomplete crypto provider registrations to avoid runtime/null-path failures and ensure backends meet minimal contract expectations. 
- Expose a safe, capability-checked path for key zeroization that uses provider `zeroize` hooks rather than treating it as a generic `invoke`. 
- Fix missing include paths so headless x86_64 QEMU builds can be executed in CI/dev workflows.

### Description

- Validate provider descriptors in `crypto_provider_register` by checking `backend_class`, non-zero `supported_ops_mask`, non-empty `name`, and that RNG backends provide `get_random`; also require providers expose at least one callable op (`invoke`, `zeroize`, or `get_random`).
- Dispatch `CRYPTO_OP_ZEROIZE_KEY` explicitly in `crypto_provider_invoke` to call the provider `zeroize` hook with argument validation (`input_buf`/`input_len`) and return appropriate errors when unsupported.
- Add new kernel selftests in `kernel/src/tests/security/test_crypto_registry.c` covering zeroize routing (`test_zeroize_dispatch`) and invalid provider registration rejection (`test_invalid_provider_registration`) and wire them into the existing `crypto_registry` test suite.
- Update documentation to reflect implemented kernel primitives and current status in `docs/architecture/security/crypto/roadmap.md` and `docs/architecture/security/crypto/kernel-contract.md` (implementation snapshot as of 2026-04-21).
- Fix build wiring by adding `hal/include` to `kernel/CMakeLists.txt` and `services/core/subsysmgr/CMakeLists.txt` so headers like `hal/hal_cpu_topology.h` are found during headless x86_64 builds.

### Testing

- Built the headless x86_64 target with `./build.sh build --target x86_64_desktop_headless`, which completed successfully. 
- Installed missing QEMU tooling and ran the headless run with `./build.sh run --target x86_64_desktop_headless` (invoked under a 35s timeout); kernel reached runtime and executed boot selftests including the `crypto_registry` suite, demonstrating the new tests exercised the registry and zeroize dispatch. 
- Note: the run was bounded by a timeout (`EXIT:124`) to keep the execution headless; boot logs show an unrelated pre-existing `rt_sched` EDF selftest failure which predates these changes and was not caused by the crypto work.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6d020bd208320a67f3119f1aeeaa8)