### PR TITLE
docs: align console and shell architecture with current implementation

### DIFF
--- a/docs/architecture/console/console_architecture.md
+++ b/docs/architecture/console/console_architecture.md
@@ -1,50 +1,155 @@
-# Console Architecture
+# Console and Shell Architecture (Aligned Runtime Contract)
 
-This document describes the design principles, layering, and responsibilities for the console and standard I/O in Bharat-OS. The architecture separates early-boot and emergency kernel mechanisms from user-facing policy and rich standard I/O management.
+This document defines the **current Bharat-OS console + shell architecture contract** and aligns it with the code that exists today.
 
-## 1. Core Principles
+It supersedes older assumptions that a userspace console already provides full TTY/session multiplexing.
 
-- **Mechanism in the Kernel, Policy in Userspace:** The kernel handles only the minimal, necessary mechanisms for early boot, safe panic output, and a minimal runtime fallback. All user-facing multiplexing, terminal sessions, and standard I/O (stdin/stdout/stderr) are managed by the userspace `services/system/console`.
-- **Driver Integration:** The console is built *on top* of the existing driver model. It does not reinvent hardware support. The stack relies on `drivers/bus`, `drivers/devices` (class modeling), and `drivers/serial`.
-- **Safe Kernel Panic:** The emergency panic path is guaranteed to be lockless, allocation-free, and polling-based. It bypasses any queues, interrupts, or scheduler states to ensure deterministic output even during severe system corruption.
+## 1) Executive summary
 
-## 2. Architecture Layers
+- Kernel console is the only production-meaningful output path today (`kernel/src/console/*`).
+- `services/system/console` exists, but is still a scaffold with TODO URPC routing and mock capability-acquisition flow.
+- `services/system/shell` exists and is substantially ahead of console service in maturity (bounded parser, capability-aware dispatch, tests), but it currently runs against a stub backend and is not yet wired to console URPC.
+- Therefore, **console and shell are architecturally compatible but not yet fully integrated at runtime**.
 
-### 2.1 Driver Layering (`drivers/`)
-Hardware support for serial communication resides entirely within the `drivers/` subsystem. The kernel console binds to a generic device class, rather than directly to an architecture-specific UART.
+## 2) Layering contract (must remain stable)
 
-1. **Bus & Device Discovery (`drivers/bus`, `drivers/devices`):** Hardware is discovered via ACPI, Device Tree, or platform-specific mechanisms.
-2. **Serial Class (`drivers/class`):** Exposes a consistent `uart_driver_ops_t` interface for all serial devices.
-3. **Hardware Drivers (`drivers/serial`):** Specific implementations like `ns16550`, `pl011`, or `sifive_uart` implement the interface. Advanced features (FIFOs, interrupts, DMA) are exposed here but remain optional capabilities.
+## 2.1 Kernel mechanism (trusted core)
 
-### 2.2 Kernel Console Mechanisms (`kernel/src/console`)
-The kernel manages three distinct console phases:
+The kernel owns mechanism only:
 
-- **Early Boot Console:** Initialized immediately after basic memory is available. It binds to an early serial fallback (e.g., a simple MMIO UART or an explicitly nominated boot UART) for basic debug output before the full driver model is up.
-- **Runtime Kernel Console:** Once the full device model is initialized, the console binds to the registered primary serial device. It handles standard kernel logging (`console_vlog`, `console_log`) via bounded buffers.
-- **Panic-Safe Console:** Upon a kernel panic (`console_enter_panic`), the console switches to a synchronous, lockless path (`console_panic_flush_backends`). It forces output through polling-based `putc` or `write_atomic` methods, ignoring any runtime locks or asynchronous queues.
+- early/runtime/panic console phases,
+- bounded formatting/log routing,
+- backend selection + fallback,
+- panic-safe flush behavior.
 
-### 2.3 Userspace Console Service (`services/system/console`)
-This service acts as the central broker for standard I/O across the system.
+Code anchors:
 
-- **Responsibilities:**
-  - Standard I/O (stdin/stdout/stderr) brokering for applications.
-  - Session and terminal (TTY) multiplexing.
-  - Interactive shell attachment.
-  - Routing logs to persistent storage or diagnostic endpoints.
-  - Enforcing policy on stream access.
-- **Hardware Access:** It does not own the UART hardware driver directly. Instead, it relies on the kernel/driver capability mechanisms to write to the underlying hardware sink, while providing rich features (e.g., ANSI colors, UTF-8 rendering) at the user level.
+- `kernel/src/console/console_core.c`
+- `kernel/src/console/console_policy.c`
+- `kernel/src/console/console_buffer.c`
+- `kernel/src/console/serial_console.c`
+- `kernel/src/console/framebuffer_console.c`
 
-## 3. Fallback Order and Selection Rules
+## 2.2 Userspace console service policy/runtime brokering
 
-The platform nominates the preferred console device. If the preferred device is unavailable, the fallback order is:
-1. Platform-nominated primary console (e.g., specific `ns16550` or `pl011`).
-2. Generic MMIO fallback (e.g., simple `uart_simple_mmio` for SBI/HTIF).
-3. Memory log (`memlog_console`) as a last resort sink.
+`services/system/console/main.c` is intended to own:
 
-The platform is responsible for wiring the correct initialization sequence during boot to ensure the kernel console binds to the intended hardware.
+- stream brokering (`stdin/stdout/stderr` style channels),
+- session/TTY attachment,
+- URPC routing,
+- capability-mediated output dispatch.
 
-## 4. Testing Strategy
+Current state: scaffold loop + placeholder IPC calls.
 
-- **QEMU Tests:** E2E testing must capture serial logs from QEMU to validate early boot messages, successful driver binding, and deterministic panic output.
-- **Board Tests:** Hardware smoke tests must verify the correct fallback and primary console initialization on physical boards, ensuring UART output matches the expected profile.
+## 2.3 Userspace shell service command plane
+
+`services/system/shell/` owns:
+
+- line parsing,
+- command registry/dispatch,
+- per-session mode/capability checks,
+- response formatting (text + `kv` machine-readable mode).
+
+Current state: implemented and unit-tested on host; still backend-stub based.
+
+## 3) Current alignment between console and shell
+
+## 3.1 What is aligned now
+
+- Layering intent is correct: shell does not poke kernel internals directly.
+- Shell command handlers are designed around service/backend abstraction (`shell_backend_api_t`).
+- Console service and shell both target capability-mediated service composition.
+
+## 3.2 What is not aligned yet
+
+1. No concrete shell↔console transport binding (no URPC session plumbing from shell into console daemon).
+2. Console daemon does not yet implement real `bharat_ipc_call`/`bharat_ipc_send` flow for write/flush and stream ops.
+3. No shared contract document for shell session-to-console stream model (PTY/TTY/session lifecycle).
+4. End-to-end boot validation does not yet prove interactive shell over console on QEMU; only baseline boot/log behavior is generally testable.
+
+## 4) Shell implementation status (as of this update)
+
+Implemented in `services/system/shell/`:
+
+- bounded parser (`SHELL_MAX_INPUT_LEN`, `SHELL_MAX_TOKENS`),
+- capability/mode gated dispatch,
+- lockout after repeated denied auth path,
+- structured output mode (`mode kv`),
+- command registry for baseline read-only + privileged commands,
+- host-side tests for parser/registry/denial/malformed/timeout/integration behavior.
+
+Not yet implemented (or intentionally stubbed):
+
+- real IPC-backed backend (currently `shell_backend_stub.c`),
+- interactive service loop main path (today `main` in `shell_service.c` is placeholder),
+- remote shell transport,
+- script mode,
+- compatibility POSIX shell (deferred to personality layer).
+
+## 5) Missing code to implement next (priority order)
+
+### P0 — Required for real console+shell integration
+
+1. **Console daemon IPC implementation**
+   - Replace mock return path in `console_acquire_output_capability`.
+   - Implement real send/call path for write/flush opcodes.
+2. **Shell backend over service IPC**
+   - Add `shell_backend_ipc_console.c` (or equivalent) implementing backend API via console + system services.
+3. **Session wiring**
+   - Introduce explicit shell session lifecycle + binding to console stream IDs.
+
+### P1 — Reliability and policy hardening
+
+4. Add command timeout enforcement with cancellation hooks (not busy-loop simulation).
+5. Add comprehensive audit sink integration for denied/failed privileged operations.
+6. Add production-mode policy tables externalized from code (profile policy files).
+
+### P2 — Feature completion
+
+7. Remote shell transport gate (`CONFIG_SHELL_REMOTE`) with auth and rate limits.
+8. Recovery/factory distinct command profiles and test matrix.
+9. Compatibility shell landing zone in `personalities/compat/` (kept separate from system shell).
+
+## 6) Unified roadmap (console + shell)
+
+## Phase A (near-term): bootstrap integration
+
+- Complete console daemon URPC plumbing.
+- Implement shell IPC backend.
+- Prove shell command round-trip to real backend on QEMU headless.
+
+## Phase B (mid-term): production policy and resiliency
+
+- Audit/event pipelines for privileged paths.
+- Deterministic timeout/cancellation in dispatch.
+- Profile-specific command policy manifests.
+
+## Phase C (later): scale and compatibility
+
+- Session multiplexing + PTY-like abstractions where needed.
+- Remote shell endpoint with strict policy.
+- Personality-scoped POSIX compatibility shell.
+
+## 7) Headless QEMU validation contract
+
+Minimum acceptance evidence for console/shell alignment work:
+
+1. QEMU boots in `-nographic` mode and emits kernel console logs.
+2. Console service starts and reports backend acquisition (success/failure with explicit code).
+3. Shell service starts with backend availability state.
+4. At least one command path (`status`/`svc list`) proves end-to-end response through service backend (not local stub).
+
+Recommended command style:
+
+```bash
+timeout 30s python3 tools/build.py all --target-yaml tools/targets/qemu/x86_64_desktop_headless.yaml
+```
+
+For now, when (4) is not yet implemented, mark this as expected gap and keep shell host-tests mandatory.
+
+## 8) Invariants (non-negotiable)
+
+- Kernel keeps mechanism; shell/console services keep policy and session behavior.
+- Panic path remains lockless/allocation-free/polling-safe.
+- Shell parser/dispatch remains bounded.
+- Compatibility/POSIX semantics never leak into core system shell path.

--- a/docs/architecture/system/shell-architecture.md
+++ b/docs/architecture/system/shell-architecture.md
@@ -2,139 +2,108 @@
 
 ## Purpose
 
-This document defines the canonical Bharat-OS shell architecture and ownership model. It standardizes shell behavior across device profiles while preserving strict layering:
+This document defines the canonical Bharat-OS system shell architecture and aligns it with the current console subsystem reality.
 
-- Kernel provides primitives and capability enforcement.
-- `services/system/shell/` provides shell mechanism and command dispatch.
-- Product/profile policy decides which shell class is enabled.
+- Kernel provides primitives and enforcement.
+- `services/system/console/` is the stream broker boundary (currently scaffold).
+- `services/system/shell/` provides parser/dispatch/policy enforcement.
+- Profile policy determines availability and command surface.
 
-> **Non-negotiable boundary:** the kernel must not own shell policy. Shell policy is a service-layer concern.
+> Non-negotiable: kernel does not own shell policy.
 
-## Shell taxonomy
+## Runtime placement and boundaries
 
-Bharat-OS defines three shell classes:
+- Runtime shell service: `services/system/shell/`
+- Runtime console service: `services/system/console/`
+- Optional shared CLI helpers: `lib/cli/` or `lib/msg/cli/`
+- Deferred POSIX compatibility shell: `personalities/compat/`
 
-1. **Mini shell**
-   - Target: UART bring-up, recovery, factory, emergency service mode.
-   - Scope: tightly bounded command set; mostly diagnostics and static status.
-   - Footprint: smallest memory/runtime budget.
+Shell handlers must use service contracts/backend APIs and must not access kernel internals directly.
 
-2. **Admin shell**
-   - Target: field operations, system administration, diagnostics.
-   - Scope: service lifecycle, health, log inspection, network/device/process status.
-   - Footprint: moderate; capability-gated mutating operations.
+## Shell classes
 
-3. **Compatibility shell** (deferred)
-   - Target: Linux/POSIX personality workloads.
-   - Scope: personality-facing interactive shell semantics.
-   - Placement: `personalities/compat/` (not in core system shell service).
+1. Mini shell: low-footprint recovery/factory/bring-up path.
+2. Admin shell: operational diagnostics and controlled mutating commands.
+3. Compatibility shell (deferred): personality-layer POSIX-style shell semantics.
 
-## Layering and placement
+## Current implementation status
 
-### Required placement
+### Implemented now
 
-- **Runtime service:** `services/system/shell/`
-- **Shared parser/output helpers (optional):** `lib/cli/` or `lib/msg/cli/`
-- **Compatibility/POSIX shell (later):** `personalities/compat/`
+- Bounded parser and tokens.
+- Command registry with namespaced multi-token command support.
+- Capability + mode gating (`dev/prod/factory/recovery`).
+- Deny path + auth lockout behavior.
+- Text and `kv` output modes.
+- Host tests covering parser, registry, denials, malformed input, timeout/backend failure, integration session.
 
-### Layering rules
+### Missing / partial
 
-- Command handlers **must** call stable service contracts (IPC/IDL or service APIs).
-- Command handlers **must not** access kernel internals directly.
-- Shell command policy (allow/deny by profile/mode) belongs to shell service/profile config, not kernel code.
+- Shell main runtime loop + interactive IPC session plumbing is not complete.
+- Backend is stubbed (`shell_backend_stub.c`) instead of live service IPC.
+- No full shell↔console daemon wiring for true end-to-end TTY/session path.
+- Remote/script/compat modes are build-flag placeholders today.
 
 ## Security and capability model
 
-Shell dispatch is capability-mediated.
+Mandatory controls:
 
-### Core requirements
+- Per-command capability metadata.
+- Deny-by-default access check.
+- Audit events on denied/failed sensitive operations.
+- Lockout/rate-limit behavior on repeated failures.
 
-- Each command declares required capability rights.
-- Session carries authenticated role and effective capability mask.
-- Dispatcher enforces deny-by-default for privileged commands.
-- Denied and failed privileged attempts generate audit records.
+Session modes:
 
-### Session roles/modes
+- `dev`
+- `prod`
+- `factory`
+- `recovery`
 
-Minimum modes:
+## Production-grade contract
 
-- `dev` (developer mode)
-- `prod` (restricted production mode)
-- `factory` (provisioning/manufacturing)
-- `recovery` (break-glass support)
+A shell is production-grade only if all are true:
 
-### Mandatory controls
+1. Deterministic bounded parse and dispatch behavior.
+2. Bounded runtime execution with timeout and cancellation behavior.
+3. Strict service layering (no direct kernel shortcuts).
+4. Stable status/message/payload contract with machine-readable output.
+5. Tests for malformed input, unknown commands, deny/auth paths, and backend failure/degraded mode.
+6. E2E validation with headless QEMU proving console-connected command path.
 
-- Failed-auth and denied-command logging.
-- Lockout policy after repeated auth failure.
-- Rate limiting on auth and sensitive command classes.
-- Recovery/factory mode restrictions are explicit and build/profile controlled.
+## Console alignment contract
 
-## Production-grade shell requirements
+The shell and console are considered aligned only when:
 
-A shell implementation is production-grade only if it satisfies all of the following:
+1. Shell backend is service-IPC based (not local stub).
+2. Console service provides stream attach/write/flush over real capability-backed transport.
+3. At least one read-only command and one privileged command are validated through end-to-end path (with deny-path evidence where expected).
 
-1. **Deterministic parser behavior**
-   - Bounded line length and token count.
-   - Stable parsing result for identical input.
-2. **Bounded runtime model**
-   - Non-blocking event loop.
-   - Timeout and cancellation contract for command handlers.
-   - No unbounded buffers or growth.
-3. **Strict layering**
-   - No direct kernel poking from command handlers.
-4. **Stable output and error contract**
-   - Standard status code + message.
-   - Optional structured payload (machine-readable mode).
-5. **Testability**
-   - Parser, dispatch, auth, malformed input, and degraded-mode tests.
-6. **Safe degraded behavior**
-   - Commands fail safely when dependent services are unavailable.
-
-## Build/profile integration contract
-
-Use build-time configuration gates to include only required shell features:
+## Build-time feature gates
 
 - `CONFIG_SHELL_MINI`
 - `CONFIG_SHELL_ADMIN`
 - `CONFIG_SHELL_REMOTE`
 - `CONFIG_SHELL_RECOVERY`
 - `CONFIG_SHELL_SCRIPT`
-- `CONFIG_SHELL_COMPAT_POSIX` (deferred personality target)
+- `CONFIG_SHELL_COMPAT_POSIX` (deferred)
 
-Profiles may additionally disable mutating command namespaces by policy.
+## Near-term roadmap
 
-## Command namespace contract
+### Phase 1 — Integration completion
 
-Recommended namespace families:
+- Implement IPC-backed shell backend.
+- Complete console service URPC/capability request flow.
+- Add shell service runtime loop that binds to console session/stream endpoints.
 
-- `sys`
-- `svc`
-- `log`
-- `dev`
-- `net`
-- `proc`
-- `mem`
-- `cap`
-- `health`
-- `update`
+### Phase 2 — Hardening
 
-New commands should be namespaced; global top-level commands should be limited to essentials (for example `help`, `version`, `status`).
+- Replace simulated timeout behavior with real timeout/cancellation paths.
+- Centralize audit sink integration.
+- Move mode/profile command policy to explicit policy manifests.
 
-## Initial command policy model
+### Phase 3 — Expansion
 
-Policy is profile/mode-driven:
-
-- **Always allowed in dev:** core read and controlled diagnostics.
-- **Read-only in prod:** status, inventory, and observability commands.
-- **Factory-only:** provisioning, calibration, secure enrollment flows.
-- **Recovery-only:** break-glass repair and rollback.
-- **Disallowed on safety-critical runtime builds:** commands that alter live safety behavior unless explicitly approved by profile policy.
-
-## Implementation scope note
-
-This document defines architecture and contract, not POSIX shell behavior. The first production shell for Bharat-OS should be a minimal capability-aware system/admin shell, with POSIX compatibility deferred to personality-layer work.
-
-## Reference implementation status
-
-A production-grade minimal system/admin shell reference implementation now exists under `services/system/shell/` with bounded parser/dispatch behavior, capability-gated privileged commands, structured output mode, and host-side tests.
+- Remote shell with strict auth/rate-limit posture.
+- Recovery/factory differentiated command catalogs.
+- Personality-scoped compatibility shell.

--- a/docs/dev/shell-testing.md
+++ b/docs/dev/shell-testing.md
@@ -2,7 +2,7 @@
 
 ## Scope
 
-This guide covers the production-grade minimal system/admin shell under `services/system/shell/`.
+This guide covers the production-grade minimal system/admin shell under `services/system/shell/` and its alignment path with `services/system/console/`.
 
 ## Build enablement
 
@@ -62,7 +62,7 @@ Verify:
 - auth lockout after repeated denied attempts,
 - restricted behavior in production mode.
 
-## Runtime smoke test
+## Runtime smoke test (host binary)
 
 After building `system_shell`, run it with stdin commands, e.g.:
 
@@ -75,3 +75,19 @@ For structured output mode:
 ```sh
 printf "mode kv\nstatus\n" | ./system_shell
 ```
+
+## Headless QEMU validation (alignment gate)
+
+Use at least one headless QEMU target to verify boot + console path:
+
+```sh
+timeout 30s python3 tools/build.py all --target-yaml tools/targets/qemu/x86_64_desktop_headless.yaml
+```
+
+Current expected reality:
+
+- kernel console logs should appear,
+- shell host tests should pass,
+- full interactive shell-over-console E2E may still be incomplete until console daemon IPC and shell IPC backend wiring are implemented.
+
+Treat missing interactive shell-over-console behavior as a tracked integration gap, not a parser/dispatch correctness failure.


### PR DESCRIPTION
### Motivation

- The repository docs were out of date: the kernel console is production-ready while the userspace console is still scaffolded and the system shell is implemented but runs against a stub backend. 
- The intent is to make the architecture, integration gaps, and roadmap explicit so implementers and reviewers know which code paths remain to be wired and tested. 

### Description

- Rewrote `docs/architecture/console/console_architecture.md` into an aligned `console + shell` contract that states current implementation status, unaligned areas, missing-code P0/P1/P2 list, unified roadmap, and headless QEMU acceptance criteria. 
- Updated `docs/architecture/system/shell-architecture.md` to reflect the real shell placement, capability model, production contract, and the concrete integration gaps with the console daemon. 
- Updated `docs/dev/shell-testing.md` to add headless QEMU validation guidance, expected current-gap behavior, and recommended runtime smoke tests for the host `system_shell` binary. 
- No production code behavior changes were made; this is a docs-only PR clarifying alignment and next steps for implementation and testing. 

### Testing

- Ran configure with `cmake -S . -B build-shell -DBHARAT_BUILD_HOST_TESTS=ON -DBHARAT_ENABLE_SYSTEM_SHELL=ON` which completed successfully. 
- Built the host shell binary with `cmake --build build-shell --target system_shell -j4` which succeeded and produced `system_shell`. 
- Attempted to build listed individual host tests and hit missing target issues in that configuration (no generated rule for the specific test invocation). 
- Attempted the full QEMU pipeline via `python3 tools/build.py all --target x86_64_desktop_headless` and related `all/run` flows which failed for environment reasons: missing Python YAML dependencies initially and then a separate unrelated kernel build error (`hal/hal_cpu_topology.h` include not found) during full image build, so end-to-end QEMU validation was not completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6d1206e5883209cc97750b02ad36f)