### PR TITLE
docs: align native ABI with new primitives and consolidate personality guidance

### DIFF
--- a/docs/architecture/personalities/README.md
+++ b/docs/architecture/personalities/README.md
@@ -1,0 +1,29 @@
+---
+title: Personalities Documentation Index
+status: active
+owner: Architecture Team
+version: 1.0
+last_updated: "2026-04-21"
+---
+
+# Personalities Documentation (Consolidated)
+
+This folder is the canonical architecture location for personality design and planning.
+
+## Core documents
+
+- `personality-layer.md`: architecture model and layering rules.
+- `personality-performance-contract.md`: mandatory performance and KPI constraints.
+- `roadmap.md`: phased delivery roadmap.
+- `zero-translation-roadmap.md`: implementation roadmap for near-zero translation overhead using modern native primitives.
+
+## Personality-specific docs
+
+- `linux/` and `linux-*.md`
+- `android/` and `android-*.md`
+- `native-personality.md`
+
+## Consolidation policy
+
+- New personality architecture and roadmap docs should be created under this folder.
+- Legacy references outside this folder can remain for historical ADR context, but active implementation guidance should link back here.

--- a/docs/architecture/personalities/personality-layer.md
+++ b/docs/architecture/personalities/personality-layer.md
@@ -3,14 +3,19 @@ title: Personality Layer Architecture
 status: active
 owner: Architecture Team
 reviewers: ["Core Team"]
-version: 1.0
-last_updated: "2024-03-23"
+version: 1.1
+last_updated: "2026-04-21"
 tags: ["architecture", "personalities"]
 ---
 
 # Personality Layer Model
 
 > **Note on Code Structure:** The architecture enforces a strict separation. Syscalls hit a generic trap layer (`kernel/src/arch/*/trap.c`) and are routed through the native UAPI. Foreign ABIs are supported through compatibility layers (`personalities/compat/linux/`, etc.) that translate POSIX and other semantics into native IPC/uRPC requests.
+
+
+## 0. Documentation Entry Point
+
+Use `docs/architecture/personalities/README.md` as the canonical index for all personality-layer architecture and roadmap content.
 
 ## Overview
 
@@ -33,6 +38,8 @@ This is the real OS contract for Bharat-native apps. It does not use POSIX paths
 ## 2. Compat Personalities (e.g., Linux POSIX)
 
 These translate foreign semantics into the native kernel and service model. They **do not** redefine the kernel core.
+
+Compat adapters should increasingly target the additive modern primitives (`intent_set/get`, class-aware allocation, fault-domain operations) via table-driven mappings, while preserving default legacy behavior when mappings are disabled.
 
 - A legacy Linux application makes a standard `openat()` or `write()` syscall.
 - The `compat/linux/` layer catches this and maps the POSIX concepts into native capability-scoped IPC messages.

--- a/docs/architecture/personalities/zero-translation-roadmap.md
+++ b/docs/architecture/personalities/zero-translation-roadmap.md
@@ -1,0 +1,83 @@
+---
+title: Personality Zero-Translation Roadmap
+status: active
+owner: Architecture Team
+version: 1.0
+last_updated: "2026-04-21"
+tags: ["architecture", "personalities", "performance", "compatibility"]
+---
+
+# Personality Zero-Translation Roadmap
+
+## Goal
+
+Ensure Linux, Android, and future personalities remain **fully functional and performance-grade**, avoiding the "works but slow" trap from repeated translation layers.
+
+## 1. Design rules
+
+1. **Boundary-only translation**: translate once at personality ABI ingress, not across every internal subsystem.
+2. **No text translation on hot path**: avoid string parsing/matching in syscall, IPC, memory, scheduling, and binder/epoll-like loops.
+3. **Native primitive reuse**: all personalities should reuse the same kernel primitives and only adapt semantics.
+4. **Fast-path determinism**: hot-path mapping must be table-driven and cacheable.
+
+## 2. Modern native primitives used
+
+The current primitive set that personalities must target:
+
+- **Intent execution**: `intent_set/get` for scheduling intent attachment.
+- **Memory class allocation**: class-tagged allocation path for policy-aware memory behavior.
+- **Fault domains**: explicit containment/restart boundaries.
+
+These are additive; default legacy paths must continue without forced remapping.
+
+## 3. Architecture pattern per personality
+
+### Linux
+- Map `sched_setscheduler`/affinity/cgroup-style hints to intent metadata only when feature-flagged.
+- Map selected DMA/packet-intensive paths to memory classes.
+- Map service groups/process trees to fault domains for controlled restarts.
+
+### Android
+- Map task profiles/foreground classes to intent metadata.
+- Map media/ML/sensor memory flows to class-tagged allocation.
+- Map critical service clusters to fault domains with supervisor orchestration.
+
+## 4. Rollout plan
+
+### Stage 0: Baseline parity
+- Keep mappings disabled by default.
+- Validate no regression in existing compatibility paths.
+
+### Stage 1: Opt-in feature flags
+- Enable mapping per subsystem (scheduler first, memory second, fault policy third).
+- Expose policy toggles through profile config.
+
+### Stage 2: Zero-translation maturity
+- Replace remaining string-heavy pathways with compact IDs/enums.
+- Add per-thread/per-domain mapping caches.
+- Remove duplicate translation between personality and services.
+
+### Stage 3: Default-on where proven
+- Enable only after KPI gates pass in CI/perf labs.
+
+## 5. KPI gates
+
+- Null syscall latency delta stays within agreed budget vs baseline.
+- `mmap`/alloc class overhead remains within low single-digit range.
+- `epoll`/wait wakeup path avoids per-event translation churn.
+- Binder-like and shared-memory flows maintain zero-copy behavior.
+- Fault-domain attach/create overhead bounded and non-disruptive.
+
+## 6. Primitive quality improvements required
+
+To maximize personality benefit, primitive implementations should mature from v1 stubs to production paths:
+
+- Intent: persist per-thread metadata and fast retrieval.
+- Mem class: replace placeholder handle flow with real mapped allocation + accounting.
+- Fault domain: persist domain state and enforce attach/lifecycle semantics.
+
+## 7. Non-negotiable guardrails
+
+- No ABI renumbering or replacement of legacy compatibility interfaces.
+- Additive UAPI only, with versioned structs and reserved fields.
+- Degrade behavior explicit per profile when semantics cannot be fully honored.

--- a/docs/architecture/uapi/native_abi.md
+++ b/docs/architecture/uapi/native_abi.md
@@ -3,9 +3,9 @@ title: Bharat-OS Native UAPI Roadmap
 status: active
 owner: Architecture Team
 reviewers: ["Core Team"]
-version: 1.0
-last_updated: "2024-03-27"
-tags: ["architecture", "uapi", "native", "capabilities"]
+version: 1.1
+last_updated: "2026-04-21"
+tags: ["architecture", "uapi", "native", "capabilities", "primitives"]
 ---
 
 # Bharat-OS Native UAPI (Application Binary Interface) Roadmap
@@ -18,82 +18,87 @@ The guiding principle for application interfaces in Bharat-OS is:
 
 > **Kernel mechanisms are native. Services are native. UAPI is native. Compat personalities translate into native.**
 
-This document outlines the roadmap for the **Native UAPI**, which resides in the `uapi/` tree. This is the explicit boundary for syscall headers, capability contracts, shared IPC structures, and stable ABI types.
+This document defines the active roadmap for the **Native UAPI** boundary across `include/bharat/uapi/` and `uapi/`. It is the explicit contract for syscall numbers, capability contracts, shared IPC structures, and stable ABI types.
 
-Foreign ABIs (like Linux/POSIX) are **not** the core identity of the OS; they exist as compatibility layers (`personalities/compat/linux/`) that translate foreign semantics into this native UAPI.
+Foreign ABIs (Linux/POSIX/Android) are **not** the core identity of the OS; they are compatibility personalities that consume these native contracts.
 
-## 2. The Native Contract Boundaries
+## 2. Current Native Primitive Set (as of April 21, 2026)
+
+The latest additive primitive set in the repo now includes:
+
+1. **Intent execution primitives**
+   - `SYSCALL_INTENT_SET`, `SYSCALL_INTENT_GET`.
+   - UAPI type: `bharat_intent_t` (`include/bharat/uapi/system/intent.h`).
+   - Kernel entry path wired through trap dispatch and scheduler syscall stubs.
+
+2. **Memory semantic class primitive**
+   - `SYSCALL_MEM_ALLOC_CLASS`.
+   - Memory class taxonomy present in `kernel/include/bharat/mem_class.h`.
+   - Kernel stub path available in `kernel/src/mm/mem_class.c`.
+
+3. **Fault-domain primitives**
+   - `SYSCALL_FAULT_DOMAIN_CREATE`, `SYSCALL_FAULT_DOMAIN_DESTROY`, `SYSCALL_FAULT_DOMAIN_ATTACH`.
+   - UAPI type: `bharat_fault_domain_attr_t` (`include/bharat/uapi/system/fault_domain.h`).
+   - Kernel path wired through `kernel/src/core/fault_domain.c` and trap dispatch.
+
+These primitives are implemented as **additive v1 APIs** and do not replace legacy compatibility-facing behavior.
+
+## 3. Native Contract Boundaries
 
 The native contract is cleanly separated across the system architecture:
 
-* **`kernel/`**: Provides mechanisms only (scheduling, memory, syscall/traps, capabilities, IPC/uRPC, faults, minimal coordination).
-* **`uapi/`**: Defines the Bharat-native ABI and stable public contracts (process/thread syscalls, capability/object rights, IPC message formats, FS/service request/response contracts, native handle and error types).
-* **`services/system/filesystem/`**: Owns namespace, paths, mount policy, FD/session policy, exposed via native IPC/uRPC.
-* **`stacks/storage/`**: Owns composed storage internals.
-* **`personalities/compat/linux/`**: Maps Linux `openat`, `read`, `write`, `stat`, etc. into the native FS/process/thread/service contracts defined in `uapi/`.
+* **`kernel/`**: mechanisms only (scheduling, memory, syscall/traps, capabilities, IPC/uRPC, faults, minimal coordination).
+* **`include/bharat/uapi/` + `uapi/`**: Bharat-native ABI and stable public contracts.
+* **`services/`**: policy and orchestration (namespace, lifecycle, supervision, telemetry).
+* **`personalities/compat/*`**: strict compatibility adapters mapping foreign semantics into native contracts.
 
-## 3. Native UAPI Domains
+## 4. Native UAPI Domains
 
-The Native UAPI encompasses several core domains, replacing global, ambient-authority APIs (like standard POSIX) with explicit, capability-scoped operations.
+### 4.1 Handles and Capabilities
+Native applications operate on capability handles with explicit rights and delegation.
 
-### 3.1 Handles and Capabilities
-Native applications do not operate on raw file descriptors as global indices. Instead, they operate on capability handles.
+### 4.2 Process and Thread Primitives
+Thread/process lifecycle remains explicit, with intent metadata attach/query as additive execution hints.
 
-* **Capability Operations**: Acquiring, copying, moving, and dropping capability handles.
-* **Rights Narrowing**: Creating derived capability handles with a restricted subset of rights (e.g., deriving a read-only handle from a read-write handle).
-* **Object Mapping**: Mapping handles to specific kernel or service objects (e.g., an IPC endpoint, a memory object, or a VFS node).
+### 4.3 Memory and Object Models
+Native memory APIs are capability-scoped and now extended with semantic allocation classes for policy-aware placement and accounting.
 
-### 3.2 Process and Thread Primitives
-A real Bharat-native application model exposes explicit lifecycle and execution control primitives.
+### 4.4 IPC and Endpoints
+Stable endpoint/message discipline for sync IPC and async uRPC rings, with zero-copy as default for high-throughput paths.
 
-* **Domain/Process Management**: Creating, destroying, and managing execution domains (processes).
-* **Thread Management**: Native thread creation, execution, suspension, and join-like primitives (`kthread_t` management via UAPI).
-* **Contexts and Faults**: Managing thread execution contexts, CPU affinity, and receiving asynchronous fault or exception messages.
+### 4.5 Fault Containment
+Fault domains provide first-class containment and restart policy metadata, while keeping restart orchestration in services.
 
-### 3.3 Memory and Object Models
-Native memory APIs focus on explicit mapping and sharing of memory objects, heavily utilized for zero-copy I/O.
+### 4.6 Namespace and Sandbox Semantics
+Sandbox and namespace visibility remain capability-mediated. No global ambient namespace is assumed.
 
-* **Memory Objects (VMOs)**: Creating and managing Virtual Memory Objects.
-* **Mapping**: Mapping VMOs into the address space with specific protection flags.
-* **Shared Memory**: Using VMOs in conjunction with IPC for zero-copy data transfer.
+## 5. Personality Integration Rule (No Translation Tax)
 
-### 3.4 IPC and Endpoints
-All complex interactions, including filesystem and network operations, are mediated through the native IPC/uRPC model.
+Compatibility personalities must follow this performance rule:
 
-* **Endpoints**: Creating and binding to IPC endpoints for message passing.
-* **Message Discipline**: Defining and enforcing stable, native message contracts and layouts for requests and responses.
-* **Synchronous vs. Asynchronous**: Supporting both fast, synchronous IPC (for signaling/control) and asynchronous uRPC rings (for high-throughput data like storage or networking).
+1. **No forced translation for legacy behavior** when mapping is not enabled.
+2. **Single-hop mapping at ABI boundary** (personality edge only), never repeated transformations through internal layers.
+3. **No text-based translation in hot paths** (string-heavy remapping loops in read/write/epoll/binder-like hot paths are forbidden).
+4. **Use shared native primitives directly** (`intent`, `mem_class`, `fault_domain`) where configured.
 
-### 3.5 Native Filesystem and Object Access
-The native FS contract is capability-oriented and service-routed, diverging significantly from ambient POSIX paths.
+This keeps Linux/Android compatibility viable without becoming “working but slow.”
 
-* **Object/Capability Based**: File and directory access requires possessing a capability handle granting rights to that object.
-* **Service-Routed**: File operations (read, write, stat) are serialized as IPC/uRPC messages sent to the VFS service (`services/system/filesystem/`) owning the capability.
-* **Namespace Mediation**: There is no global `/` by default. Applications only see the namespace explicitly granted to their sandbox via capabilities. Path resolution is relative to these granted namespace capabilities.
+## 6. Roadmap: Native Primitives + Personalities
 
-### 3.6 Namespace and Sandbox Semantics
-Sandboxing is a first-class citizen, enforced by capability possession rather than user IDs or access control lists (ACLs).
+### Phase A (Now)
+- Keep primitives additive and versioned.
+- Preserve ABI stability for Linux/Android compatibility by default.
+- Add observability counters around primitive usage and fallback paths.
 
-* **Domain Creation**: Creating new sandboxed execution domains with a strictly defined set of initial capabilities.
-* **Namespace Delegation**: Granting a subset of a parent domain's namespace to a child domain.
-* **Resource Limits**: Associating resource limits and usage quotas with specific sandboxes or domains.
+### Phase B (Opt-in mappings)
+- Linux: map scheduler/cgroup-like hints to `intent_set/get`, selected alloc paths to mem classes, service groups to fault domains.
+- Android: map task profiles/cpusets to intent, media/AI buffers to mem classes, critical services to fault domains.
 
-## 4. Relationship to `compat/linux/`
+### Phase C (Zero-translation-path maturity)
+- Promote binary/enum-based mapping tables over text/string translation.
+- Cache mapping decisions per thread/domain/endpoint.
+- Enforce per-personality KPI gates (syscall latency, mmap class overhead, fault-path cost).
 
-The Linux compatibility layer (`personalities/compat/linux/`) is built strictly *on top* of the Native UAPI.
+## 7. Immediate Documentation Follow-up
 
-For example, when a Linux binary invokes the `openat` syscall:
-1. The trap is caught and routed to the Linux personality layer.
-2. The Linux personality translates the POSIX path and flags into a native IPC request.
-3. The IPC request is sent via the Native UAPI to `services/system/filesystem/`, carrying the process's namespace capability.
-4. The VFS service resolves the path, allocates a native object handle, and returns it.
-5. The Linux personality maps this native capability handle to an integer file descriptor (FD) and returns it to the Linux application.
-
-This ensures the native ABI remains pure, while POSIX compliance is treated as a translation problem.
-
-## 5. Next Steps / Phase Integration
-
-1. **Storage/Filesystem Boundary Cleanup**: Complete the migration of VFS logic into `services/system/filesystem/` (Phase 2).
-2. **Define UAPI Headers**: Solidify the `uapi/` headers for the primitives listed above (Capabilities, Threads, IPC, Memory).
-3. **Wire Services to UAPI**: Connect `services/system/filesystem/` to accept requests structured via these new native UAPI contracts.
-4. **Build Compat Adapters**: Implement `personalities/compat/linux/` as a strict consumer of the Native UAPI, providing standard POSIX ABIs for legacy applications.
+To reduce fragmentation, personality architecture, performance contract, and roadmap references are consolidated under `docs/architecture/personalities/` with one index entrypoint.


### PR DESCRIPTION
### Motivation

- Capture recently added additive kernel primitives (`intent`, `mem_alloc_class`, `fault_domain_*`) in the Native UAPI documentation so the architecture docs match current code.  
- Reduce documentation fragmentation by consolidating personality guidance and explicitly call out the performance rule to avoid translation-tax in hot paths.  

### Description

- Updated `docs/architecture/uapi/native_abi.md` to version `1.1` and documented the in-repo primitives: `SYSCALL_INTENT_SET/GET`, `SYSCALL_MEM_ALLOC_CLASS`, and `SYSCALL_FAULT_DOMAIN_*`, their UAPI types and wiring.  
- Added a `No Translation Tax` personality integration rule and a phased roadmap for opt-in mappings from Linux/Android to native primitives.  
- Updated `docs/architecture/personalities/personality-layer.md` metadata and added a documentation entrypoint that points to a consolidated personalities index.  
- Added `docs/architecture/personalities/README.md` as the canonical personalities index and `docs/architecture/personalities/zero-translation-roadmap.md` describing the zero-translation implementation and KPI gates.  

### Testing

- Ran `git diff --check` to validate there are no whitespace/patch formatting issues, which passed.  
- Attempted to run `markdownlint` on the modified docs but the tool is not installed in this environment, so linting was skipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6dbe46c388320a2aa102ee16f55c0)