### PR TITLE
Add topology-aware CPU allocation policies and placement resolver

### DIFF
--- a/hal/common/discovery.c
+++ b/hal/common/discovery.c
@@ -23,8 +23,16 @@ bool hal_cpu_topology_query(hal_cpu_topology_info_t *out) {
     if (discovery && discovery->topology.cpu_count > 0U) {
         discovered = discovery->topology.cpu_count;
     }
+    if (discovered > 32U) {
+        discovered = 32U;
+    }
+
+    uint32_t valid_cpu_mask = (discovered == 32U) ? UINT32_MAX : ((1U << discovered) - 1U);
 
     out->discovered_cpu_count = discovered;
+    out->valid_cpu_mask = valid_cpu_mask;
+    out->performance_cluster_mask = valid_cpu_mask;
+    out->efficiency_cluster_mask = 0U;
     out->smp_available = (discovered > 1U);
     out->homogeneous_cores = true;
     return true;

--- a/hal/include/hal/hal_cpu_topology.h
+++ b/hal/include/hal/hal_cpu_topology.h
@@ -10,6 +10,9 @@ extern "C" {
 
 typedef struct {
     uint32_t discovered_cpu_count;
+    uint32_t valid_cpu_mask;
+    uint32_t performance_cluster_mask;
+    uint32_t efficiency_cluster_mask;
     bool smp_available;
     bool homogeneous_cores;
 } hal_cpu_topology_info_t;

--- a/kernel/include/hal/hal_cpu_topology.h
+++ b/kernel/include/hal/hal_cpu_topology.h
@@ -10,6 +10,9 @@ extern "C" {
 
 typedef struct {
     uint32_t discovered_cpu_count;
+    uint32_t valid_cpu_mask;
+    uint32_t performance_cluster_mask;
+    uint32_t efficiency_cluster_mask;
     bool smp_available;
     bool homogeneous_cores;
 } hal_cpu_topology_info_t;

--- a/platform/common/platform_cpu_topology.c
+++ b/platform/common/platform_cpu_topology.c
@@ -11,6 +11,9 @@ __attribute__((weak)) bool hal_cpu_topology_query(hal_cpu_topology_info_t *out) 
     }
 
     out->discovered_cpu_count = 1;
+    out->valid_cpu_mask = 0x1U;
+    out->performance_cluster_mask = out->valid_cpu_mask;
+    out->efficiency_cluster_mask = 0U;
     out->smp_available = false;
     out->homogeneous_cores = true;
 

--- a/services/core/subsysmgr/include/subsys.h
+++ b/services/core/subsysmgr/include/subsys.h
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 #include "../../kernel/include/capability.h"
+#include "hal/hal_cpu_topology.h"
 
 /*
  * Bharat-OS Subsystem Abstraction Interface
@@ -26,6 +27,24 @@ typedef enum {
     EXECUTION_MODE_TESTING = 3
 } subsys_exec_mode_t;
 
+typedef enum {
+    SUBSYS_ALLOC_DEFAULT = 0,
+    SUBSYS_ALLOC_PACKED = 1,
+    SUBSYS_ALLOC_SPREAD = 2,
+} subsys_alloc_policy_t;
+
+typedef enum {
+    SUBSYS_CLUSTER_PREFERENCE_NONE = 0,
+    SUBSYS_CLUSTER_PREFERENCE_PERFORMANCE = 1,
+    SUBSYS_CLUSTER_PREFERENCE_EFFICIENCY = 2,
+} subsys_cluster_preference_t;
+
+typedef struct {
+    subsys_alloc_policy_t policy;
+    uint32_t preferred_cpu_mask;
+    subsys_cluster_preference_t cluster_preference;
+} subsys_alloc_config_t;
+
 typedef struct {
     uint32_t subsys_id;
     subsys_type_t type;
@@ -33,7 +52,9 @@ typedef struct {
 
     // Limits and Configuration
     uint64_t memory_limit_mb;
+    uint32_t requested_cpu_mask;
     uint32_t cpu_core_allocation_mask;
+    subsys_alloc_config_t alloc_config;
 
     // The root capability representing this subsystem's isolated domain.
     uint32_t root_domain_cap;
@@ -42,8 +63,16 @@ typedef struct {
     int is_running;
 } subsys_instance_t;
 
+uint32_t subsys_resolve_effective_cpu_mask(
+    const hal_cpu_topology_info_t* topology,
+    uint32_t requested_mask,
+    const subsys_alloc_config_t* config
+);
+
 // API to spawn a new subsystem instance
 int subsys_create(subsys_type_t type, subsys_exec_mode_t mode, subsys_instance_t* out_instance);
+int subsys_create_with_config(subsys_type_t type, subsys_exec_mode_t mode, const subsys_alloc_config_t* cfg, subsys_instance_t* out_instance);
+int subsys_set_alloc_config(subsys_instance_t* instance, const subsys_alloc_config_t* cfg);
 
 // Load the root filesystem or executable environment for the subsystem
 int subsys_load_env(subsys_instance_t* instance, const char* root_path);

--- a/services/core/subsysmgr/manager.c
+++ b/services/core/subsysmgr/manager.c
@@ -4,43 +4,165 @@
 #include "../../../personalities/compat/linux/linux_compat.h"
 #include "../../../personalities/compat/windows/win_compat.h"
 
-static uint32_t subsys_allowed_cpu_mask(void) {
-    hal_cpu_topology_info_t topology = {0};
-    uint32_t discovered = 1U;
-    if (hal_cpu_topology_query(&topology) && topology.discovered_cpu_count > 0U) {
-        discovered = topology.discovered_cpu_count;
+static uint32_t mask_for_cpu_count(uint32_t count) {
+    if (count == 0U) {
+        return 0U;
     }
+    if (count >= 32U) {
+        return UINT32_MAX;
+    }
+    return (1U << count) - 1U;
+}
+
+static uint32_t popcount32(uint32_t value) {
+    uint32_t count = 0U;
+    while (value != 0U) {
+        value &= (value - 1U);
+        count++;
+    }
+    return count;
+}
+
+static uint32_t pick_lowest_n(uint32_t eligible_mask, uint32_t n) {
+    uint32_t selected = 0U;
+    for (uint32_t cpu = 0U; cpu < 32U && n > 0U; ++cpu) {
+        uint32_t bit = (1U << cpu);
+        if ((eligible_mask & bit) != 0U) {
+            selected |= bit;
+            n--;
+        }
+    }
+    return selected;
+}
+
+static uint32_t pick_spread_n(uint32_t eligible_mask, uint32_t n) {
+    uint8_t cpus[32];
+    uint32_t cpu_count = 0U;
+    for (uint32_t cpu = 0U; cpu < 32U; ++cpu) {
+        uint32_t bit = (1U << cpu);
+        if ((eligible_mask & bit) != 0U) {
+            cpus[cpu_count++] = (uint8_t)cpu;
+        }
+    }
+    if (cpu_count == 0U || n == 0U) {
+        return 0U;
+    }
+    if (n >= cpu_count) {
+        return eligible_mask;
+    }
+
+    uint32_t selected = 0U;
+    uint32_t denom = n - 1U;
+    uint32_t numer = cpu_count - 1U;
+    for (uint32_t i = 0U; i < n; ++i) {
+        uint32_t index = (denom == 0U) ? 0U : (i * numer) / denom;
+        selected |= (1U << cpus[index]);
+    }
+    return selected;
+}
+
+static subsys_alloc_config_t subsys_default_alloc_config(void) {
+    subsys_alloc_config_t cfg;
+    cfg.policy = SUBSYS_ALLOC_DEFAULT;
+    cfg.preferred_cpu_mask = 0U;
+    cfg.cluster_preference = SUBSYS_CLUSTER_PREFERENCE_NONE;
+    return cfg;
+}
+
+uint32_t subsys_resolve_effective_cpu_mask(
+    const hal_cpu_topology_info_t* topology,
+    uint32_t requested_mask,
+    const subsys_alloc_config_t* config
+) {
+    hal_cpu_topology_info_t local_topology = {0};
+    if (!topology) {
+        local_topology.discovered_cpu_count = 1U;
+        local_topology.valid_cpu_mask = 0x1U;
+        local_topology.performance_cluster_mask = local_topology.valid_cpu_mask;
+        local_topology.efficiency_cluster_mask = 0U;
+        local_topology.homogeneous_cores = true;
+        local_topology.smp_available = false;
+        topology = &local_topology;
+    }
+
+    uint32_t discovered = topology->discovered_cpu_count;
     if (discovered > 32U) {
         discovered = 32U;
     }
-
-    if (discovered == 32U) {
-        return UINT32_MAX;
+    uint32_t valid_mask = topology->valid_cpu_mask;
+    if (valid_mask == 0U) {
+        valid_mask = mask_for_cpu_count(discovered);
     }
-    return (1U << discovered) - 1U;
+
+    if (valid_mask == 0U) {
+        return 0U;
+    }
+
+    subsys_alloc_config_t effective_cfg = config ? *config : subsys_default_alloc_config();
+    uint32_t sanitized_requested = requested_mask & valid_mask;
+    uint32_t target_count = popcount32(sanitized_requested);
+    if (target_count == 0U) {
+        target_count = 1U;
+    }
+
+    uint32_t eligible_mask = sanitized_requested;
+    if (eligible_mask == 0U) {
+        eligible_mask = valid_mask;
+    }
+
+    if (effective_cfg.cluster_preference == SUBSYS_CLUSTER_PREFERENCE_PERFORMANCE) {
+        uint32_t perf_mask = topology->performance_cluster_mask & valid_mask;
+        if (perf_mask != 0U) {
+            uint32_t preferred = eligible_mask & perf_mask;
+            if (preferred != 0U) {
+                eligible_mask = preferred;
+            }
+        }
+    } else if (effective_cfg.cluster_preference == SUBSYS_CLUSTER_PREFERENCE_EFFICIENCY) {
+        uint32_t eff_mask = topology->efficiency_cluster_mask & valid_mask;
+        if (eff_mask != 0U) {
+            uint32_t preferred = eligible_mask & eff_mask;
+            if (preferred != 0U) {
+                eligible_mask = preferred;
+            }
+        }
+    }
+
+    uint32_t eligible_count = popcount32(eligible_mask);
+    if (target_count > eligible_count) {
+        target_count = eligible_count;
+    }
+
+    switch (effective_cfg.policy) {
+        case SUBSYS_ALLOC_SPREAD:
+            return pick_spread_n(eligible_mask, target_count);
+        case SUBSYS_ALLOC_DEFAULT:
+        case SUBSYS_ALLOC_PACKED:
+        default:
+            return pick_lowest_n(eligible_mask, target_count);
+    }
 }
 
-static uint32_t subsys_effective_cpu_mask(uint32_t requested_mask) {
-    uint32_t allowed_mask = subsys_allowed_cpu_mask();
-
-    uint32_t effective = requested_mask & allowed_mask;
-    if (effective == 0U) {
-        effective = 0x1U;
+static uint32_t subsys_effective_cpu_mask(uint32_t requested_mask, const subsys_alloc_config_t* cfg) {
+    hal_cpu_topology_info_t topology = {0};
+    if (!hal_cpu_topology_query(&topology)) {
+        return subsys_resolve_effective_cpu_mask(NULL, requested_mask, cfg);
     }
-
-    return effective;
+    return subsys_resolve_effective_cpu_mask(&topology, requested_mask, cfg);
 }
 
 static uint32_t next_subsys_id = 1;
 
-int subsys_create(subsys_type_t type, subsys_exec_mode_t mode, subsys_instance_t* out_instance) {
+int subsys_create_with_config(subsys_type_t type, subsys_exec_mode_t mode, const subsys_alloc_config_t* cfg, subsys_instance_t* out_instance) {
     if (!out_instance) return -1;
 
     out_instance->subsys_id = next_subsys_id++;
     out_instance->type = type;
     out_instance->exec_mode = mode;
     out_instance->memory_limit_mb = 0;
-    out_instance->cpu_core_allocation_mask = subsys_effective_cpu_mask(0U);
+    out_instance->alloc_config = cfg ? *cfg : subsys_default_alloc_config();
+    out_instance->requested_cpu_mask = out_instance->alloc_config.preferred_cpu_mask;
+    out_instance->cpu_core_allocation_mask = subsys_effective_cpu_mask(out_instance->requested_cpu_mask, &out_instance->alloc_config);
     out_instance->is_running = 0;
 
     switch (type) {
@@ -53,6 +175,25 @@ int subsys_create(subsys_type_t type, subsys_exec_mode_t mode, subsys_instance_t
     }
 }
 
+int subsys_create(subsys_type_t type, subsys_exec_mode_t mode, subsys_instance_t* out_instance) {
+    return subsys_create_with_config(type, mode, NULL, out_instance);
+}
+
+int subsys_set_alloc_config(subsys_instance_t* instance, const subsys_alloc_config_t* cfg) {
+    if (!instance || !cfg) {
+        return -1;
+    }
+    if (instance->is_running) {
+        return -2;
+    }
+
+    instance->alloc_config = *cfg;
+    instance->requested_cpu_mask = cfg->preferred_cpu_mask;
+    instance->cpu_core_allocation_mask =
+        subsys_effective_cpu_mask(instance->requested_cpu_mask, &instance->alloc_config);
+    return 0;
+}
+
 int subsys_load_env(subsys_instance_t* instance, const char* root_path) {
     if (!instance || !root_path) return -1;
     return 0;
@@ -62,7 +203,7 @@ int subsys_start(subsys_instance_t* instance) {
     if (!instance) return -1;
 
     instance->cpu_core_allocation_mask =
-        subsys_effective_cpu_mask(instance->cpu_core_allocation_mask);
+        subsys_effective_cpu_mask(instance->requested_cpu_mask, &instance->alloc_config);
 
     if (instance->exec_mode == EXECUTION_MODE_TESTING) {
         const char *subsys_name = "unknown";

--- a/tests/test_subsys_manager.c
+++ b/tests/test_subsys_manager.c
@@ -48,12 +48,89 @@ static void test_subsys_destroy_on_stopped_instance_is_safe(void) {
     printf("[PASS] test_subsys_destroy_on_stopped_instance_is_safe\n");
 }
 
+static hal_cpu_topology_info_t topo_homogeneous(uint32_t cpu_count) {
+    hal_cpu_topology_info_t topo = {0};
+    topo.discovered_cpu_count = cpu_count;
+    topo.valid_cpu_mask = (cpu_count >= 32U) ? UINT32_MAX : ((cpu_count == 0U) ? 0U : ((1U << cpu_count) - 1U));
+    topo.performance_cluster_mask = topo.valid_cpu_mask;
+    topo.efficiency_cluster_mask = 0U;
+    topo.smp_available = (cpu_count > 1U);
+    topo.homogeneous_cores = true;
+    return topo;
+}
+
+static void test_mask_sanitization_and_defaults(void) {
+    subsys_alloc_config_t cfg = {
+        .policy = SUBSYS_ALLOC_PACKED,
+        .preferred_cpu_mask = 0U,
+        .cluster_preference = SUBSYS_CLUSTER_PREFERENCE_NONE,
+    };
+
+    hal_cpu_topology_info_t topo1 = topo_homogeneous(1U);
+    assert(subsys_resolve_effective_cpu_mask(&topo1, 0U, &cfg) == 0x1U);
+    assert(subsys_resolve_effective_cpu_mask(&topo1, 0xFFFFFFFFU, &cfg) == 0x1U);
+
+    hal_cpu_topology_info_t topo4 = topo_homogeneous(4U);
+    assert(subsys_resolve_effective_cpu_mask(&topo4, 0U, &cfg) == 0x1U);
+    assert(subsys_resolve_effective_cpu_mask(&topo4, 1U << 9, &cfg) == 0x1U);
+    assert(subsys_resolve_effective_cpu_mask(&topo4, 0xFFFFFFFFU, &cfg) == 0xFU);
+    assert((subsys_resolve_effective_cpu_mask(&topo4, 0xAAAAAAAAU, &cfg) & ~topo4.valid_cpu_mask) == 0U);
+    printf("[PASS] test_mask_sanitization_and_defaults\n");
+}
+
+static void test_packed_and_spread_determinism(void) {
+    hal_cpu_topology_info_t topo8 = topo_homogeneous(8U);
+    uint32_t requested = 0xFFU;
+
+    subsys_alloc_config_t packed_cfg = {
+        .policy = SUBSYS_ALLOC_PACKED,
+        .preferred_cpu_mask = requested,
+        .cluster_preference = SUBSYS_CLUSTER_PREFERENCE_NONE,
+    };
+    subsys_alloc_config_t spread_cfg = packed_cfg;
+    spread_cfg.policy = SUBSYS_ALLOC_SPREAD;
+
+    uint32_t packed = subsys_resolve_effective_cpu_mask(&topo8, requested, &packed_cfg);
+    uint32_t spread = subsys_resolve_effective_cpu_mask(&topo8, requested, &spread_cfg);
+    assert(packed == requested);
+    assert(spread == requested);
+    assert(subsys_resolve_effective_cpu_mask(&topo8, requested, &spread_cfg) == spread);
+    printf("[PASS] test_packed_and_spread_determinism\n");
+}
+
+static void test_cluster_preferences_and_fallbacks(void) {
+    hal_cpu_topology_info_t topo = topo_homogeneous(8U);
+    topo.performance_cluster_mask = 0xF0U;
+    topo.efficiency_cluster_mask = 0x0FU;
+    topo.homogeneous_cores = false;
+
+    subsys_alloc_config_t perf_cfg = {
+        .policy = SUBSYS_ALLOC_PACKED,
+        .preferred_cpu_mask = 0U,
+        .cluster_preference = SUBSYS_CLUSTER_PREFERENCE_PERFORMANCE,
+    };
+    subsys_alloc_config_t eff_cfg = perf_cfg;
+    eff_cfg.cluster_preference = SUBSYS_CLUSTER_PREFERENCE_EFFICIENCY;
+
+    assert(subsys_resolve_effective_cpu_mask(&topo, 0U, &perf_cfg) == 0x10U);
+    assert(subsys_resolve_effective_cpu_mask(&topo, 0U, &eff_cfg) == 0x01U);
+
+    topo.performance_cluster_mask = 0U;
+    topo.efficiency_cluster_mask = 0U;
+    assert(subsys_resolve_effective_cpu_mask(&topo, 0U, &perf_cfg) == 0x01U);
+    assert(subsys_resolve_effective_cpu_mask(&topo, 0U, &eff_cfg) == 0x01U);
+    printf("[PASS] test_cluster_preferences_and_fallbacks\n");
+}
+
 int main(void) {
     printf("Running Subsystem Manager tests...\n");
 
     test_subsys_destroy_null_returns_error();
     test_subsys_destroy_stops_running_instance();
     test_subsys_destroy_on_stopped_instance_is_safe();
+    test_mask_sanitization_and_defaults();
+    test_packed_and_spread_determinism();
+    test_cluster_preferences_and_fallbacks();
 
     printf("Subsystem Manager tests passed successfully.\n");
     return 0;


### PR DESCRIPTION
### Motivation

- Provide a clear HAL → policy boundary for CPU topology and enable per-subsystem placement policies (packed/spread and cluster preference) so subsystem placement is topology-aware and testable.
- Make placement a pure, testable function that maps (topology, requested mask, policy) → effective mask and avoid policy logic leaking into HAL/platform.

### Description

- Extended the CPU topology contract (`hal_cpu_topology_info_t`) with `valid_cpu_mask`, `performance_cluster_mask`, and `efficiency_cluster_mask` in both HAL headers and populated them in the platform fallback and discovery paths with conservative defaults and 32-CPU clamping.
- Added subsystem allocation primitives: `subsys_alloc_policy_t`, `subsys_cluster_preference_t`, and `subsys_alloc_config_t`, persisted allocation config in `subsys_instance_t`, and introduced `subsys_create_with_config()` plus `subsys_set_alloc_config()` APIs.
- Implemented a pure resolver `subsys_resolve_effective_cpu_mask(...)` that sanitizes requested masks, applies cluster preference, and selects CPUs deterministically for `PACKED` (lowest N) and `SPREAD` (even distribution); wired create/start paths to use the resolver.
- Added unit-style tests in `tests/test_subsys_manager.c` to cover edge masks (zero, out-of-range, full-mask), packed vs spread determinism, and performance/efficiency cluster preference fallbacks.

### Testing

- Ran configuration and host build: `cmake -S . -B build-host -G Ninja` and `cmake --build build-host -j4`, both succeeded.
- Queried test listing with `cd build-host && ctest -N` (listed configured tests; no host-run of `test_subsys_manager` in that invocation).
- Built and exercised the full desktop headless image with `./build.sh all --target x86_64_desktop_headless`; QEMU booted headless and kernel runtime selftests executed (most passed; one runtime selftest reported a failure: `EDF Admission & Sorting` expected behavior mismatch was observed).
- Built the ARM headless target with `./build.sh build --target arm64_desktop_headless` and launched it with `./build.sh run --target arm64_desktop_headless`; the headless QEMU run produced serial output (run is long-running and was not terminated automatically during the automated run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6fb7137d08320aa853d36bb740707)