### PR TITLE
refactor: remove root include symlink and canonicalize include wiring

### DIFF
--- a/core/drivers/bus/CMakeLists.txt
+++ b/core/drivers/bus/CMakeLists.txt
@@ -38,6 +38,6 @@ endif()
 
 add_library(bharatos_driver_bus STATIC ${BHARAT_DRIVER_BUS_SOURCES})
 target_include_directories(bharatos_driver_bus PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include)
-target_include_directories(bharatos_driver_bus PRIVATE ${CMAKE_SOURCE_DIR}/lib/packet/include ${CMAKE_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/kernel/include)
+target_include_directories(bharatos_driver_bus PRIVATE ${CMAKE_SOURCE_DIR}/lib/packet/include ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/kernel/include)
 target_link_libraries(bharatos_driver_bus PRIVATE bharat_kernel_buildopts bharat_freestanding bharat_libpacket bharat_generated_includes)
 target_compile_options(bharatos_driver_bus PRIVATE -ffreestanding -nostdlib -Wall)

--- a/core/drivers/class/CMakeLists.txt
+++ b/core/drivers/class/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 
 add_library(bharatos_driver_class STATIC ${BHARAT_DRIVER_CLASS_SOURCES})
 target_include_directories(bharatos_driver_class PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include)
-target_include_directories(bharatos_driver_class PRIVATE ${CMAKE_SOURCE_DIR}/lib/packet/include ${CMAKE_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/kernel/include)
+target_include_directories(bharatos_driver_class PRIVATE ${CMAKE_SOURCE_DIR}/lib/packet/include ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/kernel/include)
 target_link_libraries(bharatos_driver_class PRIVATE bharat_kernel_buildopts bharat_freestanding bharat_libpacket bharat_generated_includes)
 target_compile_options(bharatos_driver_class PRIVATE -ffreestanding -nostdlib -Wall)
 

--- a/core/drivers/core/CMakeLists.txt
+++ b/core/drivers/core/CMakeLists.txt
@@ -9,6 +9,6 @@ add_library(bharatos_driver_baseline_core STATIC
 )
 
 target_include_directories(bharatos_driver_baseline_core PUBLIC ../include)
-target_include_directories(bharatos_driver_baseline_core PRIVATE ${CMAKE_SOURCE_DIR}/include)
+target_include_directories(bharatos_driver_baseline_core PRIVATE ${CMAKE_SOURCE_DIR}/interface/include)
 target_link_libraries(bharatos_driver_baseline_core PRIVATE bharat_kernel_buildopts bharat_freestanding bharat_generated_includes)
 target_compile_options(bharatos_driver_baseline_core PRIVATE -ffreestanding -nostdlib -Wall)

--- a/core/drivers/devices/CMakeLists.txt
+++ b/core/drivers/devices/CMakeLists.txt
@@ -23,6 +23,6 @@ endif()
 
 add_library(bharatos_driver_devices STATIC ${BHARAT_DRIVER_DEVICES_SOURCES})
 target_include_directories(bharatos_driver_devices PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include)
-target_include_directories(bharatos_driver_devices PRIVATE ${CMAKE_SOURCE_DIR}/lib/packet/include ${CMAKE_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/kernel/include)
+target_include_directories(bharatos_driver_devices PRIVATE ${CMAKE_SOURCE_DIR}/lib/packet/include ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/kernel/include)
 target_link_libraries(bharatos_driver_devices PRIVATE bharat_kernel_buildopts bharat_freestanding bharat_libpacket bharat_generated_includes)
 target_compile_options(bharatos_driver_devices PRIVATE -ffreestanding -nostdlib -Wall)

--- a/core/drivers/display/CMakeLists.txt
+++ b/core/drivers/display/CMakeLists.txt
@@ -15,6 +15,6 @@ endif()
 
 add_library(bharatos_driver_display STATIC ${BHARAT_DRIVER_DISPLAY_SOURCES})
 target_include_directories(bharatos_driver_display PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include)
-target_include_directories(bharatos_driver_display PRIVATE ${CMAKE_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/kernel/include)
+target_include_directories(bharatos_driver_display PRIVATE ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/kernel/include)
 target_link_libraries(bharatos_driver_display PRIVATE bharat_kernel_buildopts bharat_freestanding bharat_generated_includes)
 target_compile_options(bharatos_driver_display PRIVATE -ffreestanding -nostdlib -Wall)

--- a/core/drivers/input/CMakeLists.txt
+++ b/core/drivers/input/CMakeLists.txt
@@ -13,7 +13,7 @@ endif()
 
 add_library(bharatos_driver_input_static STATIC ${BHARAT_DRIVER_INPUT_SOURCES})
 target_include_directories(bharatos_driver_input_static PUBLIC ../include)
-target_include_directories(bharatos_driver_input_static PRIVATE ${CMAKE_SOURCE_DIR}/include)
+target_include_directories(bharatos_driver_input_static PRIVATE ${CMAKE_SOURCE_DIR}/interface/include)
 target_link_libraries(bharatos_driver_input_static PRIVATE bharat_kernel_buildopts bharat_freestanding bharat_generated_includes)
 target_compile_options(bharatos_driver_input_static PRIVATE -ffreestanding -nostdlib -Wall)
 

--- a/core/drivers/led/CMakeLists.txt
+++ b/core/drivers/led/CMakeLists.txt
@@ -5,6 +5,6 @@ add_library(bharatos_driver_baseline_led STATIC
 )
 
 target_include_directories(bharatos_driver_baseline_led PUBLIC ../include)
-target_include_directories(bharatos_driver_baseline_led PRIVATE ${CMAKE_SOURCE_DIR}/include)
+target_include_directories(bharatos_driver_baseline_led PRIVATE ${CMAKE_SOURCE_DIR}/interface/include)
 target_link_libraries(bharatos_driver_baseline_led PRIVATE bharat_kernel_buildopts bharat_freestanding bharat_generated_includes)
 target_compile_options(bharatos_driver_baseline_led PRIVATE -ffreestanding -nostdlib -Wall)

--- a/core/drivers/net/CMakeLists.txt
+++ b/core/drivers/net/CMakeLists.txt
@@ -13,6 +13,6 @@ endif()
 
 add_library(bharatos_driver_net STATIC ${BHARAT_DRIVER_NET_SOURCES})
 target_include_directories(bharatos_driver_net PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include)
-target_include_directories(bharatos_driver_net PRIVATE ${CMAKE_SOURCE_DIR}/lib/packet/include ${CMAKE_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/kernel/include)
+target_include_directories(bharatos_driver_net PRIVATE ${CMAKE_SOURCE_DIR}/lib/packet/include ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/kernel/include)
 target_link_libraries(bharatos_driver_net PRIVATE bharat_kernel_buildopts bharat_freestanding bharat_libpacket bharat_generated_includes)
 target_compile_options(bharatos_driver_net PRIVATE -ffreestanding -nostdlib -Wall)

--- a/core/drivers/registry/CMakeLists.txt
+++ b/core/drivers/registry/CMakeLists.txt
@@ -10,6 +10,6 @@ endif()
 
 add_library(bharatos_driver_registry STATIC ${BHARAT_DRIVER_REGISTRY_SOURCES})
 target_include_directories(bharatos_driver_registry PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include)
-target_include_directories(bharatos_driver_registry PRIVATE ${CMAKE_SOURCE_DIR}/lib/packet/include ${CMAKE_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/kernel/include)
+target_include_directories(bharatos_driver_registry PRIVATE ${CMAKE_SOURCE_DIR}/lib/packet/include ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/kernel/include)
 target_link_libraries(bharatos_driver_registry PRIVATE bharat_kernel_buildopts bharat_freestanding bharat_libpacket bharat_generated_includes)
 target_compile_options(bharatos_driver_registry PRIVATE -ffreestanding -nostdlib -Wall)

--- a/core/hal/common/CMakeLists.txt
+++ b/core/hal/common/CMakeLists.txt
@@ -18,7 +18,7 @@ target_include_directories(hal_common PRIVATE
     ${CMAKE_SOURCE_DIR}/kernel/include 
     ${CMAKE_SOURCE_DIR}/kernel/include/generated 
     ${CMAKE_SOURCE_DIR}/drivers/include
-    ${CMAKE_SOURCE_DIR}/include)
+    ${CMAKE_SOURCE_DIR}/interface/include)
 target_link_libraries(hal_common PRIVATE bharat_freestanding bharat_kernel_buildopts)
 
 # Apply targeted builtin suppression to the memory helper

--- a/core/kernel/src/cap/CMakeLists.txt
+++ b/core/kernel/src/cap/CMakeLists.txt
@@ -3,5 +3,5 @@ add_library(k_cap OBJECT
     cap_policy.c
 )
 
-target_include_directories(k_cap PRIVATE ../../include ../../include/generated ${CMAKE_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/lib/include ${BHARAT_BOOT_INCLUDE_DIR})
+target_include_directories(k_cap PRIVATE ../../include ../../include/generated ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/lib/include ${BHARAT_BOOT_INCLUDE_DIR})
 target_link_libraries(k_cap PRIVATE bharat_freestanding bharat_kernel_buildopts)

--- a/core/kernel/src/core/CMakeLists.txt
+++ b/core/kernel/src/core/CMakeLists.txt
@@ -42,7 +42,7 @@ add_library(k_core OBJECT
 target_include_directories(k_core PRIVATE
     ${BHARAT_KERNEL_INCLUDE_DIR}
     ${BHARAT_KERNEL_INCLUDE_DIR}/generated
-    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_SOURCE_DIR}/interface/include
     ${BHARAT_LIB_ROOT}/include
     ${BHARAT_BOOT_INCLUDE_DIR}
 )

--- a/core/kernel/src/debug/CMakeLists.txt
+++ b/core/kernel/src/debug/CMakeLists.txt
@@ -20,5 +20,5 @@ add_library(k_debug OBJECT
     ../../src/console/drivers/uart_simple_mmio.c
 )
 
-target_include_directories(k_debug PRIVATE ../../include ../../include/generated ${CMAKE_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/lib/include ${BHARAT_BOOT_INCLUDE_DIR} ${CMAKE_SOURCE_DIR}/drivers/include ${CMAKE_SOURCE_DIR}/platform/include)
+target_include_directories(k_debug PRIVATE ../../include ../../include/generated ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/lib/include ${BHARAT_BOOT_INCLUDE_DIR} ${CMAKE_SOURCE_DIR}/drivers/include ${CMAKE_SOURCE_DIR}/platform/include)
 target_link_libraries(k_debug PRIVATE bharat_freestanding bharat_kernel_buildopts)

--- a/core/kernel/src/fs/CMakeLists.txt
+++ b/core/kernel/src/fs/CMakeLists.txt
@@ -8,5 +8,5 @@ add_library(k_fs OBJECT
     ../../src/fs/object_store.c
 )
 
-target_include_directories(k_fs PRIVATE ../../include ../../include/generated ${CMAKE_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/lib/include ${BHARAT_BOOT_INCLUDE_DIR})
+target_include_directories(k_fs PRIVATE ../../include ../../include/generated ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/lib/include ${BHARAT_BOOT_INCLUDE_DIR})
 target_link_libraries(k_fs PRIVATE bharat_freestanding bharat_kernel_buildopts)

--- a/core/kernel/src/init/CMakeLists.txt
+++ b/core/kernel/src/init/CMakeLists.txt
@@ -18,7 +18,7 @@ add_library(k_init OBJECT
 target_include_directories(k_init PRIVATE
     ${BHARAT_KERNEL_INCLUDE_DIR}
     ${BHARAT_KERNEL_INCLUDE_DIR}/generated
-    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_SOURCE_DIR}/interface/include
     ${BHARAT_LIB_ROOT}/include
     ${BHARAT_BOOT_INCLUDE_DIR}
     ${CMAKE_SOURCE_DIR}/services/core/subsysmgr/include

--- a/core/kernel/src/ipc/CMakeLists.txt
+++ b/core/kernel/src/ipc/CMakeLists.txt
@@ -12,5 +12,5 @@ add_library(k_ipc OBJECT
     ../../src/urpc/urpc_channel.c
 )
 
-target_include_directories(k_ipc PRIVATE ../../include ../../include/generated ${CMAKE_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/lib/include ${BHARAT_BOOT_INCLUDE_DIR} ${CMAKE_SOURCE_DIR}/services/core/subsysmgr/include)
+target_include_directories(k_ipc PRIVATE ../../include ../../include/generated ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/lib/include ${BHARAT_BOOT_INCLUDE_DIR} ${CMAKE_SOURCE_DIR}/services/core/subsysmgr/include)
 target_link_libraries(k_ipc PRIVATE bharat_freestanding bharat_kernel_buildopts)

--- a/core/kernel/src/lib/CMakeLists.txt
+++ b/core/kernel/src/lib/CMakeLists.txt
@@ -9,7 +9,7 @@ add_library(bharat_kernel_lib_ds STATIC
 )
 target_include_directories(bharat_kernel_lib_ds PRIVATE
     ${BHARAT_KERNEL_INCLUDE_DIR}
-    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_SOURCE_DIR}/interface/include
     ${BHARAT_LIB_ROOT}/include
 )
 target_link_libraries(bharat_kernel_lib_ds PRIVATE bharat_freestanding bharat_kernel_buildopts)

--- a/core/kernel/src/monitor/CMakeLists.txt
+++ b/core/kernel/src/monitor/CMakeLists.txt
@@ -9,7 +9,7 @@ add_library(k_monitor OBJECT
 target_include_directories(k_monitor PRIVATE
     ../../include
     ../../include/generated
-    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_SOURCE_DIR}/interface/include
     ${CMAKE_SOURCE_DIR}/lib/include
     ${BHARAT_BOOT_INCLUDE_DIR}
     ${CMAKE_SOURCE_DIR}/services/core/subsysmgr/include

--- a/core/kernel/src/sched/CMakeLists.txt
+++ b/core/kernel/src/sched/CMakeLists.txt
@@ -18,7 +18,7 @@ add_library(k_sched OBJECT
 
 target_sources(k_sched PRIVATE sched_test_support.c)
 
-target_include_directories(k_sched PRIVATE ../../include ../../include/generated ${CMAKE_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/lib/include ${BHARAT_BOOT_INCLUDE_DIR})
+target_include_directories(k_sched PRIVATE ../../include ../../include/generated ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/lib/include ${BHARAT_BOOT_INCLUDE_DIR})
 target_link_libraries(k_sched PRIVATE bharat_freestanding bharat_kernel_buildopts)
 
 add_test(

--- a/core/kernel/src/tests/CMakeLists.txt
+++ b/core/kernel/src/tests/CMakeLists.txt
@@ -15,5 +15,5 @@ add_library(k_test_support OBJECT
     ktest_irq_domain.c
 )
 
-target_include_directories(k_test_support PRIVATE ../../include ../../include/generated ${CMAKE_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/lib/include ${BHARAT_BOOT_INCLUDE_DIR})
+target_include_directories(k_test_support PRIVATE ../../include ../../include/generated ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/lib/include ${BHARAT_BOOT_INCLUDE_DIR})
 target_link_libraries(k_test_support PRIVATE bharat_freestanding bharat_kernel_buildopts)

--- a/core/kernel/src/trap/CMakeLists.txt
+++ b/core/kernel/src/trap/CMakeLists.txt
@@ -5,5 +5,5 @@ add_library(k_trap OBJECT
     ../../src/fault_diag.c
 )
 
-target_include_directories(k_trap PRIVATE ../../include ../../include/generated ${CMAKE_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/lib/include ${BHARAT_BOOT_INCLUDE_DIR})
+target_include_directories(k_trap PRIVATE ../../include ../../include/generated ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/lib/include ${BHARAT_BOOT_INCLUDE_DIR})
 target_link_libraries(k_trap PRIVATE bharat_freestanding bharat_kernel_buildopts)

--- a/core/lib/cap/CMakeLists.txt
+++ b/core/lib/cap/CMakeLists.txt
@@ -6,7 +6,7 @@ add_library(bharat_libcap_base STATIC src/cap.c src/cap_validate.c)
 
 # Set the public include directory
 target_include_directories(bharat_libcap_base PUBLIC include)
-target_include_directories(bharat_libcap_base PUBLIC ${CMAKE_SOURCE_DIR}/include)
+target_include_directories(bharat_libcap_base PUBLIC ${CMAKE_SOURCE_DIR}/interface/include)
 
 # Keep the build freestanding and warning-clean using common targets
 target_link_libraries(bharat_libcap_base PUBLIC bharat_freestanding)

--- a/core/lib/elf/CMakeLists.txt
+++ b/core/lib/elf/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_library(elf_parser STATIC elf_parser.c)
-target_include_directories(elf_parser PUBLIC ${CMAKE_SOURCE_DIR}/include)
+target_include_directories(elf_parser PUBLIC ${CMAKE_SOURCE_DIR}/interface/include)
 target_link_libraries(elf_parser PUBLIC bharat_freestanding)

--- a/core/lib/syscall/CMakeLists.txt
+++ b/core/lib/syscall/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_library(bharat_syscall STATIC syscall_stubs.c)
-target_include_directories(bharat_syscall PUBLIC ${CMAKE_SOURCE_DIR}/include)
+target_include_directories(bharat_syscall PUBLIC ${CMAKE_SOURCE_DIR}/interface/include)
 target_link_libraries(bharat_syscall PUBLIC bharat_freestanding)

--- a/core/services/core/subsysmgr/CMakeLists.txt
+++ b/core/services/core/subsysmgr/CMakeLists.txt
@@ -10,7 +10,7 @@ target_include_directories(subsys_manager PUBLIC
     ${CMAKE_SOURCE_DIR}/lib/include
     ${CMAKE_SOURCE_DIR}/lib/packet/include
     ${CMAKE_SOURCE_DIR}/hal/include
-    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_SOURCE_DIR}/interface/include
     ${CMAKE_SOURCE_DIR}/stacks/network/include
 )
 target_link_libraries(subsys_manager PUBLIC

--- a/core/services/coremgr/CMakeLists.txt
+++ b/core/services/coremgr/CMakeLists.txt
@@ -11,7 +11,7 @@ add_executable(coremgr ${SOURCES})
 
 # Target include directories
 target_include_directories(coremgr PRIVATE
-    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_SOURCE_DIR}/interface/include
 )
 
 # Link against common runtime library and IPC library (assuming lib/runtime, lib/ipc)

--- a/core/services/device/accelmgr/CMakeLists.txt
+++ b/core/services/device/accelmgr/CMakeLists.txt
@@ -11,7 +11,7 @@ add_executable(accelmgr ${SOURCES})
 
 # Target include directories
 target_include_directories(accelmgr PRIVATE
-    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_SOURCE_DIR}/interface/include
 )
 
 # Link against common runtime library and IPC library

--- a/core/services/devmgr/CMakeLists.txt
+++ b/core/services/devmgr/CMakeLists.txt
@@ -11,7 +11,7 @@ add_executable(devmgr ${SOURCES})
 
 # Target include directories
 target_include_directories(devmgr PRIVATE
-    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_SOURCE_DIR}/interface/include
 )
 
 # Link against common runtime library and IPC library

--- a/core/services/faultmgr/CMakeLists.txt
+++ b/core/services/faultmgr/CMakeLists.txt
@@ -11,7 +11,7 @@ add_executable(faultmgr ${SOURCES})
 
 # Target include directories
 target_include_directories(faultmgr PRIVATE
-    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_SOURCE_DIR}/interface/include
 )
 
 # Link against common runtime library and IPC library

--- a/core/services/memmgr/CMakeLists.txt
+++ b/core/services/memmgr/CMakeLists.txt
@@ -11,7 +11,7 @@ add_executable(memmgr ${SOURCES})
 
 # Target include directories
 target_include_directories(memmgr PRIVATE
-    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_SOURCE_DIR}/interface/include
 )
 
 # Link against common runtime library and IPC library

--- a/core/services/power_mode/CMakeLists.txt
+++ b/core/services/power_mode/CMakeLists.txt
@@ -14,5 +14,5 @@ if (BHARAT_AUTOMOTIVE_PROFILE)
             bharat_libipc
             bharat_libcap
     )
-    target_include_directories(power_mode_service PRIVATE ${CMAKE_SOURCE_DIR}/services/include ${CMAKE_SOURCE_DIR}/include)
+    target_include_directories(power_mode_service PRIVATE ${CMAKE_SOURCE_DIR}/services/include ${CMAKE_SOURCE_DIR}/interface/include)
 endif()

--- a/core/services/schedmgr/CMakeLists.txt
+++ b/core/services/schedmgr/CMakeLists.txt
@@ -14,7 +14,7 @@ add_executable(schedmgr ${SOURCES})
 
 # Target include directories
 target_include_directories(schedmgr PRIVATE
-    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_SOURCE_DIR}/interface/include
     ${CMAKE_SOURCE_DIR}/services/include
 )
 

--- a/core/services/storagemgr/CMakeLists.txt
+++ b/core/services/storagemgr/CMakeLists.txt
@@ -11,7 +11,7 @@ add_executable(storagemgr ${SOURCES})
 
 # Target include directories
 target_include_directories(storagemgr PRIVATE
-    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_SOURCE_DIR}/interface/include
 )
 
 # Link against common runtime library and IPC library

--- a/core/services/telemetrymgr/CMakeLists.txt
+++ b/core/services/telemetrymgr/CMakeLists.txt
@@ -14,7 +14,7 @@ add_executable(telemetrymgr ${SOURCES})
 
 # Target include directories
 target_include_directories(telemetrymgr PRIVATE
-    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_SOURCE_DIR}/interface/include
     ${CMAKE_SOURCE_DIR}/services/include
 )
 

--- a/core/stacks/ui/lcd/CMakeLists.txt
+++ b/core/stacks/ui/lcd/CMakeLists.txt
@@ -3,5 +3,5 @@ project(BharatOS_UI_LCD C)
 
 add_library(bharat_ui_lcd_tiny STATIC tiny_ui.c)
 target_include_directories(bharat_ui_lcd_tiny PUBLIC
-    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_SOURCE_DIR}/interface/include
 )

--- a/docs/dev/project-structure-migration-status.md
+++ b/docs/dev/project-structure-migration-status.md
@@ -13,9 +13,9 @@ This tracker is the execution companion for `project-structure-refactor-plan.md`
 - Phase D.2c (kernel source tree move, bounded slice): **In progress** (remaining `kernel/src/*` moved to `core/kernel/src/*`; legacy `kernel/src/*` compatibility symlink wrappers retained).
 - Phase D.2f (kernel root build assets move, bounded slice): **In progress** (`kernel/CMakeLists.txt` and `kernel/linker*.ld` moved to canonical `core/kernel/*`; legacy `kernel/*` symlink compatibility retained).
 - Phase D.4a (lib + stacks bounded move): **In progress** (`lib/` and `stacks/` moved to canonical `core/lib/` and `core/stacks/`; legacy symlink compatibility retained).
-- Phase F.1 (public include tree): **Completed** (`include/` moved to canonical `interface/include/`; legacy `include` retained as symlink).
+- Phase F.1 (public include tree): **Completed** (`include/` moved to canonical `interface/include/`; legacy root `include` symlink removed after canonical include-path migration in CMake).
 - Phase F.2 (user-space tree): **Completed** (`user/` moved to canonical `experience/user/`; legacy `user` retained as symlink and top-level CMake now prefers `experience/user`).
-- Phase F.2 follow-up (root experience/interface/quality symlink trimming): **Completed** (root `user`, `tests`, `idl`, and `sdk` compatibility symlinks removed; `include`/`uapi` kept temporarily for compatibility).
+- Phase F.2 follow-up (root experience/interface/quality symlink trimming): **Completed** (root `user`, `tests`, `idl`, and `sdk` compatibility symlinks removed; `uapi` was previously removed and `include` has now also been removed after canonical caller migration).
 
 ## Phase Checklist
 
@@ -29,8 +29,8 @@ This tracker is the execution companion for `project-structure-refactor-plan.md`
 | B.5 | Remove root delivery symlinks once callers are canonicalized | Completed | Root `configs`, `assets`, `targets`, and `cmake` symlinks removed; canonical paths under `delivery/` are authoritative. |
 | C | `idl/`, `uapi/`, `sdk/` to `interface/` | Completed | C1 (`idl`), C2 (`uapi`), C3 (`sdk`) complete; legacy compatibility symlink for `uapi` removed after migrating in-repo callers to canonical `interface/*` paths. |
 | D | `boot/`, `kernel/`, `arch/`, etc. to `core/` | In progress | D1 is now complete (canonical `core/boot/*`, legacy `boot/{src,common,include,discovery,protocols}` symlink fanout removed, in-repo include paths migrated, and `core/kernel` CMake now uses canonical `core/boot/*` roots only). D2b landed (`kernel/include`), D2c landed (remaining `kernel/src/*` now canonical in `core/kernel/src/*` with compatibility), followed by consolidation to a single `kernel/src` compatibility symlink, D2f landed (`kernel/CMakeLists.txt` + `kernel/linker*.ld` moved to canonical `core/kernel/*` with legacy symlink compatibility), and D4a landed (`lib/` + `stacks/` moved under `core/*` with compatibility symlinks). |
-| F | `include/` + `user/` canonicalization | Completed | F1 landed (`interface/include` canonical, `include` symlink retained); F2 landed (`experience/user` canonical, `user` symlink retained) with migration-aware CMake root selection. |
-| F.3 | Trim root interface/experience/quality compatibility symlinks | Completed | Removed root `user`, `tests`, `idl`, and `sdk` symlinks; retained the `include` symlink for active compatibility needs after removing `uapi`. |
+| F | `include/` + `user/` canonicalization | Completed | F1 landed (`interface/include` canonical, root `include` symlink removed after caller migration); F2 landed (`experience/user` canonical, root `user` symlink removed in F.3) with migration-aware CMake root selection. |
+| F.3 | Trim root interface/experience/quality compatibility symlinks | Completed | Removed root `user`, `tests`, `idl`, and `sdk` symlinks; follow-up cleanup removed the remaining root `include` symlink after canonical include migration. |
 | E | Remove fallbacks + enforce new roots | Pending | Convert warnings to CI failures. |
 
 ## Mandatory Validation Matrix (per phase)

--- a/experience/user/sdk/CMakeLists.txt
+++ b/experience/user/sdk/CMakeLists.txt
@@ -14,7 +14,7 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
     include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../include)
 else()
     # Integrated mode: we are building from the top-level repo
-    include_directories(${CMAKE_SOURCE_DIR}/include)
+    include_directories(${CMAKE_SOURCE_DIR}/interface/include)
 endif()
 
 # Allow building with multikernel features / Shakti
@@ -37,7 +37,7 @@ target_include_directories(bharat PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
     target_include_directories(bharat PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../include)
 else()
-    target_include_directories(bharat PRIVATE ${CMAKE_SOURCE_DIR}/include)
+    target_include_directories(bharat PRIVATE ${CMAKE_SOURCE_DIR}/interface/include)
 endif()
 
 # Note: bharat_user_buildopts and bharat_freestanding are defined in the main project.

--- a/include
+++ b/include
@@ -1,1 +1,0 @@
-interface/include

--- a/project-structure-refactor-plan.md
+++ b/project-structure-refactor-plan.md
@@ -30,7 +30,7 @@ This plan is based on the current repo layout and build system behavior (`build.
 | D3 | `arch/` + `hal/` + `platform/` to `core/*` | ✅ Completed | D3a–D3c completed. Legacy top-level `arch`, `hal`, and `platform` compatibility symlinks have been removed; canonical roots are `core/arch`, `core/hal`, and `core/platform`. |
 | D4 | `lib/` + `stacks/` + `drivers/` + `services/` + `personalities/` to `core/*` (bounded slice) | ✅ Completed | D4a–D4b completed. Canonical roots remain `core/*`; top-level compatibility symlinks for `lib`, `stacks`, `drivers`, `services`, and `personalities` are still retained for transition-safe host test compatibility. |
 | E1 | `tests/` to `quality/tests/` (bounded Phase 5 slice) | ✅ Completed | Canonical host/unit/e2e test tree now lives under `quality/tests`; root `tests` compatibility symlink has been removed after in-repo path migration. |
-| F1 | Public umbrella `include/` to `interface/include/` | ✅ Completed | Canonical public header tree now resides in `interface/include`; root `include` compatibility symlink remains temporarily for broad CMake include compatibility while migration cleanup continues. |
+| F1 | Public umbrella `include/` to `interface/include/` | ✅ Completed | Canonical public header tree now resides in `interface/include`; root `include` compatibility symlink has been removed after migrating in-repo CMake include wiring to the canonical interface path. |
 | F2 | `user/` apps+SDK to `experience/user/` | ✅ Completed | Canonical user-space tree now resides in `experience/user`; root `user` compatibility symlink has been removed and top-level CMake still prefers canonical path with fallback warning support. |
 
 ---

--- a/quality/tests/CMakeLists.txt
+++ b/quality/tests/CMakeLists.txt
@@ -418,13 +418,13 @@ add_test(NAME test_benchmark_hw_caps COMMAND test_benchmark_hw_caps)
 
 add_executable(test_syscall_abi test_syscall_abi.c)
 target_include_directories(test_syscall_abi PRIVATE
-    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_SOURCE_DIR}/interface/include
     ${CMAKE_SOURCE_DIR}/kernel/include
 )
 add_test(NAME SyscallABITest COMMAND test_syscall_abi)
 
 add_executable(test_elf_parser test_elf_parser.c)
-target_include_directories(test_elf_parser PRIVATE ${CMAKE_SOURCE_DIR}/include)
+target_include_directories(test_elf_parser PRIVATE ${CMAKE_SOURCE_DIR}/interface/include)
 target_link_libraries(test_elf_parser PRIVATE elf_parser)
 add_test(NAME ELFParserTest COMMAND test_elf_parser)
 add_executable(test_storage_profile test_storage_profile.c ../stacks/storage/profile.c)

--- a/quality/tests/host/CMakeLists.txt
+++ b/quality/tests/host/CMakeLists.txt
@@ -175,44 +175,44 @@ target_include_directories(test_netmgr_address_table PRIVATE ../../services/netm
 add_test(NAME host_test_netmgr_address_table COMMAND test_netmgr_address_table)
 
 add_executable(test_pmm_pcache test_pmm_pcache.c ../../kernel/src/mm/pmm/pmm.c ../../kernel/src/mm/pmm/pmm_pcache.c ../../kernel/src/mm/pmm/numa.c)
-target_include_directories(test_pmm_pcache PRIVATE ${CMAKE_SOURCE_DIR}/kernel/include ${CMAKE_SOURCE_DIR}/kernel/src ${CMAKE_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/lib/include ${CMAKE_SOURCE_DIR}/core/boot/include)
+target_include_directories(test_pmm_pcache PRIVATE ${CMAKE_SOURCE_DIR}/kernel/include ${CMAKE_SOURCE_DIR}/kernel/src ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/lib/include ${CMAKE_SOURCE_DIR}/core/boot/include)
 add_test(NAME host_test_pmm_pcache COMMAND test_pmm_pcache)
 add_executable(test_netmgr_interface_table services/test_netmgr_interface_table.c ../../services/netmgr/src/interface_table.c ../../lib/runtime/src/freestanding_string.c)
 target_include_directories(test_netmgr_interface_table PRIVATE ../../services/netmgr/src ../../services/netmgr/include ../../services/core/subsysmgr/include ../../lib/net/include ../../lib/runtime/include)
 add_test(NAME host_test_netmgr_interface_table COMMAND test_netmgr_interface_table)
 
 add_executable(test_smp_tlb_active_cores test_smp_tlb_active_cores.c ../../kernel/src/mm/tlb/tlb_shootdown.c ../../kernel/src/mm/tlb/tlb_pending.c ../../kernel/src/mm/tlb/tlb_stats.c host_stubs.c ../../kernel/src/lib/base/string.c)
-target_include_directories(test_smp_tlb_active_cores PRIVATE ${CMAKE_SOURCE_DIR}/kernel/include ${CMAKE_SOURCE_DIR}/kernel/src ${CMAKE_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/core/boot/include ${CMAKE_SOURCE_DIR}/lib/include ${CMAKE_BINARY_DIR}/generated/include ${CMAKE_SOURCE_DIR}/services/monitor/generated)
+target_include_directories(test_smp_tlb_active_cores PRIVATE ${CMAKE_SOURCE_DIR}/kernel/include ${CMAKE_SOURCE_DIR}/kernel/src ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/core/boot/include ${CMAKE_SOURCE_DIR}/lib/include ${CMAKE_BINARY_DIR}/generated/include ${CMAKE_SOURCE_DIR}/services/monitor/generated)
 add_test(NAME host_test_smp_tlb_active_cores COMMAND test_smp_tlb_active_cores)
 
 # Memory host conformance expansion (2026-03-23)
 # HAL contracts + generic PT/TLB contracts
 add_executable(host_test_hal_pt_common ../../tests/mm/pt_common_tests.c ../../hal/hal_pt.c)
-target_include_directories(host_test_hal_pt_common PRIVATE ${CMAKE_SOURCE_DIR}/kernel/include ${CMAKE_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/core/boot/include)
+target_include_directories(host_test_hal_pt_common PRIVATE ${CMAKE_SOURCE_DIR}/kernel/include ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/core/boot/include)
 add_test(NAME host_test_hal_pt_common COMMAND host_test_hal_pt_common)
 
 add_executable(host_test_hal_pt_fallbacks ../../tests/test_hal_pt_fallbacks.c ../../hal/hal_pt.c)
-target_include_directories(host_test_hal_pt_fallbacks PRIVATE ${CMAKE_SOURCE_DIR}/kernel/include ${CMAKE_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/core/boot/include)
+target_include_directories(host_test_hal_pt_fallbacks PRIVATE ${CMAKE_SOURCE_DIR}/kernel/include ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/core/boot/include)
 add_test(NAME host_test_hal_pt_fallbacks COMMAND host_test_hal_pt_fallbacks)
 
 add_executable(host_test_hal_caps_consistency ../../tests/test_hal_caps_consistency.c ../../hal/hal_pt.c)
-target_include_directories(host_test_hal_caps_consistency PRIVATE ${CMAKE_SOURCE_DIR}/kernel/include ${CMAKE_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/core/boot/include)
+target_include_directories(host_test_hal_caps_consistency PRIVATE ${CMAKE_SOURCE_DIR}/kernel/include ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/core/boot/include)
 add_test(NAME host_test_hal_caps_consistency COMMAND host_test_hal_caps_consistency)
 
 add_executable(host_test_mon_vm test_mon_vm.c host_stubs.c ../../kernel/src/monitor/mon_vm_dispatch.c ../../kernel/src/monitor/mon_vm_service.c ../../kernel/src/monitor/mon_vm_state.c)
-target_include_directories(host_test_mon_vm PRIVATE ${CMAKE_SOURCE_DIR}/kernel/include ${CMAKE_SOURCE_DIR}/kernel/src ${CMAKE_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/lib/include)
+target_include_directories(host_test_mon_vm PRIVATE ${CMAKE_SOURCE_DIR}/kernel/include ${CMAKE_SOURCE_DIR}/kernel/src ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/lib/include)
 add_test(NAME host_test_mon_vm COMMAND host_test_mon_vm)
 
 # VMM / ASpace / VM base-object conformance currently remains in top-level tests
 # (`test_vmm_aspace`) due additional prot-domain and arch-cap dependencies.
 
 add_executable(host_test_vmm_fault ../test_vmm_fault.c host_stubs.c ../../kernel/src/mm/vm/fault/fault.c ../../kernel/src/mm/vm/objects/vm_object.c ../../kernel/src/mm/vm/objects/vm_object_refcount.c ../../kernel/src/mm/vm/aspace/vm_space.c ../../kernel/src/mm/vm/aspace/aspace.c ../../kernel/src/mm/pmm/early_alloc.c ../../kernel/src/mm/pmm/pmm.c ../../kernel/src/mm/pmm/pt_pool.c ../../kernel/src/mm/tlb/tlb_shootdown.c ../../kernel/src/capability.c ../../kernel/src/cap/cap_policy.c ../benchmark_stubs.c ../../kernel/src/lib/base/string.c ../../arch/common/memops_scalar.c mock_panic.c)
-target_include_directories(host_test_vmm_fault PRIVATE ${CMAKE_SOURCE_DIR}/kernel/include ${CMAKE_SOURCE_DIR}/kernel/src ${CMAKE_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/core/boot/include ${CMAKE_SOURCE_DIR}/lib/include ${CMAKE_BINARY_DIR}/generated/include)
+target_include_directories(host_test_vmm_fault PRIVATE ${CMAKE_SOURCE_DIR}/kernel/include ${CMAKE_SOURCE_DIR}/kernel/src ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/core/boot/include ${CMAKE_SOURCE_DIR}/lib/include ${CMAKE_BINARY_DIR}/generated/include)
 target_compile_definitions(host_test_vmm_fault PRIVATE TESTING=1)
 add_test(NAME host_test_vmm_fault COMMAND host_test_vmm_fault)
 
 add_executable(test_uapi_abi test_uapi_abi.c)
-target_include_directories(test_uapi_abi PRIVATE ${CMAKE_SOURCE_DIR}/include)
+target_include_directories(test_uapi_abi PRIVATE ${CMAKE_SOURCE_DIR}/interface/include)
 add_test(NAME host_test_uapi_abi COMMAND test_uapi_abi)
 
 add_executable(test_hal_cpu_features
@@ -222,7 +222,7 @@ add_executable(test_hal_cpu_features
 target_include_directories(test_hal_cpu_features PRIVATE
     ${CMAKE_SOURCE_DIR}/kernel/include
     ${CMAKE_SOURCE_DIR}/hal/include
-    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_SOURCE_DIR}/interface/include
     ${CMAKE_SOURCE_DIR}/lib/include
     ${CMAKE_SOURCE_DIR})
 add_test(NAME host_test_hal_cpu_features COMMAND test_hal_cpu_features)
@@ -299,7 +299,7 @@ if(BHARAT_BUILD_HOST_TESTS)
 
     # Memory Model AI-adjacent Primitives Host Test
     add_executable(test_mem_model_ai test_mem_model_ai.c ../../kernel/src/mm/mem_class.c)
-    target_include_directories(test_mem_model_ai PRIVATE ${CMAKE_SOURCE_DIR}/kernel/include ${CMAKE_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/lib/include)
+    target_include_directories(test_mem_model_ai PRIVATE ${CMAKE_SOURCE_DIR}/kernel/include ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/lib/include)
     add_test(NAME host_test_mem_model_ai COMMAND test_mem_model_ai)
 endif()
 add_executable(test_fdt_parser test_fdt_parser.c ../../hal/common/fdt_parser.c)

--- a/tools/abi/check_syscalls.py
+++ b/tools/abi/check_syscalls.py
@@ -3,7 +3,7 @@ import os
 import sys
 import common
 
-SYSCALL_TABLE_PATH = "include/bharat/uapi/syscall_table.def"
+SYSCALL_TABLE_PATH = "interface/include/bharat/uapi/syscall_table.def"
 
 def generate_syscall_manifest():
     if not os.path.exists(SYSCALL_TABLE_PATH):


### PR DESCRIPTION
### Motivation

- Eliminate the legacy top-level `include` symlink and standardize on `interface/include` to remove ambiguous include roots and make the repository layout canonical for production-grade use. 
- Align in-repo build wiring, host tests, and tooling with the canonical public header location so later migration phases can safely remove other compatibility symlinks.

### Description

- Removed the top-level `include` compatibility symlink so `interface/include` is the canonical public header root. 
- Migrated CMake include wiring from `${CMAKE_SOURCE_DIR}/include` to `${CMAKE_SOURCE_DIR}/interface/include` across kernel, drivers, services, libraries, host tests, and the SDK (many `core/*`, `quality/tests/*`, and `experience/user/sdk/CMakeLists.txt` files updated). 
- Updated ABI tooling to read the canonical syscall table by changing `tools/abi/check_syscalls.py` to use `interface/include/bharat/uapi/syscall_table.def`. 
- Updated migration tracker/docs (`project-structure-refactor-plan.md` and `docs/dev/project-structure-migration-status.md`) to record that the root `include` symlink has been removed.

### Testing

- Ran `cmake -S . -B build-include-removed-check` to configure the project and it completed successfully. 
- Built the host-side target with `cmake --build build-include-removed-check -j2 --target bharat_syscall` and the target built successfully. 
- Executed `python3 tools/abi/check_syscalls.py | head -n 2` which read the syscall table at the new canonical path and printed the expected syscall manifest (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebb3b72bb883208575c195bb44a146)