### PR TITLE
docs: clarify init as thin bootstrap and document control-plane split in roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -26,6 +26,7 @@ This roadmap tracks Bharat-OS from a bootable microkernel baseline toward a prod
 | Cross-core capability operations | **Partial** | Delegation/revocation path exists, but lifecycle proofs and temporal controls remain. |
 | Message-based TLB shootdown | **Partial** | Functional path exists; ack/completion semantics and stronger stress validation are still open. |
 | Basic SKB/topology discovery | **Partial** | Present as baseline subsystem direction; depth varies by architecture. |
+| Bootstrap control-plane split (`init` → `servicemgr` → `policymgr`) | **Partial** | Direction is now explicit: `init` remains a thin trusted bootstrap layer, while long-lived lifecycle policy converges into `servicemgr` and profile-aware policy managers. Remaining work is completion of supervision/event-loop depth and profile contracts. |
 | Kernel boundary + syscall ABI freeze | **Partial** | Canonical UAPI and syscall status translation path are in active convergence; remaining work includes eliminating legacy ad-hoc negative subsystem returns, adding ABI drift CI gates, and BIDL contract status conformance checks. |
 | Production-grade Interrupt Architecture | **Partial** | Core architecture unified (`hal_irq_` flow), but full `irq_domain` resolution, hardware specific mapping depth (e.g. MSI-X), and strict domain-first routing enforcement remain to be implemented. Documentation is in place. |
 
@@ -75,6 +76,7 @@ This roadmap tracks Bharat-OS from a bootable microkernel baseline toward a prod
 2. **Networking is ahead of most services**: `netmgr`/`netstack` have meaningful internal modules, while many other managers are stubs.
 3. **Security depth gap**: capability and policy structure exists, but enforcement depth (e.g., full cap checks, IOMMU depth, verified boot chain) still needs sustained implementation.
 4. **Observability gap**: baseline diagnostics exist, but production-grade trace/metrics/export and watchdog policy coverage are not fully closed.
+5. **Lifecycle authority migration gap**: architecture direction is clear, but full migration from early-boot bootstrap logic into durable `servicemgr`/policy-manager ownership is still in progress.
 
 ## B) Discrepancy log (explicit)
 

--- a/services/core/init/README.md
+++ b/services/core/init/README.md
@@ -1,9 +1,54 @@
 # services/init
 
 ## Purpose
-The first user-space root supervisor, acting strictly as a **bootstrap coordinator**. It launches the core service graph, enforces initial startup order, acts as a health gate based on kernel-provided boot status, and handles early boot failure policy (like safe mode). It is designed to be profile-aware and deterministic.
+The first trusted user-space bootstrap service, acting strictly as a **bootstrap coordinator**. It launches the minimum control-plane graph, enforces startup order for early boot, applies health gates based on kernel boot status, and handles early boot failure policy (for example safe mode). It is designed to be profile-aware and deterministic.
 
-**Crucially, `init` is NOT a permanent service supervisor, process tree owner, or a Linux-style systemd clone.** After early boot convergence and graph validation, `init` hands off long-lived lifecycle management, fault handling, and restart policies to `servicemgr` and `faultmgr`. It may then exit or become quiescent.
+**Crucially, `init` is NOT a permanent service supervisor, process tree owner, or a Linux-style systemd clone.** After early boot convergence and graph validation, `init` hands off long-lived lifecycle management, fault handling, restart policy, and dependency supervision to `servicemgr` (with `faultmgr` integration). It may then exit or become quiescent depending on profile.
+
+## Control-plane split (authoritative model)
+
+The Bharat-OS control plane is intentionally split into three layers:
+
+1. **`init`**: trusted bootstrap only.
+2. **`servicemgr`**: long-lived lifecycle authority.
+3. **policy manager (`policymgr`, profile-dependent)**: runtime policy decisions based on profile + hardware + policy config.
+
+This prevents policy-heavy orchestration from collapsing into a single permanent init daemon and keeps the kernel/services separation clean.
+
+## Bootstrap lifecycle
+
+### Stage 0: Kernel handoff (mechanism only)
+The kernel performs mechanism-level bring-up and launches the first trusted user-space service.
+
+### Stage 1: `init` bootstrap
+`init` validates boot context and starts the minimum control-plane services:
+- `capmgr`
+- `devmgr`
+- `process_manager`
+- `vm_manager`
+- `servicemgr`
+- optional `policymgr` (profile-specific)
+
+### Stage 2: `servicemgr` takeover
+`servicemgr` becomes lifecycle owner:
+- service start/stop/restart
+- dependency satisfaction
+- restart/backoff tracking
+- watchdog + health contracts
+- boot-phase transitions and degraded-mode handling
+
+### Stage 3: policy-driven runtime
+`policymgr` (when present) selects runtime behavior by profile/hardware policy:
+- allowed service sets
+- scheduler and power posture
+- lazy/dynamic activation posture
+- fault/degradation policy
+
+## Profile guidance
+
+- **Small RT/appliance/wearable:** static manifest, fixed graph, minimal `init`, compact `servicemgr`, optional compile-time policy.
+- **Automotive/robotics/medical:** safety-first boot classes, strict supervision, watchdog/fault-domain integration, degraded-mode guarantees.
+- **Desktop/server/cloud:** dynamic manifests, richer dependency graphs, stronger telemetry and runtime policy.
 
 ## Dependencies
 - **May depend on:** `lib/runtime`, `lib/ipc`, `lib/cap`, standard C library headers.


### PR DESCRIPTION
### Motivation

- Make `services/core/init` explicit about being a trusted, minimal bootstrap coordinator rather than a long-lived PID1-style supervisor.
- Surface the intended control-plane split so long-lived lifecycle and policy logic move to `servicemgr` and profile-aware policy managers instead of accumulating in `init`.
- Align the repository roadmap with the architecture guidance so roadmap readers can track lifecycle migration work and outstanding gaps.

### Description

- Expanded `services/core/init/README.md` to reword `init` as the trusted user-space bootstrap, added an explicit control-plane model (`init` → `servicemgr` → `policymgr`), and documented a staged bootstrap lifecycle (kernel handoff, init bootstrap, `servicemgr` takeover, policy-driven runtime).
- Added the minimum control-plane startup set to the init docs (`capmgr`, `devmgr`, `process_manager`, `vm_manager`, `servicemgr`, optional `policymgr`) and provided per-profile guidance (small RT/appliance, automotive/robotics/medical, desktop/server/cloud).
- Updated `ROADMAP.md` Phase 1 with a dedicated item for the bootstrap control-plane split and added a gap-analysis note tracking the lifecycle-authority migration as ongoing work.
- This change is documentation-only and does not modify runtime code or behavior.

### Testing

- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6e3f07dbc832083457c9cd42904a4)