### PR TITLE
memops: use canonical runtime memory ops in namesvc and add memmove

### DIFF
--- a/core/lib/runtime/include/bharat/runtime/freestanding_string.h
+++ b/core/lib/runtime/include/bharat/runtime/freestanding_string.h
@@ -14,6 +14,7 @@ extern "C" {
 
 void *memcpy(void *dest, const void *src, size_t n);
 void *memset(void *s, int c, size_t n);
+void *memmove(void *dest, const void *src, size_t n);
 int memcmp(const void *s1, const void *s2, size_t n);
 
 size_t strlen(const char *s);

--- a/core/lib/runtime/src/freestanding_string.c
+++ b/core/lib/runtime/src/freestanding_string.c
@@ -13,6 +13,29 @@ void *memcpy(void *dest, const void *src, size_t n) {
     return dest;
 }
 
+void *memmove(void *dest, const void *src, size_t n) {
+    unsigned char *d = (unsigned char *)dest;
+    const unsigned char *s = (const unsigned char *)src;
+
+    if (d == s || n == 0) {
+        return dest;
+    }
+
+    if (d < s || d >= (s + n)) {
+        while (n--) {
+            *d++ = *s++;
+        }
+        return dest;
+    }
+
+    d += n;
+    s += n;
+    while (n--) {
+        *(--d) = *(--s);
+    }
+    return dest;
+}
+
 int memcmp(const void *s1, const void *s2, size_t n) {
     const unsigned char *p1 = s1;
     const unsigned char *p2 = s2;
@@ -57,5 +80,4 @@ void __aeabi_memclr8(void *dest, size_t n) { memset(dest, 0, n); }
 void __aeabi_memset(void *dest, size_t n, int c) { memset(dest, c, n); }
 void __aeabi_memset4(void *dest, size_t n, int c) { memset(dest, c, n); }
 void __aeabi_memset8(void *dest, size_t n, int c) { memset(dest, c, n); }
-
 

--- a/core/services/namesvc/main.c
+++ b/core/services/namesvc/main.c
@@ -1,4 +1,5 @@
 #include <bharat/runtime/runtime.h>
+#include <bharat/runtime/freestanding_string.h>
 #include <bharat/ipc/ipc.h>
 #include "src/registry.h"
 #include "include/ipc_dispatch.h"
@@ -17,21 +18,6 @@ BHARAT_REGISTER_COMPONENT(
     BHARAT_BUILD_EPOCH,
     BHARAT_BUILD_TIME_UTC
 );
-
-// Custom memset and memcpy
-static void *custom_memset_main(void *s, int c, unsigned long n) {
-    unsigned char *p = s;
-    while(n--) *p++ = (unsigned char)c;
-    return s;
-}
-
-static void *custom_memcpy_main(void *dest, const void *src, unsigned long n) {
-    unsigned char *d = dest;
-    const unsigned char *s = src;
-    while (n--) *d++ = *s++;
-    return dest;
-}
-
 
 int main(int argc, char **argv) {
     (void)argc;
@@ -55,9 +41,9 @@ int main(int argc, char **argv) {
 
     // Simulate main IPC loop handling registration/lookup requests
     while(1) {
-        custom_memset_main(&hdr, 0, sizeof(hdr));
-        custom_memset_main(&req, 0, sizeof(req));
-        custom_memset_main(&res, 0, sizeof(res));
+        memset(&hdr, 0, sizeof(hdr));
+        memset(&req, 0, sizeof(req));
+        memset(&res, 0, sizeof(res));
 
         // Use the transport shim to receive the contract header and payload
         // In a real system, the transport would unmarshal into `hdr`.
@@ -76,7 +62,7 @@ int main(int argc, char **argv) {
             }
 
             bharat_ipc_contract_header_t rep_hdr;
-            custom_memset_main(&rep_hdr, 0, sizeof(rep_hdr));
+            memset(&rep_hdr, 0, sizeof(rep_hdr));
             rep_hdr.message_id = hdr.message_id;
             rep_hdr.payload_size = sizeof(res);
 

--- a/core/services/namesvc/src/ipc_dispatch.c
+++ b/core/services/namesvc/src/ipc_dispatch.c
@@ -2,14 +2,10 @@
 #include <registry.h>
 #include <ipc/contract_validate.h>
 #include <ipc_auth.h>
-
-static void custom_memset_ipc(void *s, int c, unsigned long n) {
-    unsigned char *p = s;
-    while(n--) *p++ = (unsigned char)c;
-}
+#include <bharat/runtime/freestanding_string.h>
 
 void namesvc_ipc_handle_request(const bharat_ipc_contract_header_t *hdr, const namesvc_ipc_req_t *req, namesvc_ipc_res_t *res) {
-    custom_memset_ipc(res, 0, sizeof(namesvc_ipc_res_t));
+    memset(res, 0, sizeof(namesvc_ipc_res_t));
 
     if (!hdr || !req) {
         res->status = NAMESVC_STATUS_ERR_INVAL;


### PR DESCRIPTION
### Motivation
- Reduce ad-hoc per-file memory helpers and align service code with the shared freestanding runtime memory primitives so services benefit from a single, maintainable memory-op baseline.
- Provide a complete, production-safe trio of portable memory operations (`memset`/`memcpy`/`memmove`) for user-space and services ahead of architecture-level fastpath/acceleration integration.

### Description
- Added `memmove` declaration to `core/lib/runtime/include/bharat/runtime/freestanding_string.h` to extend the freestanding API.
- Implemented an overlap-safe `memmove` in `core/lib/runtime/src/freestanding_string.c` with forward and backward copy paths and early-return optimizations.
- Replaced ad-hoc `custom_memset_*`/`custom_memcpy_*` helpers in the name service with canonical `memset`/`memcpy` and included the freestanding header in `core/services/namesvc/main.c` and `core/services/namesvc/src/ipc_dispatch.c`.

### Testing
- Ran `git diff --check` to validate no whitespace or simple patch issues, which completed cleanly.
- Used pattern searches (`rg -n "custom_mem(set|cpy)|memmove\("`) to verify ad-hoc helpers were removed and `memmove` was added, which showed the expected results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec3f69f6608320bc60f2de6701c97a)