### PR TITLE
Add non-invasive PCIe host bus driver scaffold

### DIFF
--- a/docs/architecture/components/proposed-drivers.md
+++ b/docs/architecture/components/proposed-drivers.md
@@ -18,7 +18,7 @@ This document updates the proposed driver roadmap to reflect what already exists
 
 | Proposal | Current baseline | Priority |
 | --- | --- | --- |
-| PCIe host bridge + full enumeration | Not explicit in current tree | High |
+| PCIe host bridge + full enumeration | Baseline scaffold now in `drivers/bus/pcie` (enumeration TODO) | High |
 | I3C support | Missing | Medium |
 | USB host hardening (xHCI/DWC3 profiles) | Generic USB folder exists | Medium |
 
@@ -63,8 +63,9 @@ This document updates the proposed driver roadmap to reflect what already exists
 
 ## Coding tasks identified
 
-1. **Real hardware NIC backlog:** implement at least one production NIC family for non-virtio environments.
-2. **Storage taxonomy cleanup:** remove ambiguity between `drivers/block` and `drivers/storage` with a documented split.
-3. **CAN production readiness:** graduate from loopback/virtual examples to hardware-backed CAN FD implementations.
-4. **Accelerator framework bring-up:** introduce shared ring/fence APIs to support multiple accelerator backends consistently.
-5. **Driver CI matrix expansion:** add per-driver smoke tests across qemu-virt x86_64/arm64/riscv64 targets.
+1. **PCIe host maturity:** expand the new non-invasive `drivers/bus/pcie` scaffold from deterministic stub behavior into full ECAM discovery and BAR assignment.
+2. **Real hardware NIC backlog:** implement at least one production NIC family for non-virtio environments.
+3. **Storage taxonomy cleanup:** remove ambiguity between `drivers/block` and `drivers/storage` with a documented split.
+4. **CAN production readiness:** graduate from loopback/virtual examples to hardware-backed CAN FD implementations.
+5. **Accelerator framework bring-up:** introduce shared ring/fence APIs to support multiple accelerator backends consistently.
+6. **Driver CI matrix expansion:** add per-driver smoke tests across qemu-virt x86_64/arm64/riscv64 targets.

--- a/drivers/CMakeLists.txt
+++ b/drivers/CMakeLists.txt
@@ -25,6 +25,7 @@ if(COMMAND bharat_component_option)
     bharat_component_option(BHARAT_ENABLE_DRIVER_SDHOST OFF "Build SD/eMMC host driver")
     bharat_component_option(BHARAT_ENABLE_DRIVER_I2C_CORE OFF "Build I2C core driver")
     bharat_component_option(BHARAT_ENABLE_DRIVER_SPI_CORE OFF "Build SPI core driver")
+    bharat_component_option(BHARAT_ENABLE_DRIVER_PCIE_HOST OFF "Build PCIe host bridge baseline driver")
 
     # Input and Sensor Drivers
     bharat_component_option(BHARAT_ENABLE_DRIVER_VIRTIO_INPUT OFF "Build virtio input driver")
@@ -58,6 +59,7 @@ else()
     option(BHARAT_ENABLE_DRIVER_SDHOST "Build SD/eMMC host driver" OFF)
     option(BHARAT_ENABLE_DRIVER_I2C_CORE "Build I2C core driver" OFF)
     option(BHARAT_ENABLE_DRIVER_SPI_CORE "Build SPI core driver" OFF)
+    option(BHARAT_ENABLE_DRIVER_PCIE_HOST "Build PCIe host bridge baseline driver" OFF)
 
     # Input and Sensor Drivers
     option(BHARAT_ENABLE_DRIVER_VIRTIO_INPUT "Build virtio input driver" OFF)

--- a/drivers/bus/CMakeLists.txt
+++ b/drivers/bus/CMakeLists.txt
@@ -12,6 +12,10 @@ if(BHARAT_ENABLE_DRIVER_SPI_CORE)
     list(APPEND BHARAT_DRIVER_BUS_SOURCES spi/spi_core.c spi/spi_registry.c)
 endif()
 
+if(BHARAT_ENABLE_DRIVER_PCIE_HOST)
+    list(APPEND BHARAT_DRIVER_BUS_SOURCES pcie/pcie_host.c)
+endif()
+
 if(BHARAT_ENABLE_GPIO)
     list(APPEND BHARAT_DRIVER_BUS_SOURCES gpio/gpio_core.c)
 endif()

--- a/drivers/bus/pcie/pcie_host.c
+++ b/drivers/bus/pcie/pcie_host.c
@@ -1,0 +1,37 @@
+#include "pcie_host.h"
+
+#include <stddef.h>
+
+static pcie_host_config_t g_pcie_host_cfg;
+static int g_pcie_host_initialized;
+
+int pcie_host_init(const pcie_host_config_t* cfg)
+{
+    if (cfg == NULL) {
+        return -1;
+    }
+
+    if ((cfg->bus_end < cfg->bus_start) || (cfg->ecam_base == 0u)) {
+        return -2;
+    }
+
+    g_pcie_host_cfg = *cfg;
+    g_pcie_host_initialized = 1;
+    return 0;
+}
+
+int pcie_host_enumerate(uint8_t* discovered_devices)
+{
+    if (!g_pcie_host_initialized || discovered_devices == NULL) {
+        return -1;
+    }
+
+    /*
+     * Non-invasive placeholder:
+     * keep in-flight code unaffected by returning a deterministic value
+     * until full ECAM scan and BAR sizing support are added.
+     */
+    *discovered_devices = 0u;
+    (void)g_pcie_host_cfg;
+    return 0;
+}

--- a/drivers/bus/pcie/pcie_host.h
+++ b/drivers/bus/pcie/pcie_host.h
@@ -1,0 +1,22 @@
+#ifndef BHARAT_DRIVERS_BUS_PCIE_HOST_H
+#define BHARAT_DRIVERS_BUS_PCIE_HOST_H
+
+#include <stdint.h>
+
+/*
+ * Minimal PCIe host bridge contract.
+ *
+ * This is intentionally small and self-contained so it can be enabled
+ * without coupling to existing in-flight driver work.
+ */
+
+typedef struct {
+    uint8_t bus_start;
+    uint8_t bus_end;
+    uintptr_t ecam_base;
+} pcie_host_config_t;
+
+int pcie_host_init(const pcie_host_config_t* cfg);
+int pcie_host_enumerate(uint8_t* discovered_devices);
+
+#endif


### PR DESCRIPTION
### Motivation

- Provide a minimal, opt-in PCIe host bridge scaffold so PCIe work can begin without disturbing existing in-flight drivers.
- Keep the initial implementation deliberately non-invasive and deterministic so it can be enabled safely behind a feature gate.

### Description

- Added a new isolated PCIe bus driver scaffold at `drivers/bus/pcie` containing `pcie_host.h` (minimal host contract) and `pcie_host.c` (deterministic stub implementation that validates config and reports zero discovered devices).
- Introduced a feature gate `BHARAT_ENABLE_DRIVER_PCIE_HOST` (default `OFF`) in `drivers/CMakeLists.txt` so the new driver is opt-in.
- Wired the new source into `drivers/bus/CMakeLists.txt` so `pcie/pcie_host.c` is included only when `BHARAT_ENABLE_DRIVER_PCIE_HOST` is enabled.
- Updated `docs/architecture/components/proposed-drivers.md` to reflect the new baseline scaffold and to add a follow-up coding task for PCIe host maturity (ECAM/BAR discovery).

### Testing

- Compiled the new source with `cc -std=c11 -Wall -Wextra -I drivers/bus/pcie -c drivers/bus/pcie/pcie_host.c -o /tmp/pcie_host.o`, which succeeded.
- Attempted a CMake configure with `cmake -S . -B build -DBHARAT_ENABLE_DRIVER_PCIE_HOST=ON`, which failed due to a pre-existing unrelated nesting error in the tree at `services/CMakeLists.txt:73` and not due to the new files.
- No further automated tests were run as the full CMake build could not complete due to the unrelated configuration issue.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8d16788208320a62616b346cc443b)