### PR TITLE
tests: stabilize EDF selftest ordering across architectures

### DIFF
--- a/kernel/src/tests/ktest_rt_sched.c
+++ b/kernel/src/tests/ktest_rt_sched.c
@@ -85,12 +85,16 @@ static bool test_edf_admission_and_queue(void) {
     int ret3 = sched_admission_edf(t3, 30, 100, 100);
     KTEST_ASSERT(ret3 != 0, "Admission of T3 should fail (budget exceeded)");
 
+    // Make absolute deadlines deterministic for the test. In boot selftests,
+    // runtime ticks may already be non-zero and can advance between enqueues
+    // on slower architectures, which makes "ticks + relative deadline"
+    // timing-sensitive. Pre-setting non-zero absolute deadlines avoids that.
+    t1->absolute_deadline_ms = 100;
+    t2->absolute_deadline_ms = 50;
+
     // Enqueue T1 and T2
     sched_enqueue(t1, 0);
     sched_enqueue(t2, 0);
-
-    // T1 absolute deadline = ticks + 100 = 100 (assuming ticks=0)
-    // T2 absolute deadline = ticks + 50 = 50
 
     // Pick next ready should return T2 because its deadline (50) is smaller than T1 (100)
     bh_thread_t *picked1 = sched_pick_next_ready_l0(0);


### PR DESCRIPTION
### Motivation
- Fix a flaky EDF scheduler boot selftest that intermittently failed on headless or slower architectures because the test assumed runtime ticks were zero and the enqueue-time absolute deadlines could drift.

### Description
- Make the EDF ordering deterministic by setting `t1->absolute_deadline_ms = 100` and `t2->absolute_deadline_ms = 50` before calling `sched_enqueue` in `kernel/src/tests/ktest_rt_sched.c`, and add a comment explaining the change.

### Testing
- Attempted to run headless build/test workflows (`./build.sh all --target x86_64_desktop_headless` and `./run_test.sh`), but the runs were blocked during CMake configure due to a pre-existing `services/CMakeLists.txt:73` error (`Flow control statements are not properly nested`), so the runtime selftests could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8d24d0cb88320b5e1808de1426d16)