### PR TITLE
Refactor: move arch-specific accelerator capability mapping into arch layer

### DIFF
--- a/core/arch/common/accel_caps_publish.c
+++ b/core/arch/common/accel_caps_publish.c
@@ -1,0 +1,122 @@
+#include "arch/common/accel_caps_publish.h"
+
+#include <stdint.h>
+
+static inline void accel_set_mask(uint64_t *mask, hal_accel_feature_t feat,
+                                  const arch_cpu_caps_t *caps, int arch_feat) {
+    if (feat >= HAL_ACCEL_FEAT__COUNT) {
+        return;
+    }
+    if (arch_cpu_caps_test(caps, arch_feat)) {
+        *mask |= (1ULL << (uint32_t)feat);
+    }
+}
+
+void arch_accel_caps_publish_target(accel_discovery_t *accel,
+                                    const arch_cpu_caps_record_t *caps_all,
+                                    const arch_cpu_caps_record_t *caps_any) {
+    if (!accel || !caps_all || !caps_any) {
+        return;
+    }
+
+#if defined(__x86_64__)
+    accel_set_mask(&accel->raw_all_mask, HAL_ACCEL_FEAT_X86_AVX,
+                   &caps_all->raw, ARCH_CPU_FEAT_X86_AVX);
+    accel_set_mask(&accel->raw_any_mask, HAL_ACCEL_FEAT_X86_AVX,
+                   &caps_any->raw, ARCH_CPU_FEAT_X86_AVX);
+    accel_set_mask(&accel->usable_all_mask, HAL_ACCEL_FEAT_X86_AVX,
+                   &caps_all->usable, ARCH_CPU_FEAT_X86_AVX);
+    accel_set_mask(&accel->usable_any_mask, HAL_ACCEL_FEAT_X86_AVX,
+                   &caps_any->usable, ARCH_CPU_FEAT_X86_AVX);
+
+    accel_set_mask(&accel->raw_all_mask, HAL_ACCEL_FEAT_X86_AVX2,
+                   &caps_all->raw, ARCH_CPU_FEAT_X86_AVX2);
+    accel_set_mask(&accel->raw_any_mask, HAL_ACCEL_FEAT_X86_AVX2,
+                   &caps_any->raw, ARCH_CPU_FEAT_X86_AVX2);
+    accel_set_mask(&accel->usable_all_mask, HAL_ACCEL_FEAT_X86_AVX2,
+                   &caps_all->usable, ARCH_CPU_FEAT_X86_AVX2);
+    accel_set_mask(&accel->usable_any_mask, HAL_ACCEL_FEAT_X86_AVX2,
+                   &caps_any->usable, ARCH_CPU_FEAT_X86_AVX2);
+
+    accel_set_mask(&accel->raw_all_mask, HAL_ACCEL_FEAT_X86_FMA,
+                   &caps_all->raw, ARCH_CPU_FEAT_X86_FMA);
+    accel_set_mask(&accel->raw_any_mask, HAL_ACCEL_FEAT_X86_FMA,
+                   &caps_any->raw, ARCH_CPU_FEAT_X86_FMA);
+    accel_set_mask(&accel->usable_all_mask, HAL_ACCEL_FEAT_X86_FMA,
+                   &caps_all->usable, ARCH_CPU_FEAT_X86_FMA);
+    accel_set_mask(&accel->usable_any_mask, HAL_ACCEL_FEAT_X86_FMA,
+                   &caps_any->usable, ARCH_CPU_FEAT_X86_FMA);
+
+    accel_set_mask(&accel->raw_all_mask, HAL_ACCEL_FEAT_X86_PCLMUL,
+                   &caps_all->raw, ARCH_CPU_FEAT_X86_PCLMUL);
+    accel_set_mask(&accel->raw_any_mask, HAL_ACCEL_FEAT_X86_PCLMUL,
+                   &caps_any->raw, ARCH_CPU_FEAT_X86_PCLMUL);
+    accel_set_mask(&accel->usable_all_mask, HAL_ACCEL_FEAT_X86_PCLMUL,
+                   &caps_all->usable, ARCH_CPU_FEAT_X86_PCLMUL);
+    accel_set_mask(&accel->usable_any_mask, HAL_ACCEL_FEAT_X86_PCLMUL,
+                   &caps_any->usable, ARCH_CPU_FEAT_X86_PCLMUL);
+#elif defined(__aarch64__)
+    accel_set_mask(&accel->raw_all_mask, HAL_ACCEL_FEAT_ARM64_SVE,
+                   &caps_all->raw, ARCH_CPU_FEAT_ARM64_SVE);
+    accel_set_mask(&accel->raw_any_mask, HAL_ACCEL_FEAT_ARM64_SVE,
+                   &caps_any->raw, ARCH_CPU_FEAT_ARM64_SVE);
+    accel_set_mask(&accel->usable_all_mask, HAL_ACCEL_FEAT_ARM64_SVE,
+                   &caps_all->usable, ARCH_CPU_FEAT_ARM64_SVE);
+    accel_set_mask(&accel->usable_any_mask, HAL_ACCEL_FEAT_ARM64_SVE,
+                   &caps_any->usable, ARCH_CPU_FEAT_ARM64_SVE);
+
+    accel_set_mask(&accel->raw_all_mask, HAL_ACCEL_FEAT_ARM64_SVE2,
+                   &caps_all->raw, ARCH_CPU_FEAT_ARM64_SVE2);
+    accel_set_mask(&accel->raw_any_mask, HAL_ACCEL_FEAT_ARM64_SVE2,
+                   &caps_any->raw, ARCH_CPU_FEAT_ARM64_SVE2);
+    accel_set_mask(&accel->usable_all_mask, HAL_ACCEL_FEAT_ARM64_SVE2,
+                   &caps_all->usable, ARCH_CPU_FEAT_ARM64_SVE2);
+    accel_set_mask(&accel->usable_any_mask, HAL_ACCEL_FEAT_ARM64_SVE2,
+                   &caps_any->usable, ARCH_CPU_FEAT_ARM64_SVE2);
+#elif defined(__riscv)
+    accel_set_mask(&accel->raw_all_mask, HAL_ACCEL_FEAT_RISCV_V,
+                   &caps_all->raw, ARCH_CPU_FEAT_RISCV_V);
+    accel_set_mask(&accel->raw_any_mask, HAL_ACCEL_FEAT_RISCV_V,
+                   &caps_any->raw, ARCH_CPU_FEAT_RISCV_V);
+    accel_set_mask(&accel->usable_all_mask, HAL_ACCEL_FEAT_RISCV_V,
+                   &caps_all->usable, ARCH_CPU_FEAT_RISCV_V);
+    accel_set_mask(&accel->usable_any_mask, HAL_ACCEL_FEAT_RISCV_V,
+                   &caps_any->usable, ARCH_CPU_FEAT_RISCV_V);
+
+    accel_set_mask(&accel->raw_all_mask, HAL_ACCEL_FEAT_RISCV_ZBA,
+                   &caps_all->raw, ARCH_CPU_FEAT_RISCV_ZBA);
+    accel_set_mask(&accel->raw_any_mask, HAL_ACCEL_FEAT_RISCV_ZBA,
+                   &caps_any->raw, ARCH_CPU_FEAT_RISCV_ZBA);
+    accel_set_mask(&accel->usable_all_mask, HAL_ACCEL_FEAT_RISCV_ZBA,
+                   &caps_all->usable, ARCH_CPU_FEAT_RISCV_ZBA);
+    accel_set_mask(&accel->usable_any_mask, HAL_ACCEL_FEAT_RISCV_ZBA,
+                   &caps_any->usable, ARCH_CPU_FEAT_RISCV_ZBA);
+
+    accel_set_mask(&accel->raw_all_mask, HAL_ACCEL_FEAT_RISCV_ZBB,
+                   &caps_all->raw, ARCH_CPU_FEAT_RISCV_ZBB);
+    accel_set_mask(&accel->raw_any_mask, HAL_ACCEL_FEAT_RISCV_ZBB,
+                   &caps_any->raw, ARCH_CPU_FEAT_RISCV_ZBB);
+    accel_set_mask(&accel->usable_all_mask, HAL_ACCEL_FEAT_RISCV_ZBB,
+                   &caps_all->usable, ARCH_CPU_FEAT_RISCV_ZBB);
+    accel_set_mask(&accel->usable_any_mask, HAL_ACCEL_FEAT_RISCV_ZBB,
+                   &caps_any->usable, ARCH_CPU_FEAT_RISCV_ZBB);
+
+    accel_set_mask(&accel->raw_all_mask, HAL_ACCEL_FEAT_RISCV_ZBC,
+                   &caps_all->raw, ARCH_CPU_FEAT_RISCV_ZBC);
+    accel_set_mask(&accel->raw_any_mask, HAL_ACCEL_FEAT_RISCV_ZBC,
+                   &caps_any->raw, ARCH_CPU_FEAT_RISCV_ZBC);
+    accel_set_mask(&accel->usable_all_mask, HAL_ACCEL_FEAT_RISCV_ZBC,
+                   &caps_all->usable, ARCH_CPU_FEAT_RISCV_ZBC);
+    accel_set_mask(&accel->usable_any_mask, HAL_ACCEL_FEAT_RISCV_ZBC,
+                   &caps_any->usable, ARCH_CPU_FEAT_RISCV_ZBC);
+
+    accel_set_mask(&accel->raw_all_mask, HAL_ACCEL_FEAT_RISCV_ZBS,
+                   &caps_all->raw, ARCH_CPU_FEAT_RISCV_ZBS);
+    accel_set_mask(&accel->raw_any_mask, HAL_ACCEL_FEAT_RISCV_ZBS,
+                   &caps_any->raw, ARCH_CPU_FEAT_RISCV_ZBS);
+    accel_set_mask(&accel->usable_all_mask, HAL_ACCEL_FEAT_RISCV_ZBS,
+                   &caps_all->usable, ARCH_CPU_FEAT_RISCV_ZBS);
+    accel_set_mask(&accel->usable_any_mask, HAL_ACCEL_FEAT_RISCV_ZBS,
+                   &caps_any->usable, ARCH_CPU_FEAT_RISCV_ZBS);
+#endif
+}

--- a/core/hal/common/discovery.c
+++ b/core/hal/common/discovery.c
@@ -1,6 +1,7 @@
 #include "hal/hal_discovery.h"
 #include <hal/hal_cpu_topology.h>
 #include "arch/arch_cpu_caps.h"
+#include "arch/common/accel_caps_publish.h"
 #include "boot/boot_info.h"
 #include <stddef.h>
 #include <stdbool.h>
@@ -113,104 +114,5 @@ void hal_discovery_publish_cpu_caps(void) {
     accel_set(&sys->accel.usable_any_mask, HAL_ACCEL_FEAT_STRONG_ATOMICS,
               arch_cpu_caps_test(&caps_any->usable, ARCH_CPU_FEAT_COMMON_STRONG_ATOMICS));
 
-#if defined(__x86_64__)
-    accel_set(&sys->accel.raw_all_mask, HAL_ACCEL_FEAT_X86_AVX,
-              arch_cpu_caps_test(&caps_all->raw, ARCH_CPU_FEAT_X86_AVX));
-    accel_set(&sys->accel.raw_any_mask, HAL_ACCEL_FEAT_X86_AVX,
-              arch_cpu_caps_test(&caps_any->raw, ARCH_CPU_FEAT_X86_AVX));
-    accel_set(&sys->accel.usable_all_mask, HAL_ACCEL_FEAT_X86_AVX,
-              arch_cpu_caps_test(&caps_all->usable, ARCH_CPU_FEAT_X86_AVX));
-    accel_set(&sys->accel.usable_any_mask, HAL_ACCEL_FEAT_X86_AVX,
-              arch_cpu_caps_test(&caps_any->usable, ARCH_CPU_FEAT_X86_AVX));
-
-    accel_set(&sys->accel.raw_all_mask, HAL_ACCEL_FEAT_X86_AVX2,
-              arch_cpu_caps_test(&caps_all->raw, ARCH_CPU_FEAT_X86_AVX2));
-    accel_set(&sys->accel.raw_any_mask, HAL_ACCEL_FEAT_X86_AVX2,
-              arch_cpu_caps_test(&caps_any->raw, ARCH_CPU_FEAT_X86_AVX2));
-    accel_set(&sys->accel.usable_all_mask, HAL_ACCEL_FEAT_X86_AVX2,
-              arch_cpu_caps_test(&caps_all->usable, ARCH_CPU_FEAT_X86_AVX2));
-    accel_set(&sys->accel.usable_any_mask, HAL_ACCEL_FEAT_X86_AVX2,
-              arch_cpu_caps_test(&caps_any->usable, ARCH_CPU_FEAT_X86_AVX2));
-
-    accel_set(&sys->accel.raw_all_mask, HAL_ACCEL_FEAT_X86_FMA,
-              arch_cpu_caps_test(&caps_all->raw, ARCH_CPU_FEAT_X86_FMA));
-    accel_set(&sys->accel.raw_any_mask, HAL_ACCEL_FEAT_X86_FMA,
-              arch_cpu_caps_test(&caps_any->raw, ARCH_CPU_FEAT_X86_FMA));
-    accel_set(&sys->accel.usable_all_mask, HAL_ACCEL_FEAT_X86_FMA,
-              arch_cpu_caps_test(&caps_all->usable, ARCH_CPU_FEAT_X86_FMA));
-    accel_set(&sys->accel.usable_any_mask, HAL_ACCEL_FEAT_X86_FMA,
-              arch_cpu_caps_test(&caps_any->usable, ARCH_CPU_FEAT_X86_FMA));
-
-    accel_set(&sys->accel.raw_all_mask, HAL_ACCEL_FEAT_X86_PCLMUL,
-              arch_cpu_caps_test(&caps_all->raw, ARCH_CPU_FEAT_X86_PCLMUL));
-    accel_set(&sys->accel.raw_any_mask, HAL_ACCEL_FEAT_X86_PCLMUL,
-              arch_cpu_caps_test(&caps_any->raw, ARCH_CPU_FEAT_X86_PCLMUL));
-    accel_set(&sys->accel.usable_all_mask, HAL_ACCEL_FEAT_X86_PCLMUL,
-              arch_cpu_caps_test(&caps_all->usable, ARCH_CPU_FEAT_X86_PCLMUL));
-    accel_set(&sys->accel.usable_any_mask, HAL_ACCEL_FEAT_X86_PCLMUL,
-              arch_cpu_caps_test(&caps_any->usable, ARCH_CPU_FEAT_X86_PCLMUL));
-#elif defined(__aarch64__)
-    accel_set(&sys->accel.raw_all_mask, HAL_ACCEL_FEAT_ARM64_SVE,
-              arch_cpu_caps_test(&caps_all->raw, ARCH_CPU_FEAT_ARM64_SVE));
-    accel_set(&sys->accel.raw_any_mask, HAL_ACCEL_FEAT_ARM64_SVE,
-              arch_cpu_caps_test(&caps_any->raw, ARCH_CPU_FEAT_ARM64_SVE));
-    accel_set(&sys->accel.usable_all_mask, HAL_ACCEL_FEAT_ARM64_SVE,
-              arch_cpu_caps_test(&caps_all->usable, ARCH_CPU_FEAT_ARM64_SVE));
-    accel_set(&sys->accel.usable_any_mask, HAL_ACCEL_FEAT_ARM64_SVE,
-              arch_cpu_caps_test(&caps_any->usable, ARCH_CPU_FEAT_ARM64_SVE));
-
-    accel_set(&sys->accel.raw_all_mask, HAL_ACCEL_FEAT_ARM64_SVE2,
-              arch_cpu_caps_test(&caps_all->raw, ARCH_CPU_FEAT_ARM64_SVE2));
-    accel_set(&sys->accel.raw_any_mask, HAL_ACCEL_FEAT_ARM64_SVE2,
-              arch_cpu_caps_test(&caps_any->raw, ARCH_CPU_FEAT_ARM64_SVE2));
-    accel_set(&sys->accel.usable_all_mask, HAL_ACCEL_FEAT_ARM64_SVE2,
-              arch_cpu_caps_test(&caps_all->usable, ARCH_CPU_FEAT_ARM64_SVE2));
-    accel_set(&sys->accel.usable_any_mask, HAL_ACCEL_FEAT_ARM64_SVE2,
-              arch_cpu_caps_test(&caps_any->usable, ARCH_CPU_FEAT_ARM64_SVE2));
-#elif defined(__riscv)
-    accel_set(&sys->accel.raw_all_mask, HAL_ACCEL_FEAT_RISCV_V,
-              arch_cpu_caps_test(&caps_all->raw, ARCH_CPU_FEAT_RISCV_V));
-    accel_set(&sys->accel.raw_any_mask, HAL_ACCEL_FEAT_RISCV_V,
-              arch_cpu_caps_test(&caps_any->raw, ARCH_CPU_FEAT_RISCV_V));
-    accel_set(&sys->accel.usable_all_mask, HAL_ACCEL_FEAT_RISCV_V,
-              arch_cpu_caps_test(&caps_all->usable, ARCH_CPU_FEAT_RISCV_V));
-    accel_set(&sys->accel.usable_any_mask, HAL_ACCEL_FEAT_RISCV_V,
-              arch_cpu_caps_test(&caps_any->usable, ARCH_CPU_FEAT_RISCV_V));
-
-    accel_set(&sys->accel.raw_all_mask, HAL_ACCEL_FEAT_RISCV_ZBA,
-              arch_cpu_caps_test(&caps_all->raw, ARCH_CPU_FEAT_RISCV_ZBA));
-    accel_set(&sys->accel.raw_any_mask, HAL_ACCEL_FEAT_RISCV_ZBA,
-              arch_cpu_caps_test(&caps_any->raw, ARCH_CPU_FEAT_RISCV_ZBA));
-    accel_set(&sys->accel.usable_all_mask, HAL_ACCEL_FEAT_RISCV_ZBA,
-              arch_cpu_caps_test(&caps_all->usable, ARCH_CPU_FEAT_RISCV_ZBA));
-    accel_set(&sys->accel.usable_any_mask, HAL_ACCEL_FEAT_RISCV_ZBA,
-              arch_cpu_caps_test(&caps_any->usable, ARCH_CPU_FEAT_RISCV_ZBA));
-
-    accel_set(&sys->accel.raw_all_mask, HAL_ACCEL_FEAT_RISCV_ZBB,
-              arch_cpu_caps_test(&caps_all->raw, ARCH_CPU_FEAT_RISCV_ZBB));
-    accel_set(&sys->accel.raw_any_mask, HAL_ACCEL_FEAT_RISCV_ZBB,
-              arch_cpu_caps_test(&caps_any->raw, ARCH_CPU_FEAT_RISCV_ZBB));
-    accel_set(&sys->accel.usable_all_mask, HAL_ACCEL_FEAT_RISCV_ZBB,
-              arch_cpu_caps_test(&caps_all->usable, ARCH_CPU_FEAT_RISCV_ZBB));
-    accel_set(&sys->accel.usable_any_mask, HAL_ACCEL_FEAT_RISCV_ZBB,
-              arch_cpu_caps_test(&caps_any->usable, ARCH_CPU_FEAT_RISCV_ZBB));
-
-    accel_set(&sys->accel.raw_all_mask, HAL_ACCEL_FEAT_RISCV_ZBC,
-              arch_cpu_caps_test(&caps_all->raw, ARCH_CPU_FEAT_RISCV_ZBC));
-    accel_set(&sys->accel.raw_any_mask, HAL_ACCEL_FEAT_RISCV_ZBC,
-              arch_cpu_caps_test(&caps_any->raw, ARCH_CPU_FEAT_RISCV_ZBC));
-    accel_set(&sys->accel.usable_all_mask, HAL_ACCEL_FEAT_RISCV_ZBC,
-              arch_cpu_caps_test(&caps_all->usable, ARCH_CPU_FEAT_RISCV_ZBC));
-    accel_set(&sys->accel.usable_any_mask, HAL_ACCEL_FEAT_RISCV_ZBC,
-              arch_cpu_caps_test(&caps_any->usable, ARCH_CPU_FEAT_RISCV_ZBC));
-
-    accel_set(&sys->accel.raw_all_mask, HAL_ACCEL_FEAT_RISCV_ZBS,
-              arch_cpu_caps_test(&caps_all->raw, ARCH_CPU_FEAT_RISCV_ZBS));
-    accel_set(&sys->accel.raw_any_mask, HAL_ACCEL_FEAT_RISCV_ZBS,
-              arch_cpu_caps_test(&caps_any->raw, ARCH_CPU_FEAT_RISCV_ZBS));
-    accel_set(&sys->accel.usable_all_mask, HAL_ACCEL_FEAT_RISCV_ZBS,
-              arch_cpu_caps_test(&caps_all->usable, ARCH_CPU_FEAT_RISCV_ZBS));
-    accel_set(&sys->accel.usable_any_mask, HAL_ACCEL_FEAT_RISCV_ZBS,
-              arch_cpu_caps_test(&caps_any->usable, ARCH_CPU_FEAT_RISCV_ZBS));
-#endif
+    arch_accel_caps_publish_target(&sys->accel, caps_all, caps_any);
 }

--- a/core/kernel/CMakeLists.txt
+++ b/core/kernel/CMakeLists.txt
@@ -416,6 +416,7 @@ set(KERNEL_SRCS
     ${ARCH_CPU_CAPS_SRC}
     # arch/common source files (fixed string.h dependency)
     ${BHARAT_ARCH_ROOT}/common/cpu_caps_state.c
+    ${BHARAT_ARCH_ROOT}/common/accel_caps_publish.c
     $<$<STREQUAL:${ARCH},x86_64>:${BHARAT_ARCH_ROOT}/x86/x86_64/arch_caps.c>
     $<$<STREQUAL:${ARCH},x86_64>:${BHARAT_ARCH_ROOT}/x86/x86_64/arch_console.c>
     $<$<STREQUAL:${ARCH},arm32>:${BHARAT_ARCH_ROOT}/arm/arm32/arch_console.c>

--- a/core/kernel/include/arch/common/accel_caps_publish.h
+++ b/core/kernel/include/arch/common/accel_caps_publish.h
@@ -1,0 +1,11 @@
+#ifndef BHARAT_ARCH_COMMON_ACCEL_CAPS_PUBLISH_H
+#define BHARAT_ARCH_COMMON_ACCEL_CAPS_PUBLISH_H
+
+#include "arch/arch_cpu_caps.h"
+#include "hal/hal_discovery.h"
+
+void arch_accel_caps_publish_target(accel_discovery_t *accel,
+                                    const arch_cpu_caps_record_t *caps_all,
+                                    const arch_cpu_caps_record_t *caps_any);
+
+#endif // BHARAT_ARCH_COMMON_ACCEL_CAPS_PUBLISH_H


### PR DESCRIPTION
### Motivation
- `core/hal/common/discovery.c` mixed architecture-agnostic HAL discovery logic with ISA-specific accelerator feature mapping, making layering and maintenance harder. 
- The change isolates ISA-specific mapping into the arch layer so HAL keeps only portable discovery/publishing code.

### Description
- Added `core/arch/common/accel_caps_publish.c` implementing `arch_accel_caps_publish_target(...)` to encapsulate ISA-specific accelerator→HAL feature mapping for x86_64/arm64/riscv. 
- Added public declaration header at `core/kernel/include/arch/common/accel_caps_publish.h` so HAL can call the arch helper without embedding preprocessor branches. 
- Updated `core/hal/common/discovery.c` to remove the mid-file ISA branches and delegate architecture-specific accel mapping via `arch_accel_caps_publish_target(...)`. 
- Wired the new arch source into kernel build sources by adding `${BHARAT_ARCH_ROOT}/common/accel_caps_publish.c` to `core/kernel/CMakeLists.txt` so it compiles for all architectures. 

### Testing
- Installed QEMU system emulators with `sudo apt-get update && sudo apt-get install -y qemu-system-x86 qemu-system-arm qemu-system-misc` and the install completed successfully. 
- Built cross-targets: `./build.sh build --target x86_64_desktop_headless`, `./build.sh build --target arm64_desktop_headless`, and `./build.sh build --target riscv64_desktop_headless` all completed successfully and emitted build manifests. 
- Ran headless QEMU smoke runs: `timeout 25s ./build.sh run --target x86_64_desktop_headless` and `timeout 25s ./build.sh run --target arm64_desktop_headless` booted to runtime self-tests (reached runtime logs) within the timebound. 
- `timeout 25s ./build.sh run --target riscv64_desktop_headless` booted successfully but hit a known runtime panic path after boot (observed failure during runtime self-tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec2ed947dc8320b3422e55b2ec709d)