### PR TITLE
Add scoped CPU feature helpers and use system_all for global gating

### DIFF
--- a/core/arch/common/cpu_caps_state.c
+++ b/core/arch/common/cpu_caps_state.c
@@ -91,14 +91,31 @@ const arch_cpu_caps_record_t *arch_cpu_caps_system_any(void) {
 }
 
 bool arch_cpu_has(int feat) {
+    return arch_cpu_has_system_all(feat);
+}
+
+bool arch_cpu_has_system_all(int feat) {
     return arch_cpu_caps_test(&g_system_caps_all.usable, feat);
 }
 
 bool arch_cpu_has_on(size_t cpu_index, int feat) {
+    return arch_cpu_has_cpu(cpu_index, feat);
+}
+
+bool arch_cpu_has_cpu(size_t cpu_index, int feat) {
     if (cpu_index < MAX_CPUS) {
         return arch_cpu_caps_test(&g_per_cpu_caps[cpu_index].usable, feat);
     }
     return false;
+}
+
+bool arch_cpu_has_system_any(int feat) {
+    return arch_cpu_caps_test(&g_system_caps_any.usable, feat);
+}
+
+bool arch_cpu_has_current(int feat) {
+    unsigned int cpu_id = hal_cpu_get_id();
+    return arch_cpu_has_cpu(cpu_id, feat);
 }
 
 void cpu_caps_state_set_boot(const arch_cpu_caps_record_t *caps) {

--- a/core/hal/common/cpu_features.c
+++ b/core/hal/common/cpu_features.c
@@ -1,6 +1,7 @@
 #include "hal/hal_cpu_features.h"
 
 #include "arch/arch_cpu_caps.h"
+#include "hal/hal.h"
 #include <string.h>
 
 static inline void feature_set_bit(uint64_t *bits, hal_cpu_feature_t feature, bool enabled) {
@@ -103,8 +104,29 @@ bool hal_cpu_has_feature(size_t cpu_id, hal_cpu_feature_t feature) {
 }
 
 bool hal_cpu_has_system_feature(hal_cpu_feature_t feature, hal_cpu_feature_scope_t scope) {
+    if (scope == HAL_CPU_FEATURE_SCOPE_ANY) {
+        return hal_cpu_has_system_feature_any(feature);
+    }
+    return hal_cpu_has_system_feature_all(feature);
+}
+
+bool hal_cpu_has_feature_current(hal_cpu_feature_t feature) {
+    return hal_cpu_has_feature((size_t)hal_cpu_get_id(), feature);
+}
+
+bool hal_cpu_has_system_feature_all(hal_cpu_feature_t feature) {
     hal_cpu_feature_set_t set;
-    if (!hal_cpu_feature_set_system(scope, &set) || feature >= HAL_CPU_FEATURE__COUNT) {
+    if (!hal_cpu_feature_set_system(HAL_CPU_FEATURE_SCOPE_ALL, &set) ||
+        feature >= HAL_CPU_FEATURE__COUNT) {
+        return false;
+    }
+    return (set.usable_bits[(size_t)feature / 64u] & (1ULL << ((size_t)feature % 64u))) != 0;
+}
+
+bool hal_cpu_has_system_feature_any(hal_cpu_feature_t feature) {
+    hal_cpu_feature_set_t set;
+    if (!hal_cpu_feature_set_system(HAL_CPU_FEATURE_SCOPE_ANY, &set) ||
+        feature >= HAL_CPU_FEATURE__COUNT) {
         return false;
     }
     return (set.usable_bits[(size_t)feature / 64u] & (1ULL << ((size_t)feature % 64u))) != 0;

--- a/core/hal/include/hal/hal_cpu_features.h
+++ b/core/hal/include/hal/hal_cpu_features.h
@@ -35,3 +35,8 @@ bool hal_cpu_has_feature(size_t cpu_id, hal_cpu_feature_t feature);
 bool hal_cpu_has_system_feature(hal_cpu_feature_t feature, hal_cpu_feature_scope_t scope);
 bool hal_cpu_feature_set_for_cpu(size_t cpu_id, hal_cpu_feature_set_t *out);
 bool hal_cpu_feature_set_system(hal_cpu_feature_scope_t scope, hal_cpu_feature_set_t *out);
+
+/* Explicit scope helpers for callsites that want readability and safety-by-default. */
+bool hal_cpu_has_feature_current(hal_cpu_feature_t feature);
+bool hal_cpu_has_system_feature_all(hal_cpu_feature_t feature);
+bool hal_cpu_has_system_feature_any(hal_cpu_feature_t feature);

--- a/core/hal/x86_64/hal_pt_x86_64.c
+++ b/core/hal/x86_64/hal_pt_x86_64.c
@@ -648,7 +648,7 @@ hal_tlb_ops_t x86_hal_tlb_ops = {
 };
 
 void x86_pt_caps_init(void) {
-    g_x86_pcid_supported = arch_cpu_has(ARCH_CPU_FEAT_X86_PCID);
+    g_x86_pcid_supported = arch_cpu_has_system_all(ARCH_CPU_FEAT_X86_PCID);
     if (g_x86_pcid_supported) {
         x86_pt_caps.supports_pcid = true;
         x86_tlb_caps.supports_asid_selective_flush = true;

--- a/core/kernel/include/arch/arch_cpu_caps.h
+++ b/core/kernel/include/arch/arch_cpu_caps.h
@@ -64,9 +64,16 @@ const arch_cpu_caps_record_t *arch_cpu_caps_for_cpu(size_t cpu_index);
 const arch_cpu_caps_record_t *arch_cpu_caps_system_all(void);
 const arch_cpu_caps_record_t *arch_cpu_caps_system_any(void);
 
-// Helper to query the usable bitset of system_all
+// Scoped helpers for usable feature checks.
+bool arch_cpu_has_system_all(int feat);
+bool arch_cpu_has_system_any(int feat);
+bool arch_cpu_has_current(int feat);
+bool arch_cpu_has_cpu(size_t cpu_index, int feat);
+
+// Legacy helper names (kept for compatibility).
+// arch_cpu_has() == arch_cpu_has_system_all()
 bool arch_cpu_has(int feat);
-// Helper to query the usable bitset of a specific CPU
+// arch_cpu_has_on() == arch_cpu_has_cpu()
 bool arch_cpu_has_on(size_t cpu_index, int feat);
 // Helper to query a specific bitset
 bool arch_cpu_caps_test(const arch_cpu_caps_t *caps, int feat);

--- a/core/kernel/include/arch/capabilities.h
+++ b/core/kernel/include/arch/capabilities.h
@@ -9,7 +9,7 @@ static inline void arch_capabilities_init(void) {
 
 static inline int arch_has_feature_avx2(void) {
 #if defined(__x86_64__)
-    return arch_cpu_has(ARCH_CPU_FEAT_X86_AVX2);
+    return arch_cpu_has_system_all(ARCH_CPU_FEAT_X86_AVX2);
 #else
     return 0;
 #endif
@@ -17,24 +17,24 @@ static inline int arch_has_feature_avx2(void) {
 
 static inline int arch_has_feature_fma(void) {
 #if defined(__x86_64__)
-    return arch_cpu_has(ARCH_CPU_FEAT_X86_FMA);
+    return arch_cpu_has_system_all(ARCH_CPU_FEAT_X86_FMA);
 #else
     return 0;
 #endif
 }
 
 static inline int arch_has_feature_aes(void) {
-    return arch_cpu_has(ARCH_CPU_FEAT_COMMON_AES);
+    return arch_cpu_has_system_all(ARCH_CPU_FEAT_COMMON_AES);
 }
 
 static inline int arch_has_feature_vector(void) {
-    return arch_cpu_has(ARCH_CPU_FEAT_COMMON_VECTOR);
+    return arch_cpu_has_system_all(ARCH_CPU_FEAT_COMMON_VECTOR);
 }
 
 static inline int arch_has_feature_crypto(void) {
-    return arch_cpu_has(ARCH_CPU_FEAT_COMMON_AES) ||
-           arch_cpu_has(ARCH_CPU_FEAT_COMMON_SHA) ||
-           arch_cpu_has(ARCH_CPU_FEAT_COMMON_PMULL);
+    return arch_cpu_has_system_all(ARCH_CPU_FEAT_COMMON_AES) ||
+           arch_cpu_has_system_all(ARCH_CPU_FEAT_COMMON_SHA) ||
+           arch_cpu_has_system_all(ARCH_CPU_FEAT_COMMON_PMULL);
 }
 
 #endif /* BHARAT_ARCH_CAPABILITIES_H */

--- a/docs/reviews/gap_analysis/runtime_isa_extension_production_tasklist.md
+++ b/docs/reviews/gap_analysis/runtime_isa_extension_production_tasklist.md
@@ -1,0 +1,259 @@
+# Runtime ISA Extension Strategy → Production Tasklist
+
+**Date:** 2026-04-25  
+**Reviewed doc:** `docs/reviews/gap_analysis/runtime_isa_extension_strategy.md`  
+**Focus requested:** low-level ISA implementation work in `core/arch/*` and HAL abstraction in `core/hal/*`.
+
+---
+
+## 1) What changed since the original gap analysis
+
+The referenced strategy doc assumes CPU capability probes are still stubs. In the current tree, runtime CPU-capability plumbing exists and is partially implemented:
+
+- Shared capability model and query API are present in `core/kernel/include/arch/arch_cpu_caps.h`.
+- Per-arch probe implementations exist in:
+  - `core/arch/x86/x86_64/cpu_caps.c`
+  - `core/arch/arm/arm64/cpu_caps.c`
+  - `core/arch/riscv/riscv64/cpu_caps.c`
+- HAL-level mapping/publication is already wired in:
+  - `core/hal/common/cpu_features.c`
+  - `core/hal/common/discovery.c`
+
+So the production gap is no longer “build API from zero”; it is now **hardening, correctness gating, heterogeneous CPU handling, and accelerated path dispatch integration**.
+
+---
+
+## 2) Production-grade implementation tasks
+
+## 2.1 Cross-architecture tasks (must do first)
+
+### A. Capability source-of-truth and dependency validation
+
+**Goal:** make `raw` vs `usable` semantics strict and auditable.
+
+**Code work**
+- Add explicit dependency helpers in arch layer (e.g., feature implies feature) and enforce before setting `usable` bits.
+- Add policy hook(s) so security/perf policy can disable usable bits without changing raw probes.
+
+**Primary files**
+- `core/kernel/include/arch/arch_cpu_caps.h`
+- `core/arch/common/cpu_caps_state.c`
+- `core/hal/common/cpu_features.c`
+
+### B. Per-CPU heterogeneity correctness
+
+**Goal:** prevent unsupported instructions on mixed-feature systems.
+
+**Code work**
+- Ensure all optimized kernel paths check either:
+  - `system_all` (safe globally), or
+  - current-CPU bit when execution is strictly CPU-local and non-migrating.
+- Add API helper names in arch/HAL to make scope explicit (`_system_all`, `_system_any`, `_current_cpu`).
+
+**Primary files**
+- `core/kernel/include/arch/arch_cpu_caps.h`
+- `core/hal/include/hal/hal_cpu_features.h`
+- callsites in memops/crypto/atomic dispatch modules.
+
+### C. Common fast-path dispatch table
+
+**Goal:** centralized dispatch so all hot paths use one gating strategy.
+
+**Code work**
+- Introduce `core/arch/common/fastops_dispatch.c` + header.
+- Dispatch targets:
+  - `memcpy`/`memset`/page-clear
+  - crypto primitive selector
+  - atomics/lock primitive selector
+- Tie dispatch decision to `arch_cpu_caps_system_all()` by default.
+
+**Primary files**
+- `core/arch/common/fastops_dispatch.c` (new)
+- `core/arch/common/memops_scalar.c`
+- `core/kernel/include/arch/memops.h`
+- `core/lib/runtime/crypto/crypto_dispatch.c`
+
+### D. Telemetry and verification hooks
+
+**Goal:** prove acceleration is a net win and safe.
+
+**Code work**
+- Per-path counters (selected/fallback/hit-rate) exported via HAL discovery or debug endpoint.
+- A/B boot knobs to force-disable each acceleration family.
+
+**Primary files**
+- `core/hal/common/discovery.c`
+- arch-specific boot/options parsing paths
+- runtime debug/service exposure module (existing telemetry surface).
+
+---
+
+## 2.2 x86_64 tasks (`core/arch/x86/x86_64` + `core/hal/x86_64`)
+
+### A. Correct CPUID leaf usage and gating fixes
+
+**Code work**
+- Fix PCID bit detection location (currently read from CPUID leaf 7 ECX; should be leaf 1 ECX).
+- Add/verify XSAVE+XCR0 gating for every vector-level path actually emitted.
+- Split “detected” vs “enabled by kernel context policy” for AVX/AVX2 (and future AVX-512).
+
+**Primary files**
+- `core/arch/x86/x86_64/cpu_caps.c`
+- `core/arch/x86/x86_64/ext_state.c`
+- `core/arch/x86/x86_64/context_switch.S`
+
+### B. TLB/context acceleration integration
+
+**Code work**
+- Wire `PCID`/`INVPCID` to set `ARCH_CPU_FEAT_COMMON_FAST_TLB_CTX` when full prerequisites hold.
+- Use this in x86 HAL page-table/TLB shootdown paths.
+
+**Primary files**
+- `core/arch/x86/x86_64/cpu_caps.c`
+- `core/hal/x86_64/hal_pt_x86_64.c`
+- `core/hal/x86_64/apic.c` (if shootdown policy ties here)
+
+### C. First production fast paths
+
+**Code work**
+- Keep `rep movsb/stosb` baseline fast-string path.
+- Add AES/PCLMUL-backed crypto helper integration where runtime-gated.
+
+**Primary files**
+- `core/arch/x86/x86_64/memops_fast_string.c`
+- `core/hal/x86_64/hash/hash_x86_64.c`
+- `core/lib/runtime/crypto/crypto_dispatch.c`
+
+---
+
+## 2.3 arm64 tasks (`core/arch/arm/arm64` + `core/hal/arm64`)
+
+### A. Feature decoding completeness
+
+**Code work**
+- Expand decode coverage for SHA2/SHA3 variants and expose explicit bits.
+- Add strict EL/firmware/policy checks before promoting raw→usable for sensitive features.
+
+**Primary files**
+- `core/arch/arm/arm64/cpu_caps.c`
+- `core/kernel/include/arch/arch_cpu_caps.h` and arm64 feature defs
+
+### B. LSE and atomic fast-path routing
+
+**Code work**
+- Route lock/atomic internals through LSE-optimized path when `ARCH_CPU_FEAT_ARM64_LSE` usable.
+- Keep LL/SC fallback mandatory.
+
+**Primary files**
+- `core/arch/arm/arm64/cpu_caps.c`
+- arm64 lock/atomic implementation files (where atomics are defined)
+- `core/hal/common/cpu_features.c`
+
+### C. SVE/SVE2 production-readiness track
+
+**Code work**
+- Keep SVE/SVE2 as raw-only until full context-switch support is verified.
+- When enabling usable bits, ensure save/restore logic and preemption model are complete.
+
+**Primary files**
+- `core/arch/arm/arm64/ext_state.c`
+- `core/arch/arm/arm64/context_switch.S`
+- `core/arch/arm/arm64/cpu_caps.c`
+
+---
+
+## 2.4 riscv64 tasks (`core/arch/riscv/riscv64` + `core/hal/riscv64`)
+
+### A. Replace compile-time-only extension model
+
+**Code work**
+- Move from compile-time `BHARAT_ISA_FEATURE_*` flags to runtime extension discovery via DT/SBI/HWCAP source.
+- Preserve compile-time flags only as fallback/developer override.
+
+**Primary files**
+- `core/arch/riscv/riscv64/cpu_caps.c`
+- `core/hal/riscv64/discovery.c`
+- `core/hal/riscv64/boot_sbi.c`
+- `core/hal/riscv64/topology_fdt.c`
+
+### B. Minimal stable extension set enablement
+
+**Code work**
+- Production-enable Zba/Zbb/Zbc/Zbs feature use in bit operations.
+- Add zicbo* handling in DMA/cache maintenance where platform says safe.
+
+**Primary files**
+- `core/arch/riscv/riscv64/cpu_caps.c`
+- `core/hal/riscv64/dma.c`
+- bitmap/scheduler/capability utility modules that can exploit bitmanip.
+
+### C. RVV readiness gates
+
+**Code work**
+- Keep RVV raw-only until vector context and VLEN-agnostic routines are validated.
+- Add per-platform opt-in knob before setting usable RVV bits.
+
+**Primary files**
+- `core/arch/riscv/riscv64/ext_state.c`
+- `core/arch/riscv/riscv64/context_switch.S`
+- `core/arch/riscv/riscv64/cpu_caps.c`
+
+---
+
+## 2.5 HAL abstraction tasks (`core/hal`)
+
+### A. Unify ISA capability surface for subsystems
+
+**Code work**
+- Decide one canonical HAL API (`hal_cpu_features` vs `hal_isa_caps`) and remove duplicate/parallel reporting.
+- Keep raw/usable + system_all/system_any semantics visible to subsystems.
+
+**Primary files**
+- `core/hal/include/hal/hal_cpu_features.h`
+- `core/hal/include/hal/hal_isa_caps.h`
+- `core/hal/common/cpu_features.c`
+- `core/hal/common/discovery.c`
+
+### B. HAL-level dispatch helpers for safe usage
+
+**Code work**
+- Add HAL helper wrappers for common checks used by runtime code paths:
+  - `hal_accel_can_use_vector_global()`
+  - `hal_accel_can_use_crypto_global()`
+  - `hal_accel_has_bitmanip_any_cpu()` etc.
+
+**Primary files**
+- `core/hal/include/hal/*.h`
+- `core/hal/common/*.c`
+
+### C. Test/CI matrix integration
+
+**Code work**
+- Add QEMU/CI modes that explicitly force capability on/off combinations.
+- Verify dispatch and fallback behavior per mode.
+
+**Primary files**
+- build/test scripts in repo root
+- architecture-specific run/test scripts and HAL discovery assertions.
+
+---
+
+## 3) Recommended execution order (production roadmap)
+
+1. **Correctness hardening** (dependency checks, heterogeneity-safe APIs, CPUID/ID register fixes).  
+2. **Dispatch layer** (single fastops dispatch + mandatory fallbacks).  
+3. **Low-risk acceleration** (x86 AES/PCLMUL, arm64 LSE+crypto, riscv bitmanip).  
+4. **CI coverage** (feature present/absent permutations).  
+5. **Advanced vectors** (AVX-class/SVE/RVV only after context-state readiness).  
+
+---
+
+## 4) Definition of done for “production-grade ISA leverage”
+
+A feature is production-ready only when all are true:
+
+- Runtime detection is accurate on real hardware/VM and represented in per-CPU + system aggregates.
+- `usable` bit is gated by OS context-management + security/perf policy.
+- Hot path uses centralized dispatch with guaranteed scalar fallback.
+- CI verifies both accelerated and fallback execution paths.
+- Telemetry proves no regression under mixed/unsupported systems.


### PR DESCRIPTION
### Motivation

- Introduce explicit, scoped helpers to make CPU feature queries unambiguous between per-CPU, current-CPU, and system-wide semantics to reduce accidental use of the wrong scope in hot paths. 
- Harden HAL/arch integration by providing readability-safe helper functions and switching global acceleration checks to use the `system_all` semantics by default. 

### Description

- Added scoped arch helpers `arch_cpu_has_system_all`, `arch_cpu_has_system_any`, `arch_cpu_has_current`, and `arch_cpu_has_cpu` and kept legacy wrappers `arch_cpu_has`/`arch_cpu_has_on` for compatibility, and updated `arch_cpu_caps_state.c` to implement them. 
- Extended HAL surface with `hal_cpu_has_feature_current`, `hal_cpu_has_system_feature_all`, and `hal_cpu_has_system_feature_any` and updated `core/hal/common/cpu_features.c` to route `hal_cpu_has_system_feature` to the explicit all/any helpers and to provide a `hal_cpu_has_feature_current` helper. 
- Replaced several callsites to use the new `system_all`-scoped checks (e.g., `x86_pt_caps_init`, `arch_capabilities` helpers) so global acceleration gating is based on `system_all`. 
- Added missing include (`hal/hal.h`) in `cpu_features.c` and added the new production tasklist doc `docs/reviews/gap_analysis/runtime_isa_extension_production_tasklist.md` describing next steps for runtime ISA extension hardening and rollout. 

### Testing

- Performed a full kernel build on x86_64 which completed successfully. 
- Ran HAL/feature unit tests and the `hal_cpu_feature_set` related tests which passed. 
- Executed platform smoke tests for x86_64 TLB/pt-paths that exercise `x86_pt_caps_init` and those tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec2a1985948320968cec6c262bf7e0)