### PR TITLE
docs(storage): make storage architecture governance-grade and add canonical sandbox policy

### DIFF
--- a/docs/architecture/storage-and-sandbox-strategy.md
+++ b/docs/architecture/storage-and-sandbox-strategy.md
@@ -1,6 +1,6 @@
 # Storage & Filesystem Strategy (Advanced)
 
-> Consolidation note: normative storage/filesystem architecture now lives in `docs/architecture/storage/`. This document remains as an advanced strategy companion.
+> Consolidation note: normative storage/filesystem architecture now lives in `docs/architecture/storage/` (`vfs-and-filesystem-architecture.md`, `file-system-detailed-design.md`, `sandbox-policy.md`, `roadmap.md`). This document remains an advanced strategy companion for long-horizon ideas and must not be read as current-state or normative contract.
 
 ## Goals
 

--- a/docs/architecture/storage/README.md
+++ b/docs/architecture/storage/README.md
@@ -1,19 +1,27 @@
-# Storage & Filesystem Architecture (Consolidated Index)
+# Storage & Filesystem Architecture (Canonical Index)
 
 This directory is the **canonical home** for Bharat-OS storage and filesystem architecture.
 
-## Documents
+## Canonical documents
 
-- [`vfs-and-filesystem-architecture.md`](vfs-and-filesystem-architecture.md): normative architecture contract and layering.
-- [`file-system-detailed-design.md`](file-system-detailed-design.md): implementation-aligned deep dive mapped to current code.
-- [`roadmap.md`](roadmap.md): phased roadmap with code/doc alignment checkpoints.
+- [`vfs-and-filesystem-architecture.md`](vfs-and-filesystem-architecture.md): **normative contract** (ownership, boundaries, allowlists).
+- [`file-system-detailed-design.md`](file-system-detailed-design.md): **current implementation state** (what is real/partial/transitional now).
+- [`sandbox-policy.md`](sandbox-policy.md): **canonical sandbox policy** for namespace/path/storage-class controls.
+- [`roadmap.md`](roadmap.md): **future delivery sequence** and platform gates.
+
+## Reading order
+
+1. Start with the contract.
+2. Validate current state in detailed design.
+3. Apply sandbox policy constraints.
+4. Use roadmap for planned changes.
 
 ## Consolidation note
 
-The following older architecture notes discussed overlapping topics and are now consolidated here:
+Older architecture notes discussed overlapping topics and are now subordinate to this folder for storage/filesystem boundaries:
 
 - `docs/architecture/vfs-storage-architecture.md`
 - `docs/architecture/storage-and-sandbox-strategy.md`
 - `docs/architecture/profile-driven-storage-network-subsystems.md` (storage portions)
 
-When content conflicts, this folder should be treated as source of truth for storage/filesystem boundaries and delivery sequence.
+When content conflicts, this folder is source of truth.

--- a/docs/architecture/storage/file-system-detailed-design.md
+++ b/docs/architecture/storage/file-system-detailed-design.md
@@ -1,93 +1,91 @@
-# Storage and Filesystem Detailed Design (Code-Aligned)
+# Storage and Filesystem Detailed Design (Current Implementation State)
 
-## 1. Scope and intent
+## 1. Purpose
 
-This document maps storage/filesystem design to **current code** and records what is real, partial, or planned.
+This document is **descriptive**: it captures current code reality, including partial implementations and transitional duplication.
+
+It is not a normative boundary spec. Normative rules live in `vfs-and-filesystem-architecture.md`.
 
 ---
 
-## 2. Implementation map
+## 2. Current implementation map
 
 ## 2.1 Filesystem service (`services/system/filesystem/`)
 
 - `main.c`
-  - selects profile at build/runtime macro level,
-  - reads block geometry via `block_get_info`,
-  - resolves storage policy via `storage_profile_resolve`,
-  - initializes cache via `cache_init_with_profile`.
+  - profile-aware startup path,
+  - block geometry lookup (`block_get_info`),
+  - policy/profile resolution (`storage_profile_resolve`),
+  - cache initialization (`cache_init_with_profile`).
 - `fd_mgr.c`
-  - owns open-file table,
-  - enforces capability-aware checks for open/read/write/close,
-  - keeps `openat` in limited transitional mode (`AT_FDCWD`-style fallback only).
-- `vfs_stub.c`
-  - service-side driver registry helpers and path-prefix helpers.
+  - open-file table lifecycle,
+  - capability-aware checks on open/read/write/close,
+  - limited transitional `openat` behavior (fallback-focused subset).
+- `mount_mgr.c`, `namespace_mgr.c`, `vfs_stub.c`
+  - service-side mount/namespace and VFS helper scaffolding.
 
 ## 2.2 Storage stack (`stacks/storage/`)
 
 - `block/block.c`
-  - validates request, routes to virtio-blk path for device 0,
-  - handles flush request as explicit semantic.
+  - normalized request validation/routing,
+  - read/write/flush request semantics.
 - `cache/cache.c`
-  - fixed-size global cache entries with profile-sized active capacity,
-  - lookup + victim selection,
-  - dirty block writeback and device flush in `cache_sync`.
+  - bounded cache entries,
+  - dirty tracking and writeback,
+  - explicit sync/flush path.
 - `profile.c`
-  - profile resolver with device-size thresholds and arch clamping,
-  - backend/cache/queue depth strategy,
-  - string helpers for reporting.
+  - profile resolver (app profile + device + architecture signals),
+  - backend/cache/queue-depth policy shaping.
 - `fs/adapter.c`
-  - lightweight adapter registration and lookup.
+  - adapter registry and lookup.
 - `fs/ramfs/ramfs.c`
-  - concrete page-backed RAMFS implementation with block-table growth.
+  - strongest concrete backend path currently in-tree.
 - `fs/blob/blob_backend.c`
-  - explicit compatibility placeholder returning service-required errors.
+  - compatibility placeholder (not production blob backend).
 
-## 2.3 Kernel fs boundary (`kernel/src/fs/`)
+## 2.3 Kernel FS boundary (`kernel/src/fs`, `kernel/include/fs`)
 
-- Contains compatibility units that intentionally return service-required status, preserving build/ABI continuity while policy migrates out of kernel.
-- `kernel/include/fs/` remains important as shared contract surface for FS/VFS objects and operations.
+- Mixed transitional state remains:
+  - `kernel/include/fs/*` provides shared contracts/types.
+  - `kernel/src/fs/*` still contains compatibility-oriented behavior in some units.
 
-## 2.4 Client boundary (`lib/fs/`)
+## 2.4 Client boundary (`lib/fs`)
 
-- `fs_client` forwards operations to filesystem service symbols and acts as migration boundary for callers.
-
----
-
-## 3. What is aligned now
-
-1. **Profile-aware initialization exists in the service startup path.**
-2. **Cache/writeback/flush scaffolding exists and is callable from service flow.**
-3. **Filesystem adapter boundary exists (`adapter.c`) with concrete RAMFS backend present.**
-4. **Driver side includes both virtio-blk and NVMe implementation baselines.**
-5. **Capability-aware checks are present in active file operation path.**
+- `fs_client` forwards operations toward filesystem service paths and remains a migration boundary for callers.
 
 ---
 
-## 4. Known mismatches and debt
+## 3. Hybrid-state reality (explicit)
 
-1. **Hybrid ownership remains:** some VFS-related behavior is still available in multiple transitional locations.
-2. **Service API coverage is incomplete:** no full syscall/IPC-complete `openat/read/write/stat/mkdir/unlink/rename` route set yet.
-3. **Persistent FS adapters are not production-complete:** RAMFS is strongest concrete path today.
-4. **Blob backend is contract placeholder only.**
-5. **Kernel-to-service cutover is not fully complete for all consumers/tests.**
+Current tree remains hybrid by design during migration:
 
----
-
-## 5. Documentation contract for contributors
-
-When changing storage/filesystem code, contributors should keep these invariants:
-
-- Do not move policy-rich namespace/mount behavior back into kernel internals.
-- Keep driver code free of path/permission/POSIX policy logic.
-- Route new profile decisions through `stacks/storage/profile.c` and consume them from service startup/config paths.
-- Use `lib/fs/fs_client.*` as boundary for clients while transport evolves.
+1. Service path already performs meaningful FD operations.
+2. Kernel FS transitional path still exists for compatibility continuity.
+3. Duplicate/overlapping symbol ownership patterns still exist in some areas.
+4. Service API surface is incomplete for a full POSIX-complete route set.
 
 ---
 
-## 6. Relationship to roadmap
+## 4. Known gaps and technical debt
 
-Delivery phases, priorities, and completion criteria are tracked in:
+1. **Ownership cleanup debt**
+   - duplicate transitional ownership patterns still need collapse.
+2. **Service request coverage gap**
+   - not all operations (`openat/read/write/stat/mkdir/unlink/rename`) are complete end-to-end through service boundary.
+3. **Persistent backend maturity gap**
+   - RAMFS is currently the strongest concrete backend path.
+4. **Blob backend maturity gap**
+   - blob backend remains placeholder compatibility surface.
+5. **Cutover completeness gap**
+   - not all tests/consumers are fully migrated to clean service-owned paths.
 
-- [`roadmap.md`](roadmap.md)
+---
 
-This detailed design document should be updated alongside roadmap status changes whenever storage/filesystem behavior changes materially.
+## 5. Contributor guidance for implementation updates
+
+When code changes storage/filesystem behavior:
+
+- keep this document reality-based (shipped/partial/stubbed only),
+- move normative boundary changes to `vfs-and-filesystem-architecture.md`,
+- move future plans to `roadmap.md`,
+- keep sandbox-policy semantics aligned with `sandbox-policy.md`.

--- a/docs/architecture/storage/roadmap.md
+++ b/docs/architecture/storage/roadmap.md
@@ -1,4 +1,4 @@
-# Storage & Filesystem Roadmap (Code + Docs Alignment)
+# Storage & Filesystem Roadmap (Delivery Sequencing)
 
 ## Status legend
 
@@ -8,14 +8,27 @@
 
 ---
 
+## Platform gate policy (must hold)
+
+Storage phases are gated by broader platform readiness:
+
+1. **Capability baseline gate**
+   - No Phase 2 persistent-FS expansion without baseline capability enforcement for service-owned FS policy.
+2. **Service runtime maturity gate**
+   - No Phase 3 blob/object activation without service runtime/event-loop maturity for reliable policy and request handling.
+3. **Memory authority-path gate**
+   - No Phase 4 performance/NUMA push without memory authority-path hardening sufficient for safe scale features.
+
+---
+
 ## Phase 0 — Baseline consolidation (Done)
 
 - [x] Consolidate storage/filesystem architecture docs under `docs/architecture/storage/`.
-- [x] Record repository-aligned architecture contract.
-- [x] Record current hybrid migration state (kernel shim + service path).
+- [x] Separate canonical document roles: contract, current-state design, roadmap.
+- [x] Add canonical sandbox policy under storage architecture folder.
 
 Exit criteria:
-- storage architecture readers can find canonical docs in one folder.
+- storage architecture readers can find canonical boundary, state, policy, and roadmap docs in one folder.
 
 ---
 
@@ -40,33 +53,45 @@ Exit criteria:
 
 ---
 
-## Phase 2 — Persistent filesystem maturity (Planned)
+## Phase 2 — Persistent filesystem maturity (Planned; gated)
 
 - [ ] keep RAMFS for early boot/tests, add persistent adapter track (FAT/littlefs/ext-like baseline by profile).
 - [ ] add mount capability negotiation against backend feature descriptors.
 - [ ] strengthen crash-consistency behavior (write ordering + sync semantics by policy).
+
+Gate to enter Phase 2:
+- capability baseline gate satisfied.
 
 Exit criteria:
 - at least one persistent filesystem backend available and test-covered per non-volatile profile class.
 
 ---
 
-## Phase 3 — Blob/object and policy hardening (Planned)
+## Phase 3 — Blob/object and policy hardening (Planned; gated)
 
 - [ ] replace blob backend placeholder with working object path.
 - [ ] enforce storage-class restrictions (fs/block/blob) from capability policy.
 - [ ] define staged write + commit semantics for object backend.
 
+**Maturity note:** URI-backed mounts, remote providers, and staged-write commit/rename flows are Phase 3 targets only; they are not current runtime maturity claims.
+
+Gate to enter Phase 3:
+- service runtime maturity gate satisfied.
+
 Exit criteria:
-- blob backend is usable for read flow with capability enforcement.
+- blob backend usable for read path with capability enforcement;
+- write path staged/commit semantics validated for declared scope.
 
 ---
 
-## Phase 4 — Performance and scale features (Planned)
+## Phase 4 — Performance and scale features (Planned; gated)
 
 - [ ] deepen queue and completion model (virtio/NVMe multi-queue maturity).
 - [ ] integrate NUMA locality behavior behind profile toggles where supported.
 - [ ] add stress/fault-injection coverage for cache, flush, and recovery paths.
+
+Gate to enter Phase 4:
+- memory authority-path gate satisfied.
 
 Exit criteria:
 - measurable throughput/latency improvements under profile-appropriate workloads with repeatable test evidence.
@@ -77,6 +102,10 @@ Exit criteria:
 
 For every storage/filesystem PR:
 
-1. Verify `docs/architecture/storage/*.md` reflects changed ownership/boundary behavior.
-2. If interfaces in `kernel/include/fs`, `stacks/include/bharat/stacks/storage`, or `lib/fs` change, update architecture contract text in same PR.
+1. Update the right document type:
+   - contract changes → `vfs-and-filesystem-architecture.md`
+   - current-state changes → `file-system-detailed-design.md`
+   - future sequencing changes → `roadmap.md`
+   - sandbox-policy changes → `sandbox-policy.md`
+2. If interfaces in `kernel/include/fs`, `stacks/include/bharat/stacks/storage`, or `lib/fs` change, update contract text in same PR.
 3. Keep transitional claims explicit; do not document planned behavior as shipped.

--- a/docs/architecture/storage/sandbox-policy.md
+++ b/docs/architecture/storage/sandbox-policy.md
@@ -1,0 +1,104 @@
+# Storage Sandbox Policy (Canonical)
+
+## 1. Purpose
+
+This document defines canonical storage/filesystem sandbox policy for Bharat-OS.
+
+It complements the normative storage architecture contract and centralizes policy that was previously scattered in strategy notes.
+
+---
+
+## 2. Policy dimensions
+
+Every sandbox context is evaluated across three dimensions:
+
+1. **Namespace view**
+   - which mount roots are visible.
+2. **Path rights**
+   - per-prefix rights: `read`, `write`, `exec`, `create`, `delete`, `metadata`.
+3. **Storage-class rights**
+   - whether `filesystem`, `block`, and `blob` classes are allowed.
+
+---
+
+## 3. Path-right matrix model
+
+Policy evaluation should follow this order:
+
+1. resolve caller sandbox context,
+2. resolve namespace visibility for target path,
+3. resolve path-prefix rights,
+4. resolve storage-class permission,
+5. enforce mount flags and descriptor provenance constraints.
+
+Deny by default when any step is unresolved.
+
+---
+
+## 4. Storage-class policy baseline
+
+### Filesystem class
+
+- allowed when sandbox grants filesystem access for the namespace/path.
+
+### Raw block class
+
+- denied by default.
+- explicit grant required for any raw block access.
+
+### Blob/object class
+
+- read may be granted independently of write.
+- write must be explicitly scoped to approved buckets/prefixes.
+
+---
+
+## 5. Mount token concept
+
+Mount operations should be capability-anchored with structured mount tokens carrying at minimum:
+
+- allowed namespace/path scope,
+- storage-class constraints,
+- allowed mount flags,
+- optional TTL/expiry and issuer identity.
+
+Tokens are evaluated by filesystem service policy before mount admission.
+
+---
+
+## 6. Descriptor provenance
+
+File descriptors should carry provenance sufficient to verify:
+
+- namespace source,
+- mount identity/policy context,
+- storage-class lineage,
+- rights envelope at open time.
+
+Policy checks for sensitive operations must consider descriptor provenance, not only pathname re-resolution.
+
+---
+
+## 7. Recommended default restrictions
+
+For writable app-facing mounts, default to restrictive baseline:
+
+- `noexec`
+- `nodev`
+- `nosuid`
+
+Additional hardening defaults:
+
+- deny raw block unless explicitly needed,
+- default blob writes to deny,
+- allow only minimal required path prefixes.
+
+---
+
+## 8. Relationship to roadmap phases
+
+- Phase 1: baseline capability-aware path checks and service-owned enforcement.
+- Phase 2: stronger mount admission and persistent backend policy integration.
+- Phase 3: full blob/object policy semantics with staged-write/commit governance.
+
+Roadmap sequencing and delivery gates live in `roadmap.md`.

--- a/docs/architecture/storage/vfs-and-filesystem-architecture.md
+++ b/docs/architecture/storage/vfs-and-filesystem-architecture.md
@@ -1,128 +1,114 @@
-# Storage and Filesystem Architecture Contract (Repository-Aligned)
+# Storage and Filesystem Architecture Contract (Normative)
 
-## 1. Purpose
+## 1. Purpose and scope
 
-This document defines the **current authoritative architecture** for storage and filesystem behavior in Bharat-OS, aligned to code in:
+This document is the **normative contract** for storage/filesystem ownership and boundaries in Bharat-OS.
 
-- `services/system/filesystem/`
-- `stacks/storage/`
-- `drivers/block/` and `drivers/storage/`
-- `kernel/src/fs/` and `kernel/include/fs/`
-- `lib/fs/`
+It defines what is **allowed**, **forbidden**, and **owned** by each layer. It does **not** describe implementation maturity or roadmap sequencing.
 
-It intentionally separates:
-
-- **What exists today** (implemented or stubbed), and
-- **What is target architecture** (phased roadmap).
+For implementation status, see `file-system-detailed-design.md`.
+For delivery sequencing, see `roadmap.md`.
+For sandbox policy details, see `sandbox-policy.md`.
 
 ---
 
-## 2. Layer model (current + target)
+## 2. Ownership matrix (canonical)
 
-### Layer A — Driver layer (hardware-facing)
-
-- `drivers/block/virtio_blk/`: block submission stub + init path.
-- `drivers/storage/nvme/`: NVMe controller init/admin queue baseline.
-
-**Contract:** no pathname parsing, no capability policy, no POSIX semantic ownership.
-
-### Layer B — Storage stack primitives
-
-- `stacks/storage/block/`: generic block request API (`READ`, `WRITE`, `FLUSH`).
-- `stacks/storage/cache/`: bounded cache table with dirty tracking and flush path.
-- `stacks/storage/profile.c`: profile resolver for backend, cache, queue depth, journaling/NUMA toggles.
-- `stacks/storage/fs/adapter.c`: filesystem adapter registry.
-- `stacks/storage/fs/ramfs/`: concrete in-memory filesystem backend.
-- `stacks/storage/fs/blob/`: blob backend compatibility stub.
-
-**Contract:** reusable policy/mechanism helpers, but not user ABI ownership.
-
-### Layer C — Filesystem service
-
-- `services/system/filesystem/main.c`: service bootstrap with storage profile selection + cache init.
-- `services/system/filesystem/fd_mgr.c`: open/read/write/close table and capability-gated checks.
-- `services/system/filesystem/mount_mgr.c`, `namespace_mgr.c`, `vfs_stub.c`: service-side namespace/mount and VFS helper scaffolding.
-
-**Contract:** owns mount/namespace/file-descriptor policy and request dispatch behavior.
-
-### Layer D — Kernel compatibility surface (transitional)
-
-- `kernel/include/fs/*.h`: shared FS/VFS types and operation contracts.
-- `kernel/src/fs/*.c`: currently mixed state; some files are compatibility shims returning `K_ERR_REQUIRES_FS_SERVICE`.
-
-**Contract target:** kernel keeps only mechanism/ABI stubs required for safe transition; policy migrates to service.
-
-### Layer E — Client boundary
-
-- `lib/fs/fs_client.c`: fs client wrappers forwarding to filesystem-service symbols.
-
-**Contract:** call-site stable entrypoints while IPC transport matures.
+| Area | Primary ownership | Must do | Must not do |
+|---|---|---|---|
+| `drivers/block/*` | Block frontend engines | Consume normalized block requests, submit hardware-facing I/O | Path parsing, namespace logic, mount policy, POSIX permission semantics |
+| `drivers/storage/*` | Transport/controller specialization | Implement protocol/controller queueing and device management | Path policy, VFS policy, capability policy decisions |
+| `stacks/storage/*` | Reusable storage primitives | Provide block/cache/profile/backend adapter building blocks | Own user ABI contract or global namespace policy |
+| `services/system/filesystem/*` | Filesystem service policy | Own namespace, mount, FD lifecycle, capability-aware access policy, request dispatch | Push policy back into kernel internals |
+| `kernel/include/fs/*` | Shared kernel-service contract types | Define minimal shared ABI/type contracts needed by both sides | Encode namespace/mount/path policy |
+| `kernel/src/fs/*` | Transitional mechanism-only compatibility surface | Keep minimal dispatch/forwarding/error bridging while migration completes | Introduce new pathname, namespace, mount, or sandbox policy |
+| `lib/fs/*` | Client boundary | Provide stable client entrypoints while service IPC/runtime matures | Re-implement service policy logic |
 
 ---
 
-## 3. Current reality check (important)
+## 3. Layer contract
 
-The repository is in a **hybrid migration state**:
+### Layer A — Drivers (`drivers/block`, `drivers/storage`)
 
-1. **Service path exists and performs real work for FD operations.**
-2. **Kernel fs path still exists** and contains transitional compatibility shims in some units.
-3. **Dual symbol patterns remain** (`vfs_*`-style behaviors in multiple places), which is accepted short-term but must be collapsed.
-4. **Storage profile and cache wiring are present** in the service startup path.
+- Hardware/transport mechanism only.
+- No policy authority for namespace, mount, descriptor, or capability semantics.
 
-This is expected for current phase, but documentation and code must explicitly acknowledge the hybrid state to avoid architectural drift.
+### Layer B — Storage stack (`stacks/storage`)
 
----
+- Reusable mechanisms (block API, cache, profile resolution, backend adapters).
+- May encode tunable behavior, but not user-visible policy ownership.
 
-## 4. Capability and authority model
+### Layer C — Filesystem service (`services/system/filesystem`)
 
-Authority is capability-scoped. In current code paths, this is represented by:
+- Sole owner of:
+  - namespace visibility,
+  - mount policy,
+  - file descriptor lifecycle,
+  - capability interpretation for filesystem access.
 
-- capability checks when opening and operating files (`caller_cap`, rights masks, target object checks).
-- per-open file handle capability association in service FD tables.
-- transitional dummy capability fallbacks in compatibility wrappers.
+### Layer D — Kernel compatibility surface (`kernel/include/fs`, `kernel/src/fs`)
 
-**Hard rule:** no ambient authority assumptions in new storage/filesystem work.
+- Transitional surface only.
+- Kernel stays mechanism-oriented and migration-safe.
 
----
+### Layer E — Client boundary (`lib/fs`)
 
-## 5. Driver taxonomy rule (`drivers/block` vs `drivers/storage`)
-
-To keep current tree while reducing ambiguity:
-
-- `drivers/block/*`: frontend request engines that consume normalized block requests.
-- `drivers/storage/*`: transport/protocol-specialized storage controllers and queue managers.
-
-Both remain valid now, but future docs/code should keep this split explicit.
+- Stable call boundary for applications/components during transport/runtime migration.
+- Must remain thin and policy-neutral.
 
 ---
 
-## 6. Profile-driven policy baseline
+## 4. Kernel FS transitional allowlist (normative)
 
-The storage profile resolver currently derives:
+`kernel/src/fs/*` is temporary and constrained.
 
-- FS backend family intent (ramfs/littlefs/fat/ext4-like/xfs-like/blob)
-- cache policy
-- queue depth
-- cache budget
-- NUMA/journaling flags
+### Allowed in kernel FS transitional code
 
-Inputs are:
+1. ABI-preserving stubs and forwarding shims.
+2. Shared object/type plumbing strictly required for compatibility.
+3. Minimal dispatch glue to reach service-owned implementation.
+4. Error-code forwarding/translation without policy reinterpretation.
+5. Validation hooks limited to structural sanity checks.
 
-- app profile (`RT`, `EDGE`, `DATACENTER`)
-- device size
-- hardware architecture family
+### Forbidden in kernel FS transitional code
 
-This baseline is already wired into filesystem service boot initialization.
+1. Pathname policy (path prefix authorization, directory policy, path ACL logic).
+2. Namespace policy (mount namespace visibility, remap rules, per-process namespace shaping).
+3. Mount policy (who may mount, mount flag governance, storage-class admission).
+4. Sandbox policy (`noexec/nodev/nosuid` policy ownership, sandbox defaulting, tenant policy matrices).
+5. Rich capability interpretation beyond minimal validation hooks.
+
+Any new kernel FS code must justify itself as transitional mechanism support and must not expand policy ownership.
 
 ---
 
-## 7. Out of scope for current phase
+## 5. Capability and authority contract
 
-Not yet treated as implemented architecture commitments:
+- No ambient authority assumptions.
+- Filesystem authority is capability-scoped and enforced by service-owned policy.
+- Service-level capability checks must gate namespace, mount, FD, and storage-class decisions.
+- Kernel transitional path may validate structure, but policy decisions remain service-owned.
 
-- full userspace IPC protocol for complete POSIX file API surface,
-- production persistent FS adapters beyond RAMFS-level baseline,
-- complete blob/object implementation,
-- full NUMA-local IO worker scheduling and queue pinning.
+---
 
-These remain roadmap items.
+## 6. Storage classes (contract-level)
+
+Bharat-OS storage-class policy distinguishes at least:
+
+- filesystem mounts,
+- raw block interfaces,
+- blob/object backends.
+
+Authorization for storage-class use is service-owned policy, with sandbox policy rules defined in `sandbox-policy.md`.
+
+---
+
+## 7. Change-control rules for this contract
+
+A storage/filesystem PR must update this document when it changes any normative boundary involving:
+
+- ownership movement across driver/stack/service/kernel/lib layers,
+- kernel transitional allowlist scope,
+- capability/policy ownership boundaries.
+
+If implementation diverges from this contract, implementation must be fixed or deviation must be explicitly approved and documented in the same change.


### PR DESCRIPTION
### Motivation

- Make the storage/docs set governance-grade by separating normative contract, current implementation state, sandbox policy, and roadmap to avoid mixing prescriptive rules with descriptive reality.
- Prevent architectural drift by explicitly constraining what may live in the kernel transitional surface and by anchoring roadmap phase entry to platform readiness gates.
- Centralize sandbox policy material previously scattered in strategy notes so security-sensitive concepts (mount tokens, path-right matrices, storage-class rights, and descriptor provenance) are easy to find and review.

### Description

- Rewrote `vfs-and-filesystem-architecture.md` into a strict normative contract that includes a canonical ownership matrix and a kernel FS transitional allowlist (explicit allowed vs forbidden kernel responsibilities). 
- Converted `file-system-detailed-design.md` into a purely descriptive current-state document that records hybrid migration reality and known gaps without mixing in normative directives.
- Added `sandbox-policy.md` as the canonical storage sandbox policy covering namespace view, path-right matrix, storage-class gating, mount tokens, descriptor provenance, and recommended defaults (`noexec/nodev/nosuid`).
- Updated `roadmap.md` with explicit platform gates (capability baseline, service runtime maturity, memory authority-path) and clearer phase-entry/exit criteria, and updated `README.md` and the legacy strategy note to point readers to the new canonical documents.

### Testing

- Ran `git diff --check` to validate style/whitespace issues and it reported no problems.
- Verified the new policy file exists with `test -f docs/architecture/storage/sandbox-policy.md` and the canonical index was updated accordingly.
- Confirmed repository working tree shows no unstaged changes after the doc updates (clean status).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e851c611c48320816de657cfc18b71)