### PR TITLE
Reduce arch coupling: move TLB include, derive perf topology from HAL, update review and run headless builds

### DIFF
--- a/docs/reviews/scaffold_todo_and_arch_separation_review_2026-04-22.md
+++ b/docs/reviews/scaffold_todo_and_arch_separation_review_2026-04-22.md
@@ -134,9 +134,9 @@ First-pass aggregate counts from this scan:
 
 | ID | Area | File/Path | Finding Type | Summary | Current Owner | Correct Owner | Action | Priority | Status |
 |----|------|-----------|--------------|---------|---------------|---------------|--------|----------|--------|
-| F-001 | MM | `hal/hal_pt.c` | Mixed arch | Architecture-specific TLB and PT initialization mixed with weak symbols | hal | arch/hal | SPLIT_BY_ARCH | P1 | OPEN |
+| F-001 | MM | `hal/hal_pt.c` | Mixed arch | Architecture-specific TLB and PT initialization mixed with weak symbols (mid-file include debt removed in follow-up pass) | hal | arch/hal | SPLIT_BY_ARCH | P1 | IN_PROGRESS |
 | F-002 | CPU | `hal/common/discovery.c` | Mixed arch | `x86_64`, `aarch64`, `riscv` CPU capabilities parsing mixed in common HAL | hal | arch/hal | SPLIT_BY_ARCH | P1 | OPEN |
-| F-003 | Power | `kernel/src/power_thermal_perf.c` | Policy Creep / Mixed arch | Kernel contains topology defaults, thermal policy logic, and arch checks | kernel | services/arch | MOVE_TO_CORRECT_LAYER | P0 | OPEN |
+| F-003 | Power | `kernel/src/power_thermal_perf.c` | Policy Creep / Mixed arch | Kernel contains topology defaults and thermal policy logic; compile-time arch checks removed, remaining policy move still pending | kernel | services/arch | MOVE_TO_CORRECT_LAYER | P0 | IN_PROGRESS |
 | F-004 | Storage | `services/system/filesystem/main.c` | Mixed arch / Mock | App profile and HW arch checks directly in filesystem service main; simulated block device | services | stacks/services | KEEP_AS_SCAFFOLD_WITH_TRACKING | P1 | DONE |
 | F-005 | Video | `kernel/src/display/boot_video_map.c` | Mixed arch | TLB flushes and VA calculations using arch macros directly in kernel | kernel | arch/hal | MOVE_TO_CORRECT_LAYER | P1 | DONE |
 | F-006 | Drivers | `drivers/serial/ns16550/ns16550.c` | Mixed arch | Architecture-specific `x86_inb`/`x86_outb` mixed with MMIO | drivers | arch/drivers | SPLIT_BY_ARCH | P1 | OPEN |
@@ -365,6 +365,10 @@ This review item is only considered complete when:
   - Split one high-value mixed-arch source file into per-arch files.
 - **Task C (architecture split follow-up):** Deferred to next patch set for additional files.
 - **Task D (docs sync):** This review document updated with inventory and actions.
+- **Task E (headless build matrix check):** Partially completed.
+  - `x86_64_desktop_headless`: configure/build/package successful; run stage blocked by missing `qemu-system-x86_64`.
+  - `arm64_desktop_headless`: configure/build successful; package DTB generation blocked by missing `qemu-system-aarch64`.
+  - `riscv64_desktop_headless`: configure/build/package successful.
 
 ---
 
@@ -385,6 +389,8 @@ This review item is only considered complete when:
 - Split `kernel/src/cpu_local.c` inline assembly into architecture-specific files under `arch/`.
 - Replace inline-assembly architecture-specific flushes in `kernel/src/display/boot_video_map.c` with neutral HAL call `hal_tlb_invalidate_all()`.
 - Gated scaffolded/experimental service `system/filesystem` behind `BHARAT_BUILD_EXPERIMENTAL_SERVICES` in `services/CMakeLists.txt`.
+- Removed include-order compatibility debt in `hal/hal_pt.c` by moving `mm/tlb.h` into the regular include block.
+- Reduced architecture coupling in `kernel/src/power_thermal_perf.c` by switching default topology sizing to `hal_cpu_topology_query()` and removing compile-time arch branches.
 
 ### In progress
 -

--- a/hal/hal_pt.c
+++ b/hal/hal_pt.c
@@ -1,6 +1,7 @@
 #include "../kernel/include/hal/hal_pt.h"
 #include "../kernel/include/hal/hal_tlb.h"
 #include "../kernel/include/kernel.h"
+#include "mm/tlb.h"
 #include <stdbool.h>
 #include <stddef.h>
 
@@ -63,9 +64,6 @@ void hal_pt_init(void) {
     active_hal_tlb = &mpu_hal_tlb_ops;
 #endif
 }
-
-// TODO: Needs refactor: #include directive placed mid-file for dependency/order compatibility.
-#include "mm/tlb.h"
 
 void hal_tlb_init(void) {
     if (!active_hal_tlb) {

--- a/kernel/src/power_thermal_perf.c
+++ b/kernel/src/power_thermal_perf.c
@@ -1,5 +1,6 @@
 #include "power_thermal_perf.h"
 
+#include "hal/hal_cpu_topology.h"
 #include "sched/sched.h"
 
 static ptp_topology_info_t g_topology;
@@ -17,28 +18,26 @@ static ptp_thermal_summary_t g_thermal_summary;
 static uint32_t g_system_sleep_state;
 static uint32_t g_system_suspended;
 
-static ptp_arch_t ptp_detect_arch(void) {
-#if defined(__x86_64__)
-    return PTP_ARCH_X86_64;
-#elif defined(__aarch64__)
-    return PTP_ARCH_ARM64;
-#elif defined(__riscv)
-    return PTP_ARCH_RISCV64;
-#else
-    return PTP_ARCH_UNKNOWN;
-#endif
-}
-
 static void perf_topology_build_defaults(void) {
+    hal_cpu_topology_info_t hal_topology;
     uint32_t core;
+    uint32_t discovered = BHARAT_MAX_CORES;
+    bool homogeneous = true;
 
-    g_topology.arch = ptp_detect_arch();
+    if (hal_cpu_topology_query(&hal_topology)) {
+        if (hal_topology.discovered_cpu_count > 0U && hal_topology.discovered_cpu_count <= BHARAT_MAX_CORES) {
+            discovered = hal_topology.discovered_cpu_count;
+        }
+        homogeneous = hal_topology.homogeneous_cores;
+    }
+
+    g_topology.arch = PTP_ARCH_UNKNOWN;
     g_topology.discovered_numa_nodes = 1U;
-    g_topology.discovered_cpu_count = BHARAT_MAX_CORES;
-    g_topology.heterogeneous_cores = 0U;
+    g_topology.discovered_cpu_count = discovered;
+    g_topology.heterogeneous_cores = homogeneous ? 0U : 1U;
     g_topology.accelerator_count = 0U;
 
-    for (core = 0U; core < BHARAT_MAX_CORES; ++core) {
+    for (core = 0U; core < discovered; ++core) {
         g_topology.cpu[core].package_id = 0U;
         g_topology.cpu[core].cluster_id = core / 4U;
         g_topology.cpu[core].core_id = core;
@@ -47,19 +46,6 @@ static void perf_topology_build_defaults(void) {
         g_topology.cpu[core].max_freq_khz = 2000000U;
         g_topology.cpu[core].perf_class = PTP_PERF_CLASS_BALANCED;
     }
-
-#if defined(__aarch64__)
-    for (core = 0U; core < BHARAT_MAX_CORES; ++core) {
-        if ((core & 1U) == 0U) {
-            g_topology.cpu[core].perf_class = PTP_PERF_CLASS_LITTLE;
-            g_topology.cpu[core].max_freq_khz = 1500000U;
-            g_topology.heterogeneous_cores = 1U;
-        } else {
-            g_topology.cpu[core].perf_class = PTP_PERF_CLASS_BIG;
-            g_topology.cpu[core].max_freq_khz = 2500000U;
-        }
-    }
-#endif
 
     g_topology.cache_levels = 3U;
     g_topology.cache[0].level = 1U;
@@ -75,7 +61,7 @@ static void perf_topology_build_defaults(void) {
     g_topology.cache[2].level = 3U;
     g_topology.cache[2].size_kb = 4096U;
     g_topology.cache[2].line_size = 64U;
-    g_topology.cache[2].shared_cpu_count = BHARAT_MAX_CORES;
+    g_topology.cache[2].shared_cpu_count = discovered;
 }
 
 static ptp_thermal_level_t thermal_level_from_temp(const ptp_thermal_zone_t *zone, int32_t temperature_mc) {


### PR DESCRIPTION
### Motivation
- Reduce mixed-architecture coupling and include-order debt in HAL routing code so platform/arch registration can be cleaned in follow-up refactors. 
- Move kernel policy/assumption out of compile-time arch checks in the power/thermal module to rely on HAL-provided topology information. 
- Keep the review inventory and build-triage up to date by recording progress and validating headless builds across x86/ARM/RISC-V targets.

### Description
- Moved `mm/tlb.h` into the regular include block in `hal/hal_pt.c` to remove a mid-file `#include` and the associated include-order compatibility debt, leaving runtime behavior unchanged. 
- Reworked `kernel/src/power_thermal_perf.c` to remove the compile-time `ptp_detect_arch()` branching and instead call `hal_cpu_topology_query()` to size defaults (sets `g_topology.arch` to `PTP_ARCH_UNKNOWN` and derives `discovered`/`homogeneous` from HAL). 
- Updated `docs/reviews/scaffold_todo_and_arch_separation_review_2026-04-22.md` to mark F-001/F-003 as `IN_PROGRESS`, record the include-order change, and add headless build matrix results for this pass.

### Testing
- Installed optional YAML target deps with `python3 -m pip install --user pyyaml jsonschema` which completed successfully. 
- Ran `./build.sh all --target-yaml tools/targets/qemu/x86_64_desktop_headless.yaml` where configure/build/package succeeded but the run stage failed due to missing `qemu-system-x86_64`. 
- Ran `./build.sh build --target-yaml tools/targets/qemu/arm64_desktop_headless.yaml` which succeeded, and `./build.sh package --target-yaml tools/targets/qemu/arm64_desktop_headless.yaml` which failed in this environment due to missing `qemu-system-aarch64` required for DTB generation. 
- Ran `./build.sh build` and `./build.sh package` for `tools/targets/qemu/riscv64_desktop_headless.yaml` which both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e985ae4b808320870b45065151c276)