### PR TITLE
Enforce lib/kernel layer boundaries and add host string fallback tests

### DIFF
--- a/docs/architecture/shared/lib_architecture.md
+++ b/docs/architecture/shared/lib_architecture.md
@@ -29,6 +29,7 @@ The top-level `lib/` directory contains platform-agnostic, dependency-discipline
 * **Explicit Allocations:** Must not call kernel-internal allocators (`kalloc`, etc.) directly. Memory ownership and allocator functions must be explicitly injected or passed.
 * **Platform Agnostic:** Should rely on generic architectural definitions or explicit HAL abstractions, not hardcoded hardware assumptions.
 * **Header Placement:** Only keep a header under `lib/include/` if it is supported as a shared/public library contract. If it is only used by the kernel, it must be moved to `kernel/include/`.
+* **Build Enforcement:** The `lib/` CMake layer must fail configuration if shared-library targets attempt to link to kernel-private targets.
 
 **Examples of Valid Contents:**
 * Generic data structures (e.g., intrusive lists, ring buffers)

--- a/docs/architecture/shared/lib_roadmap.md
+++ b/docs/architecture/shared/lib_roadmap.md
@@ -16,6 +16,7 @@ This roadmap outlines the plan to strictly enforce the boundaries defined in `do
    * **Header Isolation:** Relocate any headers intended for kernel-only implementations from `lib/include/` into a kernel-private include layer such as `kernel/include/lib/` or `kernel/include/ds/`. Only keep a header under `lib/include/` if it is supported as a shared/public library contract.
 2. **Build System Restrictions:**
    * Introduce CMake rules (e.g., in `lib/CMakeLists.txt` or a common policy file) that strictly prevent target linkage from `lib/` back to kernel targets.
+   * **Status (2026-04-22):** Implemented a configure-time enforcement pass in `lib/CMakeLists.txt` that fails configuration if any `lib/` target links kernel-private targets.
 3. **Identify Misplaced Code:**
    * Audit `kernel/src/lib/` (e.g., `rbtree.c`, `string.c`, `status.c`) and migrate purely logical, zero-kernel-state data structures (like standard linked lists or rbtrees, if allocation-free) to `lib/`.
    * Conversely, move any helper currently in `lib/` that relies on kernel locking, traps, or physical memory allocation directly into `kernel/src/lib/`.
@@ -70,6 +71,7 @@ This roadmap outlines the plan to strictly enforce the boundaries defined in `do
 ## Build and Testing Strategy
 
 * **Host-Testing:** Everything in `lib/` must be compiled and tested on the host (e.g., `cmake --preset host-test`). Any dependency on kernel headers or target hardware limits this ability and is considered a violation.
+* **Current Coverage Update (2026-04-22):** Added dedicated host test `host_test_lib_string` for the fallback string/memory path in `lib/string/string.c`, including overlap-sensitive `memmove` behavior.
 * **Scalability Testing:** Stress-test lock-free and parallel structures with high core counts (e.g., 64+ cores) to validate scalability and hardware leveraging.
 * **Formal Methods:** As the lock-free data structures stabilize (especially MPMC rings and RCU), utilize formal verification (e.g., Isabelle/HOL) to prove their correctness.
 * **Continuous Enforcement:** Add pre-commit static analysis or CMake assertion checks to verify dependency directions.

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -101,3 +101,36 @@ bharat_configure_userspace_library(bharat_libdiag)
 add_library(ool_desc ALIAS bharat_libdiag)
 add_library(transport ALIAS bharat_libtransport)
 
+# ---------------------------------------------------------
+# Layer boundary enforcement
+# ---------------------------------------------------------
+# Enforce the architecture rule from docs/architecture/shared/lib_architecture.md:
+# targets defined under top-level lib/ must not link against kernel-private
+# targets (e.g., bharat_kernel_*).
+function(_bharat_assert_no_kernel_links DIRPATH)
+    get_property(_targets DIRECTORY "${DIRPATH}" PROPERTY BUILDSYSTEM_TARGETS)
+
+    foreach(_target IN LISTS _targets)
+        foreach(_prop IN ITEMS LINK_LIBRARIES INTERFACE_LINK_LIBRARIES)
+            get_target_property(_links "${_target}" "${_prop}")
+            if(NOT _links)
+                continue()
+            endif()
+
+            foreach(_link IN LISTS _links)
+                if(_link MATCHES "(^|;)bharat_kernel|(^|;)kernel")
+                    message(FATAL_ERROR
+                        "Library layering violation: target '${_target}' in lib/ links against '${_link}'. "
+                        "Shared lib/ targets must not depend on kernel-private targets.")
+                endif()
+            endforeach()
+        endforeach()
+    endforeach()
+
+    get_property(_subdirs DIRECTORY "${DIRPATH}" PROPERTY SUBDIRECTORIES)
+    foreach(_subdir IN LISTS _subdirs)
+        _bharat_assert_no_kernel_links("${_subdir}")
+    endforeach()
+endfunction()
+
+_bharat_assert_no_kernel_links("${CMAKE_CURRENT_SOURCE_DIR}")

--- a/tests/host/CMakeLists.txt
+++ b/tests/host/CMakeLists.txt
@@ -128,6 +128,9 @@ target_include_directories(test_sched PRIVATE ../../kernel/include ../../include
 
 add_test(NAME host_test_sched COMMAND test_sched)
 
+add_executable(test_lib_string test_lib_string.c ../../lib/string/string.c)
+add_test(NAME host_test_lib_string COMMAND test_lib_string)
+
 # Phase 3: Core IPC/Profile Tests
 add_executable(test_ipc_profile test_ipc_profile.c ../../kernel/src/profile/profile.c ../../kernel/src/ipc/ipc_traffic.c)
 target_include_directories(test_ipc_profile PRIVATE ../../kernel/include ../../include ../../lib/include)

--- a/tests/host/test_lib_string.c
+++ b/tests/host/test_lib_string.c
@@ -1,0 +1,65 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+static int test_memcpy_basic(void) {
+    const uint8_t src[8] = {0, 1, 2, 3, 4, 5, 6, 7};
+    uint8_t dst[8] = {0};
+
+    memcpy(dst, src, sizeof(src));
+    return (memcmp(dst, src, sizeof(src)) == 0) ? 0 : 1;
+}
+
+static int test_memset_basic(void) {
+    uint8_t buf[16];
+    memset(buf, 0xA5, sizeof(buf));
+
+    for (size_t i = 0; i < sizeof(buf); ++i) {
+        if (buf[i] != 0xA5) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static int test_memmove_overlap_forward(void) {
+    char buf[8] = {'a', 'b', 'c', 'd', 'e', 'f', '\0', '\0'};
+    memmove(buf + 2, buf, 4);
+    return (memcmp(buf, "ababcd", 6) == 0) ? 0 : 1;
+}
+
+static int test_memmove_overlap_backward(void) {
+    char buf[8] = {'a', 'b', 'c', 'd', 'e', 'f', '\0', '\0'};
+    memmove(buf, buf + 2, 4);
+    return (memcmp(buf, "cdef", 4) == 0) ? 0 : 1;
+}
+
+static int test_strlen_strcmp(void) {
+    if (strlen("bharat") != 6) {
+        return 1;
+    }
+    if (strcmp("bharat", "bharat") != 0) {
+        return 1;
+    }
+    if (strcmp("bharat", "bharati") >= 0) {
+        return 1;
+    }
+    return 0;
+}
+
+int main(void) {
+    int failures = 0;
+
+    failures += test_memcpy_basic();
+    failures += test_memset_basic();
+    failures += test_memmove_overlap_forward();
+    failures += test_memmove_overlap_backward();
+    failures += test_strlen_strcmp();
+
+    if (failures != 0) {
+        fprintf(stderr, "test_lib_string: %d checks failed\n", failures);
+        return 1;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
### Motivation

- Enforce the architecture rule that top-level `lib/` targets must not depend on kernel-private targets to preserve layer isolation and host-testability.
- Provide concrete host-test coverage for the portable fallback `lib/string` implementations to validate correctness across architectures.

### Description

- Added a configure-time enforcement pass in `lib/CMakeLists.txt` (`_bharat_assert_no_kernel_links`) that recursively inspects `lib/` build targets and fails configuration if any shared `lib/` target links kernel-private targets.
- Added a new host test `tests/host/test_lib_string.c` which exercises `memcpy`, `memset`, overlap-sensitive `memmove`, `strlen`, and `strcmp` against the portable fallback in `lib/string/string.c`.
- Registered the new test in `tests/host/CMakeLists.txt` as `host_test_lib_string` so it is available under the host-test preset.
- Updated `docs/architecture/shared/lib_roadmap.md` and `docs/architecture/shared/lib_architecture.md` to document the new build-time enforcement and the host-test coverage update (status notes dated 2026-04-22).

### Testing

- Ran `cmake --preset host-test` which configured successfully (host-test generation completed). (✅)
- Attempted full host build with `cmake --build build/host-test -j4` which stopped due to an existing unrelated build failure in `test_lib_ipc_contract` (`lib/ipc/src/ipc.c` missing `lib/base/string.h` include); this is unrelated to the changes introduced here. (⚠️)
- Built the new test only with `cmake --build build/host-test --target test_lib_string` and linked the test binary successfully. (✅)
- Executed the test with `ctest --test-dir build/host-test -R host_test_lib_string --output-on-failure` and it passed. (✅)
- Cross-architecture validation: configured and built the kernel on multiple presets (`arm32-qemu-mmu-lite-headless`, `arm64-edge`, `riscv64-edge`) and built `kernel.elf` successfully for each target to ensure the enforcement and test additions do not break cross-target builds. (✅)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8c9ec9a408320802367890d866275)