### PR TITLE
Migrate build/include paths to core/ layout and add capability authorization + tests for services

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -356,7 +356,7 @@ add_subdirectory(core/drivers)
 add_subdirectory(core/services)
 set(BHARAT_USER_ROOT_CANDIDATES
     "${CMAKE_SOURCE_DIR}/experience/user"
-    "${CMAKE_SOURCE_DIR}/user"
+    "${CMAKE_SOURCE_DIR}/core/user"
 )
 set(BHARAT_USER_ROOT "")
 foreach(_user_root IN LISTS BHARAT_USER_ROOT_CANDIDATES)
@@ -378,7 +378,7 @@ add_subdirectory(core/personalities)
 if(BHARAT_BUILD_HOST_TESTS)
     set(BHARAT_TESTS_ROOT_CANDIDATES
         "${CMAKE_SOURCE_DIR}/quality/tests"
-        "${CMAKE_SOURCE_DIR}/tests"
+        "${CMAKE_SOURCE_DIR}/core/tests"
     )
     set(BHARAT_TESTS_ROOT "")
     foreach(_tests_root IN LISTS BHARAT_TESTS_ROOT_CANDIDATES)

--- a/core/drivers/accel/virt_accel.c
+++ b/core/drivers/accel/virt_accel.c
@@ -1,5 +1,5 @@
-#include "../../include/bharat/accel/accel.h"
-#include "../../kernel/include/kernel/status.h"
+#include <bharat/accel/accel.h>
+#include <kernel/status.h>
 
 // Pure mock device driver, strictly backend logic. No test logic here.
 

--- a/core/drivers/bus/CMakeLists.txt
+++ b/core/drivers/bus/CMakeLists.txt
@@ -38,6 +38,6 @@ endif()
 
 add_library(bharatos_driver_bus STATIC ${BHARAT_DRIVER_BUS_SOURCES})
 target_include_directories(bharatos_driver_bus PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include)
-target_include_directories(bharatos_driver_bus PRIVATE ${CMAKE_SOURCE_DIR}/lib/packet/include ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/kernel/include)
+target_include_directories(bharatos_driver_bus PRIVATE ${CMAKE_SOURCE_DIR}/core/lib/packet/include ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/core/kernel/include)
 target_link_libraries(bharatos_driver_bus PRIVATE bharat_kernel_buildopts bharat_freestanding bharat_libpacket bharat_generated_includes)
 target_compile_options(bharatos_driver_bus PRIVATE -ffreestanding -nostdlib -Wall)

--- a/core/drivers/class/CMakeLists.txt
+++ b/core/drivers/class/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 
 add_library(bharatos_driver_class STATIC ${BHARAT_DRIVER_CLASS_SOURCES})
 target_include_directories(bharatos_driver_class PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include)
-target_include_directories(bharatos_driver_class PRIVATE ${CMAKE_SOURCE_DIR}/lib/packet/include ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/kernel/include)
+target_include_directories(bharatos_driver_class PRIVATE ${CMAKE_SOURCE_DIR}/core/lib/packet/include ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/core/kernel/include)
 target_link_libraries(bharatos_driver_class PRIVATE bharat_kernel_buildopts bharat_freestanding bharat_libpacket bharat_generated_includes)
 target_compile_options(bharatos_driver_class PRIVATE -ffreestanding -nostdlib -Wall)
 

--- a/core/drivers/devices/CMakeLists.txt
+++ b/core/drivers/devices/CMakeLists.txt
@@ -23,6 +23,10 @@ endif()
 
 add_library(bharatos_driver_devices STATIC ${BHARAT_DRIVER_DEVICES_SOURCES})
 target_include_directories(bharatos_driver_devices PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include)
-target_include_directories(bharatos_driver_devices PRIVATE ${CMAKE_SOURCE_DIR}/lib/packet/include ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/kernel/include)
+target_include_directories(bharatos_driver_devices PRIVATE
+    ${CMAKE_SOURCE_DIR}/core/lib/packet/include
+    ${CMAKE_SOURCE_DIR}/interface/include
+    ${CMAKE_SOURCE_DIR}/core/kernel/include
+)
 target_link_libraries(bharatos_driver_devices PRIVATE bharat_kernel_buildopts bharat_freestanding bharat_libpacket bharat_generated_includes)
 target_compile_options(bharatos_driver_devices PRIVATE -ffreestanding -nostdlib -Wall)

--- a/core/drivers/display/CMakeLists.txt
+++ b/core/drivers/display/CMakeLists.txt
@@ -15,6 +15,6 @@ endif()
 
 add_library(bharatos_driver_display STATIC ${BHARAT_DRIVER_DISPLAY_SOURCES})
 target_include_directories(bharatos_driver_display PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include)
-target_include_directories(bharatos_driver_display PRIVATE ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/kernel/include)
+target_include_directories(bharatos_driver_display PRIVATE ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/core/kernel/include)
 target_link_libraries(bharatos_driver_display PRIVATE bharat_kernel_buildopts bharat_freestanding bharat_generated_includes)
 target_compile_options(bharatos_driver_display PRIVATE -ffreestanding -nostdlib -Wall)

--- a/core/drivers/input/virtio_input/CMakeLists.txt
+++ b/core/drivers/input/virtio_input/CMakeLists.txt
@@ -10,5 +10,5 @@ endif()
 
 add_library(bharatos_driver_input_virtio_input STATIC ${BHARAT_DRIVER_VIRTIO_INPUT_SOURCES})
 target_include_directories(bharatos_driver_input_virtio_input PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-target_include_directories(bharatos_driver_input_virtio_input PRIVATE ${CMAKE_SOURCE_DIR}/drivers/input/include)
+target_include_directories(bharatos_driver_input_virtio_input PRIVATE ${CMAKE_SOURCE_DIR}/core/drivers/input/include)
 target_compile_options(bharatos_driver_input_virtio_input PRIVATE -ffreestanding -nostdlib -Wall)

--- a/core/drivers/net/CMakeLists.txt
+++ b/core/drivers/net/CMakeLists.txt
@@ -13,6 +13,6 @@ endif()
 
 add_library(bharatos_driver_net STATIC ${BHARAT_DRIVER_NET_SOURCES})
 target_include_directories(bharatos_driver_net PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include)
-target_include_directories(bharatos_driver_net PRIVATE ${CMAKE_SOURCE_DIR}/lib/packet/include ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/kernel/include)
+target_include_directories(bharatos_driver_net PRIVATE ${CMAKE_SOURCE_DIR}/core/lib/packet/include ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/core/kernel/include)
 target_link_libraries(bharatos_driver_net PRIVATE bharat_kernel_buildopts bharat_freestanding bharat_libpacket bharat_generated_includes)
 target_compile_options(bharatos_driver_net PRIVATE -ffreestanding -nostdlib -Wall)

--- a/core/drivers/registry/CMakeLists.txt
+++ b/core/drivers/registry/CMakeLists.txt
@@ -10,6 +10,6 @@ endif()
 
 add_library(bharatos_driver_registry STATIC ${BHARAT_DRIVER_REGISTRY_SOURCES})
 target_include_directories(bharatos_driver_registry PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include)
-target_include_directories(bharatos_driver_registry PRIVATE ${CMAKE_SOURCE_DIR}/lib/packet/include ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/kernel/include)
+target_include_directories(bharatos_driver_registry PRIVATE ${CMAKE_SOURCE_DIR}/core/lib/packet/include ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/core/kernel/include)
 target_link_libraries(bharatos_driver_registry PRIVATE bharat_kernel_buildopts bharat_freestanding bharat_libpacket bharat_generated_includes)
 target_compile_options(bharatos_driver_registry PRIVATE -ffreestanding -nostdlib -Wall)

--- a/core/drivers/serial/CMakeLists.txt
+++ b/core/drivers/serial/CMakeLists.txt
@@ -61,10 +61,10 @@ target_compile_options(serial_drivers PRIVATE
 )
 
 target_include_directories(serial_drivers PRIVATE
-    ${CMAKE_SOURCE_DIR}/kernel/include
-    ${CMAKE_SOURCE_DIR}/kernel/include/generated
-    ${CMAKE_SOURCE_DIR}/drivers/include
-    ${CMAKE_SOURCE_DIR}/platform/include
+    ${CMAKE_SOURCE_DIR}/core/kernel/include
+    ${CMAKE_SOURCE_DIR}/core/kernel/include/generated
+    ${CMAKE_SOURCE_DIR}/core/drivers/include
+    ${CMAKE_SOURCE_DIR}/core/platform/include
 )
 
 target_link_libraries(serial_drivers PRIVATE bharat_freestanding bharat_kernel_buildopts)

--- a/core/hal/common/CMakeLists.txt
+++ b/core/hal/common/CMakeLists.txt
@@ -13,11 +13,11 @@ add_library(hal_common OBJECT
 )
 
 target_include_directories(hal_common PRIVATE 
-    ${CMAKE_SOURCE_DIR}/hal/include
-    ${CMAKE_SOURCE_DIR}/kernel/src
-    ${CMAKE_SOURCE_DIR}/kernel/include 
-    ${CMAKE_SOURCE_DIR}/kernel/include/generated 
-    ${CMAKE_SOURCE_DIR}/drivers/include
+    ${CMAKE_SOURCE_DIR}/core/hal/include
+    ${CMAKE_SOURCE_DIR}/core/kernel/src
+    ${CMAKE_SOURCE_DIR}/core/kernel/include 
+    ${CMAKE_SOURCE_DIR}/core/kernel/include/generated 
+    ${CMAKE_SOURCE_DIR}/core/drivers/include
     ${CMAKE_SOURCE_DIR}/interface/include)
 target_link_libraries(hal_common PRIVATE bharat_freestanding bharat_kernel_buildopts)
 

--- a/core/kernel/src/cap/CMakeLists.txt
+++ b/core/kernel/src/cap/CMakeLists.txt
@@ -3,5 +3,5 @@ add_library(k_cap OBJECT
     cap_policy.c
 )
 
-target_include_directories(k_cap PRIVATE ../../include ../../include/generated ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/lib/include ${BHARAT_BOOT_INCLUDE_DIR})
+target_include_directories(k_cap PRIVATE ../../include ../../include/generated ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/core/lib/include ${BHARAT_BOOT_INCLUDE_DIR})
 target_link_libraries(k_cap PRIVATE bharat_freestanding bharat_kernel_buildopts)

--- a/core/kernel/src/debug/CMakeLists.txt
+++ b/core/kernel/src/debug/CMakeLists.txt
@@ -20,5 +20,5 @@ add_library(k_debug OBJECT
     ../../src/console/drivers/uart_simple_mmio.c
 )
 
-target_include_directories(k_debug PRIVATE ../../include ../../include/generated ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/lib/include ${BHARAT_BOOT_INCLUDE_DIR} ${CMAKE_SOURCE_DIR}/drivers/include ${CMAKE_SOURCE_DIR}/platform/include)
+target_include_directories(k_debug PRIVATE ../../include ../../include/generated ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/core/lib/include ${BHARAT_BOOT_INCLUDE_DIR} ${CMAKE_SOURCE_DIR}/core/drivers/include ${CMAKE_SOURCE_DIR}/core/platform/include)
 target_link_libraries(k_debug PRIVATE bharat_freestanding bharat_kernel_buildopts)

--- a/core/kernel/src/fs/CMakeLists.txt
+++ b/core/kernel/src/fs/CMakeLists.txt
@@ -8,5 +8,5 @@ add_library(k_fs OBJECT
     ../../src/fs/object_store.c
 )
 
-target_include_directories(k_fs PRIVATE ../../include ../../include/generated ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/lib/include ${BHARAT_BOOT_INCLUDE_DIR})
+target_include_directories(k_fs PRIVATE ../../include ../../include/generated ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/core/lib/include ${BHARAT_BOOT_INCLUDE_DIR})
 target_link_libraries(k_fs PRIVATE bharat_freestanding bharat_kernel_buildopts)

--- a/core/kernel/src/init/CMakeLists.txt
+++ b/core/kernel/src/init/CMakeLists.txt
@@ -21,6 +21,6 @@ target_include_directories(k_init PRIVATE
     ${CMAKE_SOURCE_DIR}/interface/include
     ${BHARAT_LIB_ROOT}/include
     ${BHARAT_BOOT_INCLUDE_DIR}
-    ${CMAKE_SOURCE_DIR}/services/core/subsysmgr/include
+    ${CMAKE_SOURCE_DIR}/core/services/core/subsysmgr/include
 )
 target_link_libraries(k_init PRIVATE bharat_freestanding bharat_kernel_buildopts)

--- a/core/kernel/src/ipc/CMakeLists.txt
+++ b/core/kernel/src/ipc/CMakeLists.txt
@@ -12,5 +12,5 @@ add_library(k_ipc OBJECT
     ../../src/urpc/urpc_channel.c
 )
 
-target_include_directories(k_ipc PRIVATE ../../include ../../include/generated ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/lib/include ${BHARAT_BOOT_INCLUDE_DIR} ${CMAKE_SOURCE_DIR}/services/core/subsysmgr/include)
+target_include_directories(k_ipc PRIVATE ../../include ../../include/generated ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/core/lib/include ${BHARAT_BOOT_INCLUDE_DIR} ${CMAKE_SOURCE_DIR}/core/services/core/subsysmgr/include)
 target_link_libraries(k_ipc PRIVATE bharat_freestanding bharat_kernel_buildopts)

--- a/core/kernel/src/monitor/CMakeLists.txt
+++ b/core/kernel/src/monitor/CMakeLists.txt
@@ -10,9 +10,9 @@ target_include_directories(k_monitor PRIVATE
     ../../include
     ../../include/generated
     ${CMAKE_SOURCE_DIR}/interface/include
-    ${CMAKE_SOURCE_DIR}/lib/include
+    ${CMAKE_SOURCE_DIR}/core/lib/include
     ${BHARAT_BOOT_INCLUDE_DIR}
-    ${CMAKE_SOURCE_DIR}/services/core/subsysmgr/include
+    ${CMAKE_SOURCE_DIR}/core/services/core/subsysmgr/include
 )
 
 target_link_libraries(k_monitor PRIVATE bharat_freestanding bharat_kernel_buildopts)

--- a/core/kernel/src/sched/CMakeLists.txt
+++ b/core/kernel/src/sched/CMakeLists.txt
@@ -18,7 +18,7 @@ add_library(k_sched OBJECT
 
 target_sources(k_sched PRIVATE sched_test_support.c)
 
-target_include_directories(k_sched PRIVATE ../../include ../../include/generated ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/lib/include ${BHARAT_BOOT_INCLUDE_DIR})
+target_include_directories(k_sched PRIVATE ../../include ../../include/generated ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/core/lib/include ${BHARAT_BOOT_INCLUDE_DIR})
 target_link_libraries(k_sched PRIVATE bharat_freestanding bharat_kernel_buildopts)
 
 add_test(

--- a/core/kernel/src/tests/CMakeLists.txt
+++ b/core/kernel/src/tests/CMakeLists.txt
@@ -15,5 +15,5 @@ add_library(k_test_support OBJECT
     ktest_irq_domain.c
 )
 
-target_include_directories(k_test_support PRIVATE ../../include ../../include/generated ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/lib/include ${BHARAT_BOOT_INCLUDE_DIR})
+target_include_directories(k_test_support PRIVATE ../../include ../../include/generated ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/core/lib/include ${BHARAT_BOOT_INCLUDE_DIR})
 target_link_libraries(k_test_support PRIVATE bharat_freestanding bharat_kernel_buildopts)

--- a/core/kernel/src/trap/CMakeLists.txt
+++ b/core/kernel/src/trap/CMakeLists.txt
@@ -5,5 +5,5 @@ add_library(k_trap OBJECT
     ../../src/fault_diag.c
 )
 
-target_include_directories(k_trap PRIVATE ../../include ../../include/generated ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/lib/include ${BHARAT_BOOT_INCLUDE_DIR})
+target_include_directories(k_trap PRIVATE ../../include ../../include/generated ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/core/lib/include ${BHARAT_BOOT_INCLUDE_DIR})
 target_link_libraries(k_trap PRIVATE bharat_freestanding bharat_kernel_buildopts)

--- a/core/lib/CMakeLists.txt
+++ b/core/lib/CMakeLists.txt
@@ -13,7 +13,11 @@ bharat_configure_userspace_library(bharat_libcmin)
 # bharat_libtransport (URPC / Loopsback)
 # ---------------------------------------------------------
 add_library(bharat_libtransport STATIC urpc/urpc.c transport/loopback.c)
-target_include_directories(bharat_libtransport PUBLIC urpc ../../services/core/subsysmgr/include runtime/include)
+target_include_directories(bharat_libtransport PUBLIC
+    urpc
+    ${CMAKE_SOURCE_DIR}/core/services/core/subsysmgr/include
+    runtime/include
+)
 target_link_libraries(bharat_libtransport PUBLIC bharat_freestanding)
 bharat_configure_userspace_library(bharat_libtransport)
 
@@ -21,7 +25,7 @@ bharat_configure_userspace_library(bharat_libtransport)
 # bharat_version_api
 # ---------------------------------------------------------
 add_library(bharat_version_api STATIC version_api.c)
-target_include_directories(bharat_version_api PUBLIC ../../include)
+target_include_directories(bharat_version_api PUBLIC ${CMAKE_SOURCE_DIR}/interface/include)
 target_link_libraries(bharat_version_api PUBLIC bharat_freestanding bharat_generated_includes)
 bharat_configure_userspace_library(bharat_version_api)
 
@@ -65,7 +69,10 @@ add_library(bharat_libmsg STATIC ${BHARAT_LIBMSG_SOURCES})
 if (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|ARM64")
     set_source_files_properties(msg/crc_aarch64.c PROPERTIES COMPILE_FLAGS "-march=armv8-a+crc")
 endif()
-target_include_directories(bharat_libmsg PUBLIC ../../services/core/subsysmgr/include runtime/include)
+target_include_directories(bharat_libmsg PUBLIC
+    ${CMAKE_SOURCE_DIR}/core/services/core/subsysmgr/include
+    runtime/include
+)
 target_link_libraries(bharat_libmsg PUBLIC bharat_freestanding)
 bharat_configure_userspace_library(bharat_libmsg)
 
@@ -79,7 +86,7 @@ add_library(bharat_libcap STATIC
     capwire/cap_codec.c
     capwire/cap_validate.c
 )
-target_include_directories(bharat_libcap PUBLIC ../../services/core/subsysmgr/include)
+target_include_directories(bharat_libcap PUBLIC ${CMAKE_SOURCE_DIR}/core/services/core/subsysmgr/include)
 target_link_libraries(bharat_libcap PUBLIC bharat_libmsg bharat_freestanding)
 bharat_configure_userspace_library(bharat_libcap)
 
@@ -93,7 +100,7 @@ add_library(bharat_libdiag STATIC
     ool/ool_codec.c
     ool/ool_validate.c
 )
-target_include_directories(bharat_libdiag PUBLIC ../../services/core/subsysmgr/include)
+target_include_directories(bharat_libdiag PUBLIC ${CMAKE_SOURCE_DIR}/core/services/core/subsysmgr/include)
 target_link_libraries(bharat_libdiag PUBLIC bharat_libmsg bharat_freestanding)
 bharat_configure_userspace_library(bharat_libdiag)
 

--- a/core/lib/ipc/CMakeLists.txt
+++ b/core/lib/ipc/CMakeLists.txt
@@ -5,7 +5,11 @@ project(BharatOS_Lib_IPC C ASM)
 add_library(bharat_libipc STATIC src/ipc.c)
 
 # Set the public include directory
-target_include_directories(bharat_libipc PUBLIC include ${CMAKE_SOURCE_DIR}/core/lib/include ${CMAKE_SOURCE_DIR}/kernel/include)
+target_include_directories(bharat_libipc PUBLIC
+    include
+    ${CMAKE_SOURCE_DIR}/core/lib/include
+    ${CMAKE_SOURCE_DIR}/core/kernel/include
+)
 
 # IPC depends on cap headers
 target_link_libraries(bharat_libipc PUBLIC cap bharat_freestanding bharat_syscall)

--- a/core/lib/runtime/CMakeLists.txt
+++ b/core/lib/runtime/CMakeLists.txt
@@ -28,7 +28,11 @@ target_link_libraries(bharat_runtime_tensor PUBLIC bharat_freestanding bharat_ru
 bharat_configure_userspace_library(bharat_runtime_tensor)
 
 # Set the public include directory
-target_include_directories(bharat_libruntime PUBLIC include ${CMAKE_SOURCE_DIR}/interface/uapi/runtime)
+target_include_directories(bharat_libruntime PUBLIC
+    include
+    ${CMAKE_SOURCE_DIR}/interface/uapi/runtime
+    ${CMAKE_SOURCE_DIR}/core/kernel/include
+)
 target_link_libraries(bharat_libruntime PRIVATE bharat_runtime_backend_dispatch bharat_runtime_crypto bharat_runtime_tensor)
 
 # Runtime depends on cap and ipc headers

--- a/core/services/can/CMakeLists.txt
+++ b/core/services/can/CMakeLists.txt
@@ -12,7 +12,7 @@ if (BHARAT_AUTOMOTIVE_PROFILE OR BHARAT_ENABLE_CAN)
         bharatos_stack_can
     )
     bharat_configure_userspace_binary(canmgr_service)
-    target_include_directories(canmgr_service PRIVATE ${CMAKE_SOURCE_DIR}/services/include)
+    target_include_directories(canmgr_service PRIVATE ${CMAKE_SOURCE_DIR}/core/services/include)
 
     add_executable(cangw_service
         cangw/gateway.c
@@ -24,7 +24,7 @@ if (BHARAT_AUTOMOTIVE_PROFILE OR BHARAT_ENABLE_CAN)
         bharatos_stack_can
     )
     bharat_configure_userspace_binary(cangw_service)
-    target_include_directories(cangw_service PRIVATE ${CMAKE_SOURCE_DIR}/services/include)
+    target_include_directories(cangw_service PRIVATE ${CMAKE_SOURCE_DIR}/core/services/include)
 
     add_executable(candiag_service
         candiag/diag_service.c
@@ -36,5 +36,5 @@ if (BHARAT_AUTOMOTIVE_PROFILE OR BHARAT_ENABLE_CAN)
         bharatos_stack_can
     )
     bharat_configure_userspace_binary(candiag_service)
-    target_include_directories(candiag_service PRIVATE ${CMAKE_SOURCE_DIR}/services/include)
+    target_include_directories(candiag_service PRIVATE ${CMAKE_SOURCE_DIR}/core/services/include)
 endif()

--- a/core/services/core/subsysmgr/CMakeLists.txt
+++ b/core/services/core/subsysmgr/CMakeLists.txt
@@ -5,13 +5,13 @@ add_library(subsys_manager STATIC
     ../../../personalities/common/version_registry.c
 )
 target_include_directories(subsys_manager PUBLIC
-    ${CMAKE_SOURCE_DIR}/services/core/subsysmgr/include
-    ${CMAKE_SOURCE_DIR}/kernel/include
-    ${CMAKE_SOURCE_DIR}/lib/include
-    ${CMAKE_SOURCE_DIR}/lib/packet/include
-    ${CMAKE_SOURCE_DIR}/hal/include
+    ${CMAKE_SOURCE_DIR}/core/services/core/subsysmgr/include
+    ${CMAKE_SOURCE_DIR}/core/kernel/include
+    ${CMAKE_SOURCE_DIR}/core/lib/include
+    ${CMAKE_SOURCE_DIR}/core/lib/packet/include
+    ${CMAKE_SOURCE_DIR}/core/hal/include
     ${CMAKE_SOURCE_DIR}/interface/include
-    ${CMAKE_SOURCE_DIR}/stacks/network/include
+    ${CMAKE_SOURCE_DIR}/core/stacks/network/include
 )
 target_link_libraries(subsys_manager PUBLIC
     bharat_freestanding

--- a/core/services/device/actuator_mgr/CMakeLists.txt
+++ b/core/services/device/actuator_mgr/CMakeLists.txt
@@ -12,5 +12,5 @@ if (BHARAT_AUTOMOTIVE_PROFILE)
             bharat_libipc
             bharat_libcap
     )
-    target_include_directories(actuator_mgr_service PRIVATE ${CMAKE_SOURCE_DIR}/services/include ${CMAKE_SOURCE_DIR}/drivers/include)
+    target_include_directories(actuator_mgr_service PRIVATE ${CMAKE_SOURCE_DIR}/core/services/include ${CMAKE_SOURCE_DIR}/core/drivers/include)
 endif()

--- a/core/services/device/inputmgr/CMakeLists.txt
+++ b/core/services/device/inputmgr/CMakeLists.txt
@@ -7,7 +7,7 @@ add_library(inputmgr STATIC
 target_include_directories(inputmgr PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     ${CMAKE_SOURCE_DIR}/interface/uapi
-    ${CMAKE_SOURCE_DIR}/drivers/input/include
+    ${CMAKE_SOURCE_DIR}/core/drivers/input/include
 )
 
 target_link_libraries(inputmgr PRIVATE bharat_user_buildopts bharat_freestanding)

--- a/core/services/power_mode/CMakeLists.txt
+++ b/core/services/power_mode/CMakeLists.txt
@@ -14,5 +14,5 @@ if (BHARAT_AUTOMOTIVE_PROFILE)
             bharat_libipc
             bharat_libcap
     )
-    target_include_directories(power_mode_service PRIVATE ${CMAKE_SOURCE_DIR}/services/include ${CMAKE_SOURCE_DIR}/interface/include)
+    target_include_directories(power_mode_service PRIVATE ${CMAKE_SOURCE_DIR}/core/services/include ${CMAKE_SOURCE_DIR}/interface/include)
 endif()

--- a/core/services/process_manager/CMakeLists.txt
+++ b/core/services/process_manager/CMakeLists.txt
@@ -5,3 +5,14 @@ target_include_directories(process_manager PRIVATE ../../kernel/include ../../se
 target_link_libraries(process_manager PRIVATE bharat_libtransport subsys_manager bharat_libstring)
 
 bharat_configure_userspace_binary(process_manager)
+
+if(CMAKE_CROSSCOMPILING)
+    message(STATUS "Skipping test_process_manager_caps build during cross-compilation")
+else()
+    add_executable(test_process_manager_caps tests/test_process_manager_caps.c process_manager.c)
+    target_include_directories(test_process_manager_caps PRIVATE ../../kernel/include ../../services/core/subsysmgr/include ../../lib/bharat_libtransport ../../include ../../lib/cap/include ../../lib/ipc/include ../../../interface/include)
+    target_link_libraries(test_process_manager_caps PRIVATE bharat_libcap_base)
+    set_target_properties(test_process_manager_caps PROPERTIES COMPILE_OPTIONS "")
+    set_target_properties(test_process_manager_caps PROPERTIES LINK_OPTIONS "")
+    add_test(NAME test_process_manager_caps COMMAND test_process_manager_caps)
+endif()

--- a/core/services/process_manager/process_manager.c
+++ b/core/services/process_manager/process_manager.c
@@ -1,5 +1,7 @@
 #include "process_manager.h"
 #include <stddef.h>
+#include <bharat/cap/cap_validate.h>
+#include <bharat/uapi/ipc/status.h>
 
 // Basic string/mem stub for freestanding tests
 void *memset(void *s, int c, size_t n);
@@ -8,6 +10,64 @@ char *strncpy(char *dest, const char *src, size_t n);
 
 static process_entry_t process_table[MAX_PROCESSES];
 static uint32_t next_pid = 1;
+
+int32_t process_manager_authorize(
+    uint32_t opcode,
+    const void *req,
+    bharat_cap_handle_t caller_cap)
+{
+    if (caller_cap == BHARAT_CAP_INVALID_HANDLE) {
+        return BHARAT_IPC_STATUS_ERR_PERM;
+    }
+
+    uint64_t required_rights = 0;
+    uint64_t target_object_id = 0;
+    bharat_cap_scope_t scope = {
+        .kind = BHARAT_CAP_SCOPE_SERVICE,
+        .scope_id = 0
+    };
+
+    switch (opcode) {
+        case PM_OP_CREATE: {
+            required_rights = BHARAT_CAP_RIGHT_WRITE;
+            break;
+        }
+        case PM_OP_QUERY: {
+            const pm_req_query_t *typed_req = (const pm_req_query_t *)req;
+            required_rights = BHARAT_CAP_RIGHT_READ;
+            target_object_id = typed_req->process_id;
+            scope.kind = BHARAT_CAP_SCOPE_OBJECT;
+            scope.scope_id = typed_req->process_id;
+            break;
+        }
+        case PM_OP_START:
+        case PM_OP_STOP: {
+            const pm_req_start_t *typed_req = (const pm_req_start_t *)req;
+            required_rights = BHARAT_CAP_RIGHT_EXECUTE;
+            target_object_id = typed_req->process_id;
+            scope.kind = BHARAT_CAP_SCOPE_OBJECT;
+            scope.scope_id = typed_req->process_id;
+            break;
+        }
+        default:
+            return BHARAT_IPC_STATUS_ERR_OPCODE;
+    }
+
+    bharat_cap_validation_result_t vr = {0};
+    bharat_cap_status_t st = bharat_cap_validate(
+        caller_cap,
+        BHARAT_CAP_OBJ_PROCESS,
+        target_object_id,
+        required_rights,
+        &scope,
+        &vr);
+
+    if (st != BHARAT_CAP_OK || !vr.allowed) {
+        return BHARAT_IPC_STATUS_ERR_PERM;
+    }
+
+    return BHARAT_IPC_STATUS_OK;
+}
 
 void process_manager_init(void) {
     memset(process_table, 0, sizeof(process_table));
@@ -108,6 +168,13 @@ void process_manager_loop(bharat_ipc_endpoint_t endpoint) {
                 if (req_header.payload_size >= sizeof(pm_req_create_t)) {
                     pm_req_create_t *req = (pm_req_create_t*)payload_buf;
                     pm_resp_create_t *resp = (pm_resp_create_t*)resp_payload_buf;
+                    int32_t auth_status = process_manager_authorize(req_header.opcode, req, req_header.capability_transfer);
+                    if (auth_status != BHARAT_IPC_STATUS_OK) {
+                        resp->status = auth_status;
+                        dispatch_status = auth_status;
+                        resp_size = sizeof(pm_resp_create_t);
+                        break;
+                    }
                     dispatch_status = process_manager_handle_create(req, resp);
                     resp_size = sizeof(pm_resp_create_t);
                 } else {
@@ -119,6 +186,13 @@ void process_manager_loop(bharat_ipc_endpoint_t endpoint) {
                 if (req_header.payload_size >= sizeof(pm_req_start_t)) {
                     pm_req_start_t *req = (pm_req_start_t*)payload_buf;
                     pm_resp_start_t *resp = (pm_resp_start_t*)resp_payload_buf;
+                    int32_t auth_status = process_manager_authorize(req_header.opcode, req, req_header.capability_transfer);
+                    if (auth_status != BHARAT_IPC_STATUS_OK) {
+                        resp->status = auth_status;
+                        dispatch_status = auth_status;
+                        resp_size = sizeof(pm_resp_start_t);
+                        break;
+                    }
                     dispatch_status = process_manager_handle_start(req, resp);
                     resp_size = sizeof(pm_resp_start_t);
                 } else {
@@ -130,6 +204,13 @@ void process_manager_loop(bharat_ipc_endpoint_t endpoint) {
                 if (req_header.payload_size >= sizeof(pm_req_stop_t)) {
                     pm_req_stop_t *req = (pm_req_stop_t*)payload_buf;
                     pm_resp_stop_t *resp = (pm_resp_stop_t*)resp_payload_buf;
+                    int32_t auth_status = process_manager_authorize(req_header.opcode, req, req_header.capability_transfer);
+                    if (auth_status != BHARAT_IPC_STATUS_OK) {
+                        resp->status = auth_status;
+                        dispatch_status = auth_status;
+                        resp_size = sizeof(pm_resp_stop_t);
+                        break;
+                    }
                     dispatch_status = process_manager_handle_stop(req, resp);
                     resp_size = sizeof(pm_resp_stop_t);
                 } else {
@@ -141,6 +222,13 @@ void process_manager_loop(bharat_ipc_endpoint_t endpoint) {
                 if (req_header.payload_size >= sizeof(pm_req_query_t)) {
                     pm_req_query_t *req = (pm_req_query_t*)payload_buf;
                     pm_resp_query_t *resp = (pm_resp_query_t*)resp_payload_buf;
+                    int32_t auth_status = process_manager_authorize(req_header.opcode, req, req_header.capability_transfer);
+                    if (auth_status != BHARAT_IPC_STATUS_OK) {
+                        resp->status = auth_status;
+                        dispatch_status = auth_status;
+                        resp_size = sizeof(pm_resp_query_t);
+                        break;
+                    }
                     dispatch_status = process_manager_handle_query(req, resp);
                     resp_size = sizeof(pm_resp_query_t);
                 } else {

--- a/core/services/process_manager/process_manager.h
+++ b/core/services/process_manager/process_manager.h
@@ -22,5 +22,6 @@ int32_t process_manager_handle_create(const pm_req_create_t *req, pm_resp_create
 int32_t process_manager_handle_start(const pm_req_start_t *req, pm_resp_start_t *resp);
 int32_t process_manager_handle_stop(const pm_req_stop_t *req, pm_resp_stop_t *resp);
 int32_t process_manager_handle_query(const pm_req_query_t *req, pm_resp_query_t *resp);
+int32_t process_manager_authorize(uint32_t opcode, const void *req, bharat_cap_handle_t caller_cap);
 
 #endif // PROCESS_MANAGER_H

--- a/core/services/process_manager/tests/test_process_manager_caps.c
+++ b/core/services/process_manager/tests/test_process_manager_caps.c
@@ -1,0 +1,53 @@
+#include "../process_manager.h"
+#include <assert.h>
+#include <stdio.h>
+#include <bharat/cap/cap_validate.h>
+#include <bharat/uapi/ipc/status.h>
+
+int32_t bharat_ipc_send(bharat_ipc_endpoint_t endpoint, const bharat_ipc_msg_header_t *header, const void *payload) { (void)endpoint; (void)header; (void)payload; return 0; }
+int32_t bharat_ipc_recv(bharat_ipc_endpoint_t endpoint, bharat_ipc_msg_header_t *header, void *payload_buf, uint32_t max_size) { (void)endpoint; (void)header; (void)payload_buf; (void)max_size; return -1; }
+
+static bharat_cap_status_t fake_backend(
+    bharat_cap_handle_t handle,
+    bharat_cap_object_type_t expected_object_type,
+    uint64_t expected_object_id,
+    uint64_t required_rights,
+    const bharat_cap_scope_t *required_scope,
+    bharat_cap_validation_result_t *out_result)
+{
+    (void)required_rights;
+    if (!out_result) return BHARAT_CAP_INVALID;
+    out_result->allowed = false;
+    out_result->status = BHARAT_CAP_INVALID;
+
+    if (handle == 100 && expected_object_type == BHARAT_CAP_OBJ_PROCESS) {
+        out_result->allowed = true;
+        out_result->status = BHARAT_CAP_OK;
+        return BHARAT_CAP_OK;
+    }
+
+    if (handle == 200) { // replay/stale token
+        out_result->status = BHARAT_CAP_STALE;
+        return BHARAT_CAP_STALE;
+    }
+
+    if (handle == 300 && required_scope && required_scope->kind == BHARAT_CAP_SCOPE_OBJECT && required_scope->scope_id != expected_object_id) {
+        out_result->status = BHARAT_CAP_SCOPE_DENIED;
+        return BHARAT_CAP_SCOPE_DENIED;
+    }
+
+    return BHARAT_CAP_INVALID;
+}
+
+int main(void) {
+    bharat_cap_set_validate_backend_for_tests(fake_backend);
+
+    pm_req_start_t start_req = {.process_id = 42};
+    assert(process_manager_authorize(PM_OP_START, &start_req, BHARAT_CAP_INVALID_HANDLE) == BHARAT_IPC_STATUS_ERR_PERM);
+    assert(process_manager_authorize(PM_OP_START, &start_req, 200) == BHARAT_IPC_STATUS_ERR_PERM);
+    assert(process_manager_authorize(PM_OP_START, &start_req, 300) == BHARAT_IPC_STATUS_ERR_PERM);
+    assert(process_manager_authorize(PM_OP_START, &start_req, 100) == BHARAT_IPC_STATUS_OK);
+
+    puts("process_manager capability negative tests passed");
+    return 0;
+}

--- a/core/services/schedmgr/CMakeLists.txt
+++ b/core/services/schedmgr/CMakeLists.txt
@@ -15,7 +15,7 @@ add_executable(schedmgr ${SOURCES})
 # Target include directories
 target_include_directories(schedmgr PRIVATE
     ${CMAKE_SOURCE_DIR}/interface/include
-    ${CMAKE_SOURCE_DIR}/services/include
+    ${CMAKE_SOURCE_DIR}/core/services/include
 )
 
 # Link against common runtime library and IPC library

--- a/core/services/sensor_hub/CMakeLists.txt
+++ b/core/services/sensor_hub/CMakeLists.txt
@@ -13,5 +13,5 @@ if (BHARAT_AUTOMOTIVE_PROFILE)
             bharat_libipc
             bharat_libcap
     )
-    target_include_directories(sensor_hub_service PRIVATE ${CMAKE_SOURCE_DIR}/services/include ${CMAKE_SOURCE_DIR}/drivers/include)
+    target_include_directories(sensor_hub_service PRIVATE ${CMAKE_SOURCE_DIR}/core/services/include ${CMAKE_SOURCE_DIR}/core/drivers/include)
 endif()

--- a/core/services/servicemgr/CMakeLists.txt
+++ b/core/services/servicemgr/CMakeLists.txt
@@ -3,3 +3,14 @@ target_link_libraries(servicemgr PRIVATE bharat_user_buildopts bharat_freestandi
 target_include_directories(servicemgr PRIVATE ../../kernel/include ../../include)
 
 bharat_configure_userspace_binary(servicemgr)
+
+if(CMAKE_CROSSCOMPILING)
+    message(STATUS "Skipping test_servicemgr_caps build during cross-compilation")
+else()
+    add_executable(test_servicemgr_caps tests/test_servicemgr_caps.c servicemgr.c)
+    target_include_directories(test_servicemgr_caps PRIVATE ../../kernel/include ../../include ../../lib/cap/include ../../lib/ipc/include ../../../interface/include)
+    target_link_libraries(test_servicemgr_caps PRIVATE bharat_libcap_base)
+    set_target_properties(test_servicemgr_caps PROPERTIES COMPILE_OPTIONS "")
+    set_target_properties(test_servicemgr_caps PROPERTIES LINK_OPTIONS "")
+    add_test(NAME test_servicemgr_caps COMMAND test_servicemgr_caps)
+endif()

--- a/core/services/servicemgr/servicemgr.c
+++ b/core/services/servicemgr/servicemgr.c
@@ -1,5 +1,7 @@
 #include "servicemgr.h"
 #include <stddef.h>
+#include <bharat/cap/cap_validate.h>
+#include <bharat/uapi/ipc/status.h>
 
 // Basic string/mem stub for freestanding tests
 void *memset(void *s, int c, size_t n);
@@ -7,6 +9,64 @@ char *strncpy(char *dest, const char *src, size_t n);
 
 static service_entry_t service_registry[MAX_SERVICES];
 static uint32_t next_service_id = 1;
+
+int32_t servicemgr_authorize(
+    uint32_t opcode,
+    const void *req,
+    bharat_cap_handle_t caller_cap)
+{
+    if (caller_cap == BHARAT_CAP_INVALID_HANDLE) {
+        return BHARAT_IPC_STATUS_ERR_PERM;
+    }
+
+    uint64_t required_rights = 0;
+    uint64_t target_service_id = 0;
+    bharat_cap_scope_t scope = {
+        .kind = BHARAT_CAP_SCOPE_SERVICE,
+        .scope_id = 0
+    };
+
+    switch (opcode) {
+        case SM_OP_REGISTER:
+            required_rights = BHARAT_CAP_RIGHT_WRITE;
+            break;
+        case SM_OP_QUERY: {
+            const sm_req_query_t *typed_req = (const sm_req_query_t *)req;
+            required_rights = BHARAT_CAP_RIGHT_READ;
+            target_service_id = typed_req->service_id;
+            scope.kind = BHARAT_CAP_SCOPE_OBJECT;
+            scope.scope_id = typed_req->service_id;
+            break;
+        }
+        case SM_OP_START:
+        case SM_OP_STOP:
+        case SM_OP_HEARTBEAT: {
+            const sm_req_start_t *typed_req = (const sm_req_start_t *)req;
+            required_rights = BHARAT_CAP_RIGHT_WRITE;
+            target_service_id = typed_req->service_id;
+            scope.kind = BHARAT_CAP_SCOPE_OBJECT;
+            scope.scope_id = typed_req->service_id;
+            break;
+        }
+        default:
+            return BHARAT_IPC_STATUS_ERR_OPCODE;
+    }
+
+    bharat_cap_validation_result_t vr = {0};
+    bharat_cap_status_t st = bharat_cap_validate(
+        caller_cap,
+        BHARAT_CAP_OBJ_SERVICE,
+        target_service_id,
+        required_rights,
+        &scope,
+        &vr);
+
+    if (st != BHARAT_CAP_OK || !vr.allowed) {
+        return BHARAT_IPC_STATUS_ERR_PERM;
+    }
+
+    return BHARAT_IPC_STATUS_OK;
+}
 
 void servicemgr_init(void) {
     memset(service_registry, 0, sizeof(service_registry));
@@ -149,6 +209,13 @@ void servicemgr_loop(bharat_ipc_endpoint_t endpoint) {
                 if (req_header.payload_size >= sizeof(sm_req_register_t)) {
                     sm_req_register_t *req = (sm_req_register_t*)payload_buf;
                     sm_resp_register_t *resp = (sm_resp_register_t*)resp_payload_buf;
+                    int32_t auth_status = servicemgr_authorize(req_header.opcode, req, req_header.capability_transfer);
+                    if (auth_status != BHARAT_IPC_STATUS_OK) {
+                        resp->status = auth_status;
+                        dispatch_status = auth_status;
+                        resp_size = sizeof(sm_resp_register_t);
+                        break;
+                    }
                     dispatch_status = servicemgr_handle_register(req, resp);
                     resp_size = sizeof(sm_resp_register_t);
                 } else {
@@ -160,6 +227,13 @@ void servicemgr_loop(bharat_ipc_endpoint_t endpoint) {
                 if (req_header.payload_size >= sizeof(sm_req_start_t)) {
                     sm_req_start_t *req = (sm_req_start_t*)payload_buf;
                     sm_resp_start_t *resp = (sm_resp_start_t*)resp_payload_buf;
+                    int32_t auth_status = servicemgr_authorize(req_header.opcode, req, req_header.capability_transfer);
+                    if (auth_status != BHARAT_IPC_STATUS_OK) {
+                        resp->status = auth_status;
+                        dispatch_status = auth_status;
+                        resp_size = sizeof(sm_resp_start_t);
+                        break;
+                    }
                     dispatch_status = servicemgr_handle_start(req, resp);
                     resp_size = sizeof(sm_resp_start_t);
                 } else {
@@ -171,6 +245,13 @@ void servicemgr_loop(bharat_ipc_endpoint_t endpoint) {
                 if (req_header.payload_size >= sizeof(sm_req_stop_t)) {
                     sm_req_stop_t *req = (sm_req_stop_t*)payload_buf;
                     sm_resp_stop_t *resp = (sm_resp_stop_t*)resp_payload_buf;
+                    int32_t auth_status = servicemgr_authorize(req_header.opcode, req, req_header.capability_transfer);
+                    if (auth_status != BHARAT_IPC_STATUS_OK) {
+                        resp->status = auth_status;
+                        dispatch_status = auth_status;
+                        resp_size = sizeof(sm_resp_stop_t);
+                        break;
+                    }
                     dispatch_status = servicemgr_handle_stop(req, resp);
                     resp_size = sizeof(sm_resp_stop_t);
                 } else {
@@ -182,6 +263,13 @@ void servicemgr_loop(bharat_ipc_endpoint_t endpoint) {
                 if (req_header.payload_size >= sizeof(sm_req_query_t)) {
                     sm_req_query_t *req = (sm_req_query_t*)payload_buf;
                     sm_resp_query_t *resp = (sm_resp_query_t*)resp_payload_buf;
+                    int32_t auth_status = servicemgr_authorize(req_header.opcode, req, req_header.capability_transfer);
+                    if (auth_status != BHARAT_IPC_STATUS_OK) {
+                        resp->status = auth_status;
+                        dispatch_status = auth_status;
+                        resp_size = sizeof(sm_resp_query_t);
+                        break;
+                    }
                     dispatch_status = servicemgr_handle_query(req, resp);
                     resp_size = sizeof(sm_resp_query_t);
                 } else {
@@ -193,6 +281,13 @@ void servicemgr_loop(bharat_ipc_endpoint_t endpoint) {
                 if (req_header.payload_size >= sizeof(sm_req_heartbeat_t)) {
                     sm_req_heartbeat_t *req = (sm_req_heartbeat_t*)payload_buf;
                     sm_resp_heartbeat_t *resp = (sm_resp_heartbeat_t*)resp_payload_buf;
+                    int32_t auth_status = servicemgr_authorize(req_header.opcode, req, req_header.capability_transfer);
+                    if (auth_status != BHARAT_IPC_STATUS_OK) {
+                        resp->status = auth_status;
+                        dispatch_status = auth_status;
+                        resp_size = sizeof(sm_resp_heartbeat_t);
+                        break;
+                    }
                     dispatch_status = servicemgr_handle_heartbeat(req, resp);
                     resp_size = sizeof(sm_resp_heartbeat_t);
                 } else {

--- a/core/services/servicemgr/servicemgr.h
+++ b/core/services/servicemgr/servicemgr.h
@@ -28,5 +28,6 @@ int32_t servicemgr_handle_stop(const sm_req_stop_t *req, sm_resp_stop_t *resp);
 int32_t servicemgr_handle_query(const sm_req_query_t *req, sm_resp_query_t *resp);
 int32_t servicemgr_handle_heartbeat(const sm_req_heartbeat_t *req, sm_resp_heartbeat_t *resp);
 void servicemgr_check_health(uint32_t current_time);
+int32_t servicemgr_authorize(uint32_t opcode, const void *req, bharat_cap_handle_t caller_cap);
 
 #endif // SERVICEMGR_H

--- a/core/services/servicemgr/tests/test_servicemgr_caps.c
+++ b/core/services/servicemgr/tests/test_servicemgr_caps.c
@@ -1,0 +1,50 @@
+#include "../servicemgr.h"
+#include <assert.h>
+#include <stdio.h>
+#include <bharat/cap/cap_validate.h>
+#include <bharat/uapi/ipc/status.h>
+
+int32_t bharat_ipc_send(bharat_ipc_endpoint_t endpoint, const bharat_ipc_msg_header_t *header, const void *payload) { (void)endpoint; (void)header; (void)payload; return 0; }
+int32_t bharat_ipc_recv(bharat_ipc_endpoint_t endpoint, bharat_ipc_msg_header_t *header, void *payload_buf, uint32_t max_size) { (void)endpoint; (void)header; (void)payload_buf; (void)max_size; return -1; }
+
+static bharat_cap_status_t fake_backend(
+    bharat_cap_handle_t handle,
+    bharat_cap_object_type_t expected_object_type,
+    uint64_t expected_object_id,
+    uint64_t required_rights,
+    const bharat_cap_scope_t *required_scope,
+    bharat_cap_validation_result_t *out_result)
+{
+    (void)required_rights;
+    if (!out_result) return BHARAT_CAP_INVALID;
+    out_result->allowed = false;
+    out_result->status = BHARAT_CAP_INVALID;
+
+    if (handle == 10 && expected_object_type == BHARAT_CAP_OBJ_SERVICE) {
+        out_result->allowed = true;
+        out_result->status = BHARAT_CAP_OK;
+        return BHARAT_CAP_OK;
+    }
+    if (handle == 11) {
+        out_result->status = BHARAT_CAP_STALE;
+        return BHARAT_CAP_STALE;
+    }
+    if (handle == 12 && required_scope && required_scope->kind == BHARAT_CAP_SCOPE_OBJECT && required_scope->scope_id != expected_object_id) {
+        out_result->status = BHARAT_CAP_SCOPE_DENIED;
+        return BHARAT_CAP_SCOPE_DENIED;
+    }
+    return BHARAT_CAP_INVALID;
+}
+
+int main(void) {
+    bharat_cap_set_validate_backend_for_tests(fake_backend);
+
+    sm_req_start_t req = {.service_id = 7};
+    assert(servicemgr_authorize(SM_OP_START, &req, BHARAT_CAP_INVALID_HANDLE) == BHARAT_IPC_STATUS_ERR_PERM);
+    assert(servicemgr_authorize(SM_OP_START, &req, 11) == BHARAT_IPC_STATUS_ERR_PERM);
+    assert(servicemgr_authorize(SM_OP_START, &req, 12) == BHARAT_IPC_STATUS_ERR_PERM);
+    assert(servicemgr_authorize(SM_OP_START, &req, 10) == BHARAT_IPC_STATUS_OK);
+
+    puts("servicemgr capability negative tests passed");
+    return 0;
+}

--- a/core/services/telemetrymgr/CMakeLists.txt
+++ b/core/services/telemetrymgr/CMakeLists.txt
@@ -15,7 +15,7 @@ add_executable(telemetrymgr ${SOURCES})
 # Target include directories
 target_include_directories(telemetrymgr PRIVATE
     ${CMAKE_SOURCE_DIR}/interface/include
-    ${CMAKE_SOURCE_DIR}/services/include
+    ${CMAKE_SOURCE_DIR}/core/services/include
 )
 
 # Link against common runtime library and IPC library

--- a/core/services/time_sync/CMakeLists.txt
+++ b/core/services/time_sync/CMakeLists.txt
@@ -12,5 +12,5 @@ if (BHARAT_AUTOMOTIVE_PROFILE)
             bharat_libipc
             bharat_libcap
     )
-    target_include_directories(time_sync_service PRIVATE ${CMAKE_SOURCE_DIR}/services/include)
+    target_include_directories(time_sync_service PRIVATE ${CMAKE_SOURCE_DIR}/core/services/include)
 endif()

--- a/core/services/vm_manager/CMakeLists.txt
+++ b/core/services/vm_manager/CMakeLists.txt
@@ -3,3 +3,14 @@ target_link_libraries(vm_manager PRIVATE bharat_user_buildopts bharat_freestandi
 target_include_directories(vm_manager PRIVATE ../../kernel/include ../../include)
 
 bharat_configure_userspace_binary(vm_manager)
+
+if(CMAKE_CROSSCOMPILING)
+    message(STATUS "Skipping test_vm_manager_caps build during cross-compilation")
+else()
+    add_executable(test_vm_manager_caps tests/test_vm_manager_caps.c vm_manager.c)
+    target_include_directories(test_vm_manager_caps PRIVATE ../../kernel/include ../../include ../../lib/cap/include ../../lib/ipc/include ../../../interface/include)
+    target_link_libraries(test_vm_manager_caps PRIVATE bharat_libcap_base)
+    set_target_properties(test_vm_manager_caps PROPERTIES COMPILE_OPTIONS "")
+    set_target_properties(test_vm_manager_caps PROPERTIES LINK_OPTIONS "")
+    add_test(NAME test_vm_manager_caps COMMAND test_vm_manager_caps)
+endif()

--- a/core/services/vm_manager/tests/test_vm_manager_caps.c
+++ b/core/services/vm_manager/tests/test_vm_manager_caps.c
@@ -1,0 +1,55 @@
+#include "../vm_manager.h"
+#include <assert.h>
+#include <stdio.h>
+#include <bharat/cap/cap_validate.h>
+#include <bharat/uapi/ipc/status.h>
+
+int32_t bharat_ipc_send(bharat_ipc_endpoint_t endpoint, const bharat_ipc_msg_header_t *header, const void *payload) { (void)endpoint; (void)header; (void)payload; return 0; }
+int32_t bharat_ipc_recv(bharat_ipc_endpoint_t endpoint, bharat_ipc_msg_header_t *header, void *payload_buf, uint32_t max_size) { (void)endpoint; (void)header; (void)payload_buf; (void)max_size; return -1; }
+
+static bharat_cap_status_t fake_backend(
+    bharat_cap_handle_t handle,
+    bharat_cap_object_type_t expected_object_type,
+    uint64_t expected_object_id,
+    uint64_t required_rights,
+    const bharat_cap_scope_t *required_scope,
+    bharat_cap_validation_result_t *out_result)
+{
+    (void)required_rights;
+    if (!out_result) return BHARAT_CAP_INVALID;
+    out_result->allowed = false;
+    out_result->status = BHARAT_CAP_INVALID;
+
+    if (handle == 21 && expected_object_type == BHARAT_CAP_OBJ_VM_SPACE && expected_object_id == 9) {
+        out_result->allowed = true;
+        out_result->status = BHARAT_CAP_OK;
+        return BHARAT_CAP_OK;
+    }
+    if (handle == 22) {
+        out_result->status = BHARAT_CAP_STALE;
+        return BHARAT_CAP_STALE;
+    }
+    if (handle == 23 && required_scope && required_scope->kind == BHARAT_CAP_SCOPE_OBJECT && required_scope->scope_id != expected_object_id) {
+        out_result->status = BHARAT_CAP_SCOPE_DENIED;
+        return BHARAT_CAP_SCOPE_DENIED;
+    }
+    return BHARAT_CAP_INVALID;
+}
+
+int main(void) {
+    bharat_cap_set_validate_backend_for_tests(fake_backend);
+    vm_manager_init();
+
+    vm_req_map_t map_req = {.aspace_id = 9, .vaddr = 0x1000, .size = 0x1000, .flags = 0};
+    vm_resp_map_t map_resp = {0};
+    assert(vm_manager_authorize(VM_OP_MAP, &map_req, BHARAT_CAP_INVALID_HANDLE) == BHARAT_IPC_STATUS_ERR_PERM);
+    assert(vm_manager_authorize(VM_OP_MAP, &map_req, 22) == BHARAT_IPC_STATUS_ERR_PERM);
+    assert(vm_manager_authorize(VM_OP_MAP, &map_req, 21) == BHARAT_IPC_STATUS_OK);
+    assert(vm_manager_handle_map(&map_req, &map_resp) == BHARAT_IPC_STATUS_OK);
+
+    vm_req_unmap_t unmap_req = {.region_id = map_resp.region_id};
+    assert(vm_manager_authorize(VM_OP_UNMAP, &unmap_req, 23) == BHARAT_IPC_STATUS_ERR_PERM);
+
+    puts("vm_manager capability negative tests passed");
+    return 0;
+}

--- a/core/services/vm_manager/vm_manager.c
+++ b/core/services/vm_manager/vm_manager.c
@@ -1,11 +1,99 @@
 #include "vm_manager.h"
 #include <stddef.h>
+#include <bharat/cap/cap_validate.h>
+#include <bharat/uapi/ipc/status.h>
 
 // Basic string/mem stub for freestanding tests
 void *memset(void *s, int c, size_t n);
 
 static region_entry_t region_table[MAX_REGIONS];
 static uint32_t next_region_id = 1;
+
+static const region_entry_t *vm_manager_find_region(uint32_t region_id) {
+    for (int i = 0; i < MAX_REGIONS; i++) {
+        if (region_table[i].in_use && region_table[i].region_id == region_id) {
+            return &region_table[i];
+        }
+    }
+    return NULL;
+}
+
+int32_t vm_manager_authorize(
+    uint32_t opcode,
+    const void *req,
+    bharat_cap_handle_t caller_cap)
+{
+    if (caller_cap == BHARAT_CAP_INVALID_HANDLE) {
+        return BHARAT_IPC_STATUS_ERR_PERM;
+    }
+
+    uint64_t required_rights = 0;
+    uint64_t target_vm_space = 0;
+    bharat_cap_scope_t scope = {
+        .kind = BHARAT_CAP_SCOPE_OBJECT,
+        .scope_id = 0
+    };
+
+    switch (opcode) {
+        case VM_OP_MAP: {
+            const vm_req_map_t *typed_req = (const vm_req_map_t *)req;
+            required_rights = BHARAT_CAP_RIGHT_WRITE;
+            target_vm_space = typed_req->aspace_id;
+            scope.scope_id = typed_req->aspace_id;
+            break;
+        }
+        case VM_OP_FAULT: {
+            const vm_req_fault_t *typed_req = (const vm_req_fault_t *)req;
+            required_rights = BHARAT_CAP_RIGHT_WRITE;
+            target_vm_space = typed_req->aspace_id;
+            scope.scope_id = typed_req->aspace_id;
+            break;
+        }
+        case VM_OP_UNMAP:
+        case VM_OP_PROTECT:
+        case VM_OP_QUERY: {
+            uint32_t region_id = 0;
+            if (opcode == VM_OP_UNMAP) {
+                const vm_req_unmap_t *typed_req = (const vm_req_unmap_t *)req;
+                region_id = typed_req->region_id;
+                required_rights = BHARAT_CAP_RIGHT_WRITE;
+            } else if (opcode == VM_OP_PROTECT) {
+                const vm_req_protect_t *typed_req = (const vm_req_protect_t *)req;
+                region_id = typed_req->region_id;
+                required_rights = BHARAT_CAP_RIGHT_WRITE;
+            } else {
+                const vm_req_query_t *typed_req = (const vm_req_query_t *)req;
+                region_id = typed_req->region_id;
+                required_rights = BHARAT_CAP_RIGHT_READ;
+            }
+
+            const region_entry_t *region = vm_manager_find_region(region_id);
+            if (!region) {
+                return BHARAT_IPC_STATUS_ERR_NOT_FOUND;
+            }
+            target_vm_space = region->aspace_id;
+            scope.scope_id = region->aspace_id;
+            break;
+        }
+        default:
+            return BHARAT_IPC_STATUS_ERR_OPCODE;
+    }
+
+    bharat_cap_validation_result_t vr = {0};
+    bharat_cap_status_t st = bharat_cap_validate(
+        caller_cap,
+        BHARAT_CAP_OBJ_VM_SPACE,
+        target_vm_space,
+        required_rights,
+        &scope,
+        &vr);
+
+    if (st != BHARAT_CAP_OK || !vr.allowed) {
+        return BHARAT_IPC_STATUS_ERR_PERM;
+    }
+
+    return BHARAT_IPC_STATUS_OK;
+}
 
 void vm_manager_init(void) {
     memset(region_table, 0, sizeof(region_table));
@@ -116,6 +204,13 @@ void vm_manager_loop(bharat_ipc_endpoint_t endpoint) {
                 if (req_header.payload_size >= sizeof(vm_req_map_t)) {
                     vm_req_map_t *req = (vm_req_map_t*)payload_buf;
                     vm_resp_map_t *resp = (vm_resp_map_t*)resp_payload_buf;
+                    int32_t auth_status = vm_manager_authorize(req_header.opcode, req, req_header.capability_transfer);
+                    if (auth_status != BHARAT_IPC_STATUS_OK) {
+                        resp->status = auth_status;
+                        dispatch_status = auth_status;
+                        resp_size = sizeof(vm_resp_map_t);
+                        break;
+                    }
                     dispatch_status = vm_manager_handle_map(req, resp);
                     resp_size = sizeof(vm_resp_map_t);
                 } else {
@@ -127,6 +222,13 @@ void vm_manager_loop(bharat_ipc_endpoint_t endpoint) {
                 if (req_header.payload_size >= sizeof(vm_req_unmap_t)) {
                     vm_req_unmap_t *req = (vm_req_unmap_t*)payload_buf;
                     vm_resp_unmap_t *resp = (vm_resp_unmap_t*)resp_payload_buf;
+                    int32_t auth_status = vm_manager_authorize(req_header.opcode, req, req_header.capability_transfer);
+                    if (auth_status != BHARAT_IPC_STATUS_OK) {
+                        resp->status = auth_status;
+                        dispatch_status = auth_status;
+                        resp_size = sizeof(vm_resp_unmap_t);
+                        break;
+                    }
                     dispatch_status = vm_manager_handle_unmap(req, resp);
                     resp_size = sizeof(vm_resp_unmap_t);
                 } else {
@@ -138,6 +240,13 @@ void vm_manager_loop(bharat_ipc_endpoint_t endpoint) {
                 if (req_header.payload_size >= sizeof(vm_req_protect_t)) {
                     vm_req_protect_t *req = (vm_req_protect_t*)payload_buf;
                     vm_resp_protect_t *resp = (vm_resp_protect_t*)resp_payload_buf;
+                    int32_t auth_status = vm_manager_authorize(req_header.opcode, req, req_header.capability_transfer);
+                    if (auth_status != BHARAT_IPC_STATUS_OK) {
+                        resp->status = auth_status;
+                        dispatch_status = auth_status;
+                        resp_size = sizeof(vm_resp_protect_t);
+                        break;
+                    }
                     dispatch_status = vm_manager_handle_protect(req, resp);
                     resp_size = sizeof(vm_resp_protect_t);
                 } else {
@@ -149,6 +258,13 @@ void vm_manager_loop(bharat_ipc_endpoint_t endpoint) {
                 if (req_header.payload_size >= sizeof(vm_req_query_t)) {
                     vm_req_query_t *req = (vm_req_query_t*)payload_buf;
                     vm_resp_query_t *resp = (vm_resp_query_t*)resp_payload_buf;
+                    int32_t auth_status = vm_manager_authorize(req_header.opcode, req, req_header.capability_transfer);
+                    if (auth_status != BHARAT_IPC_STATUS_OK) {
+                        resp->status = auth_status;
+                        dispatch_status = auth_status;
+                        resp_size = sizeof(vm_resp_query_t);
+                        break;
+                    }
                     dispatch_status = vm_manager_handle_query(req, resp);
                     resp_size = sizeof(vm_resp_query_t);
                 } else {
@@ -160,6 +276,13 @@ void vm_manager_loop(bharat_ipc_endpoint_t endpoint) {
                 if (req_header.payload_size >= sizeof(vm_req_fault_t)) {
                     vm_req_fault_t *req = (vm_req_fault_t*)payload_buf;
                     vm_resp_fault_t *resp = (vm_resp_fault_t*)resp_payload_buf;
+                    int32_t auth_status = vm_manager_authorize(req_header.opcode, req, req_header.capability_transfer);
+                    if (auth_status != BHARAT_IPC_STATUS_OK) {
+                        resp->action = -1;
+                        dispatch_status = auth_status;
+                        resp_size = sizeof(vm_resp_fault_t);
+                        break;
+                    }
                     dispatch_status = vm_manager_handle_fault(req, resp);
                     resp_size = sizeof(vm_resp_fault_t);
                 } else {

--- a/core/services/vm_manager/vm_manager.h
+++ b/core/services/vm_manager/vm_manager.h
@@ -25,5 +25,6 @@ int32_t vm_manager_handle_unmap(const vm_req_unmap_t *req, vm_resp_unmap_t *resp
 int32_t vm_manager_handle_protect(const vm_req_protect_t *req, vm_resp_protect_t *resp);
 int32_t vm_manager_handle_query(const vm_req_query_t *req, vm_resp_query_t *resp);
 int32_t vm_manager_handle_fault(const vm_req_fault_t *req, vm_resp_fault_t *resp);
+int32_t vm_manager_authorize(uint32_t opcode, const void *req, bharat_cap_handle_t caller_cap);
 
 #endif // VM_MANAGER_H

--- a/core/stacks/can/CMakeLists.txt
+++ b/core/stacks/can/CMakeLists.txt
@@ -6,8 +6,8 @@ add_library(bharatos_stack_can STATIC
 )
 target_include_directories(bharatos_stack_can PUBLIC
     ${CMAKE_SOURCE_DIR}/core/stacks/include
-    ${CMAKE_SOURCE_DIR}/services/include
-    ${CMAKE_SOURCE_DIR}/drivers/include
+    ${CMAKE_SOURCE_DIR}/core/services/include
+    ${CMAKE_SOURCE_DIR}/core/drivers/include
     ${CMAKE_SOURCE_DIR}/core/lib/include
 )
 target_compile_options(bharatos_stack_can PRIVATE -ffreestanding -fno-builtin)

--- a/core/stacks/network/CMakeLists.txt
+++ b/core/stacks/network/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_library(bharatos_stack_network STATIC skb.c)
-target_include_directories(bharatos_stack_network PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/kernel/include ${CMAKE_SOURCE_DIR}/core/lib/packet/include)
+target_include_directories(bharatos_stack_network PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/core/kernel/include ${CMAKE_SOURCE_DIR}/core/lib/packet/include)
 target_link_libraries(bharatos_stack_network PRIVATE bharat_kernel_buildopts bharat_freestanding bharat_libpacket)

--- a/core/stacks/storage/CMakeLists.txt
+++ b/core/stacks/storage/CMakeLists.txt
@@ -7,6 +7,6 @@ add_library(bharat_stacks_storage STATIC
     fs/blob/blob_backend.c
 )
 target_include_directories(bharat_stacks_storage PUBLIC ../include)
-target_include_directories(bharat_stacks_storage PRIVATE ../../../kernel/include)
-target_include_directories(bharat_stacks_storage PRIVATE ../../../include)
+target_include_directories(bharat_stacks_storage PRIVATE ../../kernel/include)
+target_include_directories(bharat_stacks_storage PRIVATE ${CMAKE_SOURCE_DIR}/interface/include)
 target_link_libraries(bharat_stacks_storage PRIVATE bharat_user_buildopts bharat_freestanding)

--- a/quality/tests/CMakeLists.txt
+++ b/quality/tests/CMakeLists.txt
@@ -3,7 +3,7 @@ project(BharatOS-Tests C)
 
 enable_testing()
 
-if(EXISTS "${CMAKE_SOURCE_DIR}/kernel" AND EXISTS "${CMAKE_SOURCE_DIR}/tests")
+if(EXISTS "${CMAKE_SOURCE_DIR}/core/kernel" AND EXISTS "${CMAKE_SOURCE_DIR}/core/tests")
     set(REPO_ROOT "${CMAKE_SOURCE_DIR}")
 elseif(EXISTS "${CMAKE_SOURCE_DIR}/../kernel")
     get_filename_component(REPO_ROOT "${CMAKE_SOURCE_DIR}/.." ABSOLUTE)
@@ -251,7 +251,7 @@ if (EXISTS "${CMAKE_SOURCE_DIR}/core/personalities/compat/android/android_person
         ../core/personalities/common/translation_events.c
         subsys/test_personality_stubs.c
     )
-    target_include_directories(test_android_personality PRIVATE ${CMAKE_SOURCE_DIR}/kernel/include ${CMAKE_SOURCE_DIR}/core/lib/include ${CMAKE_SOURCE_DIR}/core/services/core/subsysmgr/include)
+    target_include_directories(test_android_personality PRIVATE ${CMAKE_SOURCE_DIR}/core/kernel/include ${CMAKE_SOURCE_DIR}/core/lib/include ${CMAKE_SOURCE_DIR}/core/services/core/subsysmgr/include)
     add_test(NAME test_android_personality COMMAND test_android_personality)
 
     if (EXISTS "${CMAKE_SOURCE_DIR}/core/personalities/compat/linux/linux_compat.c")
@@ -261,7 +261,7 @@ if (EXISTS "${CMAKE_SOURCE_DIR}/core/personalities/compat/android/android_person
             ../core/personalities/compat/android/android_binder_dist.c
             ../core/personalities/common/translation_events.c
         )
-        target_include_directories(test_personality_translation_guards PRIVATE ${CMAKE_SOURCE_DIR}/kernel/include ${CMAKE_SOURCE_DIR}/core/lib/include ${CMAKE_SOURCE_DIR}/core/services/core/subsysmgr/include)
+        target_include_directories(test_personality_translation_guards PRIVATE ${CMAKE_SOURCE_DIR}/core/kernel/include ${CMAKE_SOURCE_DIR}/core/lib/include ${CMAKE_SOURCE_DIR}/core/services/core/subsysmgr/include)
         add_test(NAME test_personality_translation_guards COMMAND test_personality_translation_guards)
     endif()
 endif()
@@ -419,7 +419,7 @@ add_test(NAME test_benchmark_hw_caps COMMAND test_benchmark_hw_caps)
 add_executable(test_syscall_abi test_syscall_abi.c)
 target_include_directories(test_syscall_abi PRIVATE
     ${CMAKE_SOURCE_DIR}/interface/include
-    ${CMAKE_SOURCE_DIR}/kernel/include
+    ${CMAKE_SOURCE_DIR}/core/kernel/include
 )
 add_test(NAME SyscallABITest COMMAND test_syscall_abi)
 
@@ -565,8 +565,8 @@ add_executable(test_constraint_validation
     core/test_constraint_validation.c
 )
 target_include_directories(test_constraint_validation PRIVATE
-    ${CMAKE_SOURCE_DIR}/kernel/include
+    ${CMAKE_SOURCE_DIR}/core/kernel/include
     ${CMAKE_SOURCE_DIR}/interface/uapi
 )
-target_sources(test_constraint_validation PRIVATE ${CMAKE_SOURCE_DIR}/kernel/src/core/constraints/constraints_common.c ${CMAKE_SOURCE_DIR}/kernel/src/core/constraints/constraint_validate.c)
+target_sources(test_constraint_validation PRIVATE ${CMAKE_SOURCE_DIR}/core/kernel/src/core/constraints/constraints_common.c ${CMAKE_SOURCE_DIR}/core/kernel/src/core/constraints/constraint_validate.c)
 add_test(NAME test_constraint_validation COMMAND test_constraint_validation)

--- a/quality/tests/host/CMakeLists.txt
+++ b/quality/tests/host/CMakeLists.txt
@@ -175,39 +175,39 @@ target_include_directories(test_netmgr_address_table PRIVATE ../../core/services
 add_test(NAME host_test_netmgr_address_table COMMAND test_netmgr_address_table)
 
 add_executable(test_pmm_pcache test_pmm_pcache.c ../../kernel/src/mm/pmm/pmm.c ../../kernel/src/mm/pmm/pmm_pcache.c ../../kernel/src/mm/pmm/numa.c)
-target_include_directories(test_pmm_pcache PRIVATE ${CMAKE_SOURCE_DIR}/kernel/include ${CMAKE_SOURCE_DIR}/kernel/src ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/core/lib/include ${CMAKE_SOURCE_DIR}/core/boot/include)
+target_include_directories(test_pmm_pcache PRIVATE ${CMAKE_SOURCE_DIR}/core/kernel/include ${CMAKE_SOURCE_DIR}/core/kernel/src ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/core/lib/include ${CMAKE_SOURCE_DIR}/core/boot/include)
 add_test(NAME host_test_pmm_pcache COMMAND test_pmm_pcache)
 add_executable(test_netmgr_interface_table services/test_netmgr_interface_table.c ../../core/services/netmgr/src/interface_table.c ../../core/lib/runtime/src/freestanding_string.c)
 target_include_directories(test_netmgr_interface_table PRIVATE ../../core/services/netmgr/src ../../core/services/netmgr/include ../../core/services/core/subsysmgr/include ../../core/lib/net/include ../../core/lib/runtime/include)
 add_test(NAME host_test_netmgr_interface_table COMMAND test_netmgr_interface_table)
 
 add_executable(test_smp_tlb_active_cores test_smp_tlb_active_cores.c ../../kernel/src/mm/tlb/tlb_shootdown.c ../../kernel/src/mm/tlb/tlb_pending.c ../../kernel/src/mm/tlb/tlb_stats.c host_stubs.c ../../kernel/src/lib/base/string.c)
-target_include_directories(test_smp_tlb_active_cores PRIVATE ${CMAKE_SOURCE_DIR}/kernel/include ${CMAKE_SOURCE_DIR}/kernel/src ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/core/boot/include ${CMAKE_SOURCE_DIR}/core/lib/include ${CMAKE_BINARY_DIR}/generated/include ${CMAKE_SOURCE_DIR}/core/services/monitor/generated)
+target_include_directories(test_smp_tlb_active_cores PRIVATE ${CMAKE_SOURCE_DIR}/core/kernel/include ${CMAKE_SOURCE_DIR}/core/kernel/src ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/core/boot/include ${CMAKE_SOURCE_DIR}/core/lib/include ${CMAKE_BINARY_DIR}/generated/include ${CMAKE_SOURCE_DIR}/core/services/monitor/generated)
 add_test(NAME host_test_smp_tlb_active_cores COMMAND test_smp_tlb_active_cores)
 
 # Memory host conformance expansion (2026-03-23)
 # HAL contracts + generic PT/TLB contracts
 add_executable(host_test_hal_pt_common ../../tests/mm/pt_common_tests.c ../../hal/hal_pt.c)
-target_include_directories(host_test_hal_pt_common PRIVATE ${CMAKE_SOURCE_DIR}/kernel/include ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/core/boot/include)
+target_include_directories(host_test_hal_pt_common PRIVATE ${CMAKE_SOURCE_DIR}/core/kernel/include ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/core/boot/include)
 add_test(NAME host_test_hal_pt_common COMMAND host_test_hal_pt_common)
 
 add_executable(host_test_hal_pt_fallbacks ../../tests/test_hal_pt_fallbacks.c ../../hal/hal_pt.c)
-target_include_directories(host_test_hal_pt_fallbacks PRIVATE ${CMAKE_SOURCE_DIR}/kernel/include ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/core/boot/include)
+target_include_directories(host_test_hal_pt_fallbacks PRIVATE ${CMAKE_SOURCE_DIR}/core/kernel/include ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/core/boot/include)
 add_test(NAME host_test_hal_pt_fallbacks COMMAND host_test_hal_pt_fallbacks)
 
 add_executable(host_test_hal_caps_consistency ../../tests/test_hal_caps_consistency.c ../../hal/hal_pt.c)
-target_include_directories(host_test_hal_caps_consistency PRIVATE ${CMAKE_SOURCE_DIR}/kernel/include ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/core/boot/include)
+target_include_directories(host_test_hal_caps_consistency PRIVATE ${CMAKE_SOURCE_DIR}/core/kernel/include ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/core/boot/include)
 add_test(NAME host_test_hal_caps_consistency COMMAND host_test_hal_caps_consistency)
 
 add_executable(host_test_mon_vm test_mon_vm.c host_stubs.c ../../kernel/src/monitor/mon_vm_dispatch.c ../../kernel/src/monitor/mon_vm_service.c ../../kernel/src/monitor/mon_vm_state.c)
-target_include_directories(host_test_mon_vm PRIVATE ${CMAKE_SOURCE_DIR}/kernel/include ${CMAKE_SOURCE_DIR}/kernel/src ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/core/lib/include)
+target_include_directories(host_test_mon_vm PRIVATE ${CMAKE_SOURCE_DIR}/core/kernel/include ${CMAKE_SOURCE_DIR}/core/kernel/src ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/core/lib/include)
 add_test(NAME host_test_mon_vm COMMAND host_test_mon_vm)
 
 # VMM / ASpace / VM base-object conformance currently remains in top-level tests
 # (`test_vmm_aspace`) due additional prot-domain and arch-cap dependencies.
 
 add_executable(host_test_vmm_fault ../test_vmm_fault.c host_stubs.c ../../kernel/src/mm/vm/fault/fault.c ../../kernel/src/mm/vm/objects/vm_object.c ../../kernel/src/mm/vm/objects/vm_object_refcount.c ../../kernel/src/mm/vm/aspace/vm_space.c ../../kernel/src/mm/vm/aspace/aspace.c ../../kernel/src/mm/pmm/early_alloc.c ../../kernel/src/mm/pmm/pmm.c ../../kernel/src/mm/pmm/pt_pool.c ../../kernel/src/mm/tlb/tlb_shootdown.c ../../kernel/src/capability.c ../../kernel/src/cap/cap_policy.c ../benchmark_stubs.c ../../kernel/src/lib/base/string.c ../../arch/common/memops_scalar.c mock_panic.c)
-target_include_directories(host_test_vmm_fault PRIVATE ${CMAKE_SOURCE_DIR}/kernel/include ${CMAKE_SOURCE_DIR}/kernel/src ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/core/boot/include ${CMAKE_SOURCE_DIR}/core/lib/include ${CMAKE_BINARY_DIR}/generated/include)
+target_include_directories(host_test_vmm_fault PRIVATE ${CMAKE_SOURCE_DIR}/core/kernel/include ${CMAKE_SOURCE_DIR}/core/kernel/src ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/core/boot/include ${CMAKE_SOURCE_DIR}/core/lib/include ${CMAKE_BINARY_DIR}/generated/include)
 target_compile_definitions(host_test_vmm_fault PRIVATE TESTING=1)
 add_test(NAME host_test_vmm_fault COMMAND host_test_vmm_fault)
 
@@ -220,8 +220,8 @@ add_executable(test_hal_cpu_features
     ../../arch/common/cpu_caps_state.c
     ../../hal/common/cpu_features.c)
 target_include_directories(test_hal_cpu_features PRIVATE
-    ${CMAKE_SOURCE_DIR}/kernel/include
-    ${CMAKE_SOURCE_DIR}/hal/include
+    ${CMAKE_SOURCE_DIR}/core/kernel/include
+    ${CMAKE_SOURCE_DIR}/core/hal/include
     ${CMAKE_SOURCE_DIR}/interface/include
     ${CMAKE_SOURCE_DIR}/core/lib/include
     ${CMAKE_SOURCE_DIR})
@@ -252,54 +252,54 @@ add_test(NAME host_test_e2e_service_runtime COMMAND test_e2e_service_runtime)
 
 if(BHARAT_BUILD_HOST_TESTS)
     # I2C Core Host Tests
-    add_executable(test_i2c_registry ${CMAKE_SOURCE_DIR}/tests/host/drivers/test_i2c_registry.c ${CMAKE_SOURCE_DIR}/core/drivers/bus/i2c/i2c_core.c ${CMAKE_SOURCE_DIR}/core/drivers/bus/i2c/i2c_registry.c)
+    add_executable(test_i2c_registry ${CMAKE_SOURCE_DIR}/core/tests/host/drivers/test_i2c_registry.c ${CMAKE_SOURCE_DIR}/core/drivers/bus/i2c/i2c_core.c ${CMAKE_SOURCE_DIR}/core/drivers/bus/i2c/i2c_registry.c)
     target_include_directories(test_i2c_registry PRIVATE ${CMAKE_SOURCE_DIR}/core/drivers/bus/i2c)
     add_test(NAME host_test_i2c_registry COMMAND test_i2c_registry)
 
-    add_executable(test_i2c_transfer_mock ${CMAKE_SOURCE_DIR}/tests/host/drivers/test_i2c_transfer_mock.c ${CMAKE_SOURCE_DIR}/core/drivers/bus/i2c/i2c_core.c ${CMAKE_SOURCE_DIR}/core/drivers/bus/i2c/i2c_registry.c)
+    add_executable(test_i2c_transfer_mock ${CMAKE_SOURCE_DIR}/core/tests/host/drivers/test_i2c_transfer_mock.c ${CMAKE_SOURCE_DIR}/core/drivers/bus/i2c/i2c_core.c ${CMAKE_SOURCE_DIR}/core/drivers/bus/i2c/i2c_registry.c)
     target_include_directories(test_i2c_transfer_mock PRIVATE ${CMAKE_SOURCE_DIR}/core/drivers/bus/i2c)
     add_test(NAME host_test_i2c_transfer_mock COMMAND test_i2c_transfer_mock)
 
     # SPI Core Host Tests
-    add_executable(test_spi_registry ${CMAKE_SOURCE_DIR}/tests/host/drivers/test_spi_registry.c ${CMAKE_SOURCE_DIR}/core/drivers/bus/spi/spi_core.c ${CMAKE_SOURCE_DIR}/core/drivers/bus/spi/spi_registry.c)
+    add_executable(test_spi_registry ${CMAKE_SOURCE_DIR}/core/tests/host/drivers/test_spi_registry.c ${CMAKE_SOURCE_DIR}/core/drivers/bus/spi/spi_core.c ${CMAKE_SOURCE_DIR}/core/drivers/bus/spi/spi_registry.c)
     target_include_directories(test_spi_registry PRIVATE ${CMAKE_SOURCE_DIR}/core/drivers/bus/spi)
     add_test(NAME host_test_spi_registry COMMAND test_spi_registry)
 
-    add_executable(test_spi_transfer_mock ${CMAKE_SOURCE_DIR}/tests/host/drivers/test_spi_transfer_mock.c ${CMAKE_SOURCE_DIR}/core/drivers/bus/spi/spi_core.c ${CMAKE_SOURCE_DIR}/core/drivers/bus/spi/spi_registry.c)
+    add_executable(test_spi_transfer_mock ${CMAKE_SOURCE_DIR}/core/tests/host/drivers/test_spi_transfer_mock.c ${CMAKE_SOURCE_DIR}/core/drivers/bus/spi/spi_core.c ${CMAKE_SOURCE_DIR}/core/drivers/bus/spi/spi_registry.c)
     target_include_directories(test_spi_transfer_mock PRIVATE ${CMAKE_SOURCE_DIR}/core/drivers/bus/spi)
     add_test(NAME host_test_spi_transfer_mock COMMAND test_spi_transfer_mock)
 
     # DRM Core Host Tests
-    add_executable(test_drm_registry ${CMAKE_SOURCE_DIR}/tests/host/drivers/test_drm_registry.c ${CMAKE_SOURCE_DIR}/core/drivers/display/drm/drm_core.c ${CMAKE_SOURCE_DIR}/core/drivers/display/drm/drm_registry.c)
+    add_executable(test_drm_registry ${CMAKE_SOURCE_DIR}/core/tests/host/drivers/test_drm_registry.c ${CMAKE_SOURCE_DIR}/core/drivers/display/drm/drm_core.c ${CMAKE_SOURCE_DIR}/core/drivers/display/drm/drm_registry.c)
     target_include_directories(test_drm_registry PRIVATE ${CMAKE_SOURCE_DIR}/core/drivers/display/drm)
     add_test(NAME host_test_drm_registry COMMAND test_drm_registry)
 
-    add_executable(test_drm_mode_validation ${CMAKE_SOURCE_DIR}/tests/host/drivers/test_drm_mode_validation.c ${CMAKE_SOURCE_DIR}/core/drivers/display/drm/drm_core.c ${CMAKE_SOURCE_DIR}/core/drivers/display/drm/drm_registry.c)
+    add_executable(test_drm_mode_validation ${CMAKE_SOURCE_DIR}/core/tests/host/drivers/test_drm_mode_validation.c ${CMAKE_SOURCE_DIR}/core/drivers/display/drm/drm_core.c ${CMAKE_SOURCE_DIR}/core/drivers/display/drm/drm_registry.c)
     target_include_directories(test_drm_mode_validation PRIVATE ${CMAKE_SOURCE_DIR}/core/drivers/display/drm)
     add_test(NAME host_test_drm_mode_validation COMMAND test_drm_mode_validation)
 
     # NVMe Core Host Tests
-    add_executable(test_nvme_init_mock ${CMAKE_SOURCE_DIR}/tests/host/drivers/test_nvme_init_mock.c ${CMAKE_SOURCE_DIR}/core/drivers/storage/nvme/nvme_core.c ${CMAKE_SOURCE_DIR}/core/drivers/storage/nvme/nvme_admin.c ${CMAKE_SOURCE_DIR}/core/drivers/storage/nvme/nvme_queue.c)
+    add_executable(test_nvme_init_mock ${CMAKE_SOURCE_DIR}/core/tests/host/drivers/test_nvme_init_mock.c ${CMAKE_SOURCE_DIR}/core/drivers/storage/nvme/nvme_core.c ${CMAKE_SOURCE_DIR}/core/drivers/storage/nvme/nvme_admin.c ${CMAKE_SOURCE_DIR}/core/drivers/storage/nvme/nvme_queue.c)
     target_include_directories(test_nvme_init_mock PRIVATE ${CMAKE_SOURCE_DIR}/core/drivers/storage/nvme)
     add_test(NAME host_test_nvme_init_mock COMMAND test_nvme_init_mock)
 
     # I2C HID Host Tests
-    add_executable(test_i2c_hid_probe ${CMAKE_SOURCE_DIR}/tests/host/drivers/test_i2c_hid_probe.c ${CMAKE_SOURCE_DIR}/core/drivers/input/i2c_hid/i2c_hid.c ${CMAKE_SOURCE_DIR}/core/drivers/bus/i2c/i2c_core.c ${CMAKE_SOURCE_DIR}/core/drivers/bus/i2c/i2c_registry.c)
+    add_executable(test_i2c_hid_probe ${CMAKE_SOURCE_DIR}/core/tests/host/drivers/test_i2c_hid_probe.c ${CMAKE_SOURCE_DIR}/core/drivers/input/i2c_hid/i2c_hid.c ${CMAKE_SOURCE_DIR}/core/drivers/bus/i2c/i2c_core.c ${CMAKE_SOURCE_DIR}/core/drivers/bus/i2c/i2c_registry.c)
     target_include_directories(test_i2c_hid_probe PRIVATE ${CMAKE_SOURCE_DIR}/core/drivers/input/i2c_hid ${CMAKE_SOURCE_DIR}/core/drivers/bus/i2c)
     add_test(NAME host_test_i2c_hid_probe COMMAND test_i2c_hid_probe)
 
-    add_executable(test_i2c_hid_failures ${CMAKE_SOURCE_DIR}/tests/host/drivers/test_i2c_hid_failures.c ${CMAKE_SOURCE_DIR}/core/drivers/input/i2c_hid/i2c_hid.c ${CMAKE_SOURCE_DIR}/core/drivers/bus/i2c/i2c_core.c ${CMAKE_SOURCE_DIR}/core/drivers/bus/i2c/i2c_registry.c)
+    add_executable(test_i2c_hid_failures ${CMAKE_SOURCE_DIR}/core/tests/host/drivers/test_i2c_hid_failures.c ${CMAKE_SOURCE_DIR}/core/drivers/input/i2c_hid/i2c_hid.c ${CMAKE_SOURCE_DIR}/core/drivers/bus/i2c/i2c_core.c ${CMAKE_SOURCE_DIR}/core/drivers/bus/i2c/i2c_registry.c)
     target_include_directories(test_i2c_hid_failures PRIVATE ${CMAKE_SOURCE_DIR}/core/drivers/input/i2c_hid ${CMAKE_SOURCE_DIR}/core/drivers/bus/i2c)
     add_test(NAME host_test_i2c_hid_failures COMMAND test_i2c_hid_failures)
 
     # VirtIO Input Host Tests
-    add_executable(test_virtio_input ${CMAKE_SOURCE_DIR}/tests/host/drivers/test_virtio_input.c ${CMAKE_SOURCE_DIR}/core/drivers/input/virtio_input/virtio_input.c)
+    add_executable(test_virtio_input ${CMAKE_SOURCE_DIR}/core/tests/host/drivers/test_virtio_input.c ${CMAKE_SOURCE_DIR}/core/drivers/input/virtio_input/virtio_input.c)
     target_include_directories(test_virtio_input PRIVATE ${CMAKE_SOURCE_DIR}/core/drivers/input/virtio_input ${CMAKE_SOURCE_DIR}/core/drivers/input/include ${CMAKE_SOURCE_DIR}/interface/uapi)
     add_test(NAME host_test_virtio_input COMMAND test_virtio_input)
 
     # Memory Model AI-adjacent Primitives Host Test
     add_executable(test_mem_model_ai test_mem_model_ai.c ../../kernel/src/mm/mem_class.c)
-    target_include_directories(test_mem_model_ai PRIVATE ${CMAKE_SOURCE_DIR}/kernel/include ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/core/lib/include)
+    target_include_directories(test_mem_model_ai PRIVATE ${CMAKE_SOURCE_DIR}/core/kernel/include ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/core/lib/include)
     add_test(NAME host_test_mem_model_ai COMMAND test_mem_model_ai)
 endif()
 add_executable(test_fdt_parser test_fdt_parser.c ../../hal/common/fdt_parser.c)


### PR DESCRIPTION
### Motivation

- Consolidate repository layout and include paths under the `core/` prefix and enforce the new layer boundaries in CMake. 
- Add capability-based authorization for service IPC handlers to enforce access control for `servicemgr`, `vm_manager`, and `process_manager`.
- Provide unit tests that exercise negative capability validation scenarios and wire them into the host/test CMake build.

### Description

- Updated top-level and many `CMakeLists.txt` files to point include and source roots to `core/*` (e.g. `kernel/include` -> `core/kernel/include`, `lib/packet/include` -> `core/lib/packet/include`, `services/include` -> `core/services/include`, etc.) and adjusted candidate roots (`user` -> `core/user`, `tests` -> `core/tests`).
- Reworked several target include directories and library references across drivers, kernel, lib, services, stacks and quality tests to match the new `core/` layout.
- Replaced a couple of relative includes with canonical angle-bracket includes (example: `virt_accel.c` now includes `<bharat/accel/accel.h>` and `<kernel/status.h>`).
- Implemented capability authorization helpers and integrated them into the request dispatch paths for `process_manager` (`process_manager_authorize`), `servicemgr` (`servicemgr_authorize`) and `vm_manager` (`vm_manager_authorize`), and exposed their prototypes in headers.
- Added unit tests exercising negative capability/validation cases: `test_process_manager_caps.c`, `test_servicemgr_caps.c`, and `test_vm_manager_caps.c`, and added CMake wiring to build and run these tests (with cross-compilation guards to skip building them when cross-compiling).

### Testing

- No automated test runs were performed as part of this change; instead new unit tests were added and integrated into the CMake test targets: `test_process_manager_caps`, `test_servicemgr_caps`, and `test_vm_manager_caps`.
- CMake updates were applied across the tree so configuring the project will now reference the `core/*` paths and the new test targets; these tests are available to run via `ctest` once the project is configured and built for the host.
- Existing host test CMake targets in `quality/tests` were updated to reference `core/` paths to remain buildable under the new layout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebbf057ac08320bc4176255528341b)