### PR TITLE
irq: phase-1 irq_domain implementation with map/translate/unmap and boot selftests

### DIFF
--- a/docs/architecture/interrupt/interrupt-architecture.md
+++ b/docs/architecture/interrupt/interrupt-architecture.md
@@ -44,7 +44,7 @@ The lowest layer consists of the hardware-specific driver implementations (e.g.,
 
 The implementation of this architecture is executed in planned phases. The target roadmap for the core foundations includes:
 
-1.  **Fully Realizing `irq_domain`**: Migrating from placeholder structs to a fully implemented allocator, translation table, and hierarchy tracking system.
+1.  **Fully Realizing `irq_domain`**: ✅ **Phase-1 completed** with in-kernel domain allocation and explicit mapping-table based `map -> translate -> unmap` flow. The current implementation uses bounded static tables (`IRQ_DOMAIN_MAX_DOMAINS`, `IRQ_DOMAIN_MAX_MAPPINGS`) to avoid dynamic allocation in hard IRQ paths while preserving deterministic behavior.
 2.  **Descriptor State Formalization**: Enriching the `irq_desc` model with explicit state bitfields and active chip pointers.
 3.  **Domain-First Routing Enforced**: Mandating that all new device IRQ plumbing uses the domain layer.
 
@@ -60,6 +60,7 @@ These tests validate the required backend controller operations and semantic cor
 *   **Level vs. Edge Semantics**: Validating acknowledgment requirements and repetitive firing behavior.
 *   **Shared IRQ Behavior**: Testing handler chain execution and unregistration.
 *   **Affinity Move Behavior**: Testing dynamic rerouting of interrupts to different CPU cores without loss.
+*   **Domain Map/Translate/Unmap Semantics**: Boot selftests now validate domain range checks, duplicate mapping rejection, and translation invalidation after unmap.
 
 ### 2. Stress and Load Tests
 These tests push the system to identify edge cases, race conditions, and bottlenecks:

--- a/kernel/include/device/irq_domain.h
+++ b/kernel/include/device/irq_domain.h
@@ -29,6 +29,12 @@ irq_domain_t* irq_domain_create(const char* name, uint32_t irq_base, uint32_t ir
 // Map a hardware IRQ to a virtual IRQ within the domain
 int irq_domain_map(irq_domain_t* domain, uint32_t virq, uint32_t hwirq);
 
+// Unmap a virtual IRQ from a domain mapping
+int irq_domain_unmap(irq_domain_t* domain, uint32_t virq);
+
+// Translate a hardware IRQ to virtual IRQ
+int irq_domain_translate(irq_domain_t* domain, uint32_t hwirq, uint32_t* out_virq);
+
 // --- MSI Domains ---
 
 typedef struct msi_msg {

--- a/kernel/src/device/irq_domain.c
+++ b/kernel/src/device/irq_domain.c
@@ -1,28 +1,121 @@
 #include "device/irq_domain.h"
+#include "lib/base/string.h"
 #include <stddef.h>
 #include <stdint.h>
 #include <stdbool.h>
 
-// Simple placeholder implementation for IRQ/MSI domains
+// Phase-1 in-kernel IRQ domain table:
+// - Static storage (no dynamic allocation in core IRQ path)
+// - Explicit map/unmap/translate tracking
+// - Optional parent hierarchy pointer stored in descriptor
 
 static msi_domain_t* g_default_msi_domain = NULL;
 
+typedef struct irq_map_entry {
+    irq_domain_t* domain;
+    uint32_t virq;
+    uint32_t hwirq;
+    bool in_use;
+} irq_map_entry_t;
+
+#define IRQ_DOMAIN_MAX_DOMAINS 32U
+#define IRQ_DOMAIN_MAX_MAPPINGS 512U
+
+static irq_domain_t g_domains[IRQ_DOMAIN_MAX_DOMAINS];
+static irq_map_entry_t g_maps[IRQ_DOMAIN_MAX_MAPPINGS];
+static uint32_t g_domain_count = 0U;
+
+static bool irq_domain_virq_in_range(const irq_domain_t* domain, uint32_t virq) {
+    if (!domain || domain->irq_count == 0U) {
+        return false;
+    }
+    if (virq < domain->irq_base) {
+        return false;
+    }
+    return virq < (domain->irq_base + domain->irq_count);
+}
+
 irq_domain_t* irq_domain_create(const char* name, uint32_t irq_base, uint32_t irq_count, void* host_data) {
-    (void)name;
-    (void)irq_base;
-    (void)irq_count;
-    (void)host_data;
-    // A real implementation would allocate and track the domain
-    // For now, return a dummy pointer
-    return (irq_domain_t*)(uintptr_t)0x1234;
+    if (!name || irq_count == 0U) {
+        return NULL;
+    }
+    if (g_domain_count >= IRQ_DOMAIN_MAX_DOMAINS) {
+        return NULL;
+    }
+
+    irq_domain_t* domain = &g_domains[g_domain_count++];
+    memset(domain, 0, sizeof(*domain));
+    domain->name = name;
+    domain->irq_base = irq_base;
+    domain->irq_count = irq_count;
+    domain->host_data = host_data;
+    return domain;
 }
 
 int irq_domain_map(irq_domain_t* domain, uint32_t virq, uint32_t hwirq) {
-    (void)virq;
-    (void)hwirq;
+    uint32_t i;
+    int free_slot = -1;
+
     if (!domain) return -1;
-    // Map implementation
+    if (!irq_domain_virq_in_range(domain, virq)) return -1;
+
+    for (i = 0; i < IRQ_DOMAIN_MAX_MAPPINGS; i++) {
+        if (g_maps[i].in_use) {
+            // Reject duplicate virtual IRQ and duplicate hwirq in same domain.
+            if (g_maps[i].domain == domain && (g_maps[i].virq == virq || g_maps[i].hwirq == hwirq)) {
+                return -1;
+            }
+        } else if (free_slot < 0) {
+            free_slot = (int)i;
+        }
+    }
+
+    if (free_slot < 0) {
+        return -1;
+    }
+
+    g_maps[free_slot].domain = domain;
+    g_maps[free_slot].virq = virq;
+    g_maps[free_slot].hwirq = hwirq;
+    g_maps[free_slot].in_use = true;
+
+    if (domain->map) {
+        return domain->map(domain, virq, hwirq);
+    }
+
     return 0;
+}
+
+int irq_domain_unmap(irq_domain_t* domain, uint32_t virq) {
+    uint32_t i;
+    if (!domain) return -1;
+
+    for (i = 0; i < IRQ_DOMAIN_MAX_MAPPINGS; i++) {
+        if (g_maps[i].in_use && g_maps[i].domain == domain && g_maps[i].virq == virq) {
+            g_maps[i].in_use = false;
+            g_maps[i].domain = NULL;
+            if (domain->unmap) {
+                domain->unmap(domain, virq);
+            }
+            return 0;
+        }
+    }
+    return -1;
+}
+
+int irq_domain_translate(irq_domain_t* domain, uint32_t hwirq, uint32_t* out_virq) {
+    uint32_t i;
+    if (!domain || !out_virq) {
+        return -1;
+    }
+
+    for (i = 0; i < IRQ_DOMAIN_MAX_MAPPINGS; i++) {
+        if (g_maps[i].in_use && g_maps[i].domain == domain && g_maps[i].hwirq == hwirq) {
+            *out_virq = g_maps[i].virq;
+            return 0;
+        }
+    }
+    return -1;
 }
 
 int msi_domain_register(msi_domain_t* domain) {

--- a/kernel/src/tests/CMakeLists.txt
+++ b/kernel/src/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(k_test_support OBJECT
     security/test_crypto_registry.c
     ktest_string.c
     ktest_rt_sched.c
+    ktest_irq_domain.c
 )
 
 target_include_directories(k_test_support PRIVATE ../../include ../../include/generated ${CMAKE_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/lib/include ${CMAKE_SOURCE_DIR}/boot/include)

--- a/kernel/src/tests/ktest_irq_domain.c
+++ b/kernel/src/tests/ktest_irq_domain.c
@@ -1,0 +1,76 @@
+#include "tests/ktest.h"
+#include "device/irq_domain.h"
+#include "boot/boot_selftest.h"
+
+static bool test_irq_domain_create_and_map(void) {
+    irq_domain_t* domain = irq_domain_create("ktest-root", 32U, 64U, NULL);
+    uint32_t virq = 0U;
+    int ret;
+
+    KTEST_ASSERT(domain != NULL, "irq_domain_create returned NULL");
+
+    ret = irq_domain_map(domain, 40U, 7U);
+    KTEST_ASSERT(ret == 0, "irq_domain_map failed for valid mapping");
+
+    ret = irq_domain_translate(domain, 7U, &virq);
+    KTEST_ASSERT(ret == 0, "irq_domain_translate failed for mapped hwirq");
+    KTEST_ASSERT(virq == 40U, "Translated virq mismatch");
+
+    return true;
+}
+
+static bool test_irq_domain_rejects_invalid_and_duplicate_map(void) {
+    irq_domain_t* domain = irq_domain_create("ktest-dup", 128U, 16U, NULL);
+    int ret;
+
+    KTEST_ASSERT(domain != NULL, "irq_domain_create for duplicate test failed");
+
+    ret = irq_domain_map(domain, 127U, 1U);
+    KTEST_ASSERT(ret < 0, "irq_domain_map should reject virq below domain range");
+
+    ret = irq_domain_map(domain, 128U, 1U);
+    KTEST_ASSERT(ret == 0, "initial irq_domain_map failed");
+
+    ret = irq_domain_map(domain, 128U, 2U);
+    KTEST_ASSERT(ret < 0, "duplicate virq should be rejected");
+
+    ret = irq_domain_map(domain, 129U, 1U);
+    KTEST_ASSERT(ret < 0, "duplicate hwirq in same domain should be rejected");
+
+    return true;
+}
+
+static bool test_irq_domain_unmap_removes_translation(void) {
+    irq_domain_t* domain = irq_domain_create("ktest-unmap", 200U, 8U, NULL);
+    uint32_t virq = 0U;
+    int ret;
+
+    KTEST_ASSERT(domain != NULL, "irq_domain_create for unmap test failed");
+
+    ret = irq_domain_map(domain, 203U, 5U);
+    KTEST_ASSERT(ret == 0, "irq_domain_map failed before unmap");
+
+    ret = irq_domain_unmap(domain, 203U);
+    KTEST_ASSERT(ret == 0, "irq_domain_unmap failed");
+
+    ret = irq_domain_translate(domain, 5U, &virq);
+    KTEST_ASSERT(ret < 0, "translation should fail after unmap");
+
+    return true;
+}
+
+static ktest_case_t irq_domain_tests[] = {
+    {"Domain create/map/translate", test_irq_domain_create_and_map},
+    {"Domain duplicate/range checks", test_irq_domain_rejects_invalid_and_duplicate_map},
+    {"Domain unmap behavior", test_irq_domain_unmap_removes_translation},
+};
+
+static int boot_test_irq_domain(void) {
+    ktest_run_suite("IRQ Domain Unit Tests", irq_domain_tests, 3);
+    if (!test_irq_domain_create_and_map()) return -1;
+    if (!test_irq_domain_rejects_invalid_and_duplicate_map()) return -1;
+    if (!test_irq_domain_unmap_removes_translation()) return -1;
+    return 0;
+}
+
+REGISTER_BOOT_SELFTEST("irq_domain", "interrupt", boot_test_irq_domain, BOOT_TEST_STAGE_RUNTIME, BOOT_TEST_MANDATORY, 0, true)


### PR DESCRIPTION
### Motivation
- Replace the placeholder `irq_domain` with a deterministic first-phase implementation so the kernel can perform reliable hwirq↔virq translation without ad-hoc driver math.
- Provide a small, bounded, allocation-free domain/mapping model appropriate for hard-IRQ contexts and for boot-time bring-up validation.
- Expose a minimal API for unmapping and translation so higher layers and tests can validate domain-first routing semantics.

### Description
- Implemented a phase-1 in-kernel domain model in `kernel/src/device/irq_domain.c` using static pools and mapping tables with `IRQ_DOMAIN_MAX_DOMAINS` and `IRQ_DOMAIN_MAX_MAPPINGS`, and added deterministic `irq_domain_create`, `irq_domain_map`, `irq_domain_unmap`, and `irq_domain_translate` behavior including duplicate and range checks.
- Extended the public API in `kernel/include/device/irq_domain.h` with `irq_domain_unmap(...)` and `irq_domain_translate(...)` and preserved existing MSI helpers (`msi_domain_*`).
- Added boot selftests in `kernel/src/tests/ktest_irq_domain.c` covering create/map/translate success, invalid-range and duplicate mapping rejection, and unmap invalidation, and wired the test into the kernel test object list via `kernel/src/tests/CMakeLists.txt`.
- Updated the interrupt architecture documentation `docs/architecture/interrupt/interrupt-architecture.md` to mark Phase-1 `irq_domain` realization and to note the new domain conformance selftests.

### Testing
- Installed QEMU packages with `apt-get install -y qemu-system-x86 qemu-system-arm qemu-system-misc` and verified the QEMU binaries are present for the supported architectures; installation completed successfully.
- Built headless targets with `./build.sh build --target x86_64_desktop_headless`, `./build.sh build --target riscv64_desktop_headless`, and `./build.sh build --target arm64_desktop_headless` and the builds completed successfully.
- Packaged and ran headless QEMU checks using `tools/ci/run_qemu_check.sh` and observed: x86_64 run passed QEMU log assertions and showed the `IRQ Domain Unit Tests` suite passing, riscv64 run passed QEMU log assertions (boot validated), and arm64 headless boot produced logs showing `IRQ Domain Unit Tests` passed though the wrapper was terminated with an expected timeout (exit 143) during longer run orchestration.
- All added boot selftests (`irq_domain`) passed in the observed QEMU runs; an unrelated existing `rt_sched` runtime selftest still reports a known failure which is outside the scope of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8dc1aaa4883209ecb23942a01ce5e)