### PR TITLE
docs(storage): consolidate filesystem architecture and add code-aligned roadmap

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -44,6 +44,8 @@ This folder captures the current architectural baseline for Bharat-OS.
 - [`driver-model.md`](driver-model.md)
 - [`hardware-abstraction-and-drivers-baseline.md`](hardware-abstraction-and-drivers-baseline.md)
 - [`storage-and-sandbox-strategy.md`](storage-and-sandbox-strategy.md)
+- [`storage/README.md`](storage/README.md)
+- [`storage/roadmap.md`](storage/roadmap.md)
 - [`verification-scope.md`](verification-scope.md)
 - [`threat-model-and-mac.md`](threat-model-and-mac.md)
 - [`cmake-governance-and-agent-rules.md`](cmake-governance-and-agent-rules.md)

--- a/docs/architecture/storage-and-sandbox-strategy.md
+++ b/docs/architecture/storage-and-sandbox-strategy.md
@@ -1,5 +1,7 @@
 # Storage & Filesystem Strategy (Advanced)
 
+> Consolidation note: normative storage/filesystem architecture now lives in `docs/architecture/storage/`. This document remains as an advanced strategy companion.
+
 ## Goals
 
 Bharat-OS should expose a single, capability-safe storage model that can host:

--- a/docs/architecture/storage/README.md
+++ b/docs/architecture/storage/README.md
@@ -1,0 +1,19 @@
+# Storage & Filesystem Architecture (Consolidated Index)
+
+This directory is the **canonical home** for Bharat-OS storage and filesystem architecture.
+
+## Documents
+
+- [`vfs-and-filesystem-architecture.md`](vfs-and-filesystem-architecture.md): normative architecture contract and layering.
+- [`file-system-detailed-design.md`](file-system-detailed-design.md): implementation-aligned deep dive mapped to current code.
+- [`roadmap.md`](roadmap.md): phased roadmap with code/doc alignment checkpoints.
+
+## Consolidation note
+
+The following older architecture notes discussed overlapping topics and are now consolidated here:
+
+- `docs/architecture/vfs-storage-architecture.md`
+- `docs/architecture/storage-and-sandbox-strategy.md`
+- `docs/architecture/profile-driven-storage-network-subsystems.md` (storage portions)
+
+When content conflicts, this folder should be treated as source of truth for storage/filesystem boundaries and delivery sequence.

--- a/docs/architecture/storage/file-system-detailed-design.md
+++ b/docs/architecture/storage/file-system-detailed-design.md
@@ -1,156 +1,93 @@
-# Storage and Filesystem Detailed Architecture (Bharat-OS)
+# Storage and Filesystem Detailed Design (Code-Aligned)
 
-## 1. Introduction & Guiding Principles
+## 1. Scope and intent
 
-Bharat-OS embraces a strict multi-tiered architecture for storage and file systems, adhering to the capability-oriented microkernel design philosophy. The traditional monolithic "Virtual File System" (VFS) is decomposed across four distinct layers to ensure isolation, flexibility across device profiles, and high-performance I/O (DMA/NUMA awareness) without bloating the kernel.
-
-### The Four Layers
-1. **Kernel (`kernel/`):** Provides *only* the low-level mechanisms. No filesystem policy, no pathname resolution, no heavy VFS. The kernel handles capability enforcement, IPC/uRPC transport, physical memory management (PMM), DMA-safe memory allocation, and fault delivery.
-2. **System Services (`services/system/filesystem/`):** The VFS daemon. Owns mount policy, namespace rules, pathname traversal, file descriptor (session) handling, and sandbox storage policies.
-3. **Storage Stack (`stacks/storage/`):** Reusable storage subsystem logic. Owns generic block request models, page/buffer caching, writeback engines, integrity frameworks, and filesystem protocol adapters (e.g., FAT, ext4-like).
-4. **Drivers (`drivers/block/` & `drivers/storage/`):** Real device drivers (e.g., virtio-blk, NVMe, eMMC). Owns hardware probing, MMIO/registers, ring/queue submissions, DMA descriptor/SG list mapping, and interrupt/timeout handling.
+This document maps storage/filesystem design to **current code** and records what is real, partial, or planned.
 
 ---
 
-## 2. Advanced Architectural Concepts
+## 2. Implementation map
 
-### 2.1 Direct Memory Access (DMA) and Zero-Copy I/O
-To achieve near-production grade performance, the storage stack must minimize data copying across domain boundaries:
-- **DMA-Safe Memory:** The `stacks/storage/cache` (Page/Buffer Cache) allocates I/O buffers from capability-granted, DMA-safe memory pools provided by the kernel PMM.
-- **Zero-Copy IPC:** User applications issuing `read()` or `write()` calls negotiate shared memory windows (vmo/shm) via uRPC with `services/system/filesystem`.
-- **Scatter-Gather (SG) Lists:** The generic block layer (`stacks/storage/block`) constructs SG lists referencing these pinned DMA buffers and passes them via capability-restricted IPC to the hardware drivers (`drivers/block/`).
+## 2.1 Filesystem service (`services/system/filesystem/`)
 
-### 2.2 NUMA Awareness
-Modern Datacenter and Edge-Compute profiles feature Non-Uniform Memory Access (NUMA) topologies. The storage architecture accounts for this by:
-- **NUMA-Local Page Caching:** The buffer cache allocates pages from the memory node closest to the CPU core executing the application thread.
-- **I/O Queue Pinning:** Multi-queue block devices (like NVMe) map submission/completion queues to specific NUMA nodes. Interrupts and uRPC completion notifications are routed to the corresponding local cores to prevent cross-interconnect thrashing.
-- **VFS Session Locality:** The `services/system/filesystem` daemon can spawn worker threads pinned to specific NUMA domains to handle high-throughput parallel I/O.
+- `main.c`
+  - selects profile at build/runtime macro level,
+  - reads block geometry via `block_get_info`,
+  - resolves storage policy via `storage_profile_resolve`,
+  - initializes cache via `cache_init_with_profile`.
+- `fd_mgr.c`
+  - owns open-file table,
+  - enforces capability-aware checks for open/read/write/close,
+  - keeps `openat` in limited transitional mode (`AT_FDCWD`-style fallback only).
+- `vfs_stub.c`
+  - service-side driver registry helpers and path-prefix helpers.
 
----
+## 2.2 Storage stack (`stacks/storage/`)
 
-## 3. Profile-Driven Storage Features
+- `block/block.c`
+  - validates request, routes to virtio-blk path for device 0,
+  - handles flush request as explicit semantic.
+- `cache/cache.c`
+  - fixed-size global cache entries with profile-sized active capacity,
+  - lookup + victim selection,
+  - dirty block writeback and device flush in `cache_sync`.
+- `profile.c`
+  - profile resolver with device-size thresholds and arch clamping,
+  - backend/cache/queue depth strategy,
+  - string helpers for reporting.
+- `fs/adapter.c`
+  - lightweight adapter registration and lookup.
+- `fs/ramfs/ramfs.c`
+  - concrete page-backed RAMFS implementation with block-table growth.
+- `fs/blob/blob_backend.c`
+  - explicit compatibility placeholder returning service-required errors.
 
-Bharat-OS targets diverse environments. The storage stack components are conditionally compiled and configured based on the target profile:
+## 2.3 Kernel fs boundary (`kernel/src/fs/`)
 
-| Feature / Subsystem | RT / Safety (Automotive/Medical) | Edge / Mobile (IoT/Drones) | Datacenter / Server |
-| :--- | :--- | :--- | :--- |
-| **Primary Backend** | eMMC / SPI NOR Flash | UFS / eMMC / SD Card | NVMe / Virtio-Blk / Network Blob |
-| **Filesystem Type** | Deterministic (littlefs, FAT) | Wear-aware (f2fs, ext4-like) | High-throughput (xfs-like, btrfs-like) |
-| **Cache Policy** | Minimal buffer cache (strict write-through) | Moderate page cache (write-back) | Deep, NUMA-aware page cache with async writeback |
-| **I/O Queues** | Single queue, polling mode | Multi-queue, interrupt driven | Deep multi-queue, polling + interrupt hybrid |
-| **Memory Allocation** | Static, pre-allocated DMA pools | Dynamic, reclaimable page cache | Transparent Huge Pages (THP), NUMA-bound |
+- Contains compatibility units that intentionally return service-required status, preserving build/ABI continuity while policy migrates out of kernel.
+- `kernel/include/fs/` remains important as shared contract surface for FS/VFS objects and operations.
 
----
+## 2.4 Client boundary (`lib/fs/`)
 
-## 4. Directory Structure and Responsibilities
-
-Following the rigorous folder structure guidelines, the implementation is organized as follows:
-
-### 4.1 Services: `services/system/filesystem/`
-The authoritative VFS and Storage Policy Manager.
-- **`mount_mgr.c`:** Manages the mount graph and resolves capability-anchored mount tokens.
-- **`namespace_mgr.c`:** Handles per-sandbox path resolution and chroot-like environments.
-- **`vnode_mgr.c`:** Orchestrates abstract virtual nodes (vnodes/dentries).
-- **`fd_mgr.c`:** Maps per-process file descriptors to live `vnode` sessions and capability handles.
-- **`ipc_dispatch.c`:** Handles uRPC messages (`openat`, `stat`, `mkdir`) from user apps and personalities.
-
-### 4.2 Stacks: `stacks/storage/`
-The reusable subsystem building blocks.
-- **`block/`:** Generic block request queues, elevator algorithms, and I/O scheduler hints.
-- **`cache/`:** Page cache, buffer cache, readahead logic, and writeback engine.
-- **`fs/`:** Concrete filesystem format adapters (e.g., parsing superblocks, inodes, directory entries).
-- **`integrity/`:** Checksums, journaling frameworks, and Merkle-tree validation (for secure profiles).
-
-### 4.3 Drivers: `drivers/block/` & `drivers/storage/`
-The pure hardware interface layer.
-- **`drivers/block/virtio_blk/`:** Virtqueue initialization, descriptor chaining, and MMIO notifications.
-- **`drivers/storage/nvme/`:** Admin/I/O queue pair creation, PRP/SGL construction, and doorbell ringing.
-- **Constraints:** Drivers *never* parse paths, *never* check permissions, and *never* understand POSIX semantics. They only execute `block_request_t` arrays.
+- `fs_client` forwards operations to filesystem service symbols and acts as migration boundary for callers.
 
 ---
 
-## 5. Implementation Roadmap
+## 3. What is aligned now
 
-### Phase 1: Near-Production Baseline (Partially Complete / Transitional)
-1. Relocated existing VFS policy logic (`vfs.c`, `mount.c`, `file.c`, `namespace.c`, etc.) out of the kernel into `services/system/filesystem/`. The service migration has started but is still incomplete.
-2. Replaced kernel VFS logic with thin transitional capability/IPC shims. The kernel still exposes this shim ABI.
-3. Established the `stacks/storage/` framework encompassing generic block API, basic buffer cache abstracts, and fs-adapter boundaries. This is currently scaffolded, but not production-complete.
-4. Tests and legacy components still depend on the kernel shim paths instead of the service path.
-
-### Phase 2: Kernel Clean-up & POSIX Personality (Current Objective)
-1. Remove remaining direct kernel consumer dependencies on transitional VFS shims (B-phase cleanup). Migrate tests to use an `fs_client` layer that routes to the filesystem service.
-2. Implement a complete deterministic/lightweight filesystem (e.g., littlefs/FAT) in `stacks/storage/fs/`.
-3. Connect `services/system/filesystem/` to the `compat/linux` personality to support real `openat`, `read`, `write`, `stat`.
-4. Implement the NUMA-aware Page Cache in `stacks/storage/cache/` to buffer reads and aggregate writes.
-
-### Phase 3: Advanced Sandboxing & Security
-1. Enforce Path Capabilities: Validate that a sandboxed app's token allows writing to a specific subdirectory.
-2. Implement Storage Class Restrictions (e.g., block raw `/dev/nvme0n1` access from untrusted containers).
-3. Enable Secure Boot / Fast Boot profile integration (read-only verified rootfs with a volatile tmpfs overlay).
-
-### Phase 4: Datacenter & Blob Scale
-1. Implement multi-queue NVMe driver with CPU core pinning.
-2. Introduce `VFS_BACKEND_BLOB` for URI-addressed object storage.
-3. Asynchronous I/O via `io_uring`-style ring buffers mapped between the application and VFS.
+1. **Profile-aware initialization exists in the service startup path.**
+2. **Cache/writeback/flush scaffolding exists and is callable from service flow.**
+3. **Filesystem adapter boundary exists (`adapter.c`) with concrete RAMFS backend present.**
+4. **Driver side includes both virtio-blk and NVMe implementation baselines.**
+5. **Capability-aware checks are present in active file operation path.**
 
 ---
 
-## 6. Gap Review (Current Repo State) and Remaining Tasks
+## 4. Known mismatches and debt
 
-After reviewing the active code under `stacks/storage/` and `services/system/filesystem/`, the biggest remaining production gaps are:
-
-1. **Filesystem service path is still mostly stubbed**
-   - `services/system/filesystem/main.c` performs only a single synthetic block read flow.
-   - Full IPC decode/dispatch for `openat/read/write/stat` is still pending.
-
-2. **Storage cache and writeback were placeholder-only**
-   - The previous cache implementation had no residency model, no eviction policy, and no sync semantics.
-
-3. **No profile/device/architecture-aware policy resolver**
-   - Build/runtime profile intent existed in architecture docs, but there was no shared resolver translating:
-     - app profile (RT/Edge/Datacenter),
-     - device size,
-     - hardware architecture,
-     into concrete FS backend + cache + queue configuration.
-
-4. **Phase-2 service migration remains incomplete**
-   - Kernel shim consumers and some tests still rely on transitional paths.
-
-### Updated Remaining Task List (priority order)
-
-1. Complete `fs_client` + service-side syscall routing (`openat/read/write/stat/mkdir/unlink/rename`) and migrate all tests from kernel shims.
-2. Add concrete persistent adapters in `stacks/storage/fs/`:
-   - `littlefs`/`FAT` for RT/Edge,
-   - `ext4-like` baseline for general-purpose,
-   - `xfs-like`/blob for datacenter scale.
-3. Wire cache pages to DMA-safe allocator and block IO SG lists (remove placeholder buffer pointers).
-4. Add NUMA-local worker and queue pinning policy plumbing for datacenter profile.
-5. Add integrity/journaling hooks (`stacks/storage/integrity/`) and profile-gated enforcement.
-6. Add fault-injection + soak tests (power-cut/replay, media errors, queue timeouts).
+1. **Hybrid ownership remains:** some VFS-related behavior is still available in multiple transitional locations.
+2. **Service API coverage is incomplete:** no full syscall/IPC-complete `openat/read/write/stat/mkdir/unlink/rename` route set yet.
+3. **Persistent FS adapters are not production-complete:** RAMFS is strongest concrete path today.
+4. **Blob backend is contract placeholder only.**
+5. **Kernel-to-service cutover is not fully complete for all consumers/tests.**
 
 ---
 
-## 7. Implemented Baseline Improvements (This Change)
+## 5. Documentation contract for contributors
 
-To move toward production-grade behavior while keeping scope realistic, the current implementation now includes:
+When changing storage/filesystem code, contributors should keep these invariants:
 
-1. **Profile-aware storage resolver (`stacks/storage/profile.c`)**
-   - Chooses backend/cache/queue/cache-budget from:
-     - application profile,
-     - device size,
-     - hardware architecture.
-   - Includes 32-bit resource clamping for constrained targets.
+- Do not move policy-rich namespace/mount behavior back into kernel internals.
+- Keep driver code free of path/permission/POSIX policy logic.
+- Route new profile decisions through `stacks/storage/profile.c` and consume them from service startup/config paths.
+- Use `lib/fs/fs_client.*` as boundary for clients while transport evolves.
 
-2. **Configurable cache initialization (`cache_init_with_profile`)**
-   - Cache capacity now follows resolved profile budget.
-   - Added bounded in-memory cache entries, lookup, victim selection, pin/unpin tracking.
-   - Added `cache_sync()` writeback + FLUSH request path.
+---
 
-3. **Filesystem service startup policy wiring**
-   - Service now reads block device geometry and resolves profile policy at boot.
-   - Cache is initialized using the resolved policy, creating a profile/device/arch aware storage baseline.
+## 6. Relationship to roadmap
 
-4. **Block layer FLUSH semantic stub**
-   - Generic block queue now explicitly handles FLUSH requests, enabling cache-sync barrier semantics.
+Delivery phases, priorities, and completion criteria are tracked in:
 
-These changes establish the policy plane and cache baseline needed before full adapter, journaling, and service syscall completion.
+- [`roadmap.md`](roadmap.md)
+
+This detailed design document should be updated alongside roadmap status changes whenever storage/filesystem behavior changes materially.

--- a/docs/architecture/storage/roadmap.md
+++ b/docs/architecture/storage/roadmap.md
@@ -1,0 +1,82 @@
+# Storage & Filesystem Roadmap (Code + Docs Alignment)
+
+## Status legend
+
+- **Done**: implemented and visible in current codebase.
+- **In Progress**: partial implementation exists; contracts incomplete.
+- **Planned**: documented target not yet implemented.
+
+---
+
+## Phase 0 — Baseline consolidation (Done)
+
+- [x] Consolidate storage/filesystem architecture docs under `docs/architecture/storage/`.
+- [x] Record repository-aligned architecture contract.
+- [x] Record current hybrid migration state (kernel shim + service path).
+
+Exit criteria:
+- storage architecture readers can find canonical docs in one folder.
+
+---
+
+## Phase 1 — Stable service-driven baseline (In Progress)
+
+### Current progress
+
+- [x] filesystem service startup wired to block info + profile resolver + cache init.
+- [x] capability-aware open/read/write/close path in service FD manager.
+- [x] generic block API and cache sync/flush scaffolding.
+- [x] fs client forwarding layer exists.
+
+### Remaining
+
+- [ ] complete service request surface for `openat/read/write/stat/mkdir/unlink/rename`.
+- [ ] remove ambiguous duplicate transitional symbols/ownership patterns.
+- [ ] convert remaining tests/consumers to clean service boundary usage.
+
+Exit criteria:
+- service path is authoritative for normal FS operations;
+- kernel FS path reduced to explicit minimal mechanism compatibility.
+
+---
+
+## Phase 2 — Persistent filesystem maturity (Planned)
+
+- [ ] keep RAMFS for early boot/tests, add persistent adapter track (FAT/littlefs/ext-like baseline by profile).
+- [ ] add mount capability negotiation against backend feature descriptors.
+- [ ] strengthen crash-consistency behavior (write ordering + sync semantics by policy).
+
+Exit criteria:
+- at least one persistent filesystem backend available and test-covered per non-volatile profile class.
+
+---
+
+## Phase 3 — Blob/object and policy hardening (Planned)
+
+- [ ] replace blob backend placeholder with working object path.
+- [ ] enforce storage-class restrictions (fs/block/blob) from capability policy.
+- [ ] define staged write + commit semantics for object backend.
+
+Exit criteria:
+- blob backend is usable for read flow with capability enforcement.
+
+---
+
+## Phase 4 — Performance and scale features (Planned)
+
+- [ ] deepen queue and completion model (virtio/NVMe multi-queue maturity).
+- [ ] integrate NUMA locality behavior behind profile toggles where supported.
+- [ ] add stress/fault-injection coverage for cache, flush, and recovery paths.
+
+Exit criteria:
+- measurable throughput/latency improvements under profile-appropriate workloads with repeatable test evidence.
+
+---
+
+## Ongoing doc-code alignment checklist
+
+For every storage/filesystem PR:
+
+1. Verify `docs/architecture/storage/*.md` reflects changed ownership/boundary behavior.
+2. If interfaces in `kernel/include/fs`, `stacks/include/bharat/stacks/storage`, or `lib/fs` change, update architecture contract text in same PR.
+3. Keep transitional claims explicit; do not document planned behavior as shipped.

--- a/docs/architecture/storage/vfs-and-filesystem-architecture.md
+++ b/docs/architecture/storage/vfs-and-filesystem-architecture.md
@@ -1,58 +1,128 @@
-# Storage and Filesystem Architecture Contract (Bharat-OS)
+# Storage and Filesystem Architecture Contract (Repository-Aligned)
 
-## 1. Introduction & Guiding Principles
+## 1. Purpose
 
-Bharat-OS implements a strict, profile-aware, and capability-governed multi-tiered architecture for its Virtual File System (VFS) and storage subsystems. The traditional monolithic VFS is decomposed across four distinct layers to ensure scaling from tiny MPU/MMU-lite devices, appliances, drones, automotive, mobile, edge, and cloud deployments.
+This document defines the **current authoritative architecture** for storage and filesystem behavior in Bharat-OS, aligned to code in:
 
-### The Four Layers
-1. **Kernel VFS Core (`kernel/`):** Provides *minimal mechanism only*. Handles capability enforcement, object identifiers, and boundary checks. *Crucially, no policy (automount, sync strategy, media indexing) or rich VFS logic resides here.* Currently transitioning to pure capability/IPC shims.
-2. **Filesystem Service/System Layer (`services/system/filesystem/` & `stacks/storage/`):** The policy and orchestration layer. Owns mount policy, namespace rules, pathname traversal, file descriptor handling, and orchestration. (Migration in progress; scaffolding exists).
-3. **Storage Drivers/Backends (`drivers/block/`, `drivers/storage/`, & `stacks/storage/fs/`):** Separate actual backend implementations. Includes ramfs, devfs, tmpfs, flashfs (log-structured for small devices), block-backed local FS, network/distributed/cloud adapters, automotive partitioned storage, and read-only image FS for appliances.
-4. **Userspace/UAPI Layer (`uapi/include/fs/`):** Exposes a clean, language-agnostic UAPI/SDK for file, directory, metadata, mount/query, and notification/watch operations, with optional POSIX compatibility.
+- `services/system/filesystem/`
+- `stacks/storage/`
+- `drivers/block/` and `drivers/storage/`
+- `kernel/src/fs/` and `kernel/include/fs/`
+- `lib/fs/`
 
----
+It intentionally separates:
 
-## 2. Capability Matrix & Storage Profiles
-
-Bharat-OS does not optimize first for "desktop POSIX completeness." It optimizes for a **filesystem capability matrix**, supporting various deployment classes through explicit storage profiles.
-
-### 2.1 Profile Definitions
-
-*   **A. Tiny / MPU / Appliance / Drone Controller (`FS_PROFILE_TINY_RO`, `FS_PROFILE_TINY_RW_LOG`, `FS_PROFILE_APPLIANCE`)**
-    *   Tiny code size, static mount layout, mostly read-only or append-log.
-    *   Predictable latency, flash-aware write behavior, minimal namespace complexity.
-    *   Optional/no page cache.
-*   **B. Mobile / Automotive / Appliance with Richer UX (`FS_PROFILE_MOBILE`, `FS_PROFILE_AUTOMOTIVE`)**
-    *   Per-app/per-domain namespace control, journaling or crash consistency.
-    *   Notification/watch support, better caching, removable media support.
-    *   Secure partitioning, profile-aware storage classes.
-*   **C. Cloud / Edge / Server (`FS_PROFILE_CLOUD`)**
-    *   Scalable mount/namespace model, page cache/writeback sophistication, high IOPS backends.
-    *   Richer metadata, quotas/snapshots, remote FS integration, observability.
+- **What exists today** (implemented or stubbed), and
+- **What is target architecture** (phased roadmap).
 
 ---
 
-## 3. Crash Consistency Tiers
+## 2. Layer model (current + target)
 
-*   **Tier 1:** Best effort / volatile only (ramfs/tmpfs/devfs).
-*   **Tier 2:** Small-device log or copy-on-write metadata (flash/appliance/drone).
-*   **Tier 3:** Journaled/block-backed consistency (mobile/automotive/general systems).
-*   **Tier 4:** Advanced scalable/server features (snapshots/quotas/replication/integrity scrub).
+### Layer A — Driver layer (hardware-facing)
+
+- `drivers/block/virtio_blk/`: block submission stub + init path.
+- `drivers/storage/nvme/`: NVMe controller init/admin queue baseline.
+
+**Contract:** no pathname parsing, no capability policy, no POSIX semantic ownership.
+
+### Layer B — Storage stack primitives
+
+- `stacks/storage/block/`: generic block request API (`READ`, `WRITE`, `FLUSH`).
+- `stacks/storage/cache/`: bounded cache table with dirty tracking and flush path.
+- `stacks/storage/profile.c`: profile resolver for backend, cache, queue depth, journaling/NUMA toggles.
+- `stacks/storage/fs/adapter.c`: filesystem adapter registry.
+- `stacks/storage/fs/ramfs/`: concrete in-memory filesystem backend.
+- `stacks/storage/fs/blob/`: blob backend compatibility stub.
+
+**Contract:** reusable policy/mechanism helpers, but not user ABI ownership.
+
+### Layer C — Filesystem service
+
+- `services/system/filesystem/main.c`: service bootstrap with storage profile selection + cache init.
+- `services/system/filesystem/fd_mgr.c`: open/read/write/close table and capability-gated checks.
+- `services/system/filesystem/mount_mgr.c`, `namespace_mgr.c`, `vfs_stub.c`: service-side namespace/mount and VFS helper scaffolding.
+
+**Contract:** owns mount/namespace/file-descriptor policy and request dispatch behavior.
+
+### Layer D — Kernel compatibility surface (transitional)
+
+- `kernel/include/fs/*.h`: shared FS/VFS types and operation contracts.
+- `kernel/src/fs/*.c`: currently mixed state; some files are compatibility shims returning `K_ERR_REQUIRES_FS_SERVICE`.
+
+**Contract target:** kernel keeps only mechanism/ABI stubs required for safe transition; policy migrates to service.
+
+### Layer E — Client boundary
+
+- `lib/fs/fs_client.c`: fs client wrappers forwarding to filesystem-service symbols.
+
+**Contract:** call-site stable entrypoints while IPC transport matures.
 
 ---
 
-## 4. Capability-Governed FS Access
+## 3. Current reality check (important)
 
-The capability model is mandatory across services and IPC boundaries. Filesystem objects define:
-*   Object type
-*   Allowed rights (lookup, read, write, append, create, delete, execute, mount, remount, admin, watch, setattr)
-*   Scope
-*   Handle lifetime
-*   Revoke behavior
+The repository is in a **hybrid migration state**:
+
+1. **Service path exists and performs real work for FD operations.**
+2. **Kernel fs path still exists** and contains transitional compatibility shims in some units.
+3. **Dual symbol patterns remain** (`vfs_*`-style behaviors in multiple places), which is accepted short-term but must be collapsed.
+4. **Storage profile and cache wiring are present** in the service startup path.
+
+This is expected for current phase, but documentation and code must explicitly acknowledge the hybrid state to avoid architectural drift.
 
 ---
 
-## 5. Mount & Namespace Model
+## 4. Capability and authority model
 
-*   **Small-Device Mode:** Fixed mount table, no dynamic mount namespaces.
-*   **Large-Device/Cloud Mode:** Global early boot namespace, system namespace, and per-process namespace (chroot-like environments), with read-only/read-write mounts and optional bind-like remaps.
+Authority is capability-scoped. In current code paths, this is represented by:
+
+- capability checks when opening and operating files (`caller_cap`, rights masks, target object checks).
+- per-open file handle capability association in service FD tables.
+- transitional dummy capability fallbacks in compatibility wrappers.
+
+**Hard rule:** no ambient authority assumptions in new storage/filesystem work.
+
+---
+
+## 5. Driver taxonomy rule (`drivers/block` vs `drivers/storage`)
+
+To keep current tree while reducing ambiguity:
+
+- `drivers/block/*`: frontend request engines that consume normalized block requests.
+- `drivers/storage/*`: transport/protocol-specialized storage controllers and queue managers.
+
+Both remain valid now, but future docs/code should keep this split explicit.
+
+---
+
+## 6. Profile-driven policy baseline
+
+The storage profile resolver currently derives:
+
+- FS backend family intent (ramfs/littlefs/fat/ext4-like/xfs-like/blob)
+- cache policy
+- queue depth
+- cache budget
+- NUMA/journaling flags
+
+Inputs are:
+
+- app profile (`RT`, `EDGE`, `DATACENTER`)
+- device size
+- hardware architecture family
+
+This baseline is already wired into filesystem service boot initialization.
+
+---
+
+## 7. Out of scope for current phase
+
+Not yet treated as implemented architecture commitments:
+
+- full userspace IPC protocol for complete POSIX file API surface,
+- production persistent FS adapters beyond RAMFS-level baseline,
+- complete blob/object implementation,
+- full NUMA-local IO worker scheduling and queue pinning.
+
+These remain roadmap items.

--- a/docs/architecture/vfs-storage-architecture.md
+++ b/docs/architecture/vfs-storage-architecture.md
@@ -1,85 +1,17 @@
-# Bharat-OS VFS & Storage Architecture
+# Legacy VFS & Storage Architecture Note
 
-## 1. Goals
-- **Hardware-Neutral:** Abstract the complexities of storage hardware (NVMe, virtio, eMMC) behind generic block and object interfaces.
-- **Personality-Neutral:** The core kernel VFS exposes capability-based, generic object operations. POSIX (Linux), Android, and Windows NT semantics are layered on top via personality adapters.
-- **Profile-Driven:** Allow compile-time and boot-time composition. RTOS profiles can use lightweight RAM-backed filesystems, while Datacenter profiles utilize async NVMe queues and remote object storage.
-- **Capability-Native:** Eliminate global root/ACL concepts in the kernel. Mounts, file handles, and namespaces are governed exclusively by capabilities.
+This file is retained for compatibility with old references.
 
-## 2. Non-Goals
-- Implementing a monolithic Linux VFS clone inside the kernel.
-- Hardcoding POSIX-specific behaviors (e.g., specific `errno` values or Linux-specific path resolution quirks) into the core path traversal logic.
-- Building complex filesystems (like Btrfs or ZFS) before a stable, baseline POSIX and block IO path is proven.
+## Canonical location
 
-## 3. The 5-Layer Storage Stack
-The storage architecture in Bharat-OS is explicitly divided into 5 distinct layers:
+Storage/filesystem architecture is now consolidated under:
 
-### Layer 0: Hardware & HAL
-Architecture-specific bus, interrupt, and DMA management.
-*Examples: PCI-e initialization, arm64 MMIO routing, DMA memory mapping.*
+- `docs/architecture/storage/README.md`
+- `docs/architecture/storage/vfs-and-filesystem-architecture.md`
+- `docs/architecture/storage/file-system-detailed-design.md`
+- `docs/architecture/storage/roadmap.md`
 
-### Layer 1: Device Class Drivers
-Drivers that talk to specific storage hardware but implement a standard interface.
-*Examples: NVMe driver, virtio-blk driver, eMMC driver, remote blob gateway.*
+## Migration note
 
-### Layer 2: Generic Block / Object Interfaces
-The unified contract for asynchronous and synchronous I/O.
-- **Block:** Request queues, elevator algorithms, flush/barrier/FUA semantics.
-- **Object:** Put/Get semantics, URI routing, immutable read/staged write flows.
-
-### Layer 3: Cache & FS Core (VFS Spine)
-The capability-aware, neutral storage spine.
-- Page Cache integration and writeback buffering.
-- Generic inode/vnode objects (`vfs_node_t`).
-- Mount tree (`vfs_mount_t`) and namespaces (`vfs_namespace_t`).
-- Capability validation (path rights, storage-class rights).
-
-### Layer 4: Personality Shims
-Subsystems that translate the neutral VFS spine into ABIs expected by user applications.
-- **Linux:** Maps generic open/read/write/rename to POSIX `openat`, `renameat2`, `stat`, and `errno`.
-- **Android:** Adds Binder-mediated content providers and strict app sandboxing.
-- **Windows:** Translates to NT-style handles, case rules, and reparse points.
-
-## 4. Core Structures & Capability Model
-
-Bharat-OS utilizes capabilities to manage authority across the entire stack.
-
-- **`vfs_node_t`**: Represents a canonical storage object (file, directory, block device). It does *not* grant access; it contains an object ID and provenance metadata linking it to the capability system.
-- **`vfs_mount_t`**: Represents a mounted filesystem instance. It carries a **mount capability** that dictates namespace visibility, path-rooted rights (R/W/X), and storage-class rights (e.g., whether this mount allows block access or only blob access).
-- **`vfs_file_t`**: An open file description/handle. It holds a **live capability handle** that enforces specific rights (read, write, append) negotiated at open time, preventing ambient privilege escalation.
-- **`vfs_namespace_t`**: A per-process or per-sandbox view of the mount graph, filtered by the capabilities assigned to the sandbox.
-
-## 5. Profile Model
-
-Subsystem features are activated based on the deployment profile:
-- **RT/Safety Profile:** tmpfs/ramfs priority, deterministic allocation, minimal writeback buffering.
-- **Edge/Mobile Profile:** Local filesystem priority, wear-aware block policies, per-app sandboxing namespaces.
-- **Datacenter Profile:** Deep page caching, async block queues (virtio/NVMe), and remote blob storage integration.
-
-## 6. Block vs. Blob Backends
-
-- **Block Backends:** Utilize `block_device_t` and `block_request_t` for queue-based I/O. Supports hints like `sync`, `direct`, `buffered`, and `polling`.
-- **Blob Backends:** Utilize `object_store_t` for URI-based addressing (e.g., `/blob/remote/bucket/key`). Designed for immutable reads and staged, transactional writes.
-
-## 7. Phased Roadmap
-
-### Phase 1: Block + Baseline POSIX (Current Focus)
-- Implement Layer 2 generic block queues (`block.h`, `block.c`).
-- Implement Layer 3 capability-aware mounts, namespaces, and file handles.
-- Provide a stable, basic POSIX-style filesystem driver (e.g., ext2-like or FAT-like) over virtio-blk/NVMe.
-- Add personality shims for standard POSIX file operations (`openat`, `stat`, `renameat2`, symlinks/hardlinks) mapping to the neutral core.
-
-### Phase 2: Blob / Object Backend
-- Introduce `VFS_BACKEND_BLOB` as a formal mount backend.
-- Expose immutable read descriptors for remote URI paths.
-- Implement staged writes via temp objects and atomic commit flows.
-
-### Phase 3: Advanced Features (Deferred)
-- Copy-on-Write (CoW) snapshots, deduplication, and encryption trees.
-- Distributed replication and persistent memory (Optane) semantics.
-- Complex caching algorithms and ML-driven I/O prediction.
-
-## 8. Testing Strategy
-- **Unit Tests:** Verify capability token validation on mounts and file descriptors without hardware drivers.
-- **Integration Tests:** Mount a virtual ram-backed block device, create namespaces, and verify path resolution boundaries.
-- **POSIX Conformance:** Run standard POSIX filesystem test suites against the Linux personality shim to ensure correct `errno` mapping and `openat`/`renameat2` semantics.
+Earlier revisions of this file mixed aspirational and implemented behavior.
+Use the consolidated storage docs for repository-aligned current state and roadmap.


### PR DESCRIPTION
### Motivation
- Reduce duplication and drift by consolidating storage and VFS guidance into a single canonical folder aligned to the repository layout and current implementation.
- Make documentation reflect the hybrid migration state (kernel shim → userspace filesystem service) so contributors and reviewers have an accurate contract to follow.
- Provide a clear, phased delivery roadmap that ties doc expectations to code locations and completion criteria.

### Description
- Add a canonical storage index at `docs/architecture/storage/README.md` to host authoritative storage/filesystem docs.
- Replace and rework architecture text into repository-aligned files: `docs/architecture/storage/vfs-and-filesystem-architecture.md` (authoritative contract) and `docs/architecture/storage/file-system-detailed-design.md` (implementation-mapped design).
- Add a phased `docs/architecture/storage/roadmap.md` enumerating Phase 0–4 milestones, exit criteria, and a doc-code alignment checklist.
- Convert the older `docs/architecture/vfs-storage-architecture.md` into a short legacy pointer to the consolidated storage docs and add a consolidation note to `docs/architecture/storage-and-sandbox-strategy.md`.
- Update `docs/architecture/README.md` to link the new storage canonical index and roadmap so readers can discover the consolidated content from the top-level architecture index.

### Testing
- Ran `git diff --check` to validate whitespace and trivial issues; the check passed.
- Verified the consolidation with repository searches (`rg -n "consolidat|canonical|roadmap"`) to confirm new documents and pointers are present; the checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6f5e5df1c83209092934e87861649)