### PR TITLE
Enforce capability-based IPC auth for namesvc with tests, docs, and arm64 QEMU support

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -77,13 +77,14 @@ This roadmap tracks Bharat-OS from a bootable microkernel baseline toward a prod
 3. **Security depth gap**: capability and policy structure exists, but enforcement depth (e.g., full cap checks, IOMMU depth, verified boot chain) still needs sustained implementation.
 4. **Observability gap**: baseline diagnostics exist, but production-grade trace/metrics/export and watchdog policy coverage are not fully closed.
 5. **Lifecycle authority migration gap**: architecture direction is clear, but full migration from early-boot bootstrap logic into durable `servicemgr`/policy-manager ownership is still in progress.
+6. **Production gate gap**: capability mediation is not uniformly strict across all manager paths yet; until this is closed, production-readiness claims remain blocked.
 
 ## B) Discrepancy log (explicit)
 
 | Area | Discrepancy | Action |
 | --- | --- | --- |
 | Service status wording | “Implemented” may overstate runtime readiness for some services. | Keep architecture intent, but classify code status using taxonomy labels. |
-| Capability mediation claims | Some code paths still use permissive/stub checks. | Mark as partial enforcement and track hardening milestones. |
+| Capability mediation claims | `netmgr` now uses fail-closed validation, but capability mediation is still not complete across all manager/dispatch paths. | Keep mediation at **Partial**, track removal of remaining permissive/stub checks, and block production claims until strict enforcement is end-to-end. |
 | “Current phase” interpretation | Readers may assume production depth from phase labels. | Add per-item maturity labels and evidence links. |
 
 ## C) Deviation policy

--- a/docs/dev/current-code-status.md
+++ b/docs/dev/current-code-status.md
@@ -112,6 +112,15 @@ Current limitations:
 3. **Runtime wiring gap**: multiple daemons initialize state but do not yet run complete production event loops.
 4. **Hardening gap**: observability, failure semantics, and profile-specific guarantees need deeper closure.
 
+## 4.1) Security production gate (explicit blocker)
+
+To avoid status inflation, this repository treats capability enforcement maturity as a hard release gate:
+
+- **No production claim is valid while capability mediation remains Partial.**
+- A manager path must not rely on default-allow, placeholder, or stub authorization behavior.
+- Fail-closed behavior (like the current `netmgr` shim through `bharat_cap_validate()`) is required as an interim baseline, but does not by itself qualify as full production security.
+- Promotion to **Production** requires strict, code-backed capability checks across manager and dispatch paths, plus validation evidence.
+
 ---
 
 ## 5) Contributor update rules

--- a/services/namesvc/CMakeLists.txt
+++ b/services/namesvc/CMakeLists.txt
@@ -6,6 +6,7 @@ add_executable(namesvc
     main.c
     src/registry.c
     src/ipc_dispatch.c
+    src/ipc_auth.c
     src/service_manifest.c
     ../../kernel/src/ipc/contract_validate.c
 )

--- a/services/namesvc/include/ipc_auth.h
+++ b/services/namesvc/include/ipc_auth.h
@@ -1,0 +1,17 @@
+#ifndef NAMESVC_IPC_AUTH_H
+#define NAMESVC_IPC_AUTH_H
+
+#include <stdint.h>
+#include <bharat/cap/cap.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int namesvc_authorize(uint32_t opcode, bharat_cap_handle_t caller_cap);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NAMESVC_IPC_AUTH_H

--- a/services/namesvc/src/ipc_auth.c
+++ b/services/namesvc/src/ipc_auth.c
@@ -1,0 +1,48 @@
+#include "ipc_auth.h"
+#include <bharat/cap/cap_validate.h>
+#include <bharat/namesvc/namesvc_ipc.h>
+#include <bharat/uapi/ipc/status.h>
+
+static uint64_t namesvc_required_rights(uint32_t opcode) {
+    switch (opcode) {
+        case NAMESVC_OP_LOOKUP:
+            return BHARAT_CAP_RIGHT_READ;
+        case NAMESVC_OP_REGISTER:
+        case NAMESVC_OP_REMOVE:
+        case NAMESVC_OP_LIST_INTERFACES:
+            return BHARAT_CAP_RIGHT_WRITE;
+        default:
+            return 0;
+    }
+}
+
+int namesvc_authorize(uint32_t opcode, bharat_cap_handle_t caller_cap) {
+    if (caller_cap == BHARAT_CAP_INVALID_HANDLE) {
+        return BHARAT_IPC_STATUS_ERR_PERM;
+    }
+
+    uint64_t required_rights = namesvc_required_rights(opcode);
+    if (required_rights == 0) {
+        return BHARAT_IPC_STATUS_ERR_INVALID;
+    }
+
+    bharat_cap_scope_t required_scope = {
+        .kind = BHARAT_CAP_SCOPE_SERVICE,
+        .scope_id = 0
+    };
+
+    bharat_cap_validation_result_t vr = {0};
+    bharat_cap_status_t st = bharat_cap_validate(
+        caller_cap,
+        BHARAT_CAP_OBJ_SERVICE,
+        0,
+        required_rights,
+        &required_scope,
+        &vr);
+
+    if (st != BHARAT_CAP_OK || !vr.allowed) {
+        return BHARAT_IPC_STATUS_ERR_PERM;
+    }
+
+    return BHARAT_IPC_STATUS_OK;
+}

--- a/services/namesvc/src/ipc_dispatch.c
+++ b/services/namesvc/src/ipc_dispatch.c
@@ -1,6 +1,7 @@
 #include <ipc_dispatch.h>
 #include <registry.h>
 #include <ipc/contract_validate.h>
+#include <ipc_auth.h>
 
 static void custom_memset_ipc(void *s, int c, unsigned long n) {
     unsigned char *p = s;
@@ -23,6 +24,12 @@ void namesvc_ipc_handle_request(const bharat_ipc_contract_header_t *hdr, const n
             return;
         }
         res->status = NAMESVC_STATUS_ERR_INVAL;
+        return;
+    }
+
+    int auth_status = namesvc_authorize(req->opcode, hdr->capability_transfer);
+    if (auth_status != BHARAT_IPC_STATUS_OK) {
+        res->status = auth_status;
         return;
     }
 

--- a/tests/host/ipc_contracts/CMakeLists.txt
+++ b/tests/host/ipc_contracts/CMakeLists.txt
@@ -50,3 +50,21 @@ target_include_directories(test_namesvc_registry_contract PRIVATE
     ${REPO_ROOT}/lib/cap/include
     ${REPO_ROOT}/lib/runtime/include
 )
+
+add_executable(test_namesvc_ipc_caps
+    test_namesvc_ipc_caps.c
+    ${REPO_ROOT}/kernel/src/ipc/contract_validate.c
+    ${REPO_ROOT}/services/namesvc/src/registry.c
+    ${REPO_ROOT}/services/namesvc/src/ipc_dispatch.c
+    ${REPO_ROOT}/services/namesvc/src/ipc_auth.c
+    ${REPO_ROOT}/lib/cap/src/cap_validate.c
+)
+target_include_directories(test_namesvc_ipc_caps PRIVATE
+    ${REPO_ROOT}/kernel/include
+    ${REPO_ROOT}/include
+    ${REPO_ROOT}/services/namesvc/include
+    ${REPO_ROOT}/services/namesvc/src
+    ${REPO_ROOT}/lib/ipc/include
+    ${REPO_ROOT}/lib/cap/include
+)
+add_test(NAME test_namesvc_ipc_caps COMMAND test_namesvc_ipc_caps)

--- a/tests/host/ipc_contracts/test_namesvc_ipc_caps.c
+++ b/tests/host/ipc_contracts/test_namesvc_ipc_caps.c
@@ -1,0 +1,105 @@
+#include <assert.h>
+#include <string.h>
+#include <bharat/cap/cap_validate.h>
+#include <bharat/namesvc/namesvc_ipc.h>
+#include <bharat/uapi/ipc/contract.h>
+#include <bharat/uapi/ipc/status.h>
+#include <ipc_dispatch.h>
+#include <registry.h>
+
+static bool g_allow = false;
+static int g_validate_calls = 0;
+
+static bharat_cap_status_t fake_cap_validate(
+    bharat_cap_handle_t handle,
+    bharat_cap_object_type_t expected_object_type,
+    uint64_t expected_object_id,
+    uint64_t required_rights,
+    const bharat_cap_scope_t *required_scope,
+    bharat_cap_validation_result_t *out_result)
+{
+    (void)handle;
+    (void)required_rights;
+    g_validate_calls++;
+
+    assert(expected_object_type == BHARAT_CAP_OBJ_SERVICE);
+    assert(expected_object_id == 0);
+    assert(required_scope != NULL);
+    assert(required_scope->kind == BHARAT_CAP_SCOPE_SERVICE);
+    assert(required_scope->scope_id == 0);
+
+    if (out_result) {
+        memset(out_result, 0, sizeof(*out_result));
+        out_result->allowed = g_allow;
+        out_result->status = g_allow ? BHARAT_CAP_OK : BHARAT_CAP_RIGHTS_DENIED;
+    }
+    return g_allow ? BHARAT_CAP_OK : BHARAT_CAP_RIGHTS_DENIED;
+}
+
+static bharat_ipc_contract_header_t mk_hdr(uint32_t opcode, uint32_t payload_size, bharat_cap_handle_t cap) {
+    bharat_ipc_contract_header_t hdr;
+    memset(&hdr, 0, sizeof(hdr));
+    hdr.opcode = opcode;
+    hdr.interface_version = 1;
+    hdr.payload_size = payload_size;
+    hdr.capability_transfer = cap;
+    return hdr;
+}
+
+int main(void) {
+    bharat_cap_set_validate_backend_for_tests(fake_cap_validate);
+    namesvc_registry_init();
+
+    namesvc_ipc_req_t req;
+    namesvc_ipc_res_t res;
+    bharat_ipc_contract_header_t hdr;
+
+    // Invalid capability is denied before validator callback.
+    memset(&req, 0, sizeof(req));
+    memset(&res, 0, sizeof(res));
+    req.opcode = NAMESVC_OP_LOOKUP;
+    hdr = mk_hdr(NAMESVC_OP_LOOKUP, sizeof(struct namesvc_req_lookup), BHARAT_CAP_INVALID_HANDLE);
+    g_validate_calls = 0;
+    namesvc_ipc_handle_request(&hdr, &req, &res);
+    assert(res.status == BHARAT_IPC_STATUS_ERR_PERM);
+    assert(g_validate_calls == 0);
+
+    // Denied validator response is surfaced as permission error.
+    memset(&req, 0, sizeof(req));
+    memset(&res, 0, sizeof(res));
+    req.opcode = NAMESVC_OP_REGISTER;
+    strncpy(req.u.reg.service_name, "com.bharat.test", NAMESVC_MAX_NAME_LEN - 1);
+    strncpy(req.u.reg.interface_name, "Iface", NAMESVC_MAX_NAME_LEN - 1);
+    req.u.reg.interface_version = 1;
+    hdr = mk_hdr(NAMESVC_OP_REGISTER, sizeof(struct namesvc_req_register), 42);
+    g_allow = false;
+    namesvc_ipc_handle_request(&hdr, &req, &res);
+    assert(res.status == BHARAT_IPC_STATUS_ERR_PERM);
+    assert(g_validate_calls == 1);
+
+    // Allowed validator path can register then lookup.
+    g_allow = true;
+    memset(&req, 0, sizeof(req));
+    memset(&res, 0, sizeof(res));
+    req.opcode = NAMESVC_OP_REGISTER;
+    strncpy(req.u.reg.service_name, "com.bharat.test", NAMESVC_MAX_NAME_LEN - 1);
+    strncpy(req.u.reg.interface_name, "Iface", NAMESVC_MAX_NAME_LEN - 1);
+    req.u.reg.interface_version = 2;
+    hdr = mk_hdr(NAMESVC_OP_REGISTER, sizeof(struct namesvc_req_register), 77);
+    namesvc_ipc_handle_request(&hdr, &req, &res);
+    assert(res.status == NAMESVC_STATUS_OK);
+
+    memset(&req, 0, sizeof(req));
+    memset(&res, 0, sizeof(res));
+    req.opcode = NAMESVC_OP_LOOKUP;
+    strncpy(req.u.lookup.service_name, "com.bharat.test", NAMESVC_MAX_NAME_LEN - 1);
+    strncpy(req.u.lookup.interface_name, "Iface", NAMESVC_MAX_NAME_LEN - 1);
+    req.u.lookup.interface_version = 2;
+    req.u.lookup.exact_version = true;
+    hdr = mk_hdr(NAMESVC_OP_LOOKUP, sizeof(struct namesvc_req_lookup), 77);
+    namesvc_ipc_handle_request(&hdr, &req, &res);
+    assert(res.status == NAMESVC_STATUS_OK);
+    assert(res.u.lookup_res.endpoint == 77);
+
+    return 0;
+}

--- a/tools/ci/run_qemu_check.sh
+++ b/tools/ci/run_qemu_check.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 if [ "$#" -lt 3 ]; then
-  echo "usage: $0 <arch:x86_64|riscv64> <kernel.elf> <log-file> [expected-marker ...]" >&2
+  echo "usage: $0 <arch:x86_64|arm64|riscv64> <kernel.elf> <log-file> [expected-marker ...]" >&2
   exit 2
 fi
 
@@ -32,6 +32,19 @@ case "$ARCH" in
     QEMU_BIN=qemu-system-riscv64
     QEMU_ARGS=(
       -machine virt
+      -kernel "$KERNEL"
+      -m 256M
+      -no-reboot
+      -nographic
+      -monitor none
+      -serial stdio
+    )
+    ;;
+  arm64)
+    QEMU_BIN=qemu-system-aarch64
+    QEMU_ARGS=(
+      -machine virt
+      -cpu cortex-a57
       -kernel "$KERNEL"
       -m 256M
       -no-reboot


### PR DESCRIPTION
### Motivation

- Close a security gap by moving namesvc IPC handling from permissive/stub behavior toward fail-closed capability mediation. 
- Make the capability enforcement maturity explicit in documentation so production claims are gated behind end-to-end checks. 
- Add coverage and CI support for validating the new auth path and for running emulation on `arm64` where useful. 

### Description

- Introduce `services/namesvc/src/ipc_auth.c` and `services/namesvc/include/ipc_auth.h` with `namesvc_authorize()` that maps opcodes to required rights and validates using `bharat_cap_validate()`. 
- Wire the authorization check into `services/namesvc/src/ipc_dispatch.c` so requests are authorized before dispatch. 
- Update `services/namesvc/CMakeLists.txt` to build `ipc_auth.c` into the `namesvc` target and keep proper include paths. 
- Add a new unit test `tests/host/ipc_contracts/test_namesvc_ipc_caps.c` and test target `test_namesvc_ipc_caps` that fakes the cap validator to exercise deny/allow flows, and include it in the tests `CMakeLists.txt`. 
- Update documentation in `ROADMAP.md` and `docs/dev/current-code-status.md` to add a clearer "Production gate" / "Security production gate" note about capability mediation being a hard release blocker. 
- Extend `tools/ci/run_qemu_check.sh` to support the `arm64` architecture and `qemu-system-aarch64` invocations for CI/emulation. 

### Testing

- Added and executed the unit test `test_namesvc_ipc_caps` which exercises invalid-handle denial, denied validation, and allowed register+lookup flows, and it passed. 
- Existing contract validation logic continues to be built into host-side tests via `test_namesvc_registry_contract` which still builds successfully. 
- No changes were made to runtime QEMU assertions beyond adding `arm64` support in `tools/ci/run_qemu_check.sh`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e90bc84ff08320a4d10f1ec8b5a882)