### PR TITLE
docs: align BIDL v1 grammar with current parser/codegen reality

### DIFF
--- a/docs/architecture/bidl-v1.md
+++ b/docs/architecture/bidl-v1.md
@@ -1,41 +1,66 @@
-# Bharat-OS IDL (BIDL) v1 Grammar
+# Bharat-OS IDL (BIDL) v1 Grammar (Current Implementation Profile)
 
-## 1. Overview
-The **Bharat-OS Interface Definition Language (BIDL)** is a minimal, language-agnostic schema format used to generate binary serializers, parsers, and RPC dispatch stubs for the Bharat-OS Message Wire Format.
+## 1. Purpose and Scope
 
-BIDL v1 prioritizes:
-- Simplicity (Python stdlib-only parser)
-- Determinism (No hidden types or unbounded sizes)
-- C-language codegen (Inline structs for bounded buffers)
+This document defines the **currently implemented BIDL v1 profile** used by the in-repo tooling (`tools/bidl/bidlc.py` and `tools/abi/check_idl_compat.py`).
+
+It is intentionally narrower than the broader architectural language drafts in `docs/architecture/contracts/`.
+
+Use this document when you need to know what parses and code-generates **today**.
 
 ---
 
-## 2. Basic Syntax
+## 2. Implementation Status (as of April 22, 2026)
 
-### Services
-A `service` block groups related RPC methods and assigns a global `service_id`.
+Bharat-OS currently has multiple IDL-style syntaxes in `idl/` (e.g., `service/message`, `package+struct`, `namespace/interface/method`).
+
+Only the `service ... rpc ... message/struct ...` family is handled by the active Python tooling used for codegen/compat checks.
+
+- `tools/bidl/bidlc.py` parses:
+  - `service <qualified_name> = <service_id> { ... }`
+  - `rpc <Method>(<Req>) -> <Resp>`
+  - `message <Name> { ... }`
+- `tools/abi/check_idl_compat.py` additionally accepts:
+  - `service <qualified_name> { ... }` (implicit `id = 0`)
+  - `struct <Name> { ... }` as an alias for `message`
+  - `enum <Name> { ... }` with explicit integer assignments
+
+### Practical guidance
+
+If your `.bidl` must be consumed by **both** codegen and ABI compatibility checks, prefer this conservative subset:
+
+1. `service <qualified_name> = <service_id> { ... }`
+2. `rpc <Method>(<ReqType>) -> <RespType>`
+3. `message <TypeName> { <field_type> <field_name>; }`
+4. Avoid relying on parser support for attributes/annotations as semantic inputs (they are tolerated as text but not interpreted for generation).
+
+---
+
+## 3. Core Grammar (Implemented Subset)
+
+### 3.1 Service
 
 ```idl
 service <qualified_name> = <service_id> {
-  // Methods
+  // rpc definitions
 }
 ```
 
-### RPC Methods
-An `rpc` definition defines a request message and its corresponding response message. Attributes can be specified within the block to dictate transport behavior (QoS, timeouts).
+- `qualified_name` allows letters, digits, underscore, and dot.
+- `service_id` is an integer.
+
+### 3.2 RPC Method
 
 ```idl
-  rpc <MethodName>(<RequestType>) -> <ResponseType> {
-    qos = reliable | best_effort;
-    timeout_ms = <int>;
-    idempotent = true | false;
-    auth = required | optional;
-    criticality = rt_ctl | rt_data | best_effort | bulk | debug;
-  }
+rpc <MethodName>(<RequestType>) -> <ResponseType> {
+  // optional metadata lines (not consumed by codegen today)
+}
 ```
 
-### Messages
-A `message` is a struct-like collection of typed fields. It maps directly to an inline C-struct payload format.
+- RPC order is ABI-relevant for the compatibility checker (append-only evolution).
+- Dispatch codegen currently assigns opcodes incrementally in declaration order, starting at `1`.
+
+### 3.3 Message / Struct
 
 ```idl
 message <MessageName> {
@@ -43,32 +68,75 @@ message <MessageName> {
 }
 ```
 
----
+Compatibility tooling also accepts:
 
-## 3. Supported Data Types
+```idl
+struct <MessageName> {
+  <type> <field_name>;
+}
+```
 
-BIDL v1 strictly defines sizes and bounds on the wire.
+Field order is ABI-relevant and must be append-only for non-breaking evolution.
 
-### Primitives
-- `u8`, `u16`, `u32`, `u64` (unsigned integers)
-- `i8`, `i16`, `i32`, `i64` (signed integers)
-- `bool` (boolean, encoded as `u8`)
+### 3.4 Enum (compatibility checker)
 
-### Bounded Complex Types
-These generate inline bounded structs in C. No heap allocation is required during decode.
+```idl
+enum <EnumName> {
+  <NAME> = <int>;
+}
+```
 
-- `string<N>`: A UTF-8 string with a maximum length of `N` bytes (excluding length prefix).
-- `bytes<N>`: An opaque binary blob with a maximum length of `N` bytes.
-- `array<T, N>`: A fixed-size array of exactly `N` elements of type `T`.
-- `vec<T, N>`: A variable-sized list (vector) of up to `N` elements of type `T`.
-
-### Capability and OOL Types
-- `cap_descriptor`: Represents a delegated capability exported onto the wire.
-- `ool_descriptor`: Represents a pointer to an out-of-line memory payload (e.g., shared memory).
+Enum values must remain stable once published.
 
 ---
 
-## 4. Example Schema
+## 4. Data Types in the Current Code Generator
+
+`bidlc.py` currently generates C for:
+
+- `u32` → `uint32_t`
+- `u64` → `uint64_t`
+- `string<N>` → inline bounded `{ uint32_t len; char data[N]; }`
+- `bytes<N>` → inline bounded `{ uint32_t len; uint8_t data[N]; }`
+- `cap_descriptor` → `bharat_cap_wire_t`
+
+### Important limitation
+
+The parser accepts field text for many additional spellings found in repository IDLs (for example `uint32`, `int32`, `bool`), but **C code generation in `bidlc.py` only supports the type list above**. Unsupported types will fail with `Unknown type` during generation.
+
+---
+
+## 5. Metadata Blocks and Method Attributes
+
+IDL files in the repo often include per-RPC metadata such as:
+
+```idl
+qos = reliable;
+timeout_ms = 100;
+idempotent = true;
+auth = required;
+criticality = rt_ctl;
+```
+
+This metadata is currently useful as declarative documentation and policy intent, and is parsed permissively as part of the surrounding syntax. However, current `bidlc.py` codegen does **not** convert these keys into generated enforcement logic.
+
+---
+
+## 6. ABI Compatibility Rules (Current CI Contract)
+
+The compatibility checker enforces these stability rules for baseline vs current IDL:
+
+- Service removal is forbidden.
+- Service ID changes are forbidden.
+- RPC list is append-only (no delete/reorder/rename/signature change in existing prefix).
+- Message/struct fields are append-only (no delete/reorder/rename/type-change in existing prefix).
+- Enums cannot remove members or change existing numeric values.
+
+When evolving contracts, treat existing declaration order as stable ABI.
+
+---
+
+## 7. Example (Safe Profile)
 
 ```idl
 service bharat.monitor.v1 = 1 {
@@ -114,24 +182,12 @@ message NodeJoinResp {
 
 ---
 
-## 5. Code Generation Target
+## 8. Relationship to Broader BIDL Docs
 
-The generated C structures will flatten dynamically sized items (like `string<64>`) into inline arrays to maintain bounded memory lifetimes and avoid `malloc`.
+For future-direction language design (annotations, richer type system, transport semantics), see:
 
-```c
-typedef struct {
-    uint32_t protocol_version;
-    uint32_t arch;
-    uint64_t boot_nonce;
-    struct {
-        uint32_t len;
-        char data[64];
-    } node_name;
-    struct {
-        uint32_t len;
-        uint8_t data[128];
-    } topology_digest;
-} bharat_monitor_v1_node_join_req_t;
-```
+- `docs/architecture/contracts/bidl-language-spec.md`
+- `docs/architecture/contracts/bidl-runtime-mapping.md`
+- `docs/architecture/contracts/bidl-versioning-policy.md`
 
-The codec APIs will iterate field-by-field, copying from the wire buffer into these structured targets while asserting `len <= MAX`.
+Those documents describe target-state architecture. This `bidl-v1.md` describes the **currently implemented subset and constraints**.


### PR DESCRIPTION
### Motivation

- Reduce confusion by making the `bidl-v1` document reflect what the in-repo tooling actually parses and generates today. 
- Prevent accidental breakage by callers/authors of `.bidl` files by documenting parser/codegen limitations and ABI stability rules.
- Provide a single place of pragmatic guidance that reconciles the active tools with the broader BIDL design docs.

### Description

- Rewrote `docs/architecture/bidl-v1.md` to describe the "current implementation profile" for `tools/bidl/bidlc.py` and `tools/abi/check_idl_compat.py` instead of an aspirational language spec. 
- Documented the conservative implemented subset: `service <qualified_name> = <service_id>`, `rpc <Method>(<Req>) -> <Resp>`, `message/struct` blocks, and `enum` support for the compatibility checker. 
- Added an explicit type-support matrix for codegen (`u32`, `u64`, `string<N>`, `bytes<N>`, `cap_descriptor`) and called out that unsupported types will raise `Unknown type` in `bidlc.py`. 
- Clarified that per-RPC metadata (e.g., `qos`, `timeout_ms`, `criticality`) is currently parsed permissively as documentation and is not converted into enforcement code by the generator, and restated the ABI compatibility rules enforced by CI.

### Testing

- Compiled the active Python tools with `python3 -m py_compile tools/bidl/bidlc.py tools/abi/check_idl_compat.py` and the compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8cced8c88832087ddcc15661ee5f3)