### PR TITLE
Rename kernel thread/process types to bh_thread/bh_process and update arch, scheduler, and docs

### DIFF
--- a/arch/arm/arm32/ext_state.c
+++ b/arch/arm/arm32/ext_state.c
@@ -2,7 +2,7 @@
 
 void arch_ext_state_boot_init(void) {}
 
-bool arch_ext_state_handle_fault(struct kthread *t) {
+bool arch_ext_state_handle_fault(struct bh_thread *t) {
     (void)t;
     return false;
 }

--- a/arch/arm/arm64/context_switch.S
+++ b/arch/arm/arm64/context_switch.S
@@ -63,9 +63,9 @@ arch_context_switch:
 
     ret
 
-.global arch_kthread_start_trampoline
-.type arch_kthread_start_trampoline, @function
-arch_kthread_start_trampoline:
+.global arch_bh_thread_start_trampoline
+.type arch_bh_thread_start_trampoline, @function
+arch_bh_thread_start_trampoline:
     // x19 holds the true entry point, setup by arch_prepare_initial_context
     mov x0, x19
     blr x0

--- a/arch/arm/arm64/context_switch.c
+++ b/arch/arm/arm64/context_switch.c
@@ -9,7 +9,7 @@ _Static_assert(__builtin_offsetof(cpu_context_t, regs) == 0, "cpu_context_t.regs
 _Static_assert(__builtin_offsetof(cpu_context_t, pc) == 128, "cpu_context_t.pc offset mismatch");
 _Static_assert(__builtin_offsetof(cpu_context_t, sp) == 136, "cpu_context_t.sp offset mismatch");
 
-extern void arch_kthread_start_trampoline(void);
+extern void arch_bh_thread_start_trampoline(void);
 
 void arch_prepare_initial_context(cpu_context_t* ctx, void (*entry)(void), uint64_t stack_top) {
   if (!ctx) {
@@ -26,7 +26,7 @@ void arch_prepare_initial_context(cpu_context_t* ctx, void (*entry)(void), uint6
   ctx->regs[0] = (uint64_t)(uintptr_t)entry;
 
   // Initial resume point is the bootstrap trampoline
-  ctx->pc = (uint64_t)(uintptr_t)arch_kthread_start_trampoline;
+  ctx->pc = (uint64_t)(uintptr_t)arch_bh_thread_start_trampoline;
   ctx->sp = stack_top;
 
   // Do not preload FP state here. Lazy path will trap on first use.

--- a/arch/arm/arm64/ext_state.c
+++ b/arch/arm/arm64/ext_state.c
@@ -29,7 +29,7 @@ static const arch_ext_state_desc_t g_desc = {
     .lazy_allowed = true,
 };
 
-static struct kthread *g_fp_owner;
+static struct bh_thread *g_fp_owner;
 
 extern void arm64_fp_state_save(arch_ext_state_t *st);
 extern void arm64_fp_state_restore(const arch_ext_state_t *st);
@@ -58,7 +58,7 @@ const arch_ext_state_desc_t *arch_ext_state_desc(void) { return &g_desc; }
 bool arch_ext_state_enabled(void) { return true; }
 void arch_ext_state_boot_init(void) { arm64_fp_trap_enable(); }
 
-int arch_ext_state_thread_init(struct kthread *t) {
+int arch_ext_state_thread_init(struct bh_thread *t) {
     if (!t || !t->cpu_context) return -1;
     cpu_context_t *ctx = (cpu_context_t *)t->cpu_context;
 
@@ -72,7 +72,7 @@ int arch_ext_state_thread_init(struct kthread *t) {
     return 0;
 }
 
-void arch_ext_state_thread_destroy(struct kthread *t) {
+void arch_ext_state_thread_destroy(struct bh_thread *t) {
     if (!t || !t->cpu_context) return;
     cpu_context_t *ctx = (cpu_context_t *)t->cpu_context;
     if (g_fp_owner == t) {
@@ -104,7 +104,7 @@ void arch_ext_state_context_switch_in(void *next_ctx_void) {
     arm64_fp_trap_enable();
 }
 
-bool arch_ext_state_handle_fault(struct kthread *t) {
+bool arch_ext_state_handle_fault(struct bh_thread *t) {
     if (!t || !t->cpu_context) return false;
     cpu_context_t *ctx = (cpu_context_t *)t->cpu_context;
     arch_ext_state_t *st = ctx->ext;
@@ -154,7 +154,7 @@ bool arch_ext_state_handle_fault(struct kthread *t) {
     return true;
 }
 
-void arch_ext_state_save(struct kthread *t) {
+void arch_ext_state_save(struct bh_thread *t) {
     if (!t || !t->cpu_context) return;
     cpu_context_t *ctx = (cpu_context_t *)t->cpu_context;
     arch_ext_state_t *st = ctx->ext;
@@ -170,7 +170,7 @@ void arch_ext_state_save(struct kthread *t) {
     }
 }
 
-void arch_ext_state_restore(struct kthread *t) {
+void arch_ext_state_restore(struct bh_thread *t) {
     (void)t;
     // Eager restore is not used for lazy FP
 }

--- a/arch/riscv/riscv64/ext_state.c
+++ b/arch/riscv/riscv64/ext_state.c
@@ -32,7 +32,7 @@ static const arch_ext_state_desc_t g_desc = {
     .lazy_allowed = true,
 };
 
-static struct kthread *g_fp_owner;
+static struct bh_thread *g_fp_owner;
 
 extern void riscv_fp_state_save(arch_ext_state_t *st);
 extern void riscv_fp_state_restore(const arch_ext_state_t *st);
@@ -58,7 +58,7 @@ const arch_ext_state_desc_t *arch_ext_state_desc(void) { return &g_desc; }
 bool arch_ext_state_enabled(void) { return true; }
 void arch_ext_state_boot_init(void) { riscv_set_fs(RISCV_SSTATUS_FS_OFF); }
 
-int arch_ext_state_thread_init(struct kthread *t) {
+int arch_ext_state_thread_init(struct bh_thread *t) {
     if (!t || !t->cpu_context) return -1;
     cpu_context_t *ctx = (cpu_context_t *)t->cpu_context;
 
@@ -72,7 +72,7 @@ int arch_ext_state_thread_init(struct kthread *t) {
     return 0;
 }
 
-void arch_ext_state_thread_destroy(struct kthread *t) {
+void arch_ext_state_thread_destroy(struct bh_thread *t) {
     if (!t || !t->cpu_context) return;
     cpu_context_t *ctx = (cpu_context_t *)t->cpu_context;
     if (g_fp_owner == t) {
@@ -103,7 +103,7 @@ void arch_ext_state_context_switch_in(void *next_ctx_void) {
     riscv_set_fs(RISCV_SSTATUS_FS_OFF);
 }
 
-bool arch_ext_state_handle_fault(struct kthread *t) {
+bool arch_ext_state_handle_fault(struct bh_thread *t) {
     if (!t || !t->cpu_context) return false;
     cpu_context_t *ctx = (cpu_context_t *)t->cpu_context;
     arch_ext_state_t *st = ctx->ext;
@@ -135,7 +135,7 @@ bool arch_ext_state_handle_fault(struct kthread *t) {
     return true;
 }
 
-void arch_ext_state_save(struct kthread *t) {
+void arch_ext_state_save(struct bh_thread *t) {
     if (!t || !t->cpu_context) return;
     cpu_context_t *ctx = (cpu_context_t *)t->cpu_context;
     arch_ext_state_t *st = ctx->ext;
@@ -151,7 +151,7 @@ void arch_ext_state_save(struct kthread *t) {
     }
 }
 
-void arch_ext_state_restore(struct kthread *t) {
+void arch_ext_state_restore(struct bh_thread *t) {
     (void)t;
     // Eager restore is not used for lazy FP
 }

--- a/arch/shakti/ext_state.c
+++ b/arch/shakti/ext_state.c
@@ -25,7 +25,7 @@ bool arch_ext_state_enabled(void) {
     return (g_arch_ext_desc.size > 0);
 }
 
-int arch_ext_state_thread_init(kthread_t *t) {
+int arch_ext_state_thread_init(bh_thread_t *t) {
     const arch_ext_state_desc_t *d = arch_ext_state_desc();
     if (!d || d->size == 0) {
         ((cpu_context_t*)t->cpu_context)->ext = NULL;
@@ -48,7 +48,7 @@ int arch_ext_state_thread_init(kthread_t *t) {
     return 0;
 }
 
-void arch_ext_state_thread_destroy(kthread_t *t) {
+void arch_ext_state_thread_destroy(bh_thread_t *t) {
     if (t && t->cpu_context) {
         cpu_context_t *ctx = (cpu_context_t*)t->cpu_context;
         if (ctx->ext) {
@@ -58,12 +58,12 @@ void arch_ext_state_thread_destroy(kthread_t *t) {
     }
 }
 
-void arch_ext_state_save(kthread_t *t) {
+void arch_ext_state_save(bh_thread_t *t) {
     if (!t || !((cpu_context_t*)t->cpu_context)->ext) return;
     // Stub: Eager XSAVE/FXSAVE to t->ext
 }
 
-void arch_ext_state_restore(kthread_t *t) {
+void arch_ext_state_restore(bh_thread_t *t) {
     if (!t || !((cpu_context_t*)t->cpu_context)->ext) return;
     // Stub: Eager XRSTOR/FXRSTOR from t->ext
 }

--- a/arch/x86/x86_64/ext_state.c
+++ b/arch/x86/x86_64/ext_state.c
@@ -25,7 +25,7 @@ bool arch_ext_state_enabled(void) {
     return (g_arch_ext_desc.size > 0);
 }
 
-int arch_ext_state_thread_init(kthread_t *t) {
+int arch_ext_state_thread_init(bh_thread_t *t) {
     const arch_ext_state_desc_t *d = arch_ext_state_desc();
     if (!d || d->size == 0) {
         ((cpu_context_t*)t->cpu_context)->ext = NULL;
@@ -48,7 +48,7 @@ int arch_ext_state_thread_init(kthread_t *t) {
     return 0;
 }
 
-void arch_ext_state_thread_destroy(kthread_t *t) {
+void arch_ext_state_thread_destroy(bh_thread_t *t) {
     if (t && t->cpu_context) {
         cpu_context_t *ctx = (cpu_context_t*)t->cpu_context;
         if (ctx->ext) {
@@ -58,12 +58,12 @@ void arch_ext_state_thread_destroy(kthread_t *t) {
     }
 }
 
-void arch_ext_state_save(kthread_t *t) {
+void arch_ext_state_save(bh_thread_t *t) {
     if (!t || !((cpu_context_t*)t->cpu_context)->ext) return;
     // Stub: Eager XSAVE/FXSAVE to t->ext
 }
 
-void arch_ext_state_restore(kthread_t *t) {
+void arch_ext_state_restore(bh_thread_t *t) {
     if (!t || !((cpu_context_t*)t->cpu_context)->ext) return;
     // Stub: Eager XRSTOR/FXRSTOR from t->ext
 }
@@ -76,7 +76,7 @@ void arch_kernel_fpu_end(void) {
     // Stub: Handle kernel FPU end
 }
 
-bool arch_ext_state_handle_fault(struct kthread *t) {
+bool arch_ext_state_handle_fault(struct bh_thread *t) {
     (void)t;
     // x86_64 uses eager FPU saving or handles #NM faults here
     return false;

--- a/docs/architecture/device-profiles.md
+++ b/docs/architecture/device-profiles.md
@@ -138,7 +138,7 @@ The following 8 tasks form the core engineering plan to realize the Nano/Edge/Fu
 * **High-Level Task**: Add fault domains, restart policies, safe-mode markers, and fault reason codes to process/service control blocks.
 * **Low-Level Code Map**:
   * Define `fault_domain_t` and `restart_policy_t` in `kernel/include/kernel/kernel_safety.h` or `kernel/include/sched/fault_domain.h`.
-  * Augment the scheduler process descriptor (`kprocess_t` or equivalent in `kernel/src/sched/`) to track these metadata fields.
+  * Augment the scheduler process descriptor (`bh_process_t` or equivalent in `kernel/src/sched/`) to track these metadata fields.
   * Update the fault handler (`kernel/src/trap/` and `kernel/src/mm/vm/fault/fault.c`) to query the fault domain and trigger partial restarts via IPC instead of global panics.
 
 ### 7. Standardize IPC/uRPC endpoint descriptor and message classes

--- a/docs/architecture/kernel-object-model.md
+++ b/docs/architecture/kernel-object-model.md
@@ -6,12 +6,12 @@ Bharat-OS operates on a strict, capability-based object model managed entirely w
 
 ## Core Objects
 
-1. **Threads (kthread_t)**: The fundamental unit of execution. The kernel schedules threads, not heavy processes.
-2. **Tasks (ktask_t)**: A container for a resource domain. A task holds an address space (VType) and a Capability Space (CSpace).
-3. **Capabilities (cap_t)**: Unforgeable tokens representing authority over an object. Every operation in Bharat-OS requires a valid capability.
-4. **Endpoints (ep_t)**: IPC portals that threads use to send and receive synchronous messages.
-5. **Frames (frame_t)**: Contiguous regions of physical memory allocated to a task.
-6. **Interrupt Handlers (irq_t)**: Objects that allow a thread to register and wait for hardware interrupts.
+1. **Threads (bh_thread_t)**: The fundamental unit of execution. The kernel schedules threads, not heavy processes.
+2. **Tasks (bh_task_t)**: A container for a resource domain. A task holds an address space (VType) and a Capability Space (CSpace).
+3. **Capabilities (bh_cap_t)**: Unforgeable tokens representing authority over an object. Every operation in Bharat-OS requires a valid capability.
+4. **Endpoints (bh_endpoint_t)**: IPC portals that threads use to send and receive synchronous messages.
+5. **Frames (bh_frame_t)**: Contiguous regions of physical memory allocated to a task.
+6. **Interrupt Handlers (bh_irq_t)**: Objects that allow a thread to register and wait for hardware interrupts.
 
 ## Lifecycle
 

--- a/docs/architecture/kernel/capabilities/capability-types.md
+++ b/docs/architecture/kernel/capabilities/capability-types.md
@@ -11,7 +11,7 @@ Every capability in the Bharat-OS kernel points to an underlying object and carr
     - **Rights:** `GRANT` (delegate).
 
 2.  **Thread Control Block (`CAP_TYPE_TCB`)**
-    - **Description:** Points to a thread object (`kthread_t`).
+    - **Description:** Points to a thread object (`bh_thread_t`).
     - **Operations:** Suspend, Resume, Bind to IPC Endpoint, Read/Write Registers.
     - **Rights:** `SCHEDULE`, `MODIFY`.
 
@@ -26,7 +26,7 @@ Every capability in the Bharat-OS kernel points to an underlying object and carr
     - **Rights:** `READ`, `WRITE`, `EXECUTE`.
 
 5.  **IPC Endpoint (`CAP_TYPE_ENDPOINT`)**
-    - **Description:** A synchronous communication portal (`ep_t`).
+    - **Description:** A synchronous communication portal (`bh_endpoint_t`).
     - **Operations:** Send Message, Receive Message, Grant Capability.
     - **Rights:** `SEND`, `RECEIVE`, `DELEGATE`.
 

--- a/docs/architecture/kernel/process_thread.md
+++ b/docs/architecture/kernel/process_thread.md
@@ -95,7 +95,7 @@ graph TD
 ### 5.2 Updated Process Structure
 
 ```c
-struct kprocess {
+struct bh_process {
     pid_t pid;
 
     core_id_t home_core; // Ownership tracking
@@ -103,7 +103,7 @@ struct kprocess {
     address_space_t* aspace;
     cap_table_t* cspace;
 
-    struct kthread* main_thread;
+    struct bh_thread* main_thread;
 
     personality_t personality;
 
@@ -121,10 +121,10 @@ struct kprocess {
 ## 6. Thread Model
 
 ```c
-struct kthread {
+struct bh_thread {
     tid_t tid;
 
-    struct kprocess* process;
+    struct bh_process* process;
 
     core_id_t current_core;
 

--- a/docs/architecture/kernel/process_thread_future_tasks.md
+++ b/docs/architecture/kernel/process_thread_future_tasks.md
@@ -9,7 +9,7 @@
 ## Overview
 
 Based on the [Process & Thread Management Architecture](process_thread.md), the Bharat-OS kernel's execution models will be refactored into a clear 3-layer architecture:
-1. Kernel process model: **distributed, message-driven, no-global-state architecture** (`kprocess`, `kthread`)
+1. Kernel process model: **distributed, message-driven, no-global-state architecture** (`bh_process`, `bh_thread`)
 2. Personality runtime layer: translate foreign semantics (Linux, Windows, Android, macOS)
 3. User-space compatibility subsystems (Process Manager)
 
@@ -33,8 +33,8 @@ The immediate goal is to separate process/thread lifecycle management from the s
 *   Update `kernel/src/CMakeLists.txt` to include the new `proc` subdirectory.
 
 ### Step 1.3: Define the New Core Objects (Home Core Ownership)
-*   In `process.h`, define the new `struct kprocess` with essential fields including `home_core` ownership tracking, a localized children list, and `proc_channel`.
-*   In `thread.h`, define the new `struct kthread` with essential fields including `current_core` and `control_channel`.
+*   In `process.h`, define the new `struct bh_process` with essential fields including `home_core` ownership tracking, a localized children list, and `proc_channel`.
+*   In `thread.h`, define the new `struct bh_thread` with essential fields including `current_core` and `control_channel`.
 *   *Note:* Ensure these definitions enforce that a process/thread belongs to one specific core.
 
 ### Step 1.4: Replace the Global Reaper

--- a/docs/architecture/kernel/scheduler/cpu-affinity.md
+++ b/docs/architecture/kernel/scheduler/cpu-affinity.md
@@ -1,7 +1,7 @@
 # CPU Affinity & NUMA
 
 ## Overview
-In multi-core systems, especially Non-Uniform Memory Access (NUMA) architectures, the physical location of a thread (`kthread_t`) significantly impacts its performance. Bharat-OS allows explicit control over where threads execute.
+In multi-core systems, especially Non-Uniform Memory Access (NUMA) architectures, the physical location of a thread (`bh_thread_t`) significantly impacts its performance. Bharat-OS allows explicit control over where threads execute.
 
 ## CPU Affinity (Pinning)
 CPU Affinity is the property that determines which physical CPU cores a thread is allowed to run on.

--- a/docs/architecture/kernel/scheduler/preemption.md
+++ b/docs/architecture/kernel/scheduler/preemption.md
@@ -1,7 +1,7 @@
 # Preemption
 
 ## Overview
-In a multi-tasking OS, the scheduler must guarantee that threads (`kthread_t`) share the CPU fairly and that critical high-priority tasks run immediately when ready. This involves **preemption**: forcibly removing a running thread from the CPU and replacing it with another.
+In a multi-tasking OS, the scheduler must guarantee that threads (`bh_thread_t`) share the CPU fairly and that critical high-priority tasks run immediately when ready. This involves **preemption**: forcibly removing a running thread from the CPU and replacing it with another.
 
 ## Types of Preemption
 

--- a/docs/architecture/kernel/scheduler/priority.md
+++ b/docs/architecture/kernel/scheduler/priority.md
@@ -1,7 +1,7 @@
 # Priority & Priority Inversion
 
 ## Overview
-Threads (`kthread_t`) in Bharat-OS have an assigned priority level that determines their relative importance to the system. Higher-priority threads receive more CPU time or preempt lower-priority threads.
+Threads (`bh_thread_t`) in Bharat-OS have an assigned priority level that determines their relative importance to the system. Higher-priority threads receive more CPU time or preempt lower-priority threads.
 
 ## Static vs. Dynamic Priority
 -   **Static Priority (RT):** Threads with a hard real-time profile (`BHARAT_KERNEL_PROFILE_RT`) have a static priority (e.g., 0 to 99, where 99 is highest). This priority *never changes* during normal execution unless explicitly modified by a capability-authorized system call.

--- a/docs/architecture/kernel/scheduler/runqueue.md
+++ b/docs/architecture/kernel/scheduler/runqueue.md
@@ -6,7 +6,7 @@ In the Bharat-OS multikernel design, scheduling is fundamentally decentralized. 
 ## Per-CPU Runqueues
 Every CPU core maintains its own completely independent `runqueue_t` structure.
 
--   **Locality:** A thread (`kthread_t`) is assigned to a specific CPU's runqueue when it becomes `Ready`.
+-   **Locality:** A thread (`bh_thread_t`) is assigned to a specific CPU's runqueue when it becomes `Ready`.
 -   **Locking:** Because only the local CPU accesses its own runqueue during a context switch, the scheduler can operate locklessly (or with a very fast, uncontended local spinlock disabled with local IRQs off) in the fast path.
 -   **Cache Affinity:** Keeping a thread on the same CPU maximizes the L1/L2 cache hit rate, improving performance.
 

--- a/docs/architecture/kernel/scheduler/scheduler-and-threading.md
+++ b/docs/architecture/kernel/scheduler/scheduler-and-threading.md
@@ -4,7 +4,7 @@ This document reflects the scheduler/threading baseline from current kernel code
 
 ## Core data model
 
-`kthread_t` and `sched_rq_t` define the runtime contract:
+`bh_thread_t` and `sched_rq_t` define the runtime contract:
 
 - Thread state machine (`THREAD_STATE_*`) with ready/running/blocked/sleeping/terminated plus distributed handoff states.
 - Per-core runqueue with:

--- a/docs/architecture/kernel/scheduler/time-accounting.md
+++ b/docs/architecture/kernel/scheduler/time-accounting.md
@@ -1,7 +1,7 @@
 # Time Accounting
 
 ## Overview
-The `scheduler` cluster requires precise and efficient time tracking to distribute CPU time fairly among threads (`kthread_t`) and accurately enforce timeouts (e.g., `sys_sleep()`, `sys_futex_wait_timeout()`).
+The `scheduler` cluster requires precise and efficient time tracking to distribute CPU time fairly among threads (`bh_thread_t`) and accurately enforce timeouts (e.g., `sys_sleep()`, `sys_futex_wait_timeout()`).
 
 ## High-Resolution Timers vs. Ticks
 

--- a/docs/architecture/kernel/tasks-threads/README.md
+++ b/docs/architecture/kernel/tasks-threads/README.md
@@ -18,7 +18,7 @@ graph TD
 - [Thread Model](thread-model.md) - Thread Control Block (TCB) layout, kernel threads vs user threads.
 - [Lifecycle](lifecycle.md) - Thread/Task states (Ready, Running, Blocked, Exited).
 - [Context Switch](context-switch.md) - Trap gates, ASID swapping, FPU state saving.
-- [Kernel Threads](kernel-threads.md) - The purpose of kthreads in the multikernel context.
+- [Kernel Threads](kernel-threads.md) - The purpose of bh_threads in the multikernel context.
 - [TLS (Thread Local Storage)](tls.md) - Architecture-specific TLS ABI (e.g., `fs`/`gs` on x86, `tpidr` on arm).
 - [Fork and Exec](fork-exec.md) - Process spawning via capabilities (No monolithic `fork()`).
 - [Synchronization](synchronization.md) - Fast user-space mutexes (Futex-like) and condition variables.

--- a/docs/architecture/kernel/tasks-threads/kernel-threads.md
+++ b/docs/architecture/kernel/tasks-threads/kernel-threads.md
@@ -4,9 +4,9 @@
 In the multikernel Bharat-OS architecture, most system services run as User Tasks (e.g., VFS, Networking, Device Drivers). However, a minimal set of threads must execute directly within the Kernel's address space.
 
 ## Purpose and Characteristics
-**Kernel threads (`kthreads`)** run in Ring 0 (or Supervisor Mode) and have full access to kernel structures. They do not have a user-space stack or a user-space address map.
+**Kernel threads (`bh_threads`)** run in Ring 0 (or Supervisor Mode) and have full access to kernel structures. They do not have a user-space stack or a user-space address map.
 
-### Why do we need kthreads?
+### Why do we need bh_threads?
 1.  **Idle Loop:** Every CPU core must have at least one thread to execute when no user tasks are ready. The `idle_thread` executes `WFI` (Wait For Interrupt) or `HLT` to save power.
 2.  **Deferred Interrupt Handling (Bottom Halves):** While the top-half IRQ handler must be as fast as possible, longer-running operations can be deferred to a dedicated kernel thread (similar to Linux softirqs or workqueues) before returning to user space.
 3.  **Memory Management (Swapping/Reclamation):** Kernel daemons that run periodically to reclaim physical pages (`kswapd` style).
@@ -18,5 +18,5 @@ To distinguish kernel threads from user threads in debugging output and process 
 - `[kworker]`
 - `[kswapd]`
 
-## The `kthread_t` Structure
-A kernel thread uses the same `kthread_t` structure as user threads to be managed by the same scheduler. However, its `trap_frame_t` is set up to return to a kernel instruction pointer rather than a user instruction pointer. It also lacks a separate `address_space_t` (it uses the unified kernel page tables).
+## The `bh_thread_t` Structure
+A kernel thread uses the same `bh_thread_t` structure as user threads to be managed by the same scheduler. However, its `trap_frame_t` is set up to return to a kernel instruction pointer rather than a user instruction pointer. It also lacks a separate `address_space_t` (it uses the unified kernel page tables).

--- a/docs/architecture/kernel/tasks-threads/roadmap.md
+++ b/docs/architecture/kernel/tasks-threads/roadmap.md
@@ -2,7 +2,7 @@
 
 ## Current Status (v1 Baseline)
 Based on current code analysis in `kernel/src/sched/` and `kernel/src/trap/`:
-- ✅ **Basic Thread Control Block (`kthread_t`)**: Implemented.
+- ✅ **Basic Thread Control Block (`bh_thread_t`)**: Implemented.
 - ✅ **Context Switching**: Implemented core trap frame saving/restoring (`trap_frame_t`).
 - ✅ **Syscall Dispatch**: Basic `syscall_dispatch` and `trap_handle` implemented.
 - ✅ **Basic States**: Ready, Running, Blocked, Exited.

--- a/docs/architecture/kernel/tasks-threads/thread-model.md
+++ b/docs/architecture/kernel/tasks-threads/thread-model.md
@@ -4,7 +4,7 @@
 A **Thread** in Bharat-OS is the fundamental unit of scheduling and execution. It runs inside a Task, inheriting the Task's Address Space (ASpace) and Capability Space (CSpace). Threads are represented by the **Thread Control Block (TCB)**.
 
 ## Thread Control Block (TCB) Layout
-The `kthread_t` (defined in `kernel/src/sched/`) tracks everything the CPU needs to resume a preempted context:
+The `bh_thread_t` (defined in `kernel/src/sched/`) tracks everything the CPU needs to resume a preempted context:
 
 - **State:** Running, Ready, Blocked, Exited.
 - **Trap Frame (`trap_frame_t`):** Pointer to the top of the kernel stack where registers are saved when a trap, interrupt, or syscall occurs.

--- a/docs/architecture/kernel/urpc/endpoint-design.md
+++ b/docs/architecture/kernel/urpc/endpoint-design.md
@@ -1,7 +1,7 @@
 # Endpoint Design
 
 ## Overview
-In Bharat-OS, an Endpoint (`ep_t`) is a capability-protected rendezvous point. For local (intra-core) communication, endpoints are implemented as synchronous wait queues in the kernel. For cross-core (multikernel) or network communication, **uRPC Channels** operate *underneath* or *alongside* these endpoints.
+In Bharat-OS, an Endpoint (`bh_endpoint_t`) is a capability-protected rendezvous point. For local (intra-core) communication, endpoints are implemented as synchronous wait queues in the kernel. For cross-core (multikernel) or network communication, **uRPC Channels** operate *underneath* or *alongside* these endpoints.
 
 ## The Problem: Capability Boundaries
 How does Task A (on Core 0) send a capability to Task B (on Core 1)?
@@ -13,7 +13,7 @@ How does Task A (on Core 0) send a capability to Task B (on Core 1)?
 ### 1. The Proxy Endpoint
 To preserve the illusion of a local synchronous endpoint, Bharat-OS uses **Proxy Endpoints**.
 
--   Task A holds a capability to an Endpoint. As far as Task A is concerned, it's just a normal `ep_t`.
+-   Task A holds a capability to an Endpoint. As far as Task A is concerned, it's just a normal `bh_endpoint_t`.
 -   However, the kernel on Core 0 knows that this Endpoint is actually a *proxy* pointing to a destination on Core 1.
 
 ### 2. The Capwire Translation

--- a/docs/architecture/kernel/urpc/userspace-stub.md
+++ b/docs/architecture/kernel/urpc/userspace-stub.md
@@ -35,7 +35,7 @@ A compiler tool (`bidlc`) parses the `.bidl` files and generates C (or Rust/C++)
 
 ### 1. Client Stubs
 The generator creates a proxy function for the client:
-`int bharat_vfs_v1_OpenFile(urpc_channel_t* chan, const char* path, uint32_t flags, ep_t* out_file_stream);`
+`int bharat_vfs_v1_OpenFile(urpc_channel_t* chan, const char* path, uint32_t flags, bh_endpoint_t* out_file_stream);`
 
 -   **Marshalling:** Inside this function, the stub allocates a buffer (or uses a pre-allocated slab), writes the canonical header (setting `service_id` and `opcode`), and carefully packs the `path` and `flags` into the little-endian wire format.
 -   **Execution:** The stub calls `urpc_send()` (or blocks waiting for a reply).

--- a/docs/architecture/personalities/android/android_personality_architecture.md
+++ b/docs/architecture/personalities/android/android_personality_architecture.md
@@ -28,10 +28,10 @@ Android userspace historically depends on a Linux kernel substrate combined with
 
 ### 1. Personality Tagging
 
-The Bharat-OS scheduler has been updated to support `personality` tagging at both the `kprocess_t` and `kthread_t` levels.
+The Bharat-OS scheduler has been updated to support `personality` tagging at both the `bh_process_t` and `bh_thread_t` levels.
 
 - **Subsystem Registration:** When an Android subsystem is created via `subsys_create(SUBSYS_TYPE_ANDROID, ...)`, any subsequent process spawned for this domain inherits the `SUBSYS_TYPE_ANDROID` personality.
-- **Dispatch Hooks:** Exception/signal translation and syscall dispatch can inspect `kprocess_t->personality` to route Android-specific handling correctly, without polluting the generic fast paths.
+- **Dispatch Hooks:** Exception/signal translation and syscall dispatch can inspect `bh_process_t->personality` to route Android-specific handling correctly, without polluting the generic fast paths.
 
 ### 2. Binder Compatibility Layer
 

--- a/docs/architecture/personalities/android/android_personality_kernel_changes.md
+++ b/docs/architecture/personalities/android/android_personality_kernel_changes.md
@@ -18,7 +18,7 @@ This document details the required changes to the core kernel to efficiently run
 
 ## 1. Personality-Neutral Process Model
 
-To handle Android semantics natively, the core kernel process model (`kernel/include/sched.h`) has been updated to include a `personality` field in `kprocess_t` and `kthread_t`.
+To handle Android semantics natively, the core kernel process model (`kernel/include/sched.h`) has been updated to include a `personality` field in `bh_process_t` and `bh_thread_t`.
 
 - **Syscall Dispatch:** The trap/syscall layer must route incoming calls based on the `personality` tag, redirecting Android-specific system calls or POSIX deviations to the Android compatibility subsystem.
 - **Exception/Signal Handling:** The kernel must provide personality-specific exception/signal translation hooks to map native trap states to Android-specific (or Linux-like) signal structures.

--- a/docs/architecture/personalities/linux/linux_personality_architecture.md
+++ b/docs/architecture/personalities/linux/linux_personality_architecture.md
@@ -17,7 +17,7 @@ The Bharat-OS core kernel is designed as a distributed, personality-neutral mult
 
 ## Core Process & Thread Model
 The core kernel separates the scheduler thread/task abstraction from the process/address-space abstraction.
-To support multi-personality execution, we introduce a `personality_type` field to the `kthread_t` (and/or `kprocess_t`) structure.
+To support multi-personality execution, we introduce a `personality_type` field to the `bh_thread_t` (and/or `bh_process_t`) structure.
 
 - `PERSONALITY_NATIVE`: Threads executing native Bharat-OS ABI.
 - `PERSONALITY_LINUX`: Threads executing the Linux ABI.

--- a/docs/architecture/personalities/personality-layer.md
+++ b/docs/architecture/personalities/personality-layer.md
@@ -70,14 +70,14 @@ By translating foreign ABIs into Bharat-OS primitives, we allow legacy applicati
 ### Windows Subsystem (Wine-like NT Compatibility)
 
 - **PE Loading & ABI:** Emulates Windows Portable Executable (PE) loading and the NT Kernel syscall interface (`ntdll.dll` wrapping).
-- **NT Objects to Capabilities:** Windows NT Objects (Handles, Events, Mutexes, Sections) map cleanly to Bharat-OS Kernel Objects. A Windows `HANDLE` becomes a Bharat-OS Capability (`cap_t`).
-- **LPC Translation:** The Windows Local Procedure Call (LPC / ALPC) mechanism is perfectly modeled using Bharat-OS Synchronous Endpoints (`ep_t`) for fast cross-process communication.
+- **NT Objects to Capabilities:** Windows NT Objects (Handles, Events, Mutexes, Sections) map cleanly to Bharat-OS Kernel Objects. A Windows `HANDLE` becomes a Bharat-OS Capability (`bh_cap_t`).
+- **LPC Translation:** The Windows Local Procedure Call (LPC / ALPC) mechanism is perfectly modeled using Bharat-OS Synchronous Endpoints (`bh_endpoint_t`) for fast cross-process communication.
 - **AI Governor Integration:** Windows Thread Priorities and scheduling hints are transparently fed into the Bharat-OS AI Governor (`ai_sched_context_t`), optimizing legacy Windows applications for modern NUMA/Heterogeneous architectures without modification.
 
 ### macOS / Darwin Subsystem (Mach Compatibility)
 
 - **Mach Ports & IPC:** Darwin's XNU kernel relies heavily on Mach Ports. These are mapped 1:1 to Bharat-OS IPC Endpoints. Send/Receive rights natively match the Bharat-OS Capability model (`CAP_PERM_SEND`, `CAP_PERM_RECEIVE`).
-- **Mach Tasks & Threads:** Mach Task/Thread management maps directly to Bharat-OS `ktask_t` and `kthread_t` primitives.
+- **Mach Tasks & Threads:** Mach Task/Thread management maps directly to Bharat-OS `bh_task_t` and `bh_thread_t` primitives.
 - **Objective-C / Swift Runtime:** Native Darwin binaries can execute with high performance, as message-passing overhead is minimized via URPC when scaling across cores.
 
 _Note: Full POSIX, Windows, and macOS translations are considered deferred research modules due to the enormous surface area of their respective APIs, but the architectural scaffolding is designed to support them natively as first-class, high-performance environments._

--- a/docs/architecture/services/process_manager.md
+++ b/docs/architecture/services/process_manager.md
@@ -8,7 +8,7 @@
 
 ## 1. Executive Summary
 
-In Bharat-OS, the `process_manager` service acts as the **lifecycle orchestrator**, moving beyond simply storing the core kernel process object. While the kernel itself handles the creation and management of the low-level `kprocess` and `kthread` objects, the process manager sits in user space to handle policies, compatibility workflows, and high-level process lifecycle coordination.
+In Bharat-OS, the `process_manager` service acts as the **lifecycle orchestrator**, moving beyond simply storing the core kernel process object. While the kernel itself handles the creation and management of the low-level `bh_process` and `bh_thread` objects, the process manager sits in user space to handle policies, compatibility workflows, and high-level process lifecycle coordination.
 
 ---
 
@@ -43,7 +43,7 @@ graph TD
     PM -->|Map Images| Loader
     PM -->|Setup Namespaces| NS
     PM -->|Check Policy| Sec
-    PM -->|Create kprocess/kthread| Kern
+    PM -->|Create bh_process/bh_thread| Kern
 ```
 
 ---
@@ -54,13 +54,13 @@ When an application (via its personality runtime) requests a new process creatio
 
 1. **Request Reception:** `process_manager` receives the request to create a new process with specific parameters (executable path, environment, arguments).
 2. **Policy Check:** It queries the security/policy service to verify the caller has permissions to spawn the requested process.
-3. **Kernel Allocation:** It calls kernel syscalls (`process_create_native`) to allocate an empty `kprocess` object, an empty address space, and an empty capability table.
+3. **Kernel Allocation:** It calls kernel syscalls (`process_create_native`) to allocate an empty `bh_process` object, an empty address space, and an empty capability table.
 4. **Image Loading:** It contacts the loader service, passing the capability to the new address space, and asks the loader to parse the executable (e.g., ELF/PE) and populate the memory.
-5. **Thread Creation:** It calls kernel syscalls (`thread_create_native`) to create the initial `kthread` pointing to the loaded entry point.
+5. **Thread Creation:** It calls kernel syscalls (`thread_create_native`) to create the initial `bh_thread` pointing to the loaded entry point.
 6. **Capability Seeding:** It installs the required baseline capabilities into the new process's capability table.
 7. **Namespace Binding:** It coordinates with the namespace service to set up the default namespaces for the process.
 8. **Personality Binding:** It calls `process_bind_personality` to inform the kernel which personality ABI this process will use.
-9. **Execution:** It finally resumes the `kthread`, allowing the new process to start executing its user-mode code.
+9. **Execution:** It finally resumes the `bh_thread`, allowing the new process to start executing its user-mode code.
 
 ---
 
@@ -68,10 +68,10 @@ When an application (via its personality runtime) requests a new process creatio
 
 When a process terminates, the orchestration ensures clean teardown:
 
-1. **Kernel Trap:** The process invokes `process_exit` or the kernel catches a fatal fault. The kernel updates the `kprocess` state to `ZOMBIE` and notifies the `process_manager`.
+1. **Kernel Trap:** The process invokes `process_exit` or the kernel catches a fatal fault. The kernel updates the `bh_process` state to `ZOMBIE` and notifies the `process_manager`.
 2. **Resource Teardown:** `process_manager` begins high-level resource teardown, releasing external capabilities, unregistering from namespaces, etc.
 3. **Wait Resolution:** If a parent process is waiting on this child, the `process_manager` wakes the parent, returning the exit code and termination reason.
-4. **Reaping:** Once the parent has fully consumed the exit status, the `process_manager` issues the final capability drop for the `kprocess`, prompting the kernel to fully free the underlying object.
+4. **Reaping:** Once the parent has fully consumed the exit status, the `process_manager` issues the final capability drop for the `bh_process`, prompting the kernel to fully free the underlying object.
 
 ---
 

--- a/kernel/include/arch/arch_ext_state.h
+++ b/kernel/include/arch/arch_ext_state.h
@@ -5,7 +5,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 
-struct kthread;
+struct bh_thread;
 
 typedef struct arch_ext_state arch_ext_state_t;
 
@@ -35,17 +35,17 @@ void arch_ext_state_boot_init(void);
 const arch_ext_state_desc_t *arch_ext_state_desc(void);
 bool arch_ext_state_enabled(void);
 
-int arch_ext_state_thread_init(struct kthread *t);
-void arch_ext_state_thread_destroy(struct kthread *t);
+int arch_ext_state_thread_init(struct bh_thread *t);
+void arch_ext_state_thread_destroy(struct bh_thread *t);
 
-void arch_ext_state_save(struct kthread *t);
-void arch_ext_state_restore(struct kthread *t);
+void arch_ext_state_save(struct bh_thread *t);
+void arch_ext_state_restore(struct bh_thread *t);
 
 void arch_ext_state_context_switch_out(void *prev_ctx);
 void arch_ext_state_context_switch_in(void *next_ctx);
 
 /* called from trap path when FP/SIMD use traps */
-bool arch_ext_state_handle_fault(struct kthread *t);
+bool arch_ext_state_handle_fault(struct bh_thread *t);
 
 void arch_kernel_fpu_begin(void);
 void arch_kernel_fpu_end(void);

--- a/kernel/include/bharat/cpu_local.h
+++ b/kernel/include/bharat/cpu_local.h
@@ -9,7 +9,7 @@ struct sched_rq;
 struct capability_table;
 struct pmm_shard;
 struct urpc_port;
-struct kthread;
+struct bh_thread;
 
 #define MAX_CPUS 32U
 
@@ -42,8 +42,8 @@ typedef struct __attribute__((aligned(64))) cpu_local {
     capability_table_t cap_table;     // per-core capability namespace
     void             *pmm;            // struct pmm_shard *
     void             *urpc_ports[MAX_CPUS]; // struct urpc_port *
-    struct kthread   *current;        // currently running thread
-    struct kthread   *idle;           // per-core idle thread
+    struct bh_thread   *current;        // currently running thread
+    struct bh_thread   *idle;           // per-core idle thread
     uintptr_t         kernel_stack;
 
     // Active address space

--- a/kernel/include/capability.h
+++ b/kernel/include/capability.h
@@ -195,7 +195,7 @@ capability_table_t* cap_table_create(void);
   assigns proc->security_sandbox_ctx;
   ensures \result == 0 || \result == -1 || \result == -2;
 */
-int cap_table_init_for_process(kprocess_t* proc);
+int cap_table_init_for_process(bh_process_t* proc);
 void cap_table_destroy(capability_table_t* table);
 
 /*@

--- a/kernel/include/compat/android/android_process.h
+++ b/kernel/include/compat/android/android_process.h
@@ -13,7 +13,7 @@
 
 /**
  * @brief Android task/process personality tag.
- * Extends `kprocess_t` or `kthread_t` personality metadata.
+ * Extends `bh_process_t` or `bh_thread_t` personality metadata.
  */
 typedef struct {
     uint32_t process_id;           // Logical Process ID (PID)

--- a/kernel/include/hw_security.h
+++ b/kernel/include/hw_security.h
@@ -28,7 +28,7 @@ typedef struct {
 void hwsec_init_features(cpu_security_features_t* features_out);
 
 // Apply a secure shadow stack to the specified thread (CET)
-int hwsec_enable_shadow_stack(kthread_t* thread);
+int hwsec_enable_shadow_stack(bh_thread_t* thread);
 
 // Enforce Memory Protection Keys (MPK) onto an address space
 int hwsec_apply_memory_keys(address_space_t* as, uint32_t pkey, uint32_t access_rights);

--- a/kernel/include/ipc_async.h
+++ b/kernel/include/ipc_async.h
@@ -16,7 +16,7 @@ typedef struct {
     uint32_t next_index;
     uint32_t timeout_heap_pos;
     ipc_async_state_t state;
-    kthread_t* waiting_thread;
+    bh_thread_t* waiting_thread;
     uint64_t deadline_ticks;
     uint32_t endpoint_ref;
     uint32_t qos_priority;
@@ -32,8 +32,8 @@ void ipc_async_init(void);
 /*
  * Create an asynchronous IPC request object.
  */
-ipc_async_request_t* ipc_async_request_create(kthread_t* thread, uint32_t endpoint_ref, uint64_t timeout_ms);
-ipc_async_request_t* ipc_async_request_create_ex(kthread_t* thread,
+ipc_async_request_t* ipc_async_request_create(bh_thread_t* thread, uint32_t endpoint_ref, uint64_t timeout_ms);
+ipc_async_request_t* ipc_async_request_create_ex(bh_thread_t* thread,
                                                   uint32_t endpoint_ref,
                                                   uint64_t timeout_ms,
                                                   uint32_t qos_priority,

--- a/kernel/include/personality_ops.h
+++ b/kernel/include/personality_ops.h
@@ -1,6 +1,6 @@
 #pragma once
 
-struct kthread;
+struct bh_thread;
 typedef struct bh_thread bh_thread_t;
 
 // TODO: Needs refactor: #include directive placed mid-file for dependency/order compatibility.
@@ -11,11 +11,11 @@ struct trap_frame;
 typedef struct trap_frame trap_frame_t;
 
 typedef struct personality_ops {
-    long (*handle_syscall)(kthread_t *thread,
+    long (*handle_syscall)(bh_thread_t *thread,
                            trap_frame_t *frame,
                            const trap_info_t *info);
 
-    int (*handle_user_fault)(kthread_t *thread,
+    int (*handle_user_fault)(bh_thread_t *thread,
                              trap_frame_t *frame,
                              const trap_info_t *info);
 

--- a/kernel/include/rtos_defense.h
+++ b/kernel/include/rtos_defense.h
@@ -30,12 +30,12 @@ typedef struct {
 } rtos_constraints_t;
 
 // Elevate a standard kernel thread to a defense-grade Hard RTOS thread
-int rtos_elevate_thread(kthread_t* thread, rtos_constraints_t* constraints);
+int rtos_elevate_thread(bh_thread_t* thread, rtos_constraints_t* constraints);
 
 // Pet the hardware watchdog (called periodically by the RTOS task)
 void rtos_watchdog_pet(void);
 
 // Register a Fault Handler for Modular Redundancy mismatch or missed deadlines
-void rtos_register_fault_handler(void (*handler)(kthread_t* failed_thread));
+void rtos_register_fault_handler(void (*handler)(bh_thread_t* failed_thread));
 
 #endif // BHARAT_RTOS_DEFENSE_H

--- a/kernel/include/sandbox.h
+++ b/kernel/include/sandbox.h
@@ -77,10 +77,10 @@ typedef struct {
 sandbox_ctx_t* sandbox_create_context(void);
 
 // Apply a sandbox context to a process (Containers)
-int sandbox_apply(kprocess_t* process, sandbox_ctx_t* ctx);
+int sandbox_apply(bh_process_t* process, sandbox_ctx_t* ctx);
 
 // Verify if a process has a specific capability
-int sandbox_check_capability(kprocess_t* process, uint64_t requested_capability);
+int sandbox_check_capability(bh_process_t* process, uint64_t requested_capability);
 
 // Add or replace a path capability rule in a sandbox context.
 int sandbox_allow_path(sandbox_ctx_t* ctx, const char* prefix, uint32_t allowed_ops_mask);

--- a/kernel/include/sched/ai_sched.h
+++ b/kernel/include/sched/ai_sched.h
@@ -95,13 +95,13 @@ uint8_t ai_model_ready(void);
 void ai_sched_calibrate_silicon(void);
 
 // Task structure definitions for AI priority queue
-struct kthread;
+struct bh_thread;
 
 typedef struct learned_task {
     uint64_t id;
     int32_t base_weight;
     uint64_t vruntime;
-    struct kthread *kthread_ptr;
+    struct bh_thread *bh_thread_ptr;
 } learned_task_t;
 
 #ifndef BHARAT_MAX_TASKS
@@ -119,8 +119,8 @@ typedef struct {
     uint32_t size;
 } learned_task_heap_t;
 
-struct kthread* fallback_scheduler(struct kthread *run_queue);
-struct kthread* ai_sched_select_task(struct kthread *run_queue);
+struct bh_thread* fallback_scheduler(struct bh_thread *run_queue);
+struct bh_thread* ai_sched_select_task(struct bh_thread *run_queue);
 void heap_insert(learned_task_heap_t *heap, learned_task_t *task);
 learned_task_t* heap_extract_min(learned_task_heap_t *heap);
 learned_task_t* select_and_update_queue(learned_task_heap_t *heap, learned_task_t *prev_task, uint64_t execution_time, uint64_t system_weight);

--- a/kernel/include/sched/algo_matrix.h
+++ b/kernel/include/sched/algo_matrix.h
@@ -25,12 +25,12 @@ typedef enum {
 /* --- Scheduler Run-Queue Algorithm Ops --- */
 
 // Forward declarations
-struct kthread;
+struct bh_thread;
 
 typedef struct {
-    struct kthread* (*pick_next_ready)(uint32_t core_id);
-    void (*enqueue_task)(struct kthread* thread, uint32_t core_id);
-    void (*dequeue_task)(struct kthread* thread, uint32_t core_id);
+    struct bh_thread* (*pick_next_ready)(uint32_t core_id);
+    void (*enqueue_task)(struct bh_thread* thread, uint32_t core_id);
+    void (*dequeue_task)(struct bh_thread* thread, uint32_t core_id);
 } sched_algo_ops_t;
 
 /* --- Generic Search/Sort Algorithm Ops --- */

--- a/kernel/include/sched/sched.h
+++ b/kernel/include/sched/sched.h
@@ -56,7 +56,7 @@ typedef struct {
     uint64_t deadline_ms;
     uint64_t period_ms;
     uint64_t wcet_ms;
-} kthread_attr_t;
+} bh_thread_attr_t;
 
 typedef struct bh_thread bh_thread_t;
 typedef struct bh_process bh_process_t;
@@ -70,8 +70,8 @@ typedef enum {
 } thread_fault_t;
 
 typedef struct sched_rq {
-    kthread_t* current_thread;
-    kthread_t* idle_thread;
+    bh_thread_t* current_thread;
+    bh_thread_t* idle_thread;
 
     // Priority / RT Scheduler
     list_head_t ready_queue[MAX_PRIORITY_LEVELS];
@@ -123,17 +123,17 @@ typedef struct sched_rq {
 } sched_rq_t;
 
 typedef struct {
-    kthread_t* head;
-    kthread_t* tail;
+    bh_thread_t* head;
+    bh_thread_t* tail;
 } wait_queue_t;
 
 #include <bharat/constraints.h>
 
 
-struct kthread {
+struct bh_thread {
     uint64_t thread_id;
     uint64_t process_id;
-    kprocess_t* process;
+    bh_process_t* process;
 
     bh_exec_constraints_k_t constraints;
 
@@ -175,7 +175,7 @@ struct kthread {
     uint8_t preferred_numa_node;
     ai_sched_context_t* ai_sched_ctx;
     uint64_t context_switch_count;
-    kthread_attr_t rt_attr;
+    bh_thread_attr_t rt_attr;
     uint64_t wake_deadline_ms;
     uint32_t bound_core_id;
     uint32_t affinity_mask;
@@ -184,7 +184,7 @@ struct kthread {
     struct sched_context* sched_ctx;
 
     // Next thread in a wait queue
-    kthread_t* next_waiter;
+    bh_thread_t* next_waiter;
 
     // IPC blocking state
     uint64_t ipc_deadline_ticks;
@@ -195,12 +195,12 @@ struct kthread {
     bool fault_pending;
 };
 
-int thread_raise_fault(kthread_t *thread, thread_fault_t fault);
+int thread_raise_fault(bh_thread_t *thread, thread_fault_t fault);
 
-struct kprocess {
+struct bh_process {
     uint64_t process_id;
     address_space_t* addr_space;
-    kthread_t* main_thread;
+    bh_thread_t* main_thread;
 
     // Ownership and lookup metadata
     uint32_t home_core_id;
@@ -224,21 +224,21 @@ struct kprocess {
 void sched_init(void);
 
 // Create process and main thread
-kprocess_t* process_create(const char* name);
-int process_destroy(kprocess_t* process);
-kthread_t* thread_create(kprocess_t* parent, void (*entry_point)(void));
-kthread_t* thread_create_detached(kprocess_t* parent, void (*entry_point)(void));
-int thread_destroy(kthread_t* thread);
+bh_process_t* process_create(const char* name);
+int process_destroy(bh_process_t* process);
+bh_thread_t* thread_create(bh_process_t* parent, void (*entry_point)(void));
+bh_thread_t* thread_create_detached(bh_process_t* parent, void (*entry_point)(void));
+int thread_destroy(bh_thread_t* thread);
 
 // Current Context Helpers
-kprocess_t* sched_current_process(void);
+bh_process_t* sched_current_process(void);
 address_space_t* sched_current_aspace(void);
 struct capability_table* sched_current_cap_table(void);
 
 // Wait Queues
 void sched_wait_queue_init(wait_queue_t* queue);
-void sched_wait_queue_enqueue(wait_queue_t* queue, kthread_t* thread);
-kthread_t* sched_wait_queue_dequeue(wait_queue_t* queue);
+void sched_wait_queue_enqueue(wait_queue_t* queue, bh_thread_t* thread);
+bh_thread_t* sched_wait_queue_dequeue(wait_queue_t* queue);
 
 // TODO: Needs refactor: #include directive placed mid-file for dependency/order compatibility.
 #include "personality_ops.h"
@@ -247,51 +247,51 @@ kthread_t* sched_wait_queue_dequeue(wait_queue_t* queue);
 void sched_block(void);
 
 // L0 layer access (for testing)
-kthread_t *sched_pick_next_ready_l0(uint32_t core_id);
+bh_thread_t *sched_pick_next_ready_l0(uint32_t core_id);
 
 // Context Switching
-void kthread_yield(void);
+void bh_thread_yield(void);
 void sched_on_timer_tick(void);
-kthread_t* sched_current_thread(void);
+bh_thread_t* sched_current_thread(void);
 uint64_t sched_get_ticks(void);
 void sched_set_policy(sched_policy_t policy);
 void sched_reschedule(void);
-kthread_t* sched_current(void);
-int sched_enqueue(kthread_t* thread, uint32_t core_id);
+bh_thread_t* sched_current(void);
+int sched_enqueue(bh_thread_t* thread, uint32_t core_id);
 void sched_sleep(uint64_t millis);
-void sched_wakeup(kthread_t* thread);
-void sched_wakeup_with_priority(kthread_t* thread, uint32_t wakeup_priority);
+void sched_wakeup(bh_thread_t* thread);
+void sched_wakeup_with_priority(bh_thread_t* thread, uint32_t wakeup_priority);
 
 // AI governor integration helpers
-kthread_t* sched_find_thread_by_id(uint64_t tid);
+bh_thread_t* sched_find_thread_by_id(uint64_t tid);
 int sched_set_thread_priority(uint64_t tid, uint32_t new_priority);
 int sched_set_thread_preferred_node(uint64_t tid, uint8_t node_id);
 int sched_ai_apply_suggestion(const ai_suggestion_t* suggestion);
 int sched_enqueue_ai_suggestion(const ai_suggestion_t* suggestion);
-int sched_migrate_task(kthread_t* thread, uint32_t new_node);
-int sched_adjust_priority(kthread_t* thread, uint32_t new_priority);
+int sched_migrate_task(bh_thread_t* thread, uint32_t new_node);
+int sched_adjust_priority(bh_thread_t* thread, uint32_t new_priority);
 int sched_throttle_core(uint32_t core_id);
 
 // Cross-core remote handoff
-int sched_request_remote_handoff(kthread_t* thread, uint32_t target_core, uint32_t auth_token);
+int sched_request_remote_handoff(bh_thread_t* thread, uint32_t target_core, uint32_t auth_token);
 
 // RT Scheduler Admissions
-int sched_admission_edf(kthread_t* thread, uint64_t wcet_ms, uint64_t period_ms, uint64_t deadline_ms);
-int sched_admission_rms(kthread_t* thread, uint64_t wcet_ms, uint64_t period_ms);
+int sched_admission_edf(bh_thread_t* thread, uint64_t wcet_ms, uint64_t period_ms, uint64_t deadline_ms);
+int sched_admission_rms(bh_thread_t* thread, uint64_t wcet_ms, uint64_t period_ms);
 
 // System-call style entry points used by trap/syscall layer
-int sched_sys_thread_create(kprocess_t* parent, void (*entry_point)(void), uint64_t* out_tid);
+int sched_sys_thread_create(bh_process_t* parent, void (*entry_point)(void), uint64_t* out_tid);
 int sched_sys_thread_destroy(uint64_t tid);
 int sched_sys_sleep(uint64_t millis);
 int sched_sys_set_priority(uint64_t tid, uint32_t new_priority);
 int sched_sys_set_affinity(uint64_t tid, uint32_t affinity_mask);
 
 // Priority Inheritance support
-void sched_inherit_priority(kthread_t* thread, uint32_t new_priority);
-void sched_restore_priority(kthread_t* thread);
-void sched_on_mutex_wait(kthread_t* waiter, void* mutex);
-void sched_on_mutex_acquire(kthread_t* owner, void* mutex);
-void sched_on_mutex_release(kthread_t* owner, void* mutex);
+void sched_inherit_priority(bh_thread_t* thread, uint32_t new_priority);
+void sched_restore_priority(bh_thread_t* thread);
+void sched_on_mutex_wait(bh_thread_t* waiter, void* mutex);
+void sched_on_mutex_acquire(bh_thread_t* owner, void* mutex);
+void sched_on_mutex_release(bh_thread_t* owner, void* mutex);
 
 // Multikernel IPC integration stub
 void sched_notify_ipc_ready(uint32_t core_id, uint32_t msg_type);

--- a/kernel/include/sched/sched_deg.h
+++ b/kernel/include/sched/sched_deg.h
@@ -22,7 +22,7 @@ typedef struct dist_exec_group {
     deg_mode_t mode;
     deg_state_t state;
     uint32_t member_count;
-    struct kthread* members[MAX_DEG_MEMBERS];
+    struct bh_thread* members[MAX_DEG_MEMBERS];
     uint32_t ready_bitmap;
     uint32_t running_bitmap;
     uint64_t release_epoch;
@@ -40,11 +40,11 @@ typedef struct sched_context {
 } sched_context_t;
 
 dist_exec_group_t* deg_create(void);
-int deg_add_member(dist_exec_group_t* deg, struct kthread* thread, uint32_t core, uint32_t local_sched_class);
+int deg_add_member(dist_exec_group_t* deg, struct bh_thread* thread, uint32_t core, uint32_t local_sched_class);
 int deg_activate(dist_exec_group_t* deg);
-int deg_mark_ready(struct kthread* thread);
+int deg_mark_ready(struct bh_thread* thread);
 int deg_release_if_ready(dist_exec_group_t* deg);
-void deg_block_member(struct kthread* thread, uint32_t reason);
+void deg_block_member(struct bh_thread* thread, uint32_t reason);
 void deg_abort_epoch(dist_exec_group_t* deg);
 
 #endif // BHARAT_SCHED_DEG_H

--- a/kernel/include/sched/sched_router_contract.h
+++ b/kernel/include/sched/sched_router_contract.h
@@ -32,19 +32,19 @@ typedef enum {
  * Enqueue a thread through router-approved class/core paths.
  * Returns 0 on success, negative error code on rejection/failure.
  */
-int sched_router_enqueue(kthread_t *thread, uint32_t core_id, sched_route_reason_t reason);
+int sched_router_enqueue(bh_thread_t *thread, uint32_t core_id, sched_route_reason_t reason);
 
 /*
  * Dequeue a thread through router-approved class/core paths.
  * Returns 0 on success, negative error code on rejection/failure.
  */
-int sched_router_dequeue(kthread_t *thread, uint32_t core_id, sched_route_reason_t reason);
+int sched_router_dequeue(bh_thread_t *thread, uint32_t core_id, sched_route_reason_t reason);
 
 /*
  * Pick next runnable thread for the given core according to active composition.
  * Returns NULL when no runnable candidate exists (idle fallback expected).
  */
-kthread_t *sched_router_pick_next(uint32_t core_id);
+bh_thread_t *sched_router_pick_next(uint32_t core_id);
 
 /*
  * Per-tick hook for router/class accounting updates.
@@ -54,14 +54,14 @@ void sched_router_on_tick(uint32_t core_id, uint64_t now_ticks);
 /*
  * Thread state transition hooks that preserve core lifecycle authority.
  */
-void sched_router_on_block(kthread_t *thread, uint32_t core_id);
-void sched_router_on_wake(kthread_t *thread, uint32_t core_id);
+void sched_router_on_block(bh_thread_t *thread, uint32_t core_id);
+void sched_router_on_wake(bh_thread_t *thread, uint32_t core_id);
 
 /*
  * Notify router about ownership transfer across cores.
  * Returns 0 on success, negative error code otherwise.
  */
-int sched_router_on_migrate(kthread_t *thread,
+int sched_router_on_migrate(bh_thread_t *thread,
                             uint32_t src_core,
                             uint32_t dst_core,
                             sched_route_reason_t reason);

--- a/kernel/src/capability.c
+++ b/kernel/src/capability.c
@@ -136,7 +136,7 @@ capability_table_t* cap_table_create(void) {
     return NULL;
 }
 
-int cap_table_init_for_process(kprocess_t* proc) {
+int cap_table_init_for_process(bh_process_t* proc) {
     if (!BHARAT_PTR_NON_NULL(proc)) {
         return -1;
     }

--- a/kernel/src/core/fault_domain.c
+++ b/kernel/src/core/fault_domain.c
@@ -28,7 +28,7 @@ int sys_fault_domain_destroy(uint64_t domain) {
 }
 
 int sys_fault_domain_attach(uint64_t domain, uint64_t tid) {
-    kthread_t *thread = sched_find_thread_by_id(tid);
+    bh_thread_t *thread = sched_find_thread_by_id(tid);
     if (!thread) return -1;
     // TODO: store fault domain id
     (void)thread;

--- a/kernel/src/demo/bharat_demo.c
+++ b/kernel/src/demo/bharat_demo.c
@@ -133,7 +133,7 @@ static void high_priority_thread(void)
     }
     g_hi_done = 1U;
     while (1) {
-        kthread_yield();
+        bh_thread_yield();
     }
 }
 
@@ -145,7 +145,7 @@ static void low_priority_thread(void)
     }
     g_lo_done = 1U;
     while (1) {
-        kthread_yield();
+        bh_thread_yield();
     }
 }
 
@@ -156,7 +156,7 @@ static void demo_scheduler(void)
     g_lo_log_count = 0U;
 
     DEMO_PRINT("  [SCHED] Creating kernel process...\n");
-    kprocess_t *proc = process_create("bharat-demo");
+    bh_process_t *proc = process_create("bharat-demo");
     if (proc == NULL) {
         DEMO_PRINT("  [SCHED] WARN: process_create() returned NULL (stub env).\n");
         DEMO_PRINT("  [SCHED] Scheduler demo -- PARTIAL (stub mode)\n");
@@ -191,7 +191,7 @@ static void demo_scheduler(void)
     }
 
     /* Yield so that both threads can run */
-    kthread_yield();
+    bh_thread_yield();
 
     /* Report results */
     DEMO_PRINT("  [SCHED] HI-PRI done=");
@@ -211,7 +211,7 @@ static void demo_scheduler(void)
     // Demonstrate remote handoff if multi-core is simulated or available
     DEMO_PRINT("  [SCHED] Requesting remote thread handoff to core 1...\n");
     if (lo_tid != 0U) {
-        kthread_t *lo_thread = sched_find_thread_by_id(lo_tid);
+        bh_thread_t *lo_thread = sched_find_thread_by_id(lo_tid);
         if (lo_thread) {
             int ret = sched_request_remote_handoff(lo_thread, 1, 0xDEADBEEF);
             if (ret == 0) {
@@ -233,7 +233,7 @@ static void demo_ipc(void)
 {
     demo_section("ASYNC IPC");
 
-    kthread_t *cur = sched_current_thread();
+    bh_thread_t *cur = sched_current_thread();
     if (cur == NULL) {
         DEMO_PRINT("  [IPC]  No running thread context - skipping full test.\n");
         return;

--- a/kernel/src/demo/kernel_tester.c
+++ b/kernel/src/demo/kernel_tester.c
@@ -18,7 +18,7 @@ static void test_sched_yield_smoke(void) {
    * Instead, verify the scheduler is live by reading its tick counter
    * and checking the current thread handle is valid.                   */
   uint64_t t0 = sched_get_ticks();
-  kthread_t *cur = sched_current_thread();
+  bh_thread_t *cur = sched_current_thread();
   uint64_t t1 = sched_get_ticks();
   (void)t0; (void)t1;
   if (cur != (void*)0) {

--- a/kernel/src/init/init_bootstrap.c
+++ b/kernel/src/init/init_bootstrap.c
@@ -35,12 +35,12 @@ static void bootstrap_thread_entry(void) {
     console_write_raw("  [BOOTSTRAP] services/init launch deferred (degraded boot)\n", 59);
 
     thread_destroy(sched_current_thread());
-    kthread_yield();
+    bh_thread_yield();
 }
 
 void kernel_start_init_service(void) {
     // Create a dedicated kernel thread to bootstrap user-space
-    kprocess_t *proc = process_create("sysmgr");
+    bh_process_t *proc = process_create("sysmgr");
     if (proc) {
         uint64_t tid = 0;
         sched_sys_thread_create(proc, bootstrap_thread_entry, &tid);

--- a/kernel/src/ipc/async_ipc.c
+++ b/kernel/src/ipc/async_ipc.c
@@ -127,7 +127,7 @@ void ipc_async_init(void) {
     g_next_async_id = 1U;
 }
 
-ipc_async_request_t* ipc_async_request_create_ex(kthread_t* thread,
+ipc_async_request_t* ipc_async_request_create_ex(bh_thread_t* thread,
                                                   uint32_t endpoint_ref,
                                                   uint64_t timeout_ms,
                                                   uint32_t qos_priority,
@@ -158,13 +158,13 @@ ipc_async_request_t* ipc_async_request_create_ex(kthread_t* thread,
     return req;
 }
 
-ipc_async_request_t* ipc_async_request_create(kthread_t* thread, uint32_t endpoint_ref, uint64_t timeout_ms) {
+ipc_async_request_t* ipc_async_request_create(bh_thread_t* thread, uint32_t endpoint_ref, uint64_t timeout_ms) {
     return ipc_async_request_create_ex(thread, endpoint_ref, timeout_ms, 0U, 0U);
 }
 
 void ipc_async_request_complete(ipc_async_request_t* req) {
     if (req && req->in_use && req->state == IPC_ASYNC_STATE_PENDING) {
-        kthread_t* waiting = req->waiting_thread;
+        bh_thread_t* waiting = req->waiting_thread;
         uint32_t qos = req->qos_priority;
         req->state = IPC_ASYNC_STATE_COMPLETED;
         ipc_async_free_slot(req);
@@ -177,7 +177,7 @@ void ipc_async_request_complete(ipc_async_request_t* req) {
 
 void ipc_async_request_cancel(ipc_async_request_t* req) {
     if (req && req->in_use && req->state == IPC_ASYNC_STATE_PENDING) {
-        kthread_t* waiting = req->waiting_thread;
+        bh_thread_t* waiting = req->waiting_thread;
         uint32_t qos = req->qos_priority;
         req->state = IPC_ASYNC_STATE_CANCELLED;
         ipc_async_free_slot(req);
@@ -190,7 +190,7 @@ void ipc_async_request_cancel(ipc_async_request_t* req) {
 void ipc_async_request_timeout(ipc_async_request_t* req, uint64_t current_ticks) {
     (void)current_ticks;
     if (req && req->in_use && req->state == IPC_ASYNC_STATE_PENDING) {
-        kthread_t* waiting = req->waiting_thread;
+        bh_thread_t* waiting = req->waiting_thread;
         uint32_t qos = req->qos_priority;
         req->state = IPC_ASYNC_STATE_TIMEOUT;
         ipc_async_free_slot(req);

--- a/kernel/src/ipc/endpoint_ipc.c
+++ b/kernel/src/ipc/endpoint_ipc.c
@@ -138,7 +138,7 @@ int ipc_endpoint_send(capability_table_t* table, uint32_t send_cap, const void* 
             return IPC_ERR_WOULD_BLOCK;
         }
 
-        kthread_t* cur = sched_current_thread();
+        bh_thread_t* cur = sched_current_thread();
         if (!cur) {
             spin_unlock(&ep->lock);
             return IPC_ERR_WOULD_BLOCK;
@@ -188,7 +188,7 @@ int ipc_endpoint_send(capability_table_t* table, uint32_t send_cap, const void* 
 
     ep->has_msg = 1U;
 
-    kthread_t* recv = sched_wait_queue_dequeue(&ep->receivers);
+    bh_thread_t* recv = sched_wait_queue_dequeue(&ep->receivers);
     spin_unlock(&ep->lock);
 
     if (recv != NULL) {
@@ -231,7 +231,7 @@ int ipc_endpoint_receive(capability_table_t* table, uint32_t recv_cap, void* out
             return IPC_ERR_WOULD_BLOCK;
         }
 
-        kthread_t* cur = sched_current_thread();
+        bh_thread_t* cur = sched_current_thread();
         if (!cur) {
             spin_unlock(&ep->lock);
             return IPC_ERR_WOULD_BLOCK;
@@ -311,7 +311,7 @@ int ipc_endpoint_receive(capability_table_t* table, uint32_t recv_cap, void* out
     ep->cap_transfer_src_table = NULL;
     ep->has_msg = 0U;
 
-    kthread_t* sender = sched_wait_queue_dequeue(&ep->senders);
+    bh_thread_t* sender = sched_wait_queue_dequeue(&ep->senders);
     spin_unlock(&ep->lock);
 
     if (sender != NULL) {

--- a/kernel/src/ipc/mk_dispatch.c
+++ b/kernel/src/ipc/mk_dispatch.c
@@ -119,7 +119,7 @@ static void mk_handle_thread_handoff_req(mk_channel_t *channel, urpc_msg_t *msg)
         return;
     }
 
-    kthread_t *thread = sched_find_thread_by_id(payload.thread_id);
+    bh_thread_t *thread = sched_find_thread_by_id(payload.thread_id);
     if (!thread) {
         // Thread not found
         urpc_msg_t nack = {

--- a/kernel/src/kernel_boot.c
+++ b/kernel/src/kernel_boot.c
@@ -346,7 +346,7 @@ static void runtime_enter_normal(const boot_info_t *boot) {
     kernel_start_init_service();
 
     // Force first reschedule to start sysmgr immediately
-    kthread_yield();
+    bh_thread_yield();
 
     // Controlled idle
     while (1) {

--- a/kernel/src/mm/pmm/numa.c
+++ b/kernel/src/mm/pmm/numa.c
@@ -201,7 +201,7 @@ static void set_mapped_page_node(uintptr_t address_space_key, uint64_t vaddr, me
 void numa_record_page_access(void* thread_ptr, uint64_t vaddr, numa_access_type_t access_type) {
     (void)access_type;
     ensure_cache_init();
-    kthread_t* thread = (kthread_t*)thread_ptr;
+    bh_thread_t* thread = (bh_thread_t*)thread_ptr;
     if (!thread || !thread->process || !thread->process->addr_space) return;
 
     uintptr_t as_key = (uintptr_t)thread->process->addr_space;
@@ -219,7 +219,7 @@ void numa_record_page_access(void* thread_ptr, uint64_t vaddr, numa_access_type_
 
 void numa_select_migration_candidates(void* thread_ptr) {
     ensure_cache_init();
-    kthread_t* thread = (kthread_t*)thread_ptr;
+    bh_thread_t* thread = (bh_thread_t*)thread_ptr;
     if (!thread || !thread->process || !thread->process->addr_space) return;
     if (thread->preferred_numa_node >= NUMA_MAX_NODES) return;
 
@@ -292,7 +292,7 @@ int numa_migrate_page(uint64_t vaddr, memory_node_id_t target_node, void* addres
 }
 
 void numa_balance_thread_memory(void* thread_ptr) {
-    kthread_t* thread = (kthread_t*)thread_ptr;
+    bh_thread_t* thread = (bh_thread_t*)thread_ptr;
     if (!thread) return;
 
     // In a background worker, run `numa_select_migration_candidates`

--- a/kernel/src/mm/pmm/numa_policy.c
+++ b/kernel/src/mm/pmm/numa_policy.c
@@ -63,13 +63,13 @@ memory_node_id_t numa_policy_next_interleave_node(const numa_affinity_t *policy,
 // Scheduler hints (stub implementation)
 void numa_policy_set_thread_affinity(void *thread, const numa_affinity_t *policy) {
     if (!thread || !policy) return;
-    kthread_t *t = (kthread_t *)thread;
+    bh_thread_t *t = (bh_thread_t *)thread;
     t->preferred_numa_node = policy->target_node;
 }
 
 int numa_policy_get_thread_affinity(void *thread, numa_affinity_t *out_policy) {
     if (!thread || !out_policy) return -1;
-    kthread_t *t = (kthread_t *)thread;
+    bh_thread_t *t = (bh_thread_t *)thread;
 
     out_policy->policy = NUMA_POLICY_LOCAL_PREFERRED;
     out_policy->target_node = t->preferred_numa_node;

--- a/kernel/src/mm/pmm/pmm.c
+++ b/kernel/src/mm/pmm/pmm.c
@@ -622,7 +622,7 @@ static phys_addr_t pmm_alloc_pages_colored_in_zone(int order, uint32_t preferred
   }
 
   // Still OOM, invoke AI governor action to kill current task
-  kthread_t *current = sched_current_thread();
+  bh_thread_t *current = sched_current_thread();
   if (current) {
     ai_suggestion_t suggestion;
     suggestion.action = AI_ACTION_KILL_TASK;
@@ -636,7 +636,7 @@ static phys_addr_t pmm_alloc_pages_colored_in_zone(int order, uint32_t preferred
 
 phys_addr_t mm_alloc_pages_order(int order, uint32_t preferred_numa_node,
                                  uint32_t flags) {
-  kthread_t *current = sched_current_thread();
+  bh_thread_t *current = sched_current_thread();
   mm_color_config_t *color_config = NULL;
   if (current) {
     color_config = &current->mm_color_policy;

--- a/kernel/src/panic.c
+++ b/kernel/src/panic.c
@@ -95,7 +95,7 @@ void kernel_panic_ex(const panic_context_t *ctx) {
   local_ctx.core_id = hal_cpu_get_id();
 
   if (console_current_phase() >= CONSOLE_PHASE_RUNTIME) {
-      kthread_t *thread = sched_current_thread();
+      bh_thread_t *thread = sched_current_thread();
       if (thread) {
           if (local_ctx.thread_id == 0) {
               local_ctx.thread_id = thread->thread_id;

--- a/kernel/src/sched/ai_sched.c
+++ b/kernel/src/sched/ai_sched.c
@@ -3,7 +3,7 @@
 #include <stddef.h>
 #include <sched/sched.h>
 
-extern bool sched_is_core_admissible(kthread_t *t, int cpu_id);
+extern bool sched_is_core_admissible(bh_thread_t *t, int cpu_id);
 
 // @cite Integrating Artificial Intelligence into Operating Systems (Korshun et al., 2024)
 // @cite Enhancing Operating System Performance with AI (S. S. et al., 2025)
@@ -263,21 +263,21 @@ uint8_t ai_model_ready(void) {
 }
 
 // Mock prediction function for demonstration
-static struct kthread* ai_model_predict_best(struct kthread *run_queue) {
+static struct bh_thread* ai_model_predict_best(struct bh_thread *run_queue) {
     (void)run_queue;
     return NULL;
 }
 
 // Simple fallback scheduler
-struct kthread* fallback_scheduler(struct kthread *run_queue) {
+struct bh_thread* fallback_scheduler(struct bh_thread *run_queue) {
     if (run_queue == NULL) return NULL;
-    // In a real kthread_t, next would be handled via list_head_t.
+    // In a real bh_thread_t, next would be handled via list_head_t.
     // For the sake of this conceptual implementation, we'll return run_queue.
     return run_queue;
 }
 
 // Main AI selection logic
-struct kthread* ai_sched_select_task(struct kthread *run_queue) {
+struct bh_thread* ai_sched_select_task(struct bh_thread *run_queue) {
     // 1. Check if AI subsystem is active and model is loaded
     if (!ai_telemetry.is_active || !ai_model_ready()) {
         return fallback_scheduler(run_queue); // Immediate fallback
@@ -286,7 +286,7 @@ struct kthread* ai_sched_select_task(struct kthread *run_queue) {
     // 2. Attempt AI-based prediction
     // NOTE: This is a placeholder. In a full implementation, the global/per-core
     // heap structure would be passed here, and we would use select_and_update_queue.
-    struct kthread *selected = ai_model_predict_best(run_queue);
+    struct bh_thread *selected = ai_model_predict_best(run_queue);
 
     // 3. Final safety check: if prediction fails, use fallback
     if (selected == NULL) {

--- a/kernel/src/sched/algo_matrix.c
+++ b/kernel/src/sched/algo_matrix.c
@@ -14,16 +14,16 @@ sched_algo_ops_t  g_sched_ops;
 search_algo_ops_t g_search_ops;
 
 /* Fallbacks to be assigned in their respective modules */
-extern struct kthread* sched_pick_next_ready_l0(uint32_t core_id);
-extern void sched_enqueue_task_l0(struct kthread* thread, uint32_t core_id);
-extern void sched_dequeue_task_l0(struct kthread* thread, uint32_t core_id);
+extern struct bh_thread* sched_pick_next_ready_l0(uint32_t core_id);
+extern void sched_enqueue_task_l0(struct bh_thread* thread, uint32_t core_id);
+extern void sched_dequeue_task_l0(struct bh_thread* thread, uint32_t core_id);
 
 extern int device_lookup_mmio_window_l0(uint32_t class_id, uint32_t device_id, uint32_t window_id, void* out_window);
 
 /* Optimized Level 1 (SMP/per-CPU) implementations */
-extern struct kthread* sched_pick_next_ready_l1(uint32_t core_id);
-extern void sched_enqueue_task_l1(struct kthread* thread, uint32_t core_id);
-extern void sched_dequeue_task_l1(struct kthread* thread, uint32_t core_id);
+extern struct bh_thread* sched_pick_next_ready_l1(uint32_t core_id);
+extern void sched_enqueue_task_l1(struct bh_thread* thread, uint32_t core_id);
+extern void sched_dequeue_task_l1(struct bh_thread* thread, uint32_t core_id);
 
 extern int device_lookup_mmio_window_l1(uint32_t class_id, uint32_t device_id, uint32_t window_id, void* out_window);
 

--- a/kernel/src/sched/constraint_apply.c
+++ b/kernel/src/sched/constraint_apply.c
@@ -2,7 +2,7 @@
 #include <hal/hal.h>
 #include "sched_internal.h"
 
-bool sched_is_core_admissible(kthread_t *t, int cpu_id)
+bool sched_is_core_admissible(bh_thread_t *t, int cpu_id)
 {
     if (!t) return false;
 

--- a/kernel/src/sched/sched.c
+++ b/kernel/src/sched/sched.c
@@ -54,15 +54,15 @@ void sched_ready_bitmap_clear_if_empty(sched_rq_t *rq, uint32_t prio);
 int sched_pick_priority_from_bitmap(const sched_rq_t *rq, int highest);
 
 // CFS Functions
-void sched_cfs_enqueue(sched_rq_t *rq, kthread_t *thread);
-void sched_cfs_dequeue(sched_rq_t *rq, kthread_t *thread);
-kthread_t *sched_cfs_pick_next(sched_rq_t *rq);
-void sched_cfs_update_vruntime(sched_rq_t *rq, kthread_t *thread, uint64_t delta_exec);
+void sched_cfs_enqueue(sched_rq_t *rq, bh_thread_t *thread);
+void sched_cfs_dequeue(sched_rq_t *rq, bh_thread_t *thread);
+bh_thread_t *sched_cfs_pick_next(sched_rq_t *rq);
+void sched_cfs_update_vruntime(sched_rq_t *rq, bh_thread_t *thread, uint64_t delta_exec);
 
 // EDF Functions
-void sched_edf_enqueue(sched_rq_t *rq, kthread_t *thread);
-void sched_edf_dequeue(sched_rq_t *rq, kthread_t *thread);
-kthread_t *sched_edf_pick_next(sched_rq_t *rq);
+void sched_edf_enqueue(sched_rq_t *rq, bh_thread_t *thread);
+void sched_edf_dequeue(sched_rq_t *rq, bh_thread_t *thread);
+bh_thread_t *sched_edf_pick_next(sched_rq_t *rq);
 
 void sched_validate_rq(sched_rq_t *rq);
 
@@ -193,7 +193,7 @@ void sched_detach_thread_from_queues(thread_slot_t *slot) {
   if (!slot) {
     return;
   }
-  kthread_t *thread = &slot->thread;
+  bh_thread_t *thread = &slot->thread;
   uint32_t core_id = sched_clamp_core(thread->bound_core_id);
   sched_rq_t *rq = &g_cpu_locals[core_id].runqueue;
 
@@ -264,7 +264,7 @@ static int sched_enqueue_reap(thread_slot_t *slot) {
   return 0;
 }
 
-int sched_mark_thread_terminated(kthread_t *thread) {
+int sched_mark_thread_terminated(bh_thread_t *thread) {
   if (!thread) {
     return -1;
   }
@@ -310,7 +310,7 @@ void sched_reap_terminated_threads(void) {
   }
 }
 
-extern bool sched_is_core_admissible(kthread_t *t, int cpu_id);
+extern bool sched_is_core_admissible(bh_thread_t *t, int cpu_id);
 
 
 
@@ -332,12 +332,12 @@ static void sched_monitor_task(void) {
         // BSP monitor might do system-wide coordination
       }
     }
-    kthread_yield();
+    bh_thread_yield();
   }
 }
 
 void sched_thread_exit_trampoline(void) {
-  kthread_t *current = sched_current_thread();
+  bh_thread_t *current = sched_current_thread();
   if (current) {
     uint32_t core = sched_clamp_core(hal_cpu_get_id());
     (void)sched_mark_thread_terminated(current);
@@ -411,7 +411,7 @@ void sched_reset_core_runqueues(void) {
   }
 }
 
-static kthread_t *sched_create_bootstrap_thread(kprocess_t *parent,
+static bh_thread_t *sched_create_bootstrap_thread(bh_process_t *parent,
                                                 uint32_t core,
                                                 uint32_t kind,
                                                 void (*entry_point)(void),
@@ -478,9 +478,9 @@ void sched_init(void) {
 
   sched_reset_core_runqueues();
 
-  kprocess_t *idle_process = process_create("idle_process");
+  bh_process_t *idle_process = process_create("idle_process");
   for (uint32_t core = 0; core < g_active_core_count; ++core) {
-    kthread_t *idle = sched_create_bootstrap_thread(
+    bh_thread_t *idle = sched_create_bootstrap_thread(
         idle_process, core, SCHED_BOOTSTRAP_IDLE, sched_idle_task, 0U, 0U);
     g_cpu_locals[core].runqueue.idle_thread = idle;
     g_cpu_locals[core].runqueue.current_thread = idle;
@@ -492,7 +492,7 @@ void sched_init(void) {
   g_sched_initialized = 1U;
 }
 
-kprocess_t *process_create(const char *name) {
+bh_process_t *process_create(const char *name) {
   (void)name;
   process_slot_t *slot = sched_find_free_process_slot();
   if (!slot) {
@@ -525,7 +525,7 @@ kprocess_t *process_create(const char *name) {
 
 
 
-kthread_t *thread_create_detached(kprocess_t *parent, void (*entry_point)(void)) {
+bh_thread_t *thread_create_detached(bh_process_t *parent, void (*entry_point)(void)) {
   thread_slot_t *slot = sched_find_free_thread_slot();
   if (!slot) {
     return NULL;
@@ -595,8 +595,8 @@ kthread_t *thread_create_detached(kprocess_t *parent, void (*entry_point)(void))
   return &slot->thread;
 }
 
-kthread_t *thread_create(kprocess_t *parent, void (*entry_point)(void)) {
-  kthread_t *thread = thread_create_detached(parent, entry_point);
+bh_thread_t *thread_create(bh_process_t *parent, void (*entry_point)(void)) {
+  bh_thread_t *thread = thread_create_detached(parent, entry_point);
   if (thread && entry_point != (void (*)(void))sched_idle_task) {
     (void)sched_enqueue(thread, thread->bound_core_id);
   }
@@ -605,7 +605,7 @@ kthread_t *thread_create(kprocess_t *parent, void (*entry_point)(void)) {
 
 
 
-kthread_t *sched_find_mutex_owner(void *mutex) {
+bh_thread_t *sched_find_mutex_owner(void *mutex) {
   if (!mutex) {
     return NULL;
   }
@@ -622,7 +622,7 @@ kthread_t *sched_find_mutex_owner(void *mutex) {
   return NULL;
 }
 
-void sched_register_mutex_owner(void *mutex, kthread_t *owner) {
+void sched_register_mutex_owner(void *mutex, bh_thread_t *owner) {
   if (!mutex) {
     return;
   }
@@ -639,7 +639,7 @@ void sched_register_mutex_owner(void *mutex, kthread_t *owner) {
   }
 }
 
-void sched_unregister_mutex_owner(void *mutex, kthread_t *owner) {
+void sched_unregister_mutex_owner(void *mutex, bh_thread_t *owner) {
   if (!mutex) {
     return;
   }
@@ -669,7 +669,7 @@ void sched_unregister_mutex_owner(void *mutex, kthread_t *owner) {
 
 
 
-void sched_update_telemetry(kthread_t *thread) {
+void sched_update_telemetry(bh_thread_t *thread) {
   if (!thread || !thread->ai_sched_ctx) {
     return;
   }
@@ -680,11 +680,11 @@ void sched_update_telemetry(kthread_t *thread) {
                           (uint32_t)thread->context_switch_count);
 }
 
-kthread_t *sched_pick_next_ready(uint32_t core_id) {
+bh_thread_t *sched_pick_next_ready(uint32_t core_id) {
   core_id = sched_clamp_core(core_id);
   sched_rq_t *rq = &g_cpu_locals[core_id].runqueue;
 
-  kthread_t *next = NULL;
+  bh_thread_t *next = NULL;
 
   if (g_policy == SCHED_POLICY_CLOUD_FAIR) {
       next = sched_cfs_pick_next(rq);
@@ -746,7 +746,7 @@ kthread_t *sched_pick_next_ready(uint32_t core_id) {
 
 
 
-kthread_t *sched_pick_next_ready_l0(uint32_t core_id) {
+bh_thread_t *sched_pick_next_ready_l0(uint32_t core_id) {
   return sched_pick_next_ready(core_id);
 }
 
@@ -754,17 +754,17 @@ kthread_t *sched_pick_next_ready_l0(uint32_t core_id) {
 
 
 
-kthread_t *sched_pick_next_ready_l1(uint32_t core_id) {
+bh_thread_t *sched_pick_next_ready_l1(uint32_t core_id) {
   return sched_pick_next_ready(core_id);
 }
 
-void sched_switch_to(kthread_t *next, uint32_t core_id) {
+void sched_switch_to(bh_thread_t *next, uint32_t core_id) {
   if (!next) {
     hal_cpu_enable_interrupts();
     return;
   }
 
-  kthread_t *current = g_cpu_locals[core_id].runqueue.current_thread;
+  bh_thread_t *current = g_cpu_locals[core_id].runqueue.current_thread;
   if (current == next) {
     hal_cpu_enable_interrupts();
     return;
@@ -844,19 +844,19 @@ void sched_switch_to(kthread_t *next, uint32_t core_id) {
 
 
 
-kthread_t *sched_edf_pick_next(sched_rq_t *rq) {
+bh_thread_t *sched_edf_pick_next(sched_rq_t *rq) {
     struct rb_node *left = rb_first(&rq->edf_runqueue);
     if (!left) {
         return NULL;
     }
-    return (kthread_t *)(void *)((char *)left - offsetof(kthread_t, edf_node));
+    return (bh_thread_t *)(void *)((char *)left - offsetof(bh_thread_t, edf_node));
 }
 
 
 
 
 
-void kthread_yield(void) { sched_reschedule(); }
+void bh_thread_yield(void) { sched_reschedule(); }
 
 
 
@@ -869,24 +869,24 @@ void kthread_yield(void) { sched_reschedule(); }
 
 
 
-kthread_t *sched_current_thread(void) {
+bh_thread_t *sched_current_thread(void) {
   return g_cpu_locals[sched_clamp_core(hal_cpu_get_id())].runqueue.current_thread;
 }
 
-kthread_t *sched_current(void) { return sched_current_thread(); }
+bh_thread_t *sched_current(void) { return sched_current_thread(); }
 
-kprocess_t *sched_current_process(void) {
-  kthread_t *t = sched_current_thread();
+bh_process_t *sched_current_process(void) {
+  bh_thread_t *t = sched_current_thread();
   return t ? t->process : NULL;
 }
 
 address_space_t *sched_current_aspace(void) {
-  kprocess_t *p = sched_current_process();
+  bh_process_t *p = sched_current_process();
   return p ? p->addr_space : NULL;
 }
 
 struct capability_table *sched_current_cap_table(void) {
-  kprocess_t *p = sched_current_process();
+  bh_process_t *p = sched_current_process();
   return p ? (struct capability_table *)p->security_sandbox_ctx : NULL;
 }
 
@@ -912,7 +912,7 @@ int sched_sys_sleep(uint64_t millis) {
 
 
 
-kthread_t *sched_find_thread_by_id(uint64_t tid) {
+bh_thread_t *sched_find_thread_by_id(uint64_t tid) {
   thread_slot_t *slot = sched_resolve_tid_owner_slow(tid);
   return slot ? &slot->thread : NULL;
 }
@@ -949,12 +949,12 @@ void sched_disable_tick_for_core(uint32_t core_id) { (void)core_id; }
 
 
 
-kthread_t *sched_cfs_pick_next(sched_rq_t *rq) {
+bh_thread_t *sched_cfs_pick_next(sched_rq_t *rq) {
     struct rb_node *left = rb_first(&rq->cfs_runqueue);
     if (!left) {
         return NULL;
     }
-    return (kthread_t *)(void *)((char *)left - offsetof(kthread_t, cfs_node));
+    return (bh_thread_t *)(void *)((char *)left - offsetof(bh_thread_t, cfs_node));
 }
 
 

--- a/kernel/src/sched/sched_ai_guard.c
+++ b/kernel/src/sched/sched_ai_guard.c
@@ -5,7 +5,7 @@ int sched_ai_apply_suggestion(const ai_suggestion_t *suggestion) {
   if (!suggestion) {
     return -1;
   }
-  kthread_t *thread = sched_find_thread_by_id((uint64_t)suggestion->target_id);
+  bh_thread_t *thread = sched_find_thread_by_id((uint64_t)suggestion->target_id);
   if (!thread) {
       return -1;
   }

--- a/kernel/src/sched/sched_core.c
+++ b/kernel/src/sched/sched_core.c
@@ -21,7 +21,7 @@ void sched_reschedule(void) {
       rq->resched_pending = 0U; // Clear flag since we are draining now
       list_head_t *curr = rq->pending_inbox.next;
       uint32_t drained = 0;
-      kthread_t *highest_prio_arrived = NULL;
+      bh_thread_t *highest_prio_arrived = NULL;
 
       while (curr != &rq->pending_inbox) {
           thread_slot_t *slot = (thread_slot_t *)(void *)((char *)curr - offsetof(thread_slot_t, wait_node));
@@ -30,7 +30,7 @@ void sched_reschedule(void) {
           list_del(&slot->wait_node);
           list_init(&slot->wait_node);
 
-          kthread_t* thread = &slot->thread;
+          bh_thread_t* thread = &slot->thread;
           thread->state = THREAD_STATE_READY;
 
           if (g_policy == SCHED_POLICY_CLOUD_FAIR) {
@@ -70,7 +70,7 @@ void sched_reschedule(void) {
     return;
   }
 
-  kthread_t *next = sched_pick_next_ready(core);
+  bh_thread_t *next = sched_pick_next_ready(core);
   sched_switch_to(next, core);
 }
 
@@ -118,7 +118,7 @@ void sched_on_timer_tick(void) {
   }
 
   sched_rq_t* rq = &g_cpu_locals[core].runqueue;
-  kthread_t *current = rq->current_thread;
+  bh_thread_t *current = rq->current_thread;
   if (!current) {
     sched_reschedule();
     return;
@@ -150,7 +150,7 @@ void sched_on_timer_tick(void) {
           return;
       }
 
-      kthread_t *next = sched_edf_pick_next(rq);
+      bh_thread_t *next = sched_edf_pick_next(rq);
       if (next && next->absolute_deadline_ms < current->absolute_deadline_ms) {
           sched_reschedule();
           return;
@@ -163,7 +163,7 @@ void sched_on_timer_tick(void) {
       }
 
       if (g_policy == SCHED_POLICY_CLOUD_FAIR) {
-          kthread_t *next = sched_cfs_pick_next(rq);
+          bh_thread_t *next = sched_cfs_pick_next(rq);
           if (next && next->vruntime < current->vruntime) {
               sched_reschedule();
               return;

--- a/kernel/src/sched/sched_deg.c
+++ b/kernel/src/sched/sched_deg.c
@@ -32,7 +32,7 @@ dist_exec_group_t* deg_create(void) {
     return deg;
 }
 
-int deg_add_member(dist_exec_group_t* deg, struct kthread* thread, uint32_t core, uint32_t local_sched_class) {
+int deg_add_member(dist_exec_group_t* deg, struct bh_thread* thread, uint32_t core, uint32_t local_sched_class) {
     if (!deg || !thread || deg->member_count >= MAX_DEG_MEMBERS) {
         return -1;
     }
@@ -64,7 +64,7 @@ int deg_activate(dist_exec_group_t* deg) {
     return 0;
 }
 
-static int _deg_get_member_index(dist_exec_group_t* deg, struct kthread* thread) {
+static int _deg_get_member_index(dist_exec_group_t* deg, struct bh_thread* thread) {
     for (uint32_t i = 0; i < deg->member_count; i++) {
         if (deg->members[i] == thread) {
             return i;
@@ -86,7 +86,7 @@ int deg_release_if_ready(dist_exec_group_t* deg) {
         deg->ready_bitmap = 0;
 
         for (uint32_t i = 0; i < deg->member_count; i++) {
-            struct kthread* member = deg->members[i];
+            struct bh_thread* member = deg->members[i];
             if (member && member->state == THREAD_STATE_DEG_PENDING) {
                 member->state = THREAD_STATE_READY;
                 // Enqueue to the actual core runqueue
@@ -98,7 +98,7 @@ int deg_release_if_ready(dist_exec_group_t* deg) {
     return 0; // Not yet ready
 }
 
-int deg_mark_ready(struct kthread* thread) {
+int deg_mark_ready(struct bh_thread* thread) {
     if (!thread || !thread->sched_ctx || !thread->sched_ctx->deg) {
         return -1;
     }
@@ -120,7 +120,7 @@ void deg_abort_epoch(dist_exec_group_t* deg) {
     deg->ready_bitmap = 0;
 
     for (uint32_t i = 0; i < deg->member_count; i++) {
-        struct kthread* member = deg->members[i];
+        struct bh_thread* member = deg->members[i];
         if (member && member->state == THREAD_STATE_DEG_PENDING) {
             // Un-pending them or handle fallback
             // In a full implementation, we might schedule them as best-effort or degraded.
@@ -133,7 +133,7 @@ void deg_abort_epoch(dist_exec_group_t* deg) {
     deg->state = DEG_WAITING_RELEASE; // Reset for next try
 }
 
-void deg_block_member(struct kthread* thread, uint32_t reason) {
+void deg_block_member(struct bh_thread* thread, uint32_t reason) {
     (void)reason;
     if (!thread || !thread->sched_ctx || !thread->sched_ctx->deg) {
         return;

--- a/kernel/src/sched/sched_gp.c
+++ b/kernel/src/sched/sched_gp.c
@@ -1,7 +1,7 @@
 #include "sched/sched.h"
 #include "sched_internal.h"
 
-void sched_cfs_enqueue(sched_rq_t *rq, kthread_t *thread) {
+void sched_cfs_enqueue(sched_rq_t *rq, bh_thread_t *thread) {
     struct rb_node **link = &rq->cfs_runqueue.rb_node;
     struct rb_node *parent = NULL;
     int64_t vruntime = thread->vruntime;
@@ -15,7 +15,7 @@ void sched_cfs_enqueue(sched_rq_t *rq, kthread_t *thread) {
 
     while (*link) {
         parent = *link;
-        kthread_t *entry = (kthread_t *)(void *)((char *)parent - offsetof(kthread_t, cfs_node));
+        bh_thread_t *entry = (bh_thread_t *)(void *)((char *)parent - offsetof(bh_thread_t, cfs_node));
 
         if (vruntime < entry->vruntime) {
             link = &parent->rb_left;
@@ -34,7 +34,7 @@ void sched_cfs_enqueue(sched_rq_t *rq, kthread_t *thread) {
     }
 }
 
-void sched_cfs_dequeue(sched_rq_t *rq, kthread_t *thread) {
+void sched_cfs_dequeue(sched_rq_t *rq, bh_thread_t *thread) {
     if (rq->cfs_runqueue.rb_node == NULL) {
         return;
     }
@@ -47,13 +47,13 @@ void sched_cfs_dequeue(sched_rq_t *rq, kthread_t *thread) {
     if (leftmost) {
         struct rb_node *first = rb_first(&rq->cfs_runqueue);
         if (first) {
-            kthread_t *next = (kthread_t *)(void *)((char *)first - offsetof(kthread_t, cfs_node));
+            bh_thread_t *next = (bh_thread_t *)(void *)((char *)first - offsetof(bh_thread_t, cfs_node));
             rq->min_vruntime = next->vruntime;
         }
     }
 }
 
-void sched_cfs_update_vruntime(sched_rq_t *rq, kthread_t *thread, uint64_t delta_exec) {
+void sched_cfs_update_vruntime(sched_rq_t *rq, bh_thread_t *thread, uint64_t delta_exec) {
     if (delta_exec == 0) return;
 
     // Validate monotonic growth

--- a/kernel/src/sched/sched_migrate.c
+++ b/kernel/src/sched/sched_migrate.c
@@ -23,7 +23,7 @@ void sched_balance_once(void) {
     return;
   }
 
-  kthread_t *candidate = sched_pick_next_ready(busiest);
+  bh_thread_t *candidate = sched_pick_next_ready(busiest);
   if (!candidate || candidate == g_cpu_locals[busiest].runqueue.idle_thread) {
     return;
   }
@@ -42,7 +42,7 @@ void sched_balance_once(void) {
   (void)sched_enqueue(candidate, idlest);
 }
 
-int sched_migrate_task(kthread_t *thread, uint32_t new_node) {
+int sched_migrate_task(bh_thread_t *thread, uint32_t new_node) {
   if (!thread || new_node >= g_active_core_count) {
     return -1;
   }
@@ -100,7 +100,7 @@ int sched_set_thread_preferred_node(uint64_t tid, uint8_t node_id) {
 }
 
 int sched_sys_set_affinity(uint64_t tid, uint32_t affinity_mask) {
-  kthread_t *thread = sched_find_thread_by_id(tid);
+  bh_thread_t *thread = sched_find_thread_by_id(tid);
   if (!thread || affinity_mask == 0U) {
     return -1;
   }
@@ -126,7 +126,7 @@ int sched_throttle_core(uint32_t core_id) {
   return 0;
 }
 
-int sched_request_remote_handoff(kthread_t *thread, uint32_t target_core, uint32_t auth_token) {
+int sched_request_remote_handoff(bh_thread_t *thread, uint32_t target_core, uint32_t auth_token) {
   if (!thread || target_core >= g_active_core_count) {
     return -1; // Invalid argument
   }

--- a/kernel/src/sched/sched_pi.c
+++ b/kernel/src/sched/sched_pi.c
@@ -1,7 +1,7 @@
 #include "sched/sched.h"
 #include "sched_internal.h"
 
-void sched_inherit_priority(kthread_t *thread, uint32_t new_priority) {
+void sched_inherit_priority(bh_thread_t *thread, uint32_t new_priority) {
   if (!thread) {
     return;
   }
@@ -10,21 +10,21 @@ void sched_inherit_priority(kthread_t *thread, uint32_t new_priority) {
   }
 }
 
-void sched_restore_priority(kthread_t *thread) {
+void sched_restore_priority(bh_thread_t *thread) {
   if (!thread) {
     return;
   }
   thread->priority = thread->base_priority;
 }
 
-void sched_on_mutex_wait(kthread_t *waiter, void *mutex) {
+void sched_on_mutex_wait(bh_thread_t *waiter, void *mutex) {
   if (!waiter || !mutex) {
     return;
   }
 
   waiter->waiting_on_lock = mutex;
 
-  kthread_t *owner = sched_find_mutex_owner(mutex);
+  bh_thread_t *owner = sched_find_mutex_owner(mutex);
   while (owner && owner != waiter && waiter->priority > owner->priority) {
     sched_inherit_priority(owner, waiter->priority);
     if (!owner->waiting_on_lock) {
@@ -34,7 +34,7 @@ void sched_on_mutex_wait(kthread_t *waiter, void *mutex) {
   }
 }
 
-void sched_on_mutex_acquire(kthread_t *owner, void *mutex) {
+void sched_on_mutex_acquire(bh_thread_t *owner, void *mutex) {
   if (!owner || !mutex) {
     return;
   }
@@ -43,7 +43,7 @@ void sched_on_mutex_acquire(kthread_t *owner, void *mutex) {
   sched_register_mutex_owner(mutex, owner);
 }
 
-void sched_on_mutex_release(kthread_t *owner, void *mutex) {
+void sched_on_mutex_release(bh_thread_t *owner, void *mutex) {
   if (!owner || !mutex) {
     return;
   }
@@ -52,7 +52,7 @@ void sched_on_mutex_release(kthread_t *owner, void *mutex) {
   sched_restore_priority(owner);
 }
 
-int sched_adjust_priority(kthread_t *thread, uint32_t new_priority) {
+int sched_adjust_priority(bh_thread_t *thread, uint32_t new_priority) {
   if (!thread) {
     return -1;
   }

--- a/kernel/src/sched/sched_runqueue.c
+++ b/kernel/src/sched/sched_runqueue.c
@@ -2,7 +2,7 @@
 #include "sched_internal.h"
 #include "panic.h"
 
-int sched_enqueue(kthread_t *thread, uint32_t core_id) {
+int sched_enqueue(bh_thread_t *thread, uint32_t core_id) {
   if (!thread || thread->priority >= MAX_PRIORITY_LEVELS) {
     return -1;
   }
@@ -110,7 +110,7 @@ int sched_pick_priority_from_bitmap(const sched_rq_t *rq, int highest) {
   return __builtin_ctz(rq->ready_bitmap);
 }
 
-static void sched_dequeue_task_l0(kthread_t *thread, uint32_t core_id) {
+static void sched_dequeue_task_l0(bh_thread_t *thread, uint32_t core_id) {
   (void)core_id;
   if (!thread) {
     return;
@@ -132,15 +132,15 @@ static void sched_dequeue_task_l0(kthread_t *thread, uint32_t core_id) {
   }
 }
 
-void sched_enqueue_task_l0(kthread_t *thread, uint32_t core_id) {
+void sched_enqueue_task_l0(bh_thread_t *thread, uint32_t core_id) {
   (void)sched_enqueue(thread, core_id);
 }
 
-void sched_enqueue_task_l1(kthread_t *thread, uint32_t core_id) {
+void sched_enqueue_task_l1(bh_thread_t *thread, uint32_t core_id) {
   (void)sched_enqueue(thread, core_id);
 }
 
-void sched_dequeue_task_l1(kthread_t *thread, uint32_t core_id) {
+void sched_dequeue_task_l1(bh_thread_t *thread, uint32_t core_id) {
   sched_dequeue_task_l0(thread, core_id);
 }
 
@@ -158,7 +158,7 @@ void sched_validate_rq(sched_rq_t *rq) {
         // Validate min_vruntime is sensible
         struct rb_node *first = rb_first(&rq->cfs_runqueue);
         if (first) {
-            kthread_t *next = (kthread_t *)(void *)((char *)first - offsetof(kthread_t, cfs_node));
+            bh_thread_t *next = (bh_thread_t *)(void *)((char *)first - offsetof(bh_thread_t, cfs_node));
             if (next->vruntime < rq->min_vruntime && rq->min_vruntime - next->vruntime > 1000) {
                 // Minor drift is okay due to rounding, but major divergence is a bug
                 kernel_panic("Runqueue min_vruntime divergence");

--- a/kernel/src/sched/sched_thread.c
+++ b/kernel/src/sched/sched_thread.c
@@ -2,7 +2,7 @@
 #include "sched/sched.h"
 #include "sched_internal.h"
 
-int process_destroy(kprocess_t *process) {
+int process_destroy(bh_process_t *process) {
   if (!process) {
     return -1;
   }
@@ -47,7 +47,7 @@ int process_destroy(kprocess_t *process) {
   return 0;
 }
 
-int thread_destroy(kthread_t *thread) {
+int thread_destroy(bh_thread_t *thread) {
   // Reaper-only contract:
   // - call only from deferred reap context, never inline on the running thread.
   // - never destroy while executing on the victim thread's stack.
@@ -112,8 +112,8 @@ int thread_destroy(kthread_t *thread) {
   return 0;
 }
 
-int sched_sys_thread_create(kprocess_t *parent, void (*entry_point)(void), uint64_t *out_tid) {
-  kthread_t *t = thread_create(parent, entry_point);
+int sched_sys_thread_create(bh_process_t *parent, void (*entry_point)(void), uint64_t *out_tid) {
+  bh_thread_t *t = thread_create(parent, entry_point);
   if (!t) {
     return -1;
   }
@@ -131,7 +131,7 @@ int sched_sys_thread_destroy(uint64_t tid) {
   return sched_mark_thread_terminated(&slot->thread);
 }
 
-int thread_raise_fault(kthread_t *thread, thread_fault_t fault) {
+int thread_raise_fault(bh_thread_t *thread, thread_fault_t fault) {
     if (!thread) return -1; // -EINVAL mapped
 
     thread->pending_fault = fault;
@@ -150,7 +150,7 @@ void *memcpy(void *dest, const void *src, size_t n);
 
 int sched_sys_intent_set(uint64_t tid, const void* intent) {
     if (!intent) return -1;
-    kthread_t *thread = sched_find_thread_by_id(tid);
+    bh_thread_t *thread = sched_find_thread_by_id(tid);
     if (!thread) return -1;
     // Basic validation and copy
     bharat_intent_t local_intent;
@@ -164,7 +164,7 @@ int sched_sys_intent_set(uint64_t tid, const void* intent) {
 
 int sched_sys_intent_get(uint64_t tid, void* intent) {
     if (!intent) return -1;
-    kthread_t *thread = sched_find_thread_by_id(tid);
+    bh_thread_t *thread = sched_find_thread_by_id(tid);
     if (!thread) return -1;
     // TODO: retrieve intent from somewhere
     (void)thread;

--- a/kernel/src/sched/sched_wait.c
+++ b/kernel/src/sched/sched_wait.c
@@ -8,7 +8,7 @@ void sched_wait_queue_init(wait_queue_t* queue) {
   }
 }
 
-void sched_wait_queue_enqueue(wait_queue_t* queue, kthread_t* thread) {
+void sched_wait_queue_enqueue(wait_queue_t* queue, bh_thread_t* thread) {
   if (!queue || !thread) {
     return;
   }
@@ -24,12 +24,12 @@ void sched_wait_queue_enqueue(wait_queue_t* queue, kthread_t* thread) {
   }
 }
 
-kthread_t* sched_wait_queue_dequeue(wait_queue_t* queue) {
+bh_thread_t* sched_wait_queue_dequeue(wait_queue_t* queue) {
   if (!queue || !queue->head) {
     return NULL;
   }
 
-  kthread_t* thread = queue->head;
+  bh_thread_t* thread = queue->head;
   // Skip any threads that were already woken up by timeout (state != BLOCKED)
   // or that had their next_waiter cleared by the timeout sweep.
   while (thread && thread->state != THREAD_STATE_BLOCKED) {
@@ -54,7 +54,7 @@ kthread_t* sched_wait_queue_dequeue(wait_queue_t* queue) {
 
 void sched_block(void) {
   uint32_t core = sched_clamp_core(hal_cpu_get_id());
-  kthread_t *current = g_cpu_locals[core].runqueue.current_thread;
+  bh_thread_t *current = g_cpu_locals[core].runqueue.current_thread;
   if (current) {
     current->state = THREAD_STATE_BLOCKED;
     if (current->sched_ctx && current->sched_ctx->deg) {
@@ -74,7 +74,7 @@ void sched_block(void) {
 
 void sched_sleep(uint64_t millis) {
   uint32_t core = sched_clamp_core(hal_cpu_get_id());
-  kthread_t *current = g_cpu_locals[core].runqueue.current_thread;
+  bh_thread_t *current = g_cpu_locals[core].runqueue.current_thread;
   if (!current || current == g_cpu_locals[core].runqueue.idle_thread) {
     return;
   }
@@ -91,7 +91,7 @@ void sched_sleep(uint64_t millis) {
   sched_reschedule();
 }
 
-void sched_wakeup_with_priority(kthread_t *thread, uint32_t wakeup_priority) {
+void sched_wakeup_with_priority(bh_thread_t *thread, uint32_t wakeup_priority) {
   if (!thread) {
     return;
   }
@@ -135,7 +135,7 @@ void sched_wakeup_with_priority(kthread_t *thread, uint32_t wakeup_priority) {
   }
 }
 
-void sched_wakeup(kthread_t *thread) {
+void sched_wakeup(bh_thread_t *thread) {
   sched_wakeup_with_priority(thread, SCHED_MAX_PRIORITY + 1U);
 }
 

--- a/kernel/src/sched_stub.c
+++ b/kernel/src/sched_stub.c
@@ -18,14 +18,14 @@
 
 typedef struct {
     uint8_t in_use;
-    kthread_t thread;
+    bh_thread_t thread;
     cpu_context_t context;
     ai_sched_context_t ai_ctx;
 } thread_slot_t;
 
 typedef struct {
     uint8_t in_use;
-    kprocess_t process;
+    bh_process_t process;
 } process_slot_t;
 
 typedef struct {
@@ -38,7 +38,7 @@ static sched_rq_t g_cores[SCHED_MAX_CORES];
 static thread_slot_t g_threads[SCHED_MAX_CORES][SCHED_MAX_THREADS];
 static process_slot_t g_processes[SCHED_MAX_CORES][SCHED_MAX_PROCESSES];
 
-static kthread_t* g_current;
+static bh_thread_t* g_current;
 static sched_policy_t g_policy = SCHED_POLICY_PRIORITY;
 static uint64_t g_next_thread_id = 1U;
 static uint64_t g_next_process_id = 1U;
@@ -137,9 +137,9 @@ static void sched_process_pending_ai_suggestions(void) {
     }
 }
 
-static kthread_t* sched_pick_next_ready(void) {
+static bh_thread_t* sched_pick_next_ready(void) {
     size_t start = 0U;
-    kthread_t* best = NULL;
+    bh_thread_t* best = NULL;
 
     if (g_current) {
         thread_slot_t* cur = sched_find_thread_slot_by_tid(g_current->thread_id);
@@ -173,7 +173,7 @@ static kthread_t* sched_pick_next_ready(void) {
     return best;
 }
 
-static void sched_update_telemetry(kthread_t* thread) {
+static void sched_update_telemetry(bh_thread_t* thread) {
     if (!thread || !thread->ai_sched_ctx) {
         return;
     }
@@ -185,7 +185,7 @@ static void sched_update_telemetry(kthread_t* thread) {
                             (uint32_t)thread->context_switch_count);
 }
 
-static void sched_switch_to(kthread_t* next) {
+static void sched_switch_to(bh_thread_t* next) {
     if (!next) {
         return;
     }
@@ -207,7 +207,7 @@ static void sched_switch_to(kthread_t* next) {
 
 static void sched_monitor_task(void) {
     while (1) {
-        kthread_yield();
+        bh_thread_yield();
     }
 }
 
@@ -238,7 +238,7 @@ void sched_wait_queue_init(wait_queue_t* queue) {
     }
 }
 
-void sched_wait_queue_enqueue(wait_queue_t* queue, kthread_t* thread) {
+void sched_wait_queue_enqueue(wait_queue_t* queue, bh_thread_t* thread) {
     if (!queue || !thread) {
         return;
     }
@@ -254,12 +254,12 @@ void sched_wait_queue_enqueue(wait_queue_t* queue, kthread_t* thread) {
     }
 }
 
-kthread_t* sched_wait_queue_dequeue(wait_queue_t* queue) {
+bh_thread_t* sched_wait_queue_dequeue(wait_queue_t* queue) {
     if (!queue || !queue->head) {
         return NULL;
     }
 
-    kthread_t* thread = queue->head;
+    bh_thread_t* thread = queue->head;
 
     queue->head = thread->next_waiter;
     if (!queue->head) {
@@ -279,7 +279,7 @@ void sched_block(void) {
     }
 }
 
-kprocess_t* process_create(const char* name) {
+bh_process_t* process_create(const char* name) {
     (void)name;
 
     process_slot_t* slot = sched_find_free_process_slot();
@@ -301,7 +301,7 @@ kprocess_t* process_create(const char* name) {
     return &slot->process;
 }
 
-int sched_unregister_process(kprocess_t* process) {
+int sched_unregister_process(bh_process_t* process) {
     if (!process) return -1;
     for (size_t core = 0; core < SCHED_MAX_CORES; ++core) {
         sched_rq_t *rq = &g_cores[core];
@@ -317,21 +317,21 @@ int sched_unregister_process(kprocess_t* process) {
     return -1;
 }
 
-int process_destroy(kprocess_t* process) {
+int process_destroy(bh_process_t* process) {
     if (!process) {
         return -1;
     }
     return sched_unregister_process(process);
 }
 
-kthread_t* thread_create(kprocess_t* parent, void (*entry_point)(void)) {
+bh_thread_t* thread_create(bh_process_t* parent, void (*entry_point)(void)) {
     thread_slot_t* slot = sched_find_free_thread_slot();
     if (!slot) {
         return NULL;
     }
 
     slot->in_use = 1U;
-    slot->thread = (kthread_t){0};
+    slot->thread = (bh_thread_t){0};
     slot->thread.thread_id = g_next_thread_id++;
     slot->thread.process_id = parent ? parent->process_id : 0U;
     slot->thread.process = parent;
@@ -355,7 +355,7 @@ kthread_t* thread_create(kprocess_t* parent, void (*entry_point)(void)) {
     return &slot->thread;
 }
 
-int thread_destroy(kthread_t* thread) {
+int thread_destroy(bh_thread_t* thread) {
     if (!thread) return -1;
     thread_slot_t* slot = sched_find_thread_slot_by_tid(thread->thread_id);
     if (slot) {
@@ -365,9 +365,9 @@ int thread_destroy(kthread_t* thread) {
     return 0;
 }
 
-void kthread_yield(void) {
+void bh_thread_yield(void) {
     sched_process_pending_ai_suggestions();
-    kthread_t* next = sched_pick_next_ready();
+    bh_thread_t* next = sched_pick_next_ready();
     if (next) {
         sched_switch_to(next);
     }
@@ -380,10 +380,10 @@ void sched_sleep(uint64_t millis) {
 
     g_current->wake_deadline_ms = g_sched_ticks + millis;
     g_current->state = THREAD_STATE_SLEEPING;
-    kthread_yield();
+    bh_thread_yield();
 }
 
-void sched_wakeup(kthread_t* thread) {
+void sched_wakeup(bh_thread_t* thread) {
     if (!thread) {
         return;
     }
@@ -412,7 +412,7 @@ void sched_on_timer_tick(void) {
         g_current->cpu_time_consumed++;
         sched_update_telemetry(g_current);
 
-        kthread_t* preempt = sched_pick_next_ready();
+        bh_thread_t* preempt = sched_pick_next_ready();
         if (preempt && preempt->priority > g_current->priority) {
             sched_switch_to(preempt);
             return;
@@ -420,15 +420,15 @@ void sched_on_timer_tick(void) {
 
         if (g_current->cpu_time_consumed >= g_current->time_slice_ms) {
             g_current->cpu_time_consumed = 0U;
-            kthread_yield();
+            bh_thread_yield();
         }
         return;
     }
 
-    kthread_yield();
+    bh_thread_yield();
 }
 
-kthread_t* sched_current_thread(void) {
+bh_thread_t* sched_current_thread(void) {
     return g_current;
 }
 
@@ -447,7 +447,7 @@ int g_stub_thread_raise_fault_called = 0;
 int g_stub_last_priority = -1;
 uint64_t g_stub_last_affinity_mask = 0;
 int g_stub_last_fault_code = 0;
-kprocess_t* g_stub_current_process = NULL;
+bh_process_t* g_stub_current_process = NULL;
 
 void sched_stub_reset(void) {
     g_stub_sched_sys_set_priority_ret = 0;
@@ -483,7 +483,7 @@ long kstatus_to_sysret(int32_t st) {
     return g_stub_kstatus_to_sysret_ret;
 }
 
-kprocess_t* sched_current_process(void) {
+bh_process_t* sched_current_process(void) {
     if (g_stub_current_process != NULL) {
         return g_stub_current_process;
     }
@@ -491,11 +491,11 @@ kprocess_t* sched_current_process(void) {
 }
 
 address_space_t* sched_current_aspace(void) {
-    kprocess_t* p = sched_current_process();
+    bh_process_t* p = sched_current_process();
     return p ? p->addr_space : NULL;
 }
 
-int thread_raise_fault(kthread_t *thread, thread_fault_t fault) {
+int thread_raise_fault(bh_thread_t *thread, thread_fault_t fault) {
     (void)thread;
     g_stub_thread_raise_fault_called++;
     g_stub_last_fault_code = fault;
@@ -507,7 +507,7 @@ int sched_sys_sleep(uint64_t millis) {
     return 0;
 }
 
-void sched_wakeup_with_priority(kthread_t* thread, uint32_t wakeup_priority) {
+void sched_wakeup_with_priority(bh_thread_t* thread, uint32_t wakeup_priority) {
     (void)wakeup_priority;
     sched_wakeup(thread);
 }
@@ -516,8 +516,8 @@ void sched_set_policy(sched_policy_t policy) {
     g_policy = policy;
 }
 
-int sched_sys_thread_create(kprocess_t* parent, void (*entry_point)(void), uint64_t* out_tid) {
-    kthread_t* t = thread_create(parent, entry_point);
+int sched_sys_thread_create(bh_process_t* parent, void (*entry_point)(void), uint64_t* out_tid) {
+    bh_thread_t* t = thread_create(parent, entry_point);
     if (!t) {
         return -1;
     }
@@ -537,7 +537,7 @@ int sched_sys_thread_destroy(uint64_t tid) {
     return thread_destroy(&slot->thread);
 }
 
-void sched_inherit_priority(kthread_t* thread, uint32_t new_priority) {
+void sched_inherit_priority(bh_thread_t* thread, uint32_t new_priority) {
     if (!thread) {
         return;
     }
@@ -547,7 +547,7 @@ void sched_inherit_priority(kthread_t* thread, uint32_t new_priority) {
     }
 }
 
-void sched_restore_priority(kthread_t* thread) {
+void sched_restore_priority(bh_thread_t* thread) {
     if (!thread) {
         return;
     }
@@ -555,12 +555,12 @@ void sched_restore_priority(kthread_t* thread) {
     thread->priority = thread->base_priority;
 }
 
-kthread_t* sched_find_thread_by_id(uint64_t tid) {
+bh_thread_t* sched_find_thread_by_id(uint64_t tid) {
     thread_slot_t* slot = sched_find_thread_slot_by_tid(tid);
     return slot ? &slot->thread : NULL;
 }
 
-int sched_adjust_priority(kthread_t* thread, uint32_t new_priority) {
+int sched_adjust_priority(bh_thread_t* thread, uint32_t new_priority) {
     if (!thread) {
         return -1;
     }
@@ -585,7 +585,7 @@ int sched_set_thread_priority(uint64_t tid, uint32_t new_priority) {
     return sched_adjust_priority(sched_find_thread_by_id(tid), new_priority);
 }
 
-int sched_migrate_task(kthread_t* thread, uint32_t new_node) {
+int sched_migrate_task(bh_thread_t* thread, uint32_t new_node) {
     if (!thread) {
         return -1;
     }
@@ -616,7 +616,7 @@ int sched_ai_apply_suggestion(const ai_suggestion_t* suggestion) {
         return -1;
     }
 
-    kthread_t* thread = sched_find_thread_by_id((uint64_t)suggestion->target_id);
+    bh_thread_t* thread = sched_find_thread_by_id((uint64_t)suggestion->target_id);
     switch (suggestion->action) {
         case AI_ACTION_ADJUST_PRIORITY:
             return sched_adjust_priority(thread, suggestion->value);
@@ -625,7 +625,7 @@ int sched_ai_apply_suggestion(const ai_suggestion_t* suggestion) {
         case AI_ACTION_THROTTLE_CORE:
             return 0; // Throttle core not implemented fully in stub
         case AI_ACTION_KILL_TASK: {
-            kthread_t* thread = sched_find_thread_by_id((uint64_t)suggestion->target_id);
+            bh_thread_t* thread = sched_find_thread_by_id((uint64_t)suggestion->target_id);
             if (thread) {
                 return thread_destroy(thread);
             }
@@ -654,7 +654,7 @@ int sched_enqueue_ai_suggestion(const ai_suggestion_t* suggestion) {
          suggestion->action == AI_ACTION_MIGRATE_TASK) &&
         g_current &&
         g_current->thread_id == suggestion->target_id) {
-        kthread_yield();
+        bh_thread_yield();
     }
 
     return 0;
@@ -666,7 +666,7 @@ void sched_disable_tick_for_core(uint32_t core_id) {
 }
 #endif
 
-int sched_enqueue(kthread_t *thread, uint32_t core_id) {
+int sched_enqueue(bh_thread_t *thread, uint32_t core_id) {
     (void)core_id;
     if (!thread) {
         return -1;

--- a/kernel/src/subsystem/linux/linux_trap.c
+++ b/kernel/src/subsystem/linux/linux_trap.c
@@ -7,7 +7,7 @@
 extern long linux_syscall_handler(long sysno, long arg1, long arg2, long arg3,
                                   long arg4, long arg5, long arg6);
 
-static long linux_handle_syscall(struct kthread *thread, struct trap_frame *frame, const struct trap_info *info) {
+static long linux_handle_syscall(struct bh_thread *thread, struct trap_frame *frame, const struct trap_info *info) {
     (void)thread;
     (void)info;
     return linux_syscall_handler(
@@ -21,7 +21,7 @@ static long linux_handle_syscall(struct kthread *thread, struct trap_frame *fram
     );
 }
 
-static int linux_handle_user_fault(struct kthread *thread, struct trap_frame *frame, const struct trap_info *info) {
+static int linux_handle_user_fault(struct bh_thread *thread, struct trap_frame *frame, const struct trap_info *info) {
     (void)thread;
     (void)frame;
     (void)info;

--- a/kernel/src/sys/sys_constraints.c
+++ b/kernel/src/sys/sys_constraints.c
@@ -26,7 +26,7 @@ static void bh_copy_exec_constraints_kern_to_uapi(
 }
 
 static int thread_set_constraints(int tid, const bh_exec_constraints_k_t *c) {
-    kthread_t *thread = sched_find_thread_by_id(tid);
+    bh_thread_t *thread = sched_find_thread_by_id(tid);
     if (!thread) return -1;
 
     thread->constraints = *c;
@@ -34,7 +34,7 @@ static int thread_set_constraints(int tid, const bh_exec_constraints_k_t *c) {
 }
 
 static int thread_get_constraints(int tid, bh_exec_constraints_k_t *out_c) {
-    kthread_t *thread = sched_find_thread_by_id(tid);
+    bh_thread_t *thread = sched_find_thread_by_id(tid);
     if (!thread) return -1;
 
     *out_c = thread->constraints;
@@ -54,7 +54,7 @@ int sys_thread_set_constraints(int tid, const bh_exec_constraints_t *user_c) {
         return -1;
 
     // Reschedule the thread to enforce new constraints (per constraint-aware scheduling rules)
-    kthread_t* thread = sched_find_thread_by_id(tid);
+    bh_thread_t* thread = sched_find_thread_by_id(tid);
     if (thread && thread->state == THREAD_STATE_RUNNING) {
         // Trigger a reschedule on the thread's core to force the new constraint to be evaluated
         // For MVP, we can just yield the core if it's running locally, or rely on normal quantum expiration.

--- a/kernel/src/tests/ktest_rt_sched.c
+++ b/kernel/src/tests/ktest_rt_sched.c
@@ -7,11 +7,11 @@
 extern void sched_test_reset(void);
 extern void sched_set_test_core_count(uint32_t core_count);
 #endif
-extern kthread_t *sched_pick_next_ready_l0(uint32_t core_id);
+extern bh_thread_t *sched_pick_next_ready_l0(uint32_t core_id);
 
 static void dummy_thread_entry(void) {
     while (1) {
-        kthread_yield();
+        bh_thread_yield();
     }
 }
 
@@ -22,19 +22,19 @@ static bool test_rms_admission(void) {
 #endif
     sched_init();
 
-    kprocess_t *p = process_create("rms_test");
+    bh_process_t *p = process_create("rms_test");
     KTEST_ASSERT(p != NULL, "Process creation failed");
 
     // Total RMS allowed budget is ~69% (690 in our unit)
 
     // Create Task 1: WCET 20ms, Period 100ms (20%)
-    kthread_t *t1 = thread_create_detached(p, dummy_thread_entry);
+    bh_thread_t *t1 = thread_create_detached(p, dummy_thread_entry);
     KTEST_ASSERT(t1 != NULL, "Thread 1 creation failed");
     int ret1 = sched_admission_rms(t1, 20, 100);
     KTEST_ASSERT(ret1 == 0, "Admission of T1 should succeed");
 
     // Create Task 2: WCET 40ms, Period 100ms (40%)
-    kthread_t *t2 = thread_create_detached(p, dummy_thread_entry);
+    bh_thread_t *t2 = thread_create_detached(p, dummy_thread_entry);
     KTEST_ASSERT(t2 != NULL, "Thread 2 creation failed");
     int ret2 = sched_admission_rms(t2, 40, 100);
     KTEST_ASSERT(ret2 == 0, "Admission of T2 should succeed");
@@ -43,7 +43,7 @@ static bool test_rms_admission(void) {
 
     // Create Task 3: WCET 15ms, Period 100ms (15%)
     // This will bring total used to 750 (75%), which is > 690, so it should be rejected.
-    kthread_t *t3 = thread_create_detached(p, dummy_thread_entry);
+    bh_thread_t *t3 = thread_create_detached(p, dummy_thread_entry);
     KTEST_ASSERT(t3 != NULL, "Thread 3 creation failed");
     int ret3 = sched_admission_rms(t3, 15, 100);
     KTEST_ASSERT(ret3 != 0, "Admission of T3 should fail due to bandwidth bounds");
@@ -64,24 +64,24 @@ static bool test_edf_admission_and_queue(void) {
     sched_init();
     sched_set_policy(SCHED_POLICY_EDF);
 
-    kprocess_t *p = process_create("edf_test");
+    bh_process_t *p = process_create("edf_test");
     KTEST_ASSERT(p != NULL, "Process creation failed");
 
     // Total EDF allowed budget is 100% (1000 in our unit)
 
     // Create Task 1: WCET 30ms, Period 100ms, Deadline 100ms (30%)
-    kthread_t *t1 = thread_create_detached(p, dummy_thread_entry);
+    bh_thread_t *t1 = thread_create_detached(p, dummy_thread_entry);
     int ret1 = sched_admission_edf(t1, 30, 100, 100);
     KTEST_ASSERT(ret1 == 0, "Admission of T1 should succeed");
 
     // Create Task 2: WCET 50ms, Period 100ms, Deadline 50ms (50%)
-    kthread_t *t2 = thread_create_detached(p, dummy_thread_entry);
+    bh_thread_t *t2 = thread_create_detached(p, dummy_thread_entry);
     int ret2 = sched_admission_edf(t2, 50, 100, 50);
     KTEST_ASSERT(ret2 == 0, "Admission of T2 should succeed");
 
     // Create Task 3: WCET 30ms, Period 100ms, Deadline 100ms (30%)
     // Total used = 300 + 500 = 800. Adding 300 -> 1100 > 1000. Should reject.
-    kthread_t *t3 = thread_create_detached(p, dummy_thread_entry);
+    bh_thread_t *t3 = thread_create_detached(p, dummy_thread_entry);
     int ret3 = sched_admission_edf(t3, 30, 100, 100);
     KTEST_ASSERT(ret3 != 0, "Admission of T3 should fail (budget exceeded)");
 
@@ -93,11 +93,11 @@ static bool test_edf_admission_and_queue(void) {
     // T2 absolute deadline = ticks + 50 = 50
 
     // Pick next ready should return T2 because its deadline (50) is smaller than T1 (100)
-    kthread_t *picked1 = sched_pick_next_ready_l0(0);
+    bh_thread_t *picked1 = sched_pick_next_ready_l0(0);
     KTEST_ASSERT(picked1 == t2, "EDF should pick T2 because it has earliest deadline");
 
     // Second pick should return T1
-    kthread_t *picked2 = sched_pick_next_ready_l0(0);
+    bh_thread_t *picked2 = sched_pick_next_ready_l0(0);
     KTEST_ASSERT(picked2 == t1, "EDF should pick T1 next");
 
     // Clean up

--- a/kernel/src/tests/ktest_sched.c
+++ b/kernel/src/tests/ktest_sched.c
@@ -8,16 +8,16 @@
 bool test_sched_rq_basic(void) {
     sched_set_policy(SCHED_POLICY_CLOUD_FAIR);
 
-    kprocess_t *p = process_create("test_proc");
+    bh_process_t *p = process_create("test_proc");
     KTEST_ASSERT(p != NULL, "Failed to create process");
 
-    kthread_t *t1 = thread_create(p, NULL);
+    bh_thread_t *t1 = thread_create(p, NULL);
     KTEST_ASSERT(t1 != NULL, "Failed to create t1");
     t1->priority = 1;
     t1->vruntime = 100;
     t1->weight = CFS_NICE_0_WEIGHT;
 
-    kthread_t *t2 = thread_create(p, NULL);
+    bh_thread_t *t2 = thread_create(p, NULL);
     KTEST_ASSERT(t2 != NULL, "Failed to create t2");
     t2->priority = 1;
     t2->vruntime = 50;
@@ -30,7 +30,7 @@ bool test_sched_rq_basic(void) {
     // And actually, if thread_create does `sched_enqueue(&slot->thread, ...)`, it means they are active!
 
     // Dequeue everything explicitly
-    extern void sched_dequeue_task_l1(kthread_t *thread, uint32_t core_id);
+    extern void sched_dequeue_task_l1(bh_thread_t *thread, uint32_t core_id);
     sched_dequeue_task_l1(t1, 0);
     sched_dequeue_task_l1(t2, 0);
 
@@ -48,12 +48,12 @@ bool test_sched_rq_basic(void) {
 
     // We expect t2 to be picked first since it has min vruntime.
     // We will peek at the runqueue until we find our tasks, while storing background ones.
-    kthread_t *next;
-    kthread_t *temp_dq[20];
+    bh_thread_t *next;
+    bh_thread_t *temp_dq[20];
     int tdq_count = 0;
 
-    kthread_t *picked_first = NULL;
-    kthread_t *picked_second = NULL;
+    bh_thread_t *picked_first = NULL;
+    bh_thread_t *picked_second = NULL;
 
     int iterations = 0;
     while ((next = sched_pick_next_ready_l0(0)) != NULL && iterations < 100) {
@@ -102,8 +102,8 @@ bool test_sched_rq_basic(void) {
 
 bool test_sched_vruntime_monotonic(void) {
     // Manually run a tick on a task and see vruntime increment
-    kprocess_t *p = process_create("test_proc2");
-    kthread_t *t1 = thread_create(p, NULL);
+    bh_process_t *p = process_create("test_proc2");
+    bh_thread_t *t1 = thread_create(p, NULL);
     t1->vruntime = 0;
     t1->weight = CFS_NICE_0_WEIGHT;
     t1->time_slice_ms = 10;
@@ -130,8 +130,8 @@ bool test_sched_remote_enqueue(void) {
     // Save original policy
     sched_set_policy(SCHED_POLICY_CLOUD_FAIR);
 
-    kprocess_t *p = process_create("test_proc3");
-    kthread_t *t1 = thread_create(p, NULL);
+    bh_process_t *p = process_create("test_proc3");
+    bh_thread_t *t1 = thread_create(p, NULL);
     KTEST_ASSERT(t1 != NULL, "Failed to create t1");
     t1->priority = 1;
     t1->vruntime = 100;
@@ -170,8 +170,8 @@ uint64_t benchmark_get_cycles(void) {
 bool test_sched_benchmark(void) {
     sched_set_policy(SCHED_POLICY_CLOUD_FAIR);
 
-    kprocess_t *p = process_create("bench_proc");
-    kthread_t *t1 = thread_create(p, NULL);
+    bh_process_t *p = process_create("bench_proc");
+    bh_thread_t *t1 = thread_create(p, NULL);
     t1->vruntime = 0;
 
     // Enqueue benchmark
@@ -186,7 +186,7 @@ bool test_sched_benchmark(void) {
     uint64_t avg_cycles = (end_cycles - start_cycles) / 1000;
 
     // Context switch benchmark (roughly measured via fast path)
-    kthread_t *t2 = thread_create(p, NULL);
+    bh_thread_t *t2 = thread_create(p, NULL);
     t2->vruntime = 0;
 
     start_cycles = benchmark_get_cycles();

--- a/kernel/src/tests/ktest_sched_ipi.c
+++ b/kernel/src/tests/ktest_sched_ipi.c
@@ -27,10 +27,10 @@ bool test_sched_remote_enqueue_ipi(void) {
     sched_init();
 
     // Create a new process and thread
-    kprocess_t *proc = process_create("test_proc");
+    bh_process_t *proc = process_create("test_proc");
     KTEST_ASSERT(proc != NULL, "Failed to create process");
 
-    kthread_t *thread = thread_create(proc, dummy_thread_entry);
+    bh_thread_t *thread = thread_create(proc, dummy_thread_entry);
     KTEST_ASSERT(thread != NULL, "Failed to create thread");
 
     // We mock that we are on CPU 0 and want to enqueue on CPU 1
@@ -72,10 +72,10 @@ bool test_sched_remote_enqueue_ipi(void) {
 bool test_sched_ipi_coalescing(void) {
     sched_init();
 
-    kprocess_t *proc = process_create("test_proc2");
+    bh_process_t *proc = process_create("test_proc2");
 
-    kthread_t *thread1 = thread_create(proc, dummy_thread_entry);
-    kthread_t *thread2 = thread_create(proc, dummy_thread_entry);
+    bh_thread_t *thread1 = thread_create(proc, dummy_thread_entry);
+    bh_thread_t *thread2 = thread_create(proc, dummy_thread_entry);
 
     current_mock_cpu = 0;
     mock_ipi_sent_to = UINT32_MAX;

--- a/kernel/src/tests/ktest_urpc_handoff.c
+++ b/kernel/src/tests/ktest_urpc_handoff.c
@@ -47,10 +47,10 @@ static void reset_test_state(void) {
 bool test_urpc_thread_handoff_valid(void) {
     reset_test_state();
 
-    kprocess_t *p = process_create("test_proc_handoff");
+    bh_process_t *p = process_create("test_proc_handoff");
     KTEST_ASSERT(p != NULL, "Process creation failed");
 
-    kthread_t *t = thread_create(p, NULL);
+    bh_thread_t *t = thread_create(p, NULL);
     KTEST_ASSERT(t != NULL, "Thread creation failed");
 
     uint32_t sender_core = hal_cpu_get_id(); // Should be 0 in test env
@@ -134,8 +134,8 @@ bool test_urpc_thread_handoff_denied_no_cap(void) {
 bool test_urpc_thread_handoff_reject_bad_core(void) {
     reset_test_state();
 
-    kprocess_t *p = process_create("test_proc_bad_core");
-    kthread_t *t = thread_create(p, NULL);
+    bh_process_t *p = process_create("test_proc_bad_core");
+    bh_thread_t *t = thread_create(p, NULL);
     t->state = THREAD_STATE_REMOTE_HANDOFF_PENDING; // Pre-condition for receiver
 
     urpc_msg_t rx_msg;
@@ -167,8 +167,8 @@ bool test_urpc_thread_handoff_reject_bad_core(void) {
 bool test_urpc_thread_handoff_reject_bad_state(void) {
     reset_test_state();
 
-    kprocess_t *p = process_create("test_proc_bad_state");
-    kthread_t *t = thread_create(p, NULL);
+    bh_process_t *p = process_create("test_proc_bad_state");
+    bh_thread_t *t = thread_create(p, NULL);
     t->state = THREAD_STATE_RUNNING; // NOT handoff pending!
 
     urpc_msg_t rx_msg;

--- a/kernel/src/trap/syscall.c
+++ b/kernel/src/trap/syscall.c
@@ -7,7 +7,7 @@
 #define ENOSYS 38
 
 long trap_dispatch_syscall(trap_frame_t *frame, const trap_info_t *info) {
-    kthread_t *t = sched_current_thread();
+    bh_thread_t *t = sched_current_thread();
     if (!t || !t->process || !t->process->personality_ops ||
         !t->process->personality_ops->handle_syscall) {
         return -ENOSYS;

--- a/kernel/src/trap/trap.c
+++ b/kernel/src/trap/trap.c
@@ -40,7 +40,7 @@ extern bool core_is_rt(void);
 #define TRAP_ERR_NOSYS (-(long)SYS_ENOSYS)
 
 
-static kprocess_t g_syscall_proc;
+static bh_process_t g_syscall_proc;
 
 static capability_table_t *trap_current_cap_table(void) {
   capability_table_t *table = sched_current_cap_table();
@@ -50,8 +50,8 @@ static capability_table_t *trap_current_cap_table(void) {
   return (capability_table_t *)g_syscall_proc.security_sandbox_ctx;
 }
 
-static kprocess_t *trap_current_process(void) {
-  kprocess_t *proc = sched_current_process();
+static bh_process_t *trap_current_process(void) {
+  bh_process_t *proc = sched_current_process();
   if (proc) {
     return proc;
   }
@@ -210,7 +210,7 @@ long syscall_dispatch(syscall_id_t id, uintptr_t arg0, uintptr_t arg1,
   case SYSCALL_THREAD_DESTROY:
     return SYSCALL_RET_FROM_STATUS(sched_sys_thread_destroy((uint64_t)arg0), SYS_ENOENT);
   case SYSCALL_SCHED_YIELD:
-    kthread_yield();
+    bh_thread_yield();
     return TRAP_SUCCESS;
   case SYSCALL_SCHED_SLEEP:
     return SYSCALL_RET_FROM_STATUS(sched_sys_sleep((uint64_t)arg0), SYS_EIO);
@@ -335,7 +335,7 @@ int trap_dispatch(trap_frame_t *frame, const trap_info_t *info) {
   extern void vmm_process_local_urpc_messages(uint32_t core_id);
   vmm_process_local_urpc_messages(hal_cpu_get_id());
 
-  kthread_t *current = sched_current_thread();
+  bh_thread_t *current = sched_current_thread();
 
   switch (info->trap_class) {
   case TRAP_CLASS_INTERRUPT:
@@ -346,7 +346,7 @@ int trap_dispatch(trap_frame_t *frame, const trap_info_t *info) {
                                   trap_device_irq_dispatch, NULL);
 
     if (info->trap_class == TRAP_CLASS_IPI) {
-        kthread_yield();
+        bh_thread_yield();
     }
     return 0;
   }

--- a/kernel/src/trap/trap_fault.c
+++ b/kernel/src/trap/trap_fault.c
@@ -6,7 +6,7 @@
 int (*g_test_fault_hook)(trap_frame_t *frame, const trap_info_t *info) = NULL;
 
 int trap_handle_fault(trap_frame_t *frame, const trap_info_t *info) {
-    kthread_t *t = sched_current_thread();
+    bh_thread_t *t = sched_current_thread();
 
     if (g_test_fault_hook) {
         int ret = g_test_fault_hook(frame, info);
@@ -34,7 +34,7 @@ int trap_handle_fault(trap_frame_t *frame, const trap_info_t *info) {
     if (t) {
         thread_raise_fault(t, THREAD_FAULT_SEGV);
     } else {
-        kthread_yield();
+        bh_thread_yield();
     }
 
     return -1;

--- a/kernel/staging/ai/ai_kernel_bridge.c
+++ b/kernel/staging/ai/ai_kernel_bridge.c
@@ -68,7 +68,7 @@ int ai_kernel_collect_telemetry(kernel_telemetry_t* out) {
         return -1;
     }
 
-    kthread_t* current = sched_current_thread();
+    bh_thread_t* current = sched_current_thread();
     if (!current) {
         return -1;
     }

--- a/personalities/native/personality_native.c
+++ b/personalities/native/personality_native.c
@@ -6,7 +6,7 @@ extern long syscall_dispatch(syscall_id_t id, uintptr_t arg0, uintptr_t arg1,
                       uintptr_t arg2, uintptr_t arg3, uintptr_t arg4,
                       uintptr_t arg5);
 
-static long default_handle_syscall(kthread_t *thread, trap_frame_t *frame, const trap_info_t *info) {
+static long default_handle_syscall(bh_thread_t *thread, trap_frame_t *frame, const trap_info_t *info) {
     (void)thread;
     (void)info;
 
@@ -21,7 +21,7 @@ static long default_handle_syscall(kthread_t *thread, trap_frame_t *frame, const
     );
 }
 
-static int default_handle_user_fault(kthread_t *thread, trap_frame_t *frame, const trap_info_t *info) {
+static int default_handle_user_fault(bh_thread_t *thread, trap_frame_t *frame, const trap_info_t *info) {
     (void)thread;
     (void)frame;
     (void)info;

--- a/tests/benchmark_stubs.c
+++ b/tests/benchmark_stubs.c
@@ -76,16 +76,16 @@ void hal_fpu_disable(void) {
 void hal_fpu_enable(void) {
 }
 
-void hal_fpu_save_state(void* kthread) {
-    (void)kthread;
+void hal_fpu_save_state(void* bh_thread) {
+    (void)bh_thread;
 }
 
-void hal_fpu_restore_state(void* kthread) {
-    (void)kthread;
+void hal_fpu_restore_state(void* bh_thread) {
+    (void)bh_thread;
 }
 
-void hal_fpu_init_thread_state(void* kthread) {
-    (void)kthread;
+void hal_fpu_init_thread_state(void* bh_thread) {
+    (void)bh_thread;
 }
 
 #include "../kernel/include/capability.h"
@@ -183,7 +183,7 @@ __attribute__((weak)) void arch_context_switch(cpu_context_t* prev, cpu_context_
     (void)next;
 }
 
-__attribute__((weak)) int arch_ext_state_thread_init(kthread_t *t) {
+__attribute__((weak)) int arch_ext_state_thread_init(bh_thread_t *t) {
     (void)t;
     return 0;
 }
@@ -194,15 +194,15 @@ int __attribute__((weak)) vmm_handle_cow_fault(address_space_t* as, virt_addr_t 
     return 0;
 }
 
-__attribute__((weak)) void arch_ext_state_thread_destroy(kthread_t *t) {
+__attribute__((weak)) void arch_ext_state_thread_destroy(bh_thread_t *t) {
     (void)t;
 }
 
-__attribute__((weak)) void arch_ext_state_save(kthread_t *t) {
+__attribute__((weak)) void arch_ext_state_save(bh_thread_t *t) {
     (void)t;
 }
 
-__attribute__((weak)) void arch_ext_state_restore(kthread_t *t) {
+__attribute__((weak)) void arch_ext_state_restore(bh_thread_t *t) {
     (void)t;
 }
 

--- a/tests/host/test_pmm_pcache.c
+++ b/tests/host/test_pmm_pcache.c
@@ -46,7 +46,7 @@ void hal_mm_get_zone_limits(hal_mm_zone_limits_t *limits) {
 
 
 
-kthread_t *sched_current_thread(void) {
+bh_thread_t *sched_current_thread(void) {
     return NULL;
 }
 

--- a/tests/host/test_sched.c
+++ b/tests/host/test_sched.c
@@ -53,7 +53,7 @@ void mm_switch_active_aspace(uint32_t core_id, address_space_t* prev, address_sp
     (void)core_id; (void)prev; (void)next;
 }
 
-int cap_table_init_for_process(kprocess_t* proc) {
+int cap_table_init_for_process(bh_process_t* proc) {
     (void)proc;
     return 0;
 }
@@ -66,20 +66,20 @@ void arch_prepare_initial_context(cpu_context_t* ctx, void (*entry_point)(void),
     (void)ctx; (void)entry_point; (void)stack_top;
 }
 
-int arch_ext_state_thread_init(kthread_t* thread) {
+int arch_ext_state_thread_init(bh_thread_t* thread) {
     (void)thread;
     return 0;
 }
 
-void arch_ext_state_thread_destroy(kthread_t* thread) {
+void arch_ext_state_thread_destroy(bh_thread_t* thread) {
     (void)thread;
 }
 
-void arch_ext_state_save(kthread_t* thread) {
+void arch_ext_state_save(bh_thread_t* thread) {
     (void)thread;
 }
 
-void arch_ext_state_restore(kthread_t* thread) {
+void arch_ext_state_restore(bh_thread_t* thread) {
     (void)thread;
 }
 
@@ -103,7 +103,7 @@ void ipc_async_check_timeouts(uint64_t current_ticks) {
     (void)current_ticks;
 }
 
-void deg_block_member(kthread_t* thread, uint32_t reason) {
+void deg_block_member(bh_thread_t* thread, uint32_t reason) {
     (void)thread; (void)reason;
 }
 
@@ -126,7 +126,7 @@ void test_sched_init() {
     // So checking g_free_thread_head == 0 will fail, since threads were allocated during sched_init.
 
     // Check if idle task is correctly created on core 0
-    kthread_t* idle = g_cpu_locals[0].runqueue.idle_thread;
+    bh_thread_t* idle = g_cpu_locals[0].runqueue.idle_thread;
     assert(idle != NULL);
     assert(idle->priority == 0);
     assert(idle->bound_core_id == 0);
@@ -139,10 +139,10 @@ void mock_task_entry() { }
 void test_thread_create_and_enqueue() {
     sched_init(); // Reset state
 
-    kprocess_t* proc = process_create("test_proc");
+    bh_process_t* proc = process_create("test_proc");
     assert(proc != NULL);
 
-    kthread_t* thread = thread_create(proc, mock_task_entry);
+    bh_thread_t* thread = thread_create(proc, mock_task_entry);
     assert(thread != NULL);
     assert(thread->state == THREAD_STATE_READY);
     assert(thread->priority == 1); // Default
@@ -163,7 +163,7 @@ void test_thread_create_and_enqueue() {
 
 void test_thread_pick_next_ready() {
     sched_init();
-    kprocess_t* proc = process_create("test_proc");
+    bh_process_t* proc = process_create("test_proc");
 
     // Drain the run queue initially, as sched_init adds a monitor task
     while (g_cpu_locals[0].runqueue.runnable_count > 0) {
@@ -171,12 +171,12 @@ void test_thread_pick_next_ready() {
     }
 
     // Create higher priority thread (detached prevents auto-enqueue and avoids double-counting)
-    kthread_t* t1 = thread_create_detached(proc, mock_task_entry);
+    bh_thread_t* t1 = thread_create_detached(proc, mock_task_entry);
     t1->priority = 5;
     sched_enqueue(t1, 0); // Re-enqueue with new priority
 
     // Create lower priority thread
-    kthread_t* t2 = thread_create_detached(proc, mock_task_entry);
+    bh_thread_t* t2 = thread_create_detached(proc, mock_task_entry);
     t2->priority = 2;
     sched_enqueue(t2, 0);
 
@@ -184,7 +184,7 @@ void test_thread_pick_next_ready() {
     assert(g_cpu_locals[0].runqueue.runnable_count == 2);
 
     // Policy default is PRIORITY
-    kthread_t* picked = sched_pick_next_ready(0);
+    bh_thread_t* picked = sched_pick_next_ready(0);
     assert(picked == t1); // Priority 5 is higher
 
     thread_slot_t* slot1 = sched_find_thread_slot_by_tid(t1->thread_id);
@@ -200,8 +200,8 @@ void test_thread_pick_next_ready() {
 
 void test_sched_mark_terminated_and_reap() {
     sched_init();
-    kprocess_t* proc = process_create("test_proc");
-    kthread_t* t1 = thread_create(proc, mock_task_entry);
+    bh_process_t* proc = process_create("test_proc");
+    bh_thread_t* t1 = thread_create(proc, mock_task_entry);
 
     assert(t1->state == THREAD_STATE_READY);
 

--- a/tests/host/test_smp_tlb_active_cores.c
+++ b/tests/host/test_smp_tlb_active_cores.c
@@ -36,9 +36,9 @@ system_discovery_t* hal_get_system_discovery(void) {
 }
 
 // For sched tests we need these
-kprocess_t* process_create(const char* name) {
+bh_process_t* process_create(const char* name) {
     // Stub
-    kprocess_t* p = kmalloc(sizeof(kprocess_t));
+    bh_process_t* p = kmalloc(sizeof(bh_process_t));
     memset(p, 0, sizeof(*p));
     return p;
 }

--- a/tests/test_ai_kernel_bridge.c
+++ b/tests/test_ai_kernel_bridge.c
@@ -38,13 +38,13 @@ void isr32(void) {} void isr128(void) {}
 int main(void) {
     sched_init();
 
-    kprocess_t proc;
+    bh_process_t proc;
     proc.process_id = 1;
     cap_table_init_for_process(&proc); // Ensure caps are initialized
 
-    kthread_t* t = thread_create(&proc, thread_entry);
+    bh_thread_t* t = thread_create(&proc, thread_entry);
     assert(t != NULL);
-    kthread_t* t2 = thread_create(&proc, thread_entry);
+    bh_thread_t* t2 = thread_create(&proc, thread_entry);
     assert(t2 != NULL);
 
     ai_suggestion_t priority = {
@@ -55,11 +55,11 @@ int main(void) {
 
     assert(ai_kernel_apply_suggestion(&priority) == 0);
     sched_on_timer_tick();
-    kthread_t* updated = sched_find_thread_by_id(t2->thread_id);
+    bh_thread_t* updated = sched_find_thread_by_id(t2->thread_id);
     assert(updated != NULL);
     assert(updated->priority == 7U);
 
-    kthread_yield();
+    bh_thread_yield();
     assert(sched_current_thread() != NULL);
 
     assert(numa_discover_topology() == 0);
@@ -80,7 +80,7 @@ int main(void) {
 
     assert(ai_kernel_apply_suggestion(&migrate) == 0);
     sched_on_timer_tick();
-    kthread_t* migrated = sched_find_thread_by_id(t->thread_id);
+    bh_thread_t* migrated = sched_find_thread_by_id(t->thread_id);
     assert(migrated != NULL);
     assert(migrated->preferred_numa_node == 1U);
 

--- a/tests/test_bench_sched.c
+++ b/tests/test_bench_sched.c
@@ -21,7 +21,7 @@ void dummy_entry(void) {
 void test_sched_benchmark(void) {
     sched_init();
 
-    kprocess_t* proc = process_create("bench_proc");
+    bh_process_t* proc = process_create("bench_proc");
     assert(proc != NULL);
 
     const int ITERATIONS = 10000;
@@ -30,7 +30,7 @@ void test_sched_benchmark(void) {
     benchmark_start(&ctx, "Thread Creation/Destruction", BENCHMARK_LEVEL_0_REF, ITERATIONS);
 
     for (int i = 0; i < ITERATIONS; i++) {
-        kthread_t* thread = thread_create(proc, dummy_entry);
+        bh_thread_t* thread = thread_create(proc, dummy_entry);
         assert(thread != NULL);
         thread_destroy(thread);
     }
@@ -43,7 +43,7 @@ void test_sched_benchmark(void) {
 
 
     // Benchmark thread lookups
-    kthread_t* threads[100];
+    bh_thread_t* threads[100];
     for (int i = 0; i < 100; i++) {
         threads[i] = thread_create(proc, dummy_entry);
     }
@@ -52,7 +52,7 @@ void test_sched_benchmark(void) {
     for (int i = 0; i < ITERATIONS; i++) {
         // Find by pseudo-random thread ID
         uint64_t target_id = threads[i % 100]->thread_id;
-        kthread_t* found = sched_find_thread_by_id(target_id);
+        bh_thread_t* found = sched_find_thread_by_id(target_id);
         assert(found != NULL);
     }
     benchmark_stop(&ctx);
@@ -66,7 +66,7 @@ void test_sched_benchmark(void) {
     // Benchmark thread slot allocation worst-case (near-full table)
     // SCHED_MAX_THREADS is 128, but scheduler initializes idle threads for cores.
     // Let's create 100 threads to safely leave a few slots.
-    kthread_t* thread_pool[100];
+    bh_thread_t* thread_pool[100];
     for (int i = 0; i < 100; i++) {
         thread_pool[i] = thread_create(proc, dummy_entry);
         assert(thread_pool[i] != NULL);
@@ -74,7 +74,7 @@ void test_sched_benchmark(void) {
 
     benchmark_start(&ctx, "Thread Alloc/Free (Near-Full Table)", BENCHMARK_LEVEL_0_REF, ITERATIONS);
     for (int i = 0; i < ITERATIONS; i++) {
-        kthread_t* t = thread_create(proc, dummy_entry);
+        bh_thread_t* t = thread_create(proc, dummy_entry);
         assert(t != NULL);
         thread_destroy(t);
     }
@@ -88,7 +88,7 @@ void test_sched_benchmark(void) {
 
     // Benchmark process slot allocation worst-case (near-full table)
     // SCHED_MAX_PROCESSES is 32. Idle process uses 1. `bench_proc` uses 1. Total = 2 used.
-    kprocess_t* process_pool[25];
+    bh_process_t* process_pool[25];
     for (int i = 0; i < 25; i++) {
         process_pool[i] = process_create("bench_filler");
         assert(process_pool[i] != NULL);
@@ -96,7 +96,7 @@ void test_sched_benchmark(void) {
 
     benchmark_start(&ctx, "Process Alloc/Free (Near-Full Table)", BENCHMARK_LEVEL_0_REF, ITERATIONS);
     for (int i = 0; i < ITERATIONS; i++) {
-        kprocess_t* p = process_create("bench_test");
+        bh_process_t* p = process_create("bench_test");
         assert(p != NULL); // if it fails here, table was full.
         process_destroy(p);
     }

--- a/tests/test_bench_sched_timer_tick.c
+++ b/tests/test_bench_sched_timer_tick.c
@@ -65,10 +65,10 @@ static void dummy_thread_entry(void) {}
 // We measure the time taken to run sched_on_timer_tick for BENCH_ITERS.
 static void bench_sched_on_timer_tick_with_n_threads(int num_threads, int should_wakeup) {
   sched_init();
-  kprocess_t *p = process_create("bench");
+  bh_process_t *p = process_create("bench");
   assert(p != NULL);
 
-  kthread_t *threads[128];
+  bh_thread_t *threads[128];
 
   // Create threads
   for (int i = 0; i < num_threads && i < 128; i++) {

--- a/tests/test_capability_ipc.c
+++ b/tests/test_capability_ipc.c
@@ -33,7 +33,7 @@ void entry_point(void) {}
 int main(void) {
     sched_init();
 
-    kprocess_t* proc = process_create("ipc");
+    bh_process_t* proc = process_create("ipc");
     assert(proc != NULL);
 
     cap_table_init_for_process(proc);

--- a/tests/test_capability_misuse.c
+++ b/tests/test_capability_misuse.c
@@ -51,7 +51,7 @@ void test_accelerator_caps(void);
 
 int main(void) {
     sched_init();
-    kprocess_t* p = process_create("cap-misuse");
+    bh_process_t* p = process_create("cap-misuse");
     assert(p != NULL);
 
     cap_table_init_for_process(p);
@@ -114,7 +114,7 @@ void tlb_shootdown(address_space_t *as, virt_addr_t vaddr) {
 }
 
 void test_accelerator_caps(void) {
-    kprocess_t* p = process_create("accel-test");
+    bh_process_t* p = process_create("accel-test");
     assert(p != NULL);
     cap_table_init_for_process(p);
     capability_table_t* t = (capability_table_t*)p->security_sandbox_ctx;

--- a/tests/test_ipc_async_timeout.c
+++ b/tests/test_ipc_async_timeout.c
@@ -15,14 +15,14 @@ uint64_t sched_get_ticks(void) {
 
 int g_wakeup_count = 0;
 
-void sched_wakeup(kthread_t* thread) {
+void sched_wakeup(bh_thread_t* thread) {
     if (thread) {
         thread->state = THREAD_STATE_READY;
     }
     g_wakeup_count++;
 }
 
-void sched_wakeup_with_priority(kthread_t* thread, uint32_t wakeup_priority) {
+void sched_wakeup_with_priority(bh_thread_t* thread, uint32_t wakeup_priority) {
     (void)wakeup_priority;
     sched_wakeup(thread);
 }
@@ -30,7 +30,7 @@ void sched_wakeup_with_priority(kthread_t* thread, uint32_t wakeup_priority) {
 int main(void) {
     ipc_async_init();
 
-    kthread_t thread = {0};
+    bh_thread_t thread = {0};
     thread.state = THREAD_STATE_BLOCKED;
 
     g_ticks = 10;

--- a/tests/test_ipc_fuzz.c
+++ b/tests/test_ipc_fuzz.c
@@ -39,7 +39,7 @@ int vmm_map_device_mmio(virt_addr_t vaddr, phys_addr_t paddr, capability_t* cap,
 static void test_ipc_fuzzing(void) {
     printf("Running deterministic IPC fuzzing test...\n");
 
-    kprocess_t* p = process_create("fuzzer");
+    bh_process_t* p = process_create("fuzzer");
     assert(p != NULL);
 
     capability_table_t* t = (capability_table_t*)p->security_sandbox_ctx;

--- a/tests/test_ipc_multiple_waiters_fifo.c
+++ b/tests/test_ipc_multiple_waiters_fifo.c
@@ -23,7 +23,7 @@ static void dummy_entry(void) {}
 void test_ipc_multiple_waiters_fifo(void) {
     sched_init();
 
-    kprocess_t* proc = process_create("test_fifo");
+    bh_process_t* proc = process_create("test_fifo");
     assert(proc != NULL);
 
     capability_table_t* table = (capability_table_t*)proc->security_sandbox_ctx;
@@ -32,10 +32,10 @@ void test_ipc_multiple_waiters_fifo(void) {
     uint32_t send_cap, recv_cap;
     assert(ipc_endpoint_create(table, &send_cap, &recv_cap) == IPC_OK);
 
-    kthread_t* r1 = thread_create(proc, dummy_entry);
-    kthread_t* r2 = thread_create(proc, dummy_entry);
-    kthread_t* r3 = thread_create(proc, dummy_entry);
-    kthread_t* sender = thread_create(proc, dummy_entry);
+    bh_thread_t* r1 = thread_create(proc, dummy_entry);
+    bh_thread_t* r2 = thread_create(proc, dummy_entry);
+    bh_thread_t* r3 = thread_create(proc, dummy_entry);
+    bh_thread_t* sender = thread_create(proc, dummy_entry);
 
     // Get all receivers blocked
     char buf[16];

--- a/tests/test_ipc_no_spurious_self_wakeup.c
+++ b/tests/test_ipc_no_spurious_self_wakeup.c
@@ -23,7 +23,7 @@ static void dummy_entry(void) {}
 void test_ipc_no_spurious_self_wakeup(void) {
     sched_init();
 
-    kprocess_t* proc = process_create("test_spurious");
+    bh_process_t* proc = process_create("test_spurious");
     assert(proc != NULL);
 
     capability_table_t* table = (capability_table_t*)proc->security_sandbox_ctx;
@@ -32,7 +32,7 @@ void test_ipc_no_spurious_self_wakeup(void) {
     uint32_t send_cap, recv_cap;
     assert(ipc_endpoint_create(table, &send_cap, &recv_cap) == IPC_OK);
 
-    kthread_t* self = thread_create(proc, dummy_entry);
+    bh_thread_t* self = thread_create(proc, dummy_entry);
 
     while (sched_current_thread() != self) {
         sched_yield();

--- a/tests/test_ipc_sync_receiver_wakeup.c
+++ b/tests/test_ipc_sync_receiver_wakeup.c
@@ -23,7 +23,7 @@ static void dummy_entry(void) {}
 void test_ipc_sync_receiver_wakeup(void) {
     sched_init();
 
-    kprocess_t* proc = process_create("test_receiver");
+    bh_process_t* proc = process_create("test_receiver");
     assert(proc != NULL);
 
     capability_table_t* table = (capability_table_t*)proc->security_sandbox_ctx;
@@ -32,8 +32,8 @@ void test_ipc_sync_receiver_wakeup(void) {
     uint32_t send_cap, recv_cap;
     assert(ipc_endpoint_create(table, &send_cap, &recv_cap) == IPC_OK);
 
-    kthread_t* t_receiver = thread_create(proc, dummy_entry);
-    kthread_t* t_sender = thread_create(proc, dummy_entry);
+    bh_thread_t* t_receiver = thread_create(proc, dummy_entry);
+    bh_thread_t* t_sender = thread_create(proc, dummy_entry);
 
     // Initial state: buffer is empty.
     // Switch to receiver. Attempting to receive should block it.

--- a/tests/test_ipc_sync_sender_wakeup.c
+++ b/tests/test_ipc_sync_sender_wakeup.c
@@ -23,7 +23,7 @@ static void dummy_entry(void) {}
 void test_ipc_sync_sender_wakeup(void) {
     sched_init();
 
-    kprocess_t* proc = process_create("test_sender");
+    bh_process_t* proc = process_create("test_sender");
     assert(proc != NULL);
 
     capability_table_t* table = (capability_table_t*)proc->security_sandbox_ctx;
@@ -32,9 +32,9 @@ void test_ipc_sync_sender_wakeup(void) {
     uint32_t send_cap, recv_cap;
     assert(ipc_endpoint_create(table, &send_cap, &recv_cap) == IPC_OK);
 
-    kthread_t* t_sender1 = thread_create(proc, dummy_entry);
-    kthread_t* t_sender2 = thread_create(proc, dummy_entry);
-    kthread_t* t_receiver = thread_create(proc, dummy_entry);
+    bh_thread_t* t_sender1 = thread_create(proc, dummy_entry);
+    bh_thread_t* t_sender2 = thread_create(proc, dummy_entry);
+    bh_thread_t* t_receiver = thread_create(proc, dummy_entry);
 
     // Initial state: sender1 fills the endpoint buffer.
     // To pretend t_sender1 is running:

--- a/tests/test_pmm_production.c
+++ b/tests/test_pmm_production.c
@@ -64,7 +64,7 @@ char _pstore_start[1024];
 char _pstore_end[1024];
 
 memory_node_id_t numa_get_current_node(void) { return 0; }
-kthread_t *sched_current_thread(void) { return NULL; }
+bh_thread_t *sched_current_thread(void) { return NULL; }
 int sched_ai_apply_suggestion(const ai_suggestion_t *suggestion) { (void)suggestion; return 0; }
 
 // Memory block to test with

--- a/tests/test_pmm_refpin.c
+++ b/tests/test_pmm_refpin.c
@@ -58,7 +58,7 @@ void hal_mm_get_zone_limits(hal_mm_zone_limits_t *limits) {
 }
 
 memory_node_id_t numa_get_current_node(void) { return 0; }
-kthread_t *sched_current_thread(void) { return NULL; }
+bh_thread_t *sched_current_thread(void) { return NULL; }
 int sched_ai_apply_suggestion(const ai_suggestion_t *s) { (void)s; return 0; }
 
 static void setup_pmm(void) {

--- a/tests/test_pmm_zone_alloc.c
+++ b/tests/test_pmm_zone_alloc.c
@@ -59,7 +59,7 @@ void hal_mm_get_zone_limits(hal_mm_zone_limits_t *limits) {
 }
 
 memory_node_id_t numa_get_current_node(void) { return 0; }
-kthread_t *sched_current_thread(void) { return NULL; }
+bh_thread_t *sched_current_thread(void) { return NULL; }
 int sched_ai_apply_suggestion(const ai_suggestion_t *s) { (void)s; return 0; }
 
 static void setup_pmm(void) {

--- a/tests/test_sched_reap.c
+++ b/tests/test_sched_reap.c
@@ -40,9 +40,9 @@ void dummy_thread(void) {}
 int main(void) {
   sched_init();
 
-  kprocess_t *p = process_create("reap_proc");
+  bh_process_t *p = process_create("reap_proc");
   assert(p != NULL);
-  kthread_t *t = thread_create(p, dummy_thread);
+  bh_thread_t *t = thread_create(p, dummy_thread);
   assert(t != NULL);
 
   ai_suggestion_t kill = {
@@ -60,9 +60,9 @@ int main(void) {
   assert(process_destroy(p) == 0);
   assert(g_aspace_destroy_calls >= 1U);
 
-  kprocess_t *p2 = process_create("live_proc");
+  bh_process_t *p2 = process_create("live_proc");
   assert(p2 != NULL);
-  kthread_t *t2 = thread_create(p2, dummy_thread);
+  bh_thread_t *t2 = thread_create(p2, dummy_thread);
   assert(t2 != NULL);
   assert(process_destroy(p2) != 0);
 

--- a/tests/test_scheduler.c
+++ b/tests/test_scheduler.c
@@ -84,7 +84,7 @@ static int g_mutex_b;
 
 static void test_lifecycle_and_syscalls(void) {
   sched_init();
-  kprocess_t *p = process_create("init");
+  bh_process_t *p = process_create("init");
   assert(p != NULL);
 
   uint64_t tid = 0;
@@ -95,32 +95,32 @@ static void test_lifecycle_and_syscalls(void) {
 
 static void test_priority_round_robin(void) {
   sched_init();
-  kprocess_t *p = process_create("prio");
+  bh_process_t *p = process_create("prio");
   assert(p != NULL);
 
-  kthread_t *t1 = thread_create(p, thread_a);
-  kthread_t *t2 = thread_create(p, thread_b);
+  bh_thread_t *t1 = thread_create(p, thread_a);
+  bh_thread_t *t2 = thread_create(p, thread_b);
   assert(t1 && t2);
 
   assert(sched_set_thread_priority(t1->thread_id, 3) == 0);
   assert(sched_set_thread_priority(t2->thread_id, 8) == 0);
 
-  kthread_yield();
+  bh_thread_yield();
   assert(sched_current_thread() == t2);
 
-  kthread_yield();
+  bh_thread_yield();
   assert(sched_current_thread() == t1 || sched_current_thread() == t2);
 }
 
 static void test_sleep_wakeup(void) {
   sched_init();
-  kprocess_t *p = process_create("sleep");
+  bh_process_t *p = process_create("sleep");
   assert(p != NULL);
 
-  kthread_t *t = thread_create(p, thread_a);
+  bh_thread_t *t = thread_create(p, thread_a);
   assert(t != NULL);
 
-  kthread_yield();
+  bh_thread_yield();
   assert(sched_current_thread() == t);
 
   sched_sleep(2);
@@ -135,21 +135,21 @@ static void test_sleep_wakeup(void) {
 
 static void test_preempt_on_higher_priority_ready(void) {
   sched_init();
-  kprocess_t *p = process_create("preempt");
+  bh_process_t *p = process_create("preempt");
   assert(p != NULL);
 
-  kthread_t *low = thread_create(p, thread_a);
-  kthread_t *high = thread_create(p, thread_b);
+  bh_thread_t *low = thread_create(p, thread_a);
+  bh_thread_t *high = thread_create(p, thread_b);
   assert(low && high);
 
   assert(sched_set_thread_priority(low->thread_id, 2) == 0);
   assert(sched_set_thread_priority(high->thread_id, 7) == 0);
 
-  kthread_yield();
+  bh_thread_yield();
   assert(sched_current_thread() == high);
 
   sched_sleep(5);
-  kthread_yield();
+  bh_thread_yield();
   assert(sched_current_thread() != high);
 
   sched_wakeup(high);
@@ -161,41 +161,41 @@ static void test_preempt_on_higher_priority_ready(void) {
 
 static void test_policy_hooks_and_rr(void) {
   sched_init();
-  kprocess_t *p = process_create("policy");
+  bh_process_t *p = process_create("policy");
   assert(p != NULL);
 
-  kthread_t *low = thread_create(p, thread_a);
-  kthread_t *high = thread_create(p, thread_b);
+  bh_thread_t *low = thread_create(p, thread_a);
+  bh_thread_t *high = thread_create(p, thread_b);
   assert(low && high);
 
   assert(sched_set_thread_priority(low->thread_id, 1) == 0);
   assert(sched_set_thread_priority(high->thread_id, 9) == 0);
 
   sched_set_policy(SCHED_POLICY_ROUND_ROBIN);
-  kthread_yield();
+  bh_thread_yield();
   assert(sched_current_thread() != high);
 
   sched_set_policy(SCHED_POLICY_PRIORITY);
-  kthread_yield();
+  bh_thread_yield();
   assert(sched_current_thread() != NULL);
 
   sched_set_policy(SCHED_POLICY_EDF);
-  kthread_yield();
+  bh_thread_yield();
   assert(sched_current_thread() != NULL);
 
   sched_set_policy(SCHED_POLICY_RMS);
-  kthread_yield();
+  bh_thread_yield();
   assert(sched_current_thread() != NULL);
 }
 
 static void test_priority_inheritance_chain(void) {
   sched_init();
-  kprocess_t *p = process_create("inherit");
+  bh_process_t *p = process_create("inherit");
   assert(p != NULL);
 
-  kthread_t *low = thread_create(p, thread_a);
-  kthread_t *mid = thread_create(p, thread_a);
-  kthread_t *high = thread_create(p, thread_b);
+  bh_thread_t *low = thread_create(p, thread_a);
+  bh_thread_t *mid = thread_create(p, thread_a);
+  bh_thread_t *high = thread_create(p, thread_b);
   assert(low && mid && high);
 
   assert(sched_set_thread_priority(low->thread_id, 2) == 0);
@@ -223,29 +223,29 @@ static void test_priority_inheritance_chain(void) {
 
 static void test_affinity_migration_multicore(void) {
   sched_init();
-  kprocess_t *p = process_create("smp");
+  bh_process_t *p = process_create("smp");
   assert(p != NULL);
 
-  kthread_t *t = thread_create(p, thread_a);
+  bh_thread_t *t = thread_create(p, thread_a);
   assert(t != NULL);
 
   // assert(sched_sys_set_affinity(t->thread_id, (1U << 1)) == 0);
   t->bound_core_id = 1U;
 
   g_mock_core_id = 1U;
-  kthread_yield();
+  bh_thread_yield();
   assert(sched_current_thread() == t || sched_current_thread() != NULL);
   g_mock_core_id = 0U;
 }
 
 static void run_benchmark(void) {
   sched_init();
-  kprocess_t *p = process_create("bench");
+  bh_process_t *p = process_create("bench");
   assert(p != NULL);
   uint64_t tids[64];
 
   for (int i = 0; i < 64; i++) {
-    kthread_t *t = thread_create(p, thread_a);
+    bh_thread_t *t = thread_create(p, thread_a);
     assert(t != NULL);
     tids[i] = t->thread_id;
   }

--- a/tests/test_scheduler_hello_world.c
+++ b/tests/test_scheduler_hello_world.c
@@ -59,21 +59,21 @@ int main(void) {
   printf("hello scheduler test app\n");
 
   sched_init();
-  kprocess_t *p = process_create("hello");
+  bh_process_t *p = process_create("hello");
   assert(p != NULL);
 
-  kthread_t *a = thread_create(p, hello_a);
-  kthread_t *b = thread_create(p, hello_b);
+  bh_thread_t *a = thread_create(p, hello_a);
+  bh_thread_t *b = thread_create(p, hello_b);
   assert(a && b);
 
   assert(sched_set_thread_priority(a->thread_id, 3) == 0);
   assert(sched_set_thread_priority(b->thread_id, 9) == 0);
 
-  kthread_yield();
+  bh_thread_yield();
   assert(sched_current_thread() == b);
 
   sched_sleep(2);
-  kthread_yield();
+  bh_thread_yield();
   assert(sched_current_thread() != b);
 
   sched_on_timer_tick();

--- a/tests/test_security_isolation.c
+++ b/tests/test_security_isolation.c
@@ -36,11 +36,11 @@ int vmm_map_device_mmio(virt_addr_t vaddr, phys_addr_t paddr, capability_t* cap,
 }
 
 static void test_ipc_bypass(void) {
-    kprocess_t* p = process_create("p1");
+    bh_process_t* p = process_create("p1");
     assert(p != NULL);
     capability_table_t* t = (capability_table_t*)p->security_sandbox_ctx;
 
-    kprocess_t* p2 = process_create("p2");
+    bh_process_t* p2 = process_create("p2");
     assert(p2 != NULL);
     capability_table_t* t2 = (capability_table_t*)p2->security_sandbox_ctx;
 
@@ -62,7 +62,7 @@ static void test_ipc_bypass(void) {
 }
 
 static void test_device_access(void) {
-    kprocess_t* p = process_create("device_process");
+    bh_process_t* p = process_create("device_process");
     assert(p != NULL);
     capability_table_t* t = (capability_table_t*)p->security_sandbox_ctx;
 

--- a/tests/test_stress_concurrency.c
+++ b/tests/test_stress_concurrency.c
@@ -64,7 +64,7 @@ void ipc_async_check_timeouts(uint64_t current_ticks) { (void)current_ticks; }
 uint64_t hal_timer_monotonic_ticks(void) { return 0; }
 
 
-static kprocess_t* g_proc;
+static bh_process_t* g_proc;
 
 static void worker_thread(void) { }
 
@@ -78,7 +78,7 @@ static void* stress_worker(void* arg) {
         if (op == 0) {
             // sched_sys_thread_create needs careful locking in stub or limit memory leaks
             // we will simulate contention manually instead
-            kthread_yield();
+            bh_thread_yield();
         } else if (op == 1) {
             uint32_t send_cap = 0;
             uint32_t recv_cap = 0;
@@ -93,7 +93,7 @@ static void* stress_worker(void* arg) {
         } else if (op == 2) {
             sched_sys_sleep(rand_r(&seed) % 5);
         } else if (op == 3) {
-            kthread_yield();
+            bh_thread_yield();
         } else if (op == 4) {
             // Allocate and free random capabilities
             capability_table_t* t = (capability_table_t*)g_proc->security_sandbox_ctx;

--- a/tests/test_trap_syscall.c
+++ b/tests/test_trap_syscall.c
@@ -110,7 +110,7 @@ extern long syscall_dispatch(syscall_id_t id, uint64_t arg0, uint64_t arg1,
                       uint64_t arg5);
 
 // Removed duplicate default_personality_ops definition.
-static long default_handle_syscall(kthread_t *thread, trap_frame_t *frame, const trap_info_t *info) {
+static long default_handle_syscall(bh_thread_t *thread, trap_frame_t *frame, const trap_info_t *info) {
     (void)thread;
     (void)info;
 
@@ -124,7 +124,7 @@ static long default_handle_syscall(kthread_t *thread, trap_frame_t *frame, const
         trap_frame_get_arg5(frame)
     );
 }
-static int default_handle_user_fault(kthread_t *thread, trap_frame_t *frame, const trap_info_t *info) {
+static int default_handle_user_fault(bh_thread_t *thread, trap_frame_t *frame, const trap_info_t *info) {
     (void)thread;
     (void)frame;
     (void)info;

--- a/tests/test_vfs_storage.c
+++ b/tests/test_vfs_storage.c
@@ -66,10 +66,10 @@ capability_table_t *g_mock_cap_table;
 #include "sched.h"
 
 
-extern kprocess_t* g_stub_current_process;
+extern bh_process_t* g_stub_current_process;
 
 int main(void) {
-    static kprocess_t proc;
+    static bh_process_t proc;
     g_stub_current_process = &proc;
     proc.security_sandbox_ctx = g_mock_cap_table;
     // initialize g_memory_fs

--- a/tests/test_vmm_fault.c
+++ b/tests/test_vmm_fault.c
@@ -44,7 +44,7 @@ static void fake_zero_page(phys_addr_t paddr, size_t size) {
 }
 
 __attribute__((weak)) uint16_t numa_get_current_node(void) { return 0; }
-__attribute__((weak)) kthread_t *sched_current_thread(void) { return NULL; }
+__attribute__((weak)) bh_thread_t *sched_current_thread(void) { return NULL; }
 __attribute__((weak)) int sched_ai_apply_suggestion(const ai_suggestion_t* suggestion) { return 0; }
 __attribute__((weak)) void hal_mm_get_zone_limits(void) {}
 __attribute__((weak)) void *hal_get_system_discovery(void) { return NULL; }


### PR DESCRIPTION
### Motivation
- Standardize core kernel naming and API to the new `bh_*` prefix for multikernel/branding consistency and to reflect the distributed thread/process model.
- Ensure architecture-specific extended state and context-switch paths use the updated thread type so signatures and owners are consistent across ISAs.
- Propagate the rename through scheduler, IPC, NUMA, PMM, tests, and documentation to avoid mixed-type usage.

### Description
- Replaced uses of `kthread`, `kthread_t`, `kprocess`, and related identifiers with `bh_thread`, `bh_thread_t`, `bh_process`, and `bh_process_t` across headers and sources, updating typedefs and forward declarations.
- Updated function signatures that accept thread/process handles (e.g., `arch_ext_state_thread_init`, `arch_ext_state_*`, scheduler APIs, hw security, sandbox, personality hooks, ipc async, ai scheduler, etc.) to use the new `bh_*` types.
- Adjusted arm64 context switch: renamed trampoline symbol from `arch_kthread_start_trampoline` to `arch_bh_thread_start_trampoline` and updated its reference in `arch_prepare_initial_context` and assembly label.
- Converted numerous docs and architecture markdown files to use the new `bh_*` naming and updated many unit tests, stubs, and host test code to the new types; updated related helpers and weak arch/test stubs accordingly.

### Testing
- Built the kernel and unit test suites and executed scheduler/tests and host-test harnesses (`ktest` and various host/unit tests) in the test environment; all automated builds and tests completed successfully.
- Ran the scheduler self-tests (real-time and priority/runqueue tests) and IPC async/timeouts unit tests; they passed under the modified API.
- Executed host/unit test binaries and boot selftest entry points used by CI; no regressions were reported in the automated runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e84e3c212c8320861860af67bdb0aa)