### PR TITLE
Add migration path-alias helper, wire target resolver, and add migration tracker

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -341,7 +341,7 @@ Equivalent modern command:
 YAML target path equivalent:
 
 ```bash
-./build.sh all --target-yaml tools/targets/qemu/x86_64_desktop_headless.yaml
+./build.sh all --target-yaml delivery/targets/qemu/x86_64_desktop_headless.yaml
 ```
 
 ---
@@ -405,7 +405,8 @@ PY
 
 See YAML targets under:
 
-- `tools/targets/qemu/`
+- `delivery/targets/qemu/` (preferred)
+- `tools/targets/qemu/` (legacy alias accepted by `tools/build.py` during migration)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -485,7 +485,7 @@ For complete setup on **Windows, WSL/Linux, and macOS** (including QEMU/OpenOCD/
 ./build.sh all --target x86_64_desktop_headless
 ./build.sh all --target arm64_desktop_headless
 ./build.sh all --target riscv64_desktop_headless
-./build.sh tools/targets/qemu/arm32_mmu_lite_headless.yaml --run
+./build.sh run --target-yaml delivery/targets/qemu/arm32_mmu_lite_headless.yaml
 ```
 
 

--- a/docs/dev/project-structure-migration-status.md
+++ b/docs/dev/project-structure-migration-status.md
@@ -1,0 +1,57 @@
+# Project Structure Migration Status
+
+This tracker is the execution companion for `project-structure-refactor-plan.md`.
+
+## Current Snapshot (2026-04-23)
+
+- Phase A (QEMU target YAML relocation): **Completed**.
+- Phase B (tooling compatibility hardening): **In progress**.
+- Phase C+ (interface/core moves): **Not started**.
+
+## Phase Checklist
+
+| Phase | Scope | Status | Notes |
+| --- | --- | --- | --- |
+| A | Move QEMU target YAMLs to `delivery/targets/qemu/` + alias support | Completed | `tools/build/target_resolver.py` accepts legacy path references. |
+| B.1 | Shared path-alias helper for migration-aware tooling | Completed | Added `tools/build/path_aliases.py` and routed target path resolution through it. |
+| B.2 | Apply alias helper to target loaders/validators outside build pipeline | Pending | Next medium chunk. |
+| B.3 | CI guard for newly introduced legacy root references | Pending | Start warning-only, then enforce. |
+| C | `idl/`, `uapi/`, `sdk/` to `interface/` | Pending | One subtree move per PR. |
+| D | `boot/`, `kernel/`, `arch/`, etc. to `core/` | Pending | Atomic compile-safe slices only. |
+| E | Remove fallbacks + enforce new roots | Pending | Convert warnings to CI failures. |
+
+## Mandatory Validation Matrix (per phase)
+
+```bash
+./build.sh build --target x86_64_desktop_headless
+./build.sh package --target x86_64_desktop_headless
+./build.sh run --target x86_64_desktop_headless
+
+./build.sh all --target x86_64_desktop_headless_linux
+./build.sh all --target arm64_desktop_headless_linux
+./build.sh all --target riscv64_desktop_headless_linux
+
+./build.sh all --target x86_64_desktop_headless_android
+./build.sh all --target arm64_desktop_headless_android
+./build.sh all --target riscv64_desktop_headless_android
+
+./build.sh all --target arm32_mmu_lite_headless
+./build.sh all --target riscv32_mmu_lite_headless
+```
+
+## Documentation Rule (per phase)
+
+Every migration PR must update:
+
+1. User-facing build/run docs (e.g., `BUILD.md`, `README.md` command examples).
+2. Architecture/developer docs that mention moved paths.
+3. This tracker with phase status and validation outcomes.
+
+## Validation Outcomes (2026-04-23, Phase B.1)
+
+- `./build.sh build --target x86_64_desktop_headless`: **pass**.
+- `./build.sh package --target x86_64_desktop_headless`: **pass**.
+- `./build.sh run --target x86_64_desktop_headless`: boots in QEMU; command requires timeout in CI/local automation because it is an interactive long-running VM.
+- `./build.sh all --target {x86_64,arm64,riscv64}_desktop_headless_{linux,android}`: build+package+run path starts successfully; run stage is long-running and was timeout-bounded in this environment.
+- `./build.sh all --target arm32_mmu_lite_headless`: build+package+run path starts successfully; run stage was timeout-bounded.
+- `./build.sh all --target riscv32_mmu_lite_headless`: build+package passed; run failed due missing OpenSBI firmware path (`/usr/lib/riscv32-linux-gnu/opensbi/generic/fw_dynamic.bin`) in host environment.

--- a/project-structure-refactor-plan.md
+++ b/project-structure-refactor-plan.md
@@ -356,11 +356,11 @@ When build/run commands are updated in future phases:
 
 ---
 
-## Immediate next actions (start now)
+## Immediate next actions (updated to current repository state)
 
-1. Execute Phase 0 guardrails in a dedicated PR.
-2. Create phase tickets with exact directory scope and validation checklist.
-3. Start Phase 1 scaffolding only after CI guardrails are merged.
+1. Record current migration status in a tracker doc and keep it updated per PR.
+2. Complete Phase B tooling unification (shared alias helper + CI reference guard).
+3. Continue interface/core moves using thin-slice PRs with mandatory validation matrix.
 
 ---
 
@@ -368,7 +368,7 @@ When build/run commands are updated in future phases:
 
 This section converts the phase model into concrete, code-aware slices from the current tree.
 
-### Phase A (now) — QEMU target YAML relocation (medium chunk, low runtime risk)
+### Phase A (completed) — QEMU target YAML relocation (medium chunk, low runtime risk)
 
 **Objective**
 - Relocate QEMU target YAMLs from `tools/targets/qemu/` to `delivery/targets/qemu/` with compatibility path translation.
@@ -389,9 +389,13 @@ This section converts the phase model into concrete, code-aware slices from the 
 **Docs**
 - Update build docs to mark `delivery/targets/qemu/` as preferred and `tools/targets/qemu/` as legacy alias.
 
+**Current status**
+- YAML targets already reside in `delivery/targets/qemu/`.
+- Compatibility aliasing is active in `tools/build.py` target resolution.
+
 ---
 
-### Phase B — Tools root transition (`tools/targets` + `tools/ci` compatibility)
+### Phase B (active) — Tools root transition (`tools/targets` + `tools/ci` compatibility)
 
 **Scope**
 - Begin shifting non-runtime tooling assets to `delivery/targets` and `delivery/tools`.
@@ -400,6 +404,12 @@ This section converts the phase model into concrete, code-aware slices from the 
 - Introduce a reusable path-alias helper in Python tooling (`tools/build/*`, validators, lints).
 - Keep a two-way fallback (`delivery/*` preferred, legacy root fallback).
 - Add a CI check for new references to legacy roots in touched files.
+
+**Execution order (medium chunks)**
+1. Extract alias logic into a shared helper module and wire `target_resolver.py` to use it.
+2. Apply the same helper to other target-consuming scripts (`tools/targets/loader.py`, validation scripts).
+3. Add CI guard for newly introduced `tools/targets/qemu/` references.
+4. Flip guard from warning to error after two migration phases.
 
 **Validation**
 - Same matrix + lint stage.

--- a/tools/build/path_aliases.py
+++ b/tools/build/path_aliases.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+_TARGET_ALIASES: tuple[tuple[str, str], ...] = (
+    ("tools/targets/qemu/", "delivery/targets/qemu/"),
+)
+
+
+def resolve_migration_alias(path: Path, aliases: tuple[tuple[str, str], ...]) -> tuple[Path, bool]:
+    """Resolve repository path aliases during incremental migrations.
+
+    Returns: (resolved_path, used_alias)
+    """
+    if path.exists():
+        return path, False
+
+    raw = str(path).replace("\\", "/")
+    candidate_paths: list[Path] = []
+
+    for legacy_prefix, new_prefix in aliases:
+        if legacy_prefix in raw:
+            candidate_paths.append(Path(raw.replace(legacy_prefix, new_prefix, 1)))
+        if new_prefix in raw:
+            candidate_paths.append(Path(raw.replace(new_prefix, legacy_prefix, 1)))
+
+    for candidate in candidate_paths:
+        candidate_abs = candidate if candidate.is_absolute() else (REPO_ROOT / candidate)
+        if candidate_abs.exists():
+            return candidate_abs, True
+
+    return path, False
+
+
+def resolve_target_yaml_alias(path: Path) -> tuple[Path, bool]:
+    return resolve_migration_alias(path, _TARGET_ALIASES)

--- a/tools/build/target_resolver.py
+++ b/tools/build/target_resolver.py
@@ -1,6 +1,7 @@
 import sys
 from pathlib import Path
 
+from tools.build.path_aliases import resolve_target_yaml_alias
 from tools.build.models import (
     BootConfig,
     BuildConfig,
@@ -16,8 +17,6 @@ from tools.build.models import (
 )
 
 SCHEMA_PATH = Path(__file__).parent.parent / "schemas" / "target.schema.yaml"
-REPO_ROOT = Path(__file__).resolve().parents[2]
-
 
 def _require_yaml_deps():
     try:
@@ -46,24 +45,10 @@ def resolve_target_yaml_path(path: Path) -> Path:
     Preferred location is delivery/targets/qemu, while tools/targets/qemu is
     kept as a legacy alias during transition.
     """
-    if path.exists():
-        return path
-
-    raw = str(path).replace("\\", "/")
-    alias_candidates: list[Path] = []
-
-    if "tools/targets/qemu/" in raw:
-        alias_candidates.append(Path(raw.replace("tools/targets/qemu/", "delivery/targets/qemu/", 1)))
-    if "delivery/targets/qemu/" in raw:
-        alias_candidates.append(Path(raw.replace("delivery/targets/qemu/", "tools/targets/qemu/", 1)))
-
-    for candidate in alias_candidates:
-        candidate_abs = candidate if candidate.is_absolute() else (REPO_ROOT / candidate)
-        if candidate_abs.exists():
-            print(f"[migration-warning] Using aliased target-yaml path: {path} -> {candidate_abs}")
-            return candidate_abs
-
-    return path
+    resolved_path, used_alias = resolve_target_yaml_alias(path)
+    if used_alias:
+        print(f"[migration-warning] Using aliased target-yaml path: {path} -> {resolved_path}")
+    return resolved_path
 
 def validate_yaml_target(raw: dict) -> None:
     yaml, jsonschema = _require_yaml_deps()


### PR DESCRIPTION
### Motivation

- Enable an incremental repo reorganization by centralizing legacy→new path alias resolution so tooling can transparently resolve moved artifacts during phased refactors.
- Keep build/run entrypoints and YAML target usage compatible while marking the new preferred location (`delivery/targets/qemu`) and surfacing migration warnings.
- Provide a lightweight execution tracker and docs so each migration phase is recorded and validated with the mandatory build/run matrix.

### Description

- Added a reusable alias module `tools/build/path_aliases.py` that resolves migration aliases and exposes `resolve_target_yaml_alias` for target YAML path translation.
- Updated `tools/build/target_resolver.py` to use the new alias helper and to emit a `[migration-warning]` when an aliased path is used.
- Added `docs/dev/project-structure-migration-status.md` as a phase tracker with checklist, validation matrix, and current outcomes for Phase A/B.
- Updated user-facing docs and examples (`BUILD.md`, `README.md`, and `project-structure-refactor-plan.md`) to prefer `delivery/targets/qemu/` while documenting the legacy `tools/targets/qemu/` alias behavior.

### Testing

- Ran `python3 -m py_compile tools/build/target_resolver.py tools/build/path_aliases.py` which succeeded.
- Performed build and packaging smoke tests: `./build.sh build --target x86_64_desktop_headless` and `./build.sh package --target x86_64_desktop_headless`, both completed successfully.
- Ran run and multi-arch validation commands (bounded by timeouts for automation) such as `timeout 60s ./build.sh run --target x86_64_desktop_headless` and several `timeout 180s ./build.sh all --target <preset>`; QEMU booted for x86_64/arm64/riscv64 and other presets started the build+package+run flows but were timeout-bounded in CI automation.
- Installed host QEMU packages for multi-arch runs (`apt-get install -y --fix-missing qemu-system-x86 qemu-system-arm qemu-system-misc`) which succeeded, and documented an environment issue where `riscv32` run failed due to a missing OpenSBI firmware path on the host (`/usr/lib/riscv32-linux-gnu/opensbi/generic/fw_dynamic.bin`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9d92e1eb08320ad4a53fd0aea9ad9)