### PR TITLE
docs(interrupt): add production-grade profile/board/Harvard hardening plan

### DIFF
--- a/docs/adr/ADR-012-interrupt-controller-evolution.md
+++ b/docs/adr/ADR-012-interrupt-controller-evolution.md
@@ -84,3 +84,14 @@ Interrupt-related ISA extensions and accelerators (NPU/GPU/DSP/PCIe MSI-X heavy 
 1. Update kernel subcomponent architecture docs with explicit interrupt submodule status and phased non-breaking migration order.
 2. Keep gap-analysis plan synchronized with the compatibility-first rules and architecture parity matrix.
 3. Track backend conformance against the mandatory ops contract in implementation reviews.
+4. Add profile/board interrupt contract validation (`profile × arch_caps × board_caps`) as a boot-time gate for production releases.
+5. Add Harvard-architecture-safe interrupt vector/data placement constraints for MCU-class and split-memory targets.
+
+### Profile/board/Harvard enforcement addendum (2026-04-25)
+
+To preserve compatibility while enabling production deployment across heterogeneous boards, interrupt evolution adopts these additional constraints:
+
+- **Profile truth over architecture assumptions:** IRQ policy is derived from the active runtime profile and board contract, not ISA alone.
+- **Board contract is normative:** missing required interrupt capabilities must fail-closed or enter explicitly declared degraded mode.
+- **Harvard-safe portability:** targets with separate instruction/data memory must use explicit vector/data placement rules and synchronization hooks, with compile/link checks where possible.
+- **Security-first production mode:** MSI/remap/posting accelerations stay capability-gated and always retain verified fallback paths.

--- a/docs/architecture/arch-capability-matrix.md
+++ b/docs/architecture/arch-capability-matrix.md
@@ -9,6 +9,8 @@ This document defines the expected architecture capabilities for the runtime tie
 - `ARCH_CAP_MMU_FULL`: The architecture provides a full Memory Management Unit (MMU) capable of multi-level page tables and standard virtual memory semantics.
 - `ARCH_CAP_DMA_COHERENT`: The architecture supports hardware-coherent DMA.
 - `ARCH_CAP_ADV_IRQ_ROUTING`: The architecture provides advanced IRQ routing (e.g., MSI/MSI-X).
+- `ARCH_CAP_IRQ_PROFILE_POLICY`: The architecture/HAL can enforce profile-driven interrupt policy at runtime.
+- `ARCH_CAP_IRQ_HARVARD_SAFE`: The architecture/board supports explicit Harvard-safe interrupt vector and data placement rules.
 - `ARCH_CAP_USERSPACE_HIGHHALF`: The architecture natively supports or is configured for a traditional user/kernel high-half split address space layout.
 - `ARCH_CAP_HW_CRC`: The architecture provides hardware CRC acceleration instructions.
 - `ARCH_CAP_SIMD_NET_CSUM`: The architecture provides SIMD acceleration for network checksums.
@@ -25,9 +27,11 @@ Tier 1 represents the full feature set of Bharat-OS. These capabilities are **re
 - `ARCH_CAP_DMA_COHERENT`
 - `ARCH_CAP_ADV_IRQ_ROUTING`
 - `ARCH_CAP_USERSPACE_HIGHHALF`
+- `ARCH_CAP_IRQ_PROFILE_POLICY`
 
 These capabilities are **optional** (may depend on the specific SoC or feature set):
 
+- `ARCH_CAP_IRQ_HARVARD_SAFE`
 - `ARCH_CAP_HW_CRC`
 - `ARCH_CAP_SIMD_NET_CSUM`
 
@@ -47,5 +51,7 @@ These capabilities are **optional**:
 - `ARCH_CAP_DMA_COHERENT`
 - `ARCH_CAP_ADV_IRQ_ROUTING`
 - `ARCH_CAP_USERSPACE_HIGHHALF`
+- `ARCH_CAP_IRQ_PROFILE_POLICY`
+- `ARCH_CAP_IRQ_HARVARD_SAFE`
 - `ARCH_CAP_HW_CRC`
 - `ARCH_CAP_SIMD_NET_CSUM`

--- a/docs/architecture/interrupt/interrupt-architecture.md
+++ b/docs/architecture/interrupt/interrupt-architecture.md
@@ -79,3 +79,63 @@ All interrupt logic must pass through the multi-arch headless build and test mat
 *   **Tracepoints**: Hooking into `claim`, `dispatch`, and `eoi` to measure handling latency.
 *   **Spurious Rate Counters**: Tracking unhandled interrupts.
 *   **Health Counters**: Per-controller observability for active/pending metrics.
+
+## Production-Grade Profile and Board Adaptation
+
+To move from architecture-ready to production-grade, interrupt behavior must be selected by a **profile contract** and validated against **board capabilities** at boot.
+
+### Profile-driven interrupt policy
+
+Interrupt runtime behavior should be computed from `profile × arch_caps × board_caps`, not from architecture checks alone.
+
+* **RT/Safety profile**
+  * Enforce bounded ISR budget and strict threaded-bottom-half policy.
+  * Disallow shared IRQ lines for safety-critical devices unless explicitly waived.
+  * Require deterministic affinity pinning and reserved CPU shielding for critical vectors.
+* **General-purpose profile**
+  * Allow shared IRQs and adaptive interrupt moderation.
+  * Prefer throughput-optimized MSI-X spreading across CPUs.
+* **Edge/minimal profile (including Harvard-style MCU layouts)**
+  * Compile-time trim of advanced routing features (ITS/IMSIC/remapping) when unavailable.
+  * Use static vector tables and fixed virq ranges with fail-closed overflow handling.
+  * Enforce explicit MMIO-safe controller access wrappers for split instruction/data memory constraints.
+
+### Harvard-architecture readiness requirements
+
+For Harvard or Harvard-like targets (separate instruction/data memory constraints), the interrupt subsystem must additionally guarantee:
+
+1. **Vector/table placement policy**: ISR entry stubs and vector tables are placed in executable memory regions, while mutable descriptor state remains in data memory.
+2. **No implicit self-modifying paths**: runtime patching of vector code is prohibited unless profile explicitly enables secure patch flow.
+3. **Cache/ordering hooks**: board HAL provides mandatory instruction/data synchronization hooks when changing interrupt routing metadata that affects executable dispatch.
+4. **ISR code-size budgeting**: per-profile hard limit for top-half footprint to preserve deterministic instruction memory usage.
+
+### Board/platform feature contract
+
+Each board descriptor should declare an interrupt feature contract used by boot validation:
+
+* Controller topology (single, cascaded, hierarchical domain tree).
+* MSI/MSI-X availability and vector count limits.
+* Local interrupt controller availability per core/hart.
+* Secure/non-secure interrupt partitions (TrustZone-like or equivalent).
+* Wakeup-capable interrupt lines for low-power states.
+
+Boot should fail closed (or degrade according to profile policy) when required contract fields are absent.
+
+### New coding tasks for production-grade interrupt stack
+
+1. **Implement `irq_profile_policy` runtime object**
+   * Inputs: `arch_caps`, board interrupt descriptor, selected profile.
+   * Outputs: allowed IRQ features, ISR budget class, affinity constraints, fallback mode.
+2. **Add board interrupt capability schema** (`board_interrupt_caps`)
+   * Parse from board/platform descriptors and expose through HAL discovery API.
+3. **Introduce Harvard-safe vector placement API**
+   * Explicit sections/macros for vector stubs vs mutable IRQ data.
+   * Add compile/link assertions for forbidden placement.
+4. **Conformance gate: `interrupt_profile_selftest`**
+   * Validates profile requirements (e.g., MSI required/forbidden, shared IRQ policy, secure partition policy) during boot tests.
+5. **Domain hierarchy validator**
+   * Verifies parent/child domain invariants and reports mapping leaks/unbalanced unmap at shutdown test stage.
+6. **Interrupt security hardening**
+   * Per-IRQ provenance tagging, spoofed-MSI detection hooks, and optional rate-limited quarantine mode.
+7. **Board-aware CI matrix expansion**
+   * Add at least one board configuration per architecture class (x86 server, arm64 edge, arm32 MCU-like, riscv64 SBC, riscv32 embedded) with interrupt conformance must-pass checks.

--- a/docs/reviews/gap_analysis/interrupt_controller_architecture_plan.md
+++ b/docs/reviews/gap_analysis/interrupt_controller_architecture_plan.md
@@ -170,12 +170,45 @@ Rules:
    - tracepoints for claim/dispatch/eoi latency and spurious IRQ rate
    - per-controller health counters
 
+## Phase 5: Production profile, Harvard, and board conformance hardening
+
+### Objective
+
+Make the interrupt subsystem production-grade by enforcing **profile-aware policy**, **Harvard-safe behavior**, and **board-level feature contracts** in runtime and CI.
+
+### Implementation tasks
+
+1. **Interrupt profile policy engine**
+   - Add `irq_profile_policy_init(profile, arch_caps, board_caps)` in irq-core.
+   - Compute allowed modes (shared IRQ, MSI/MSI-X, remap/posting, threaded IRQ requirement, ISR budgets).
+2. **Board interrupt capability descriptor**
+   - Extend board/platform metadata with controller topology, vector capacities, secure partitioning, wakeup lines, and local controller model.
+   - Publish via HAL discovery contract consumed by irq-core.
+3. **Harvard-safe interrupt memory layout**
+   - Add linker section contracts and assertions for vector stubs (exec-only region) vs descriptor/state tables (data region).
+   - Add required cache/barrier hooks for platforms needing I/D sync when reprogramming dispatch metadata.
+4. **Security hardening tasks**
+   - Add per-IRQ provenance metadata and optional MSI source validation hooks.
+   - Add interrupt storm containment mode with profile-selectable threshold actions (throttle, isolate CPU, quarantine device domain).
+5. **Conformance and fault-injection tests**
+   - `interrupt_profile_selftest`: validates required-vs-available capability matrix at boot.
+   - `interrupt_domain_fuzz`: random map/unmap/affinity churn with leak detection.
+   - `interrupt_fault_injection`: synthetic spurious/duplicate/late-eoi scenarios per architecture backend.
+
+### Exit criteria
+
+- No profile can boot with a silently unsupported required interrupt capability.
+- At least one board per architecture class passes conformance suite in CI.
+- Harvard/split-memory targets pass vector/data placement assertions and synchronization checks.
+- Capability-gated fast paths prove fallback parity in automated tests.
+
 ## Practical execution order (recommended)
 
 1. ~~**Week 1-2**: Unify trap/IRQ flow and wire real controller ops binding.~~ **(Completed)**
 2. **Week 3-4**: Domain-first conversion for existing x86_64/arm64/riscv64 backends.
 3. **Week 5-6**: arm32 + riscv32 baseline backend completion.
 4. **Week 7+**: MSI-X scaling, accelerator policies, AIA/x2APIC advanced features.
+5. **Week 9+**: Profile/board/Harvard production hardening and conformance gates.
 
 ## ADR alignment
 


### PR DESCRIPTION
### Motivation

- Define how the interrupt architecture moves from design to production by making runtime behavior profile- and board-aware, and by addressing Harvard-style split-memory targets. 
- Close gaps identified in the ADR/gap-analysis by adding concrete engineering tasks and CI/boot conformance gates needed for multi-arch, multi-profile deployment. 

### Description

- Added a new `Production-Grade Profile and Board Adaptation` section to `docs/architecture/interrupt/interrupt-architecture.md` that defines `profile × arch_caps × board_caps` policy, Harvard readiness rules, board feature contracts, and a prioritized list of coding tasks (e.g., `irq_profile_policy`, `board_interrupt_caps`, Harvard-safe vector placement API, and `interrupt_profile_selftest`).
- Extended `docs/adr/ADR-012-interrupt-controller-evolution.md` with follow-up actions to include profile/board validation and a dated enforcement addendum clarifying compatibility and fallback expectations for production mode. 
- Added a new **Phase 5** (production/Harvard/board conformance hardening) to `docs/reviews/gap_analysis/interrupt_controller_architecture_plan.md` with implementation tasks, conformance/fault-injection tests, exit criteria, and schedule placement. 
- Updated `docs/architecture/arch-capability-matrix.md` to introduce `ARCH_CAP_IRQ_PROFILE_POLICY` and `ARCH_CAP_IRQ_HARVARD_SAFE` and to reflect tier expectations for those capabilities. 

### Testing

- Ran local validation `git diff --check` which reported no whitespace/format issues and completed successfully. 
- Performed content inspections across the modified documents to ensure links and roadmap phases remain consistent (no automated unit tests were changed or required by these documentation updates).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec43a62ba48320892d767644ee4dd9)