### PR TITLE
Enforce Phase C layering and memops tests

### DIFF
--- a/docs/reviews/memory-and-fileop-layer-placement-review_2026-04-20.md
+++ b/docs/reviews/memory-and-fileop-layer-placement-review_2026-04-20.md
@@ -136,10 +136,12 @@ Own:
 
 ### Phase C — guardrails
 
-1. [ ] Extend layer-reference checks to enforce:
+1. [x] Extend layer-reference checks to enforce:
    - no HAL/arch includes from SDK/user-facing lib unless explicitly permitted.
    - no direct service implementation symbol imports from generic lib APIs (must go through contract header).
-2. [ ] Add architecture conformance test matrix for memops behavior equivalence and overlap safety.
+   - *Status: Heuristic-based linter implemented in `tools/lint/check_layer_references.py`.*
+2. [x] Add architecture conformance test matrix for memops behavior equivalence and overlap safety.
+   - *Status: `kernel/src/tests/ktest_memops.c` added to validate `arch_mem*` primitives.*
 
 ---
 

--- a/kernel/src/tests/CMakeLists.txt
+++ b/kernel/src/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(k_test_support OBJECT
     ktest_urpc_handoff.c
     security/test_crypto_registry.c
     ktest_string.c
+    ktest_memops.c
     ktest_rt_sched.c
     ktest_irq_domain.c
 )

--- a/kernel/src/tests/ktest_memops.c
+++ b/kernel/src/tests/ktest_memops.c
@@ -1,0 +1,102 @@
+#include <arch/memops.h>
+#include <tests/ktest.h>
+#include <stdint.h>
+#include <stddef.h>
+
+#define TEST_BUF_SIZE 128
+
+static uint8_t buf1[TEST_BUF_SIZE] __attribute__((aligned(16)));
+static uint8_t buf2[TEST_BUF_SIZE] __attribute__((aligned(16)));
+
+static int test_memcpy_aligned(void) {
+    for (int i = 0; i < TEST_BUF_SIZE; i++) buf1[i] = (uint8_t)i;
+    arch_memset_scalar(buf2, 0, TEST_BUF_SIZE);
+
+    arch_memcpy(buf2, buf1, 64, ARCH_MEMOP_F_DEFAULT);
+    for (int i = 0; i < 64; i++) {
+        if (buf2[i] != (uint8_t)i) return -1;
+    }
+    for (int i = 64; i < TEST_BUF_SIZE; i++) {
+        if (buf2[i] != 0) return -2;
+    }
+    return 0;
+}
+
+static int test_memcpy_unaligned(void) {
+    for (int i = 0; i < TEST_BUF_SIZE; i++) buf1[i] = (uint8_t)i;
+    arch_memset_scalar(buf2, 0, TEST_BUF_SIZE);
+
+    // Unaligned src and dst
+    arch_memcpy(buf2 + 1, buf1 + 3, 15, ARCH_MEMOP_F_DEFAULT);
+    for (int i = 0; i < 15; i++) {
+        if (buf2[i + 1] != (uint8_t)(i + 3)) return -1;
+    }
+    return 0;
+}
+
+static int test_memset_aligned(void) {
+    arch_memset_scalar(buf1, 0, TEST_BUF_SIZE);
+    arch_memset(buf1, 0xAA, 64, ARCH_MEMOP_F_DEFAULT);
+    for (int i = 0; i < 64; i++) {
+        if (buf1[i] != 0xAA) return -1;
+    }
+    for (int i = 64; i < TEST_BUF_SIZE; i++) {
+        if (buf1[i] != 0) return -2;
+    }
+    return 0;
+}
+
+static int test_memset_unaligned(void) {
+    arch_memset_scalar(buf1, 0, TEST_BUF_SIZE);
+    arch_memset(buf1 + 1, 0xBB, 7, ARCH_MEMOP_F_DEFAULT);
+    if (buf1[0] != 0) return -1;
+    for (int i = 1; i < 8; i++) {
+        if (buf1[i] != 0xBB) return -2;
+    }
+    if (buf1[8] != 0) return -3;
+    return 0;
+}
+
+static int test_memmove_overlapping_forward(void) {
+    for (int i = 0; i < 32; i++) buf1[i] = (uint8_t)i;
+    // Copy [0..15] to [5..20] - overlap
+    arch_memmove(buf1 + 5, buf1, 16, ARCH_MEMOP_F_DEFAULT);
+    for (int i = 0; i < 16; i++) {
+        if (buf1[i + 5] != (uint8_t)i) return -1;
+    }
+    return 0;
+}
+
+static int test_memmove_overlapping_backward(void) {
+    for (int i = 0; i < 32; i++) buf1[i] = (uint8_t)i;
+    // Copy [5..20] to [0..15] - overlap
+    arch_memmove(buf1, buf1 + 5, 16, ARCH_MEMOP_F_DEFAULT);
+    for (int i = 0; i < 16; i++) {
+        if (buf1[i] != (uint8_t)(i + 5)) return -1;
+    }
+    return 0;
+}
+
+static int test_memops_zero_length(void) {
+    uint8_t b = 0xFF;
+    arch_memcpy(&b, buf1, 0, ARCH_MEMOP_F_DEFAULT);
+    if (b != 0xFF) return -1;
+    arch_memset(&b, 0, 0, ARCH_MEMOP_F_DEFAULT);
+    if (b != 0xFF) return -2;
+    arch_memmove(&b, buf1, 0, ARCH_MEMOP_F_DEFAULT);
+    if (b != 0xFF) return -3;
+    return 0;
+}
+
+static int ktest_memops_run(void) {
+    if (test_memcpy_aligned() != 0) return -1;
+    if (test_memcpy_unaligned() != 0) return -2;
+    if (test_memset_aligned() != 0) return -3;
+    if (test_memset_unaligned() != 0) return -4;
+    if (test_memmove_overlapping_forward() != 0) return -5;
+    if (test_memmove_overlapping_backward() != 0) return -6;
+    if (test_memops_zero_length() != 0) return -7;
+    return 0;
+}
+
+REGISTER_BOOT_SELFTEST("arch_memops", "arch", ktest_memops_run, BOOT_TEST_STAGE_RUNTIME, BOOT_TEST_MANDATORY, 0, false)

--- a/tools/lint/check_layer_references.py
+++ b/tools/lint/check_layer_references.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 INCLUDE_RE = re.compile(r'^\s*#\s*include\s*[<\"]([^>\"]+)[>\"]')
+SYMBOL_LEAKAGE_RE = re.compile(r'\b(fsd_|netmgr_|devmgr_)[a-zA-Z0-9_]+')
 
 LAYER_PREFIX = {
     "kernel": "kernel/",
@@ -44,7 +45,7 @@ ALLOWED_REFS = {
     "services": {"services", "stacks", "lib", "include", "uapi", "sdk", "user", "personalities"},
     "stacks": {"stacks", "services", "lib", "include", "uapi", "sdk", "user", "personalities"},
     "user": {"user", "sdk", "lib", "include", "uapi", "services", "stacks", "personalities"},
-    "sdk": {"sdk", "lib", "include", "uapi", "user", "services", "stacks", "personalities"},
+    "sdk": {"sdk", "lib", "include", "uapi", "user", "personalities"},
     "uapi": {"uapi", "include", "lib"},
     "lib": {"lib", "include", "uapi"},
     "boot": {"boot", "hal", "arch", "platform", "include", "uapi"},
@@ -124,6 +125,20 @@ def scan(repo_root: Path) -> tuple[list[Violation], int]:
         try:
             with abspath.open("r", encoding="utf-8", errors="ignore") as f:
                 for ln, line in enumerate(f, start=1):
+                    # Symbol leakage check for lib/sdk
+                    if src_layer in {"lib", "sdk"}:
+                        for match in SYMBOL_LEAKAGE_RE.finditer(line):
+                            violations.append(
+                                Violation(
+                                    relpath,
+                                    ln,
+                                    match.group(0),
+                                    src_layer,
+                                    "service-symbol",
+                                    rule="symbol-leakage",
+                                )
+                            )
+
                     m = INCLUDE_RE.match(line)
                     if not m:
                         continue
@@ -140,16 +155,12 @@ def scan(repo_root: Path) -> tuple[list[Violation], int]:
                                 rule="freestanding-header",
                             )
                         )
-                        continue
-
-                    target = include_target_layer(repo_root, src_layer, include_target)
-                    if target is None:
-                        continue
-
-                    if target not in ALLOWED_REFS.get(src_layer, set()):
-                        violations.append(
-                            Violation(relpath, ln, include_target, src_layer, target)
-                        )
+                    else:
+                        target = include_target_layer(repo_root, src_layer, include_target)
+                        if target is not None and target not in ALLOWED_REFS.get(src_layer, set()):
+                            violations.append(
+                                Violation(relpath, ln, include_target, src_layer, target)
+                            )
         except OSError:
             continue
 


### PR DESCRIPTION
This submission implements the requirements for Phase C of the Memory and File Operation Layer Placement Review.

Key changes:
1. **Linter Extension**: `tools/lint/check_layer_references.py` was updated with a heuristic-based symbol leakage detector that flags forbidden service prefixes (`fsd_`, `netmgr_`, `devmgr_`) in `lib/` and `sdk/` layers. Allowed includes for the `sdk` layer were also tightened to prevent leakage from `services` and `stacks`.
2. **Memory Operation Tests**: A new test suite `kernel/src/tests/ktest_memops.c` was added to provide comprehensive coverage for `arch_memcpy`, `arch_memset`, and `arch_memmove`, including edge cases like unaligned access and overlapping regions.
3. **Build System Integration**: The new tests were integrated into the `k_test_support` library in `kernel/src/tests/CMakeLists.txt`.
4. **Documentation Update**: The review document `docs/reviews/memory-and-fileop-layer-placement-review_2026-04-20.md` was updated to mark Phase C.1 and C.2 as addressed.
5. **Verification**: Multi-arch builds were validated for `x86_64`, `arm64`, and `riscv64` headless desktop profiles to ensure no regressions.

---
*PR created automatically by Jules for task [2179701038910369229](https://jules.google.com/task/2179701038910369229) started by @divyang4481*