### PR TITLE
docs(kernel): clarify generated config header purpose and migration options

### DIFF
--- a/core/kernel/include/bharat_config.h.in
+++ b/core/kernel/include/bharat_config.h.in
@@ -1,6 +1,8 @@
 #ifndef BHARAT_CONFIG_H
 #define BHARAT_CONFIG_H
 
+/* AUTO-GENERATED VIA CMAKE configure_file(bharat_config.h.in -> generated/bharat_config.h). */
+/* Edit bharat_config.h.in, not generated/bharat_config.h. */
 /* Architecture Family */
 #cmakedefine BHARAT_ARCH_X86 1
 #cmakedefine BHARAT_ARCH_ARM 1

--- a/core/kernel/include/generated/README.md
+++ b/core/kernel/include/generated/README.md
@@ -1,0 +1,68 @@
+# Why `core/kernel/include/generated/bharat_config.h` exists
+
+`bharat_config.h` is **not handwritten configuration**. It is produced from
+`core/kernel/include/bharat_config.h.in` via CMake `configure_file(...)` so that
+kernel code can read one canonical set of compile-time flags (`BHARAT_PROFILE_*`,
+`BHARAT_ENABLE_*`, `BHARAT_ARCH_*`, etc.).
+
+## Why keep a generated header in-tree?
+
+This repo currently supports two workflows:
+
+1. **Top-level build** (`/CMakeLists.txt`) that creates generated artifacts in the
+   build directory.
+2. **Kernel-only configuration/build** (`core/kernel/CMakeLists.txt`) that still
+   expects `bharat_config.h` to be available for include resolution in kernel
+   subtargets.
+
+Keeping this generated header under `core/kernel/include/generated/` acts as a
+stable fallback/bootstrap artifact for tooling and partial builds.
+
+## Pain points with committed generated files
+
+- Merge conflicts and noisy diffs.
+- Risk of stale values being reviewed as "source".
+- Confusion about what should be edited (`*.h.in`) vs generated (`*.h`).
+
+## Better options (brainstorm)
+
+### Option A (recommended): build-dir generated only + compatibility shim
+
+- Generate `bharat_config.h` into `${CMAKE_BINARY_DIR}/generated/include` only.
+- Add include paths so all targets prefer build-dir generated headers.
+- Keep a tiny in-tree shim header (or fail-fast stub) that points contributors to
+  regenerate if they include it directly.
+
+Pros: clean git history, single source of truth.
+Cons: requires build system cleanup and CI updates.
+
+### Option B: keep committed fallback snapshot with strict guardrails
+
+- Keep the committed generated header.
+- Add clear banner comments (`AUTO-GENERATED; DO NOT EDIT`).
+- Add CI check to verify template + CMake values regenerate exact same content.
+
+Pros: minimal migration effort.
+Cons: still noisy, still easy to misunderstand.
+
+### Option C: split stable vs dynamic config
+
+- Commit a small stable `bharat_defaults.h` (rarely changing).
+- Generate only dynamic profile/board-specific macros into build-dir header.
+- Include both from kernel config entrypoint.
+
+Pros: fewer generated deltas.
+Cons: more moving parts and include order rules.
+
+## Practical migration plan
+
+1. Standardize include use to `#include "bharat_config.h"` from one exported
+   generated include directory.
+2. Move generation output to build dir only.
+3. Add CI check for missing generation step with a clear error message.
+4. Remove committed generated snapshot after one release cycle.
+
+## Contributor rule
+
+- Edit: `core/kernel/include/bharat_config.h.in`
+- Do not edit manually: `core/kernel/include/generated/bharat_config.h`

--- a/core/kernel/include/generated/bharat_config.h
+++ b/core/kernel/include/generated/bharat_config.h
@@ -1,6 +1,8 @@
 #ifndef BHARAT_CONFIG_H
 #define BHARAT_CONFIG_H
 
+/* AUTO-GENERATED VIA CMAKE configure_file(bharat_config.h.in -> generated/bharat_config.h). */
+/* Edit bharat_config.h.in, not generated/bharat_config.h. */
 /* Architecture Family */
 #define BHARAT_ARCH_X86 1
 /* #undef BHARAT_ARCH_ARM */


### PR DESCRIPTION
### Motivation

- The kernel ships a generated header `core/kernel/include/generated/bharat_config.h` produced from `core/kernel/include/bharat_config.h.in` via CMake, which confused contributors about what to edit and why a generated file is committed in-tree. 
- The change documents the rationale and proposes cleaner workflows to reduce merge noise and stale snapshots when partial/kernel-only builds are used.

### Description

- Add `core/kernel/include/generated/README.md` that explains why `bharat_config.h` exists, outlines three options for handling generated headers (recommended: build-dir-only generation + shim), and provides a practical migration plan. 
- Insert an explicit auto-generated banner into `core/kernel/include/bharat_config.h.in` and the committed snapshot at `core/kernel/include/generated/bharat_config.h` to make it clear contributors should edit the `.in` template, not the generated file. 
- Document contributor guidance and a stepwise plan to move generation into the build directory and add CI guardrails.

### Testing

- Ran `git diff --check` to verify there are no whitespace or trivial diff issues and it completed with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec4db21f98832090adeb25034b210e)