### PR TITLE
docs: add production-grade interrupt architecture plan

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -27,6 +27,7 @@ This roadmap tracks Bharat-OS from a bootable microkernel baseline toward a prod
 | Message-based TLB shootdown | **Partial** | Functional path exists; ack/completion semantics and stronger stress validation are still open. |
 | Basic SKB/topology discovery | **Partial** | Present as baseline subsystem direction; depth varies by architecture. |
 | Kernel boundary + syscall ABI freeze | **Partial** | Canonical UAPI and syscall status translation path are in active convergence; remaining work includes eliminating legacy ad-hoc negative subsystem returns, adding ABI drift CI gates, and BIDL contract status conformance checks. |
+| Production-grade Interrupt Architecture | **Partial** | Core architecture unified (`hal_irq_` flow), but full `irq_domain` resolution, hardware specific mapping depth (e.g. MSI-X), and strict domain-first routing enforcement remain to be implemented. Documentation is in place. |
 
 ## Phase 2: Device specialization & edge UI
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -28,6 +28,7 @@ This folder captures the current architectural baseline for Bharat-OS.
 
 ### Core kernel architecture
 
+- [`interrupt/interrupt-architecture.md`](interrupt/interrupt-architecture.md)
 - [`kernel-api.md`](kernel-api.md)
 - [`capability-model.md`](capability-model.md)
 - [`kernel-object-model.md`](kernel-object-model.md)

--- a/docs/architecture/interrupt/interrupt-architecture.md
+++ b/docs/architecture/interrupt/interrupt-architecture.md
@@ -1,0 +1,80 @@
+# Interrupt Architecture
+
+## Overview
+
+Bharat-OS employs a **three-layer interrupt architecture** to provide a robust, hardware-agnostic, and feature-rich interrupt handling system. This design decouples the generic OS-level interrupt handling from the specific hardware controller details, allowing for extensibility, clean porting, and support for advanced features like MSI/MSI-X, virtualization, and accelerator profiles.
+
+The architecture strictly separates intent and routing from the hardware mechanisms.
+
+## Three-Layer Architecture
+
+### 1. Core IRQ Layer (Arch-Agnostic Kernel)
+
+The core IRQ layer is the uppermost layer, responsible for managing the logical interrupt lifecycle independent of any hardware.
+
+*   **Virtual IRQ Space (`virq`)**: The kernel primarily deals with virtual IRQ numbers, isolating it from raw hardware lines.
+*   **IRQ Descriptors**: Each `virq` maps to a descriptor (e.g., `irq_desc_t` or future `bh_irq_desc_t`). This descriptor holds:
+    *   State flags (masked, pending, in-progress, oneshot, level-triggered).
+    *   Pointers to the associated `irq_domain` and controller operations.
+    *   Handler chains (supporting shared interrupts).
+    *   Affinity masks.
+*   **Dispatch Flow**: A single, unified dispatch contract is enforced across all architectures:
+    `entry -> claim -> domain map -> dispatch -> eoi`
+*   **Deferred Work**: Hard IRQ contexts must be brief and deterministic. The core layer manages a queue for deferred work (bottom halves) executed in a pre-emptible context.
+
+*Future Naming Convention*: The core OS primitive type for an interrupt identity will migrate to a canonical `bh_irq_t` to maintain naming consistency across Bharat-OS UAPIs and kernel structures.
+
+### 2. IRQ Domain + Routing Layer
+
+The IRQ domain layer sits between the core OS and the hardware controllers. It is strictly responsible for translation and routing.
+
+*   **Translation**: It translates hardware IRQ numbers (`hwirq`) to virtual IRQ numbers (`virq`), ensuring that drivers do not perform ad-hoc interrupt math.
+*   **Hierarchical Domains**: Domains can be stacked. For example, a GPIO expander creates a domain that acts as a child of a GIC SPI domain. An MSI device domain sits above an ITS or IMSIC domain.
+*   **MSI/MSI-X Domains**: Message Signaled Interrupts are modeled as domains, providing a generic programming API rather than relying on per-driver, ad-hoc implementations.
+*   **Affinity Propagation**: The domain layer propagates affinity requests from the core descriptor down to the hardware controller programming interface.
+
+### 3. Controller Driver Layer (Arch/SoC Specific)
+
+The lowest layer consists of the hardware-specific driver implementations (e.g., APIC/IOAPIC for x86, GICv2/v3+ITS for ARM, PLIC/APLIC/IMSIC for RISC-V).
+
+*   **Controller Ops (`irq_controller_ops_t`)**: Each controller binds to the core layer by providing a standard set of operations: `mask`, `unmask`, `ack`, `eoi`, `set_affinity`, `set_type`, etc.
+*   **Feature Declarations**: Controllers expose capabilities (`ARCH_CAP_*`) indicating support for features like hierarchical domains, posted interrupts, direct injection, or MSI remap. This allows the OS to use fast paths opportunistically with guaranteed safe fallbacks.
+
+## Roadmap and Future Enhancements
+
+The implementation of this architecture is executed in planned phases. The target roadmap for the core foundations includes:
+
+1.  **Fully Realizing `irq_domain`**: Migrating from placeholder structs to a fully implemented allocator, translation table, and hierarchy tracking system.
+2.  **Descriptor State Formalization**: Enriching the `irq_desc` model with explicit state bitfields and active chip pointers.
+3.  **Domain-First Routing Enforced**: Mandating that all new device IRQ plumbing uses the domain layer.
+
+*Note: For detailed progression, refer to `ROADMAP.md`.*
+
+## Validation and Bring-up Testing Design
+
+A robust, production-grade test suite is required to validate the interrupt architecture as it is implemented across different profiles.
+
+### 1. Architecture Conformance Tests
+These tests validate the required backend controller operations and semantic correctness:
+*   **Mask/Unmask Correctness**: Ensuring that masked interrupts do not fire and are appropriately pended.
+*   **Level vs. Edge Semantics**: Validating acknowledgment requirements and repetitive firing behavior.
+*   **Shared IRQ Behavior**: Testing handler chain execution and unregistration.
+*   **Affinity Move Behavior**: Testing dynamic rerouting of interrupts to different CPU cores without loss.
+
+### 2. Stress and Load Tests
+These tests push the system to identify edge cases, race conditions, and bottlenecks:
+*   **Interrupt Storm Handling**: Flooding a line to verify rate-limiting or backpressure mechanisms without hard-locking the core.
+*   **Cross-Core IPI Throughput**: Measuring the latency and throughput of inter-processor interrupts under heavy locking contention.
+*   **High-Rate MSI-X Queue Simulation**: Simulating multi-queue devices (like NVMe or 100G NICs) to ensure the domain translation and dispatch layers do not introduce unacceptable overhead.
+
+### 3. Regression Matrix
+All interrupt logic must pass through the multi-arch headless build and test matrix:
+*   `qemu-virt-x86_64` (APIC/IOAPIC paths)
+*   `qemu-virt-arm64` (GICv3/ITS paths)
+*   `qemu-virt-riscv64` (PLIC/AIA paths)
+*   Emulated edge profiles for `arm32` and `riscv32`.
+
+### 4. Observability and Auditing
+*   **Tracepoints**: Hooking into `claim`, `dispatch`, and `eoi` to measure handling latency.
+*   **Spurious Rate Counters**: Tracking unhandled interrupts.
+*   **Health Counters**: Per-controller observability for active/pending metrics.


### PR DESCRIPTION
Adds documentation for the target production-grade three-layer interrupt architecture and updates the roadmap.

---
*PR created automatically by Jules for task [1694476072927037322](https://jules.google.com/task/1694476072927037322) started by @divyang4481*