### PR TITLE
docs(personalities): add multi-arch tri-ISA roadmap and cross-ISA enforcement

### DIFF
--- a/docs/architecture/personalities/README.md
+++ b/docs/architecture/personalities/README.md
@@ -2,8 +2,8 @@
 title: Personalities Documentation Index
 status: active
 owner: Architecture Team
-version: 1.0
-last_updated: "2026-04-21"
+version: 1.1
+last_updated: "2026-04-22"
 ---
 
 # Personalities Documentation (Consolidated)
@@ -16,6 +16,7 @@ This folder is the canonical architecture location for personality design and pl
 - `personality-performance-contract.md`: mandatory performance and KPI constraints.
 - `roadmap.md`: phased delivery roadmap.
 - `zero-translation-roadmap.md`: implementation roadmap for near-zero translation overhead using modern native primitives.
+- `multi-arch-personality-roadmap.md`: cross-ISA execution roadmap for Linux and Android personalities on x86_64, arm64, and riscv64.
 
 ## Personality-specific docs
 

--- a/docs/architecture/personalities/android/android_personality_architecture.md
+++ b/docs/architecture/personalities/android/android_personality_architecture.md
@@ -3,8 +3,8 @@ title: Android Personality Kernel Architecture
 status: active
 owner: Architecture Team
 reviewers: ["Core Team"]
-version: 0.1
-last_updated: "2024-03-23"
+version: 0.2
+last_updated: "2026-04-22"
 tags: ["architecture", "personalities"]
 ---
 
@@ -71,3 +71,13 @@ The Android personality is designed to be modular. Future work will expand these
     *   *Unit Tests:* Ensure logical IDs and handle resolution do not leak memory or raw pointers.
     *   *Integration Tests:* Spin up multiple cores, execute cross-core Binder transactions, and assert that priority metadata and reply paths function correctly.
     *   *Stress Tests:* Verify distributed COW sharing and shared-memory teardown paths under memory pressure.
+
+
+## Cross-ISA Execution Requirements (x86_64, arm64, riscv64)
+
+Android personality implementation must remain architecture-portable while preserving Binder and shared-memory fast paths.
+
+- Validate Bionic ABI assumptions (TLS, signals, loader interaction) separately per ISA.
+- Keep Binder compatibility logic shared; isolate only ABI/trap details to arch-specific glue.
+- Enforce zero-copy buffer transfer and bounded wakeup latency on all target ISAs.
+- Gate promotion on per-ISA Android service smoke tests and KPI compliance.

--- a/docs/architecture/personalities/linux/linux_personality_architecture.md
+++ b/docs/architecture/personalities/linux/linux_personality_architecture.md
@@ -3,8 +3,8 @@ title: Linux Personality Architecture
 status: active
 owner: Architecture Team
 reviewers: ["Core Team"]
-version: 1.0
-last_updated: "2024-03-23"
+version: 1.1
+last_updated: "2026-04-22"
 tags: ["architecture", "personalities"]
 ---
 
@@ -59,3 +59,13 @@ A Linux ELF loader is required for:
 - ELF64 support
 - auxv, argv/envp stack setup
 - Statically linked binaries initially, progressing to dynamic linking (interpreter path, TLS hooks).
+
+
+## Cross-ISA Contract (x86_64, arm64, riscv64)
+
+Linux personality support must be functionally consistent and performance-grade across all three target ISAs.
+
+- Maintain per-ISA syscall number maps while preserving a shared syscall implementation layer.
+- Keep ABI argument extraction architecture-local, but normalize immediately into a common internal syscall context.
+- Validate restart/error/signal edge cases with architecture-conformance tests in CI.
+- Enforce hot-path KPI budgets independently for each ISA to avoid hidden regressions.

--- a/docs/architecture/personalities/multi-arch-personality-roadmap.md
+++ b/docs/architecture/personalities/multi-arch-personality-roadmap.md
@@ -1,0 +1,181 @@
+---
+title: Multi-Architecture Personality Enablement Roadmap
+status: active
+owner: Architecture Team
+reviewers: ["Core Team", "Perf Team"]
+version: 1.0
+last_updated: "2026-04-22"
+tags: ["architecture", "personalities", "x86_64", "arm64", "riscv64", "linux", "android", "performance"]
+---
+
+# Multi-Architecture Personality Enablement Roadmap
+
+## Objective
+
+Enable Linux and Android application support across **x86_64**, **arm64**, and **riscv64** while preserving a **near-zero translation tax** on hot paths.
+
+This roadmap identifies the concrete tasks required to move from architecture-specific bootstrap support to production-grade personality execution.
+
+## Scope and Constraints
+
+- In scope:
+  - Linux personality execution (CLI/server workloads).
+  - Android personality execution (service/runtime workloads).
+  - Shared performance and observability across three target ISAs.
+- Out of scope (for this roadmap version):
+  - Full GUI stack parity for all Android devices.
+  - Legacy 32-bit ABIs (x86, armv7).
+- Non-negotiable:
+  - Boundary-only translation.
+  - Table-driven dispatch on all hot paths.
+  - No regressions to native personality fast path.
+
+## Architecture Matrix and Deliverables
+
+| Layer | x86_64 | arm64 | riscv64 |
+|---|---|---|---|
+| Trap + syscall entry ABI | Stabilize SysV entry and fast return path | Stabilize AArch64 exception entry + SVC path | Stabilize RV64 ECALL entry + return path |
+| Linux personality | Syscall number table + ABI argument marshalling | Syscall number table + ABI argument marshalling | Syscall number table + ABI argument marshalling |
+| Android personality | Bionic + Binder + ashmem/memfd compatibility | Bionic + Binder + ashmem/memfd compatibility | Bionic + Binder + ashmem/memfd compatibility |
+| Toolchain + CI | Build, boot, and microbench jobs | Build, boot, and microbench jobs | Build, boot, and microbench jobs |
+| Perf gates | Tier-2 overhead budget enforcement | Tier-2 overhead budget enforcement | Tier-2 overhead budget enforcement |
+
+## Work Breakdown Structure (WBS)
+
+### WBS-1: ISA ABI Foundations (Kernel Entry + Calling Convention)
+
+1. Define per-ISA syscall frame contract:
+   - register usage,
+   - error return encoding,
+   - restartable syscall behavior,
+   - signal/interruption return protocol.
+2. Ensure trap handlers expose uniform internal syscall context object.
+3. Add architecture-specific conformance tests for:
+   - argument extraction correctness,
+   - errno mapping,
+   - restart semantics.
+
+**Exit criteria:** identical syscall contract behavior across x86_64/arm64/riscv64 for core Linux ABI calls.
+
+### WBS-2: Linux Personality Cross-ISA Bring-Up
+
+1. Create/validate syscall number maps for each ISA (Linux ABIs differ per architecture).
+2. Implement table-generation or verification tooling to prevent syscall map drift.
+3. Prioritize hot syscall set:
+   - process/thread (`clone`, `exit_group`, `set_tid_address`),
+   - memory (`mmap`, `munmap`, `mprotect`, `madvise`),
+   - I/O (`openat`, `read`, `write`, `close`, `ioctl` subset),
+   - readiness/sync (`epoll_*`, `futex`, `eventfd`, `timerfd`).
+4. Add per-ISA Linux personality smoke suite using static busybox + syscall microtests.
+
+**Exit criteria:** same Linux smoke workload passes across all three ISAs without ISA-specific behavior forks in core logic.
+
+### WBS-3: Android Personality Cross-ISA Bring-Up
+
+1. Validate Bionic ABI assumptions per ISA:
+   - TLS model,
+   - vdso/vvar hooks (or compatible fallback),
+   - signal trampoline expectations.
+2. Implement Binder compatibility fast-path rules:
+   - fixed-size command decode tables,
+   - capability transfer path without extra copies,
+   - threadpool wakeup latency budget.
+3. Implement ashmem/memfd compatibility on shared memory object primitives.
+4. Add Android command-line/service smoke tests per ISA:
+   - property service basics,
+   - binder transact/reply loop,
+   - shared-memory producer/consumer flow.
+
+**Exit criteria:** minimal Android userspace services boot and communicate on all three ISAs with the same personality code paths.
+
+### WBS-4: Zero-Translation Performance Engineering
+
+1. Remove string-based or dynamic lookup from hot path translation.
+2. Introduce compact ID/enumeration mapping caches at personality boundary.
+3. Enforce one-time mapping policy (ABI ingress only).
+4. Add perf counters for translation hits/misses and fallback-path usage.
+
+**Exit criteria:** no repeated translation on syscall, epoll/futex, binder, or shared-memory hot loops.
+
+### WBS-5: CI, Benchmarking, and Release Gates
+
+1. Continuous jobs per ISA for:
+   - kernel build,
+   - personality unit/integration tests,
+   - Linux and Android smoke suites,
+   - microbench KPI checks.
+2. Benchmark baselines:
+   - native Linux on equivalent hardware/QEMU profile,
+   - Bharat Linux personality,
+   - Bharat Android personality.
+3. Release blockers:
+   - any ISA with KPI regressions above budget,
+   - any personality path forced into Tier-3 emulation for common operations.
+
+**Exit criteria:** all three ISAs pass build + correctness + KPI thresholds.
+
+## Performance SLOs (Tier-2 Path)
+
+Per ISA, the following targets apply to Linux and Android personalities:
+
+- Null syscall overhead delta: **<= 5%** vs baseline.
+- `mmap/munmap/mprotect` overhead delta: **<= 8%**.
+- `epoll_wait` wakeup overhead delta: **<= 10%** under load.
+- Futex wait/wake p99 latency delta: **<= 10%**.
+- Binder transact/reply median delta: **<= 10%** (Android path).
+- Zero-copy shared memory throughput delta: **<= 5%**.
+
+Any breach requires explicit waiver and mitigation plan before milestone promotion.
+
+## Milestone Timeline
+
+### M0 — Baseline and Tooling (2-4 weeks)
+- WBS-1 contracts finalized.
+- Syscall-map validation tooling in place.
+- Minimal tri-ISA build/test jobs live.
+
+### M1 — Linux Tri-ISA MVP (4-8 weeks)
+- WBS-2 hot syscall set complete.
+- Static busybox and syscall smoke tests passing on x86_64/arm64/riscv64.
+- Initial perf numbers collected.
+
+### M2 — Android Tri-ISA MVP (6-10 weeks)
+- WBS-3 compatibility core complete.
+- Binder + shared-memory smoke tests passing on all ISAs.
+- Android service-level sanity checks operational.
+
+### M3 — Zero-Translation Hardening (4-8 weeks)
+- WBS-4 mapping caches and fast-path cleanup merged.
+- Tier-2 perf SLOs met on representative hardware.
+
+### M4 — Release Candidate (2-4 weeks)
+- WBS-5 release gates green across all ISAs.
+- Documentation, profiling reports, and known gaps published.
+
+## Risks and Mitigations
+
+1. **Syscall map divergence across ISAs**
+   - Mitigation: generated tables + CI drift checks.
+2. **riscv64 toolchain/runtime maturity issues**
+   - Mitigation: dedicated nightly jobs, ABI conformance harness, fallback stubs with explicit metrics.
+3. **Android Binder performance regressions**
+   - Mitigation: zero-copy transfer audits, lock-contention tracing, scheduler intent tuning.
+4. **Feature creep into slow emulation paths**
+   - Mitigation: enforce Tier-2-first policy and block merges that add hot-path fallbacks.
+
+## Ownership Model
+
+- **Architecture Team:** ABI contracts, dispatch framework, design guardrails.
+- **Kernel Team:** trap/syscall entry, VM/IPC/scheduler fast paths.
+- **Compatibility Team:** Linux/Android personality implementation.
+- **Performance Team:** benchmarks, KPIs, regression triage.
+- **CI/Infra Team:** tri-ISA pipelines and reproducible benchmark environments.
+
+## Definition of Done (Program-Level)
+
+The multi-architecture personality program is complete when:
+
+1. Linux and Android personality smoke + integration suites pass on x86_64, arm64, riscv64.
+2. Hot-path operations meet Tier-2 SLO budgets on all ISAs.
+3. Translation is boundary-only and verified by counters/traces.
+4. Operational documentation and known limitation matrix are published and versioned.

--- a/docs/architecture/personalities/roadmap.md
+++ b/docs/architecture/personalities/roadmap.md
@@ -3,8 +3,8 @@ title: Personalities Roadmap
 status: active
 owner: Architecture Team
 reviewers: ["Core Team"]
-version: 1.0
-last_updated: "2024-03-23"
+version: 1.1
+last_updated: "2026-04-22"
 tags: ["architecture", "personalities", "roadmap"]
 ---
 
@@ -69,6 +69,17 @@ These milestones focus on deeper integration, high-performance concurrency, and 
   - Hardware Abstraction Layer (HAL) pass-through: Allowing Android user-space HALs to interact securely with Bharat-OS drivers via capability-gated IPC.
   - Zygote process spawning utilizing optimized multikernel memory sharing.
   - SELinux compatibility layer mapped to Bharat-OS capabilities.
+
+
+## Cross-Architecture Priority Track (x86_64, arm64, riscv64)
+
+To deliver Linux and Android personalities as production-grade features, all roadmap milestones must now be validated across three primary architectures:
+
+- x86_64
+- arm64
+- riscv64
+
+Execution and ownership details are tracked in `multi-arch-personality-roadmap.md`. This document is now the source of truth for ISA-specific bring-up tasks, KPI gates, and phased release criteria.
 
 ## Code Structure Constraints
 

--- a/docs/architecture/personalities/zero-translation-roadmap.md
+++ b/docs/architecture/personalities/zero-translation-roadmap.md
@@ -2,8 +2,8 @@
 title: Personality Zero-Translation Roadmap
 status: active
 owner: Architecture Team
-version: 1.0
-last_updated: "2026-04-21"
+version: 1.1
+last_updated: "2026-04-22"
 tags: ["architecture", "personalities", "performance", "compatibility"]
 ---
 
@@ -81,3 +81,12 @@ To maximize personality benefit, primitive implementations should mature from v1
 - No ABI renumbering or replacement of legacy compatibility interfaces.
 - Additive UAPI only, with versioned structs and reserved fields.
 - Degrade behavior explicit per profile when semantics cannot be fully honored.
+
+
+## 8. Cross-ISA enforcement (x86_64, arm64, riscv64)
+
+All zero-translation requirements in this document are mandatory for Linux and Android personalities on each supported ISA.
+
+- No architecture is allowed to rely on repeated translation in hot loops as a temporary default.
+- KPI pass/fail is evaluated per ISA, not as a pooled average.
+- Any ISA-specific fallback path must be explicitly measured, documented, and tracked to removal in `multi-arch-personality-roadmap.md`.


### PR DESCRIPTION
### Motivation

- Provide an actionable, architecture-driven plan to enable Linux and Android personalities across `x86_64`, `arm64`, and `riscv64` while preserving the near-zero translation-tax goals.
- Make per-ISA conformance and performance gating explicit so CI, perf, and implementation teams can validate work independently per ISA.
- Surface ownership, exit criteria, SLOs, and milestone timelines to avoid ad-hoc architecture divergence during tri-ISA bring-up.

### Description

- Added a new roadmap `docs/architecture/personalities/multi-arch-personality-roadmap.md` that contains WBS items, per-ISA exit criteria, performance SLOs, milestone timeline, risks, and definition-of-done for tri-ISA Linux/Android enablement.
- Updated the personalities index `docs/architecture/personalities/README.md` to include the new multi-architecture roadmap and bumped the doc metadata version/date.
- Updated `docs/architecture/personalities/roadmap.md` to add a **Cross-Architecture Priority Track** and link to the new multi-arch roadmap, and bumped the doc metadata version/date.
- Strengthened enforcement language in `docs/architecture/personalities/zero-translation-roadmap.md` (added Cross-ISA enforcement) and added Cross-ISA contract/gating sections to `docs/architecture/personalities/linux/linux_personality_architecture.md` and `docs/architecture/personalities/android/android_personality_architecture.md`; all updated files have metadata version/date bumps. Files changed: `README.md`, `roadmap.md`, `zero-translation-roadmap.md`, `linux_personality_architecture.md`, `android_personality_architecture.md`; file added: `multi-arch-personality-roadmap.md`.

### Testing

- Ran `git diff --check` to validate no whitespace/merge issues, which passed. 
- Searched for the new roadmap references with `rg -n "multi-arch-personality-roadmap|Cross-ISA" docs/architecture/personalities` to verify the new cross-ISA text is present, which returned the expected matches. 
- Verified the new file and changes are present via a directory/file listing and content inspection (`nl` / `sed`), confirming the roadmap, added sections, and metadata updates were written successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8b0e20234832088275f16c43dfb99)