### PR TITLE
docs: standardize docs metadata and improve documentation IA/ADR indexes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,60 +1,82 @@
+---
+title: Bharat-OS Documentation Hub
+status: Active
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - index
+  - information-architecture
+see_also:
+  - architecture/README.md
+  - adr/README.md
+  - testing/run-matrix.md
+---
+
 # Bharat-OS Documentation
 
 This directory is the canonical documentation hub for Bharat-OS.
 
-## Start here
+## Documentation Information Architecture
 
-- **Architecture index:** [`docs/architecture/README.md`](architecture/README.md)
-- **ADR index:** [`docs/adr/README.md`](adr/README.md)
-- **Build/run/testing docs:** [`docs/testing/`](testing/) and root-level [`BUILD.md`](../BUILD.md)
-- **Repository code map:** [`docs/architecture/repository-code-map.md`](architecture/repository-code-map.md)
-- **Archived material:** [`docs/archive/`](archive/)
+```mermaid
+flowchart TD
+  A[docs/] --> B[architecture/]
+  A --> C[adr/]
+  A --> D[dev/]
+  A --> E[testing/]
+  A --> F[reviews/]
+  A --> G[ai-agents/]
+  A --> H[archive/]
+  B --> B1[Subsystem + contracts + roadmaps]
+  C --> C1[Architecture decisions]
+  D --> D1[Contributor + build + policy guides]
+  E --> E1[Test matrix + E2E]
+  F --> F1[Gap analysis + audit notes]
+  H --> H1[Superseded docs]
+```
 
-## Active documentation layout
+## Source-of-Truth Precedence
 
-### 1) Architecture (`docs/architecture/`)
-Design contracts, subsystem architecture, roadmap notes, and cross-component boundaries.
+| Priority | Source | Why it wins |
+|---|---|---|
+| 1 | Accepted ADRs (`docs/adr/`) | Records explicit design decisions. |
+| 2 | Contracts (`docs/architecture/contracts/`) | Defines stable interfaces/boundaries. |
+| 3 | Subsystem architecture docs | Defines implementation direction. |
+| 4 | Reviews / plans | Tracks gaps and execution details. |
 
-Key subfolders:
-- `boot/`
-- `core/`
-- `core/kernel/`
-- `memory/`
-- `storage/`
-- `security/`
-- `network/`
-- `core/personalities/`
-- `contracts/`
+## Directory Map
 
-### 2) ADRs (`docs/adr/`)
-Decision records that take precedence when roadmap or design docs disagree.
+| Area | Purpose | Entry Point |
+|---|---|---|
+| `architecture/` | Core architecture, contracts, subsystems, profile plans | [`docs/architecture/README.md`](architecture/README.md) |
+| `adr/` | Architecture Decision Records lifecycle + index | [`docs/adr/README.md`](adr/README.md) |
+| `dev/` | Developer workflows, tooling, governance docs | [`docs/dev/developer_guidelines.md`](dev/developer_guidelines.md) |
+| `testing/` | E2E and run-matrix guidance | [`docs/testing/run-matrix.md`](testing/run-matrix.md) |
+| `ai-agents/` | Agent guardrails and templates | [`docs/ai-agents/README.md`](ai-agents/README.md) |
+| `reviews/` | Gap assessments and architecture audits | [`docs/reviews/gap_analysis/latest_gap_analysis.md`](reviews/gap_analysis/latest_gap_analysis.md) |
+| `archive/` | Historical/superseded material | [`docs/archive/README.md`](archive/README.md) |
 
-### 3) Testing (`docs/testing/`)
-Execution matrix and end-to-end testing guidance.
+## Standard Document Contract
 
-### 4) AI agent guidance (`docs/ai-agents/`)
-Standards, templates, and platform-specific agent instructions.
+Each Markdown document under `docs/` should include:
 
-### 5) Supporting docs
-- `docs/dev/`
-- `docs/boards/`
-- `docs/profiles/`
-- `docs/reviews/`
-- `docs/research_doc/`
+1. YAML frontmatter (`title`, `status`, `owner`, `last_updated`, `tags`, `see_also`).
+2. Clear section hierarchy (`## Context`, `## Design/Decision`, `## Risks/Consequences`, `## References`) where applicable.
+3. Explicit links to related docs via `see_also`.
 
-### 6) Archive (`docs/archive/`)
-Superseded/legacy material retained for traceability.
+## Status Vocabulary
 
-## Source-of-truth rule
+| Status | Meaning |
+|---|---|
+| `Draft` | In progress, not yet accepted as baseline. |
+| `Proposed` | Ready for review/decision. |
+| `Accepted` / `Active` | Current approved baseline. |
+| `Superseded` | Replaced by a newer authoritative doc. |
 
-When there is a conflict:
+## Quick Start
 
-1. **Accepted ADRs in `docs/adr/`** win.
-2. Then architecture contracts (`docs/architecture/contracts/`).
-3. Then subsystem roadmap/design docs.
-
-## Documentation quality rules
-
-- Prefer links to real code paths (for example `core/`, `interface/`, `quality/`, `tools/`, `delivery/`).
-- Use explicit status labels (`Draft`, `Active`, `Superseded`) for planning docs.
-- Move stale content to `docs/archive/` instead of deleting it.
+- New contributors: start with [`docs/dev/developer_guidelines.md`](dev/developer_guidelines.md).
+- Architecture deep dive: start with [`docs/architecture/README.md`](architecture/README.md).
+- Decisions and rationale: use [`docs/adr/README.md`](adr/README.md).
+- Validation pathways: use [`docs/testing/e2e-testing.md`](testing/e2e-testing.md).

--- a/docs/adr/008-distributed-vm-monitor-and-vm-spaces.md
+++ b/docs/adr/008-distributed-vm-monitor-and-vm-spaces.md
@@ -1,3 +1,14 @@
+---
+title: ADR 008: Distributed VM Monitor and VM Spaces
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - adr
+see_also:
+  - README.md
+---
 # ADR 008: Distributed VM Monitor and VM Spaces
 
 ## Status

--- a/docs/adr/009-sdk-libc-strategy.md
+++ b/docs/adr/009-sdk-libc-strategy.md
@@ -1,3 +1,14 @@
+---
+title: ADR 009: SDK & Libc Strategy for Bharat-OS
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - adr
+see_also:
+  - README.md
+---
 # ADR 009: SDK & Libc Strategy for Bharat-OS
 
 ## Status

--- a/docs/adr/ADR-001-microkernel-vs-hybrid.md
+++ b/docs/adr/ADR-001-microkernel-vs-hybrid.md
@@ -1,3 +1,14 @@
+---
+title: ADR-001: Microkernel vs Hybrid Architecture
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - adr
+see_also:
+  - README.md
+---
 # ADR-001: Microkernel vs Hybrid Architecture
 
 ## Status

--- a/docs/adr/ADR-002-capability-model.md
+++ b/docs/adr/ADR-002-capability-model.md
@@ -1,3 +1,14 @@
+---
+title: ADR-002: The Capability Security Model
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - adr
+see_also:
+  - README.md
+---
 # ADR-002: The Capability Security Model
 
 ## Status

--- a/docs/adr/ADR-003-multikernel-messaging.md
+++ b/docs/adr/ADR-003-multikernel-messaging.md
@@ -1,3 +1,14 @@
+---
+title: ADR-003: Multikernel Messaging Spine
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - adr
+see_also:
+  - README.md
+---
 # ADR-003: Multikernel Messaging Spine
 
 ## Status

--- a/docs/adr/ADR-004-linux-personality-first.md
+++ b/docs/adr/ADR-004-linux-personality-first.md
@@ -1,3 +1,14 @@
+---
+title: ADR-004: Linux Compatibility as a Deferred Personality
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - adr
+see_also:
+  - README.md
+---
 # ADR-004: Linux Compatibility as a Deferred Personality
 
 ## Status

--- a/docs/adr/ADR-005-ml-stays-out-of-ring-0.md
+++ b/docs/adr/ADR-005-ml-stays-out-of-ring-0.md
@@ -1,3 +1,14 @@
+---
+title: ADR-005: ML Heuristics Kept Out of Ring-0
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - adr
+see_also:
+  - README.md
+---
 # ADR-005: ML Heuristics Kept Out of Ring-0
 
 ## Status

--- a/docs/adr/ADR-006-numa-awareness.md
+++ b/docs/adr/ADR-006-numa-awareness.md
@@ -1,3 +1,14 @@
+---
+title: ADR-006: NUMA-Ready (Not NUMA-Complete) Architecture
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - adr
+see_also:
+  - README.md
+---
 # ADR-006: NUMA-Ready (Not NUMA-Complete) Architecture
 
 ## Status

--- a/docs/adr/ADR-007-experimental-scope.md
+++ b/docs/adr/ADR-007-experimental-scope.md
@@ -1,3 +1,14 @@
+---
+title: ADR-007: Scope Restriction — Experimental vs. v1 Core
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - adr
+see_also:
+  - README.md
+---
 # ADR-007: Scope Restriction — Experimental vs. v1 Core
 
 **Date:** 2026-03-06

--- a/docs/adr/ADR-008-ai-scheduler-plugin-contract.md
+++ b/docs/adr/ADR-008-ai-scheduler-plugin-contract.md
@@ -1,3 +1,14 @@
+---
+title: ADR-008: AI Scheduler Contract Across Profiles and Architectures
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - adr
+see_also:
+  - README.md
+---
 # ADR-008: AI Scheduler Contract Across Profiles and Architectures
 
 ### Contract Status

--- a/docs/adr/ADR-009-documentation-status-and-claims.md
+++ b/docs/adr/ADR-009-documentation-status-and-claims.md
@@ -1,3 +1,14 @@
+---
+title: ADR-009: Documentation Status Labels and Research-Influenced Claims
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - adr
+see_also:
+  - README.md
+---
 # ADR-009: Documentation Status Labels and Research-Influenced Claims
 
 ## Status

--- a/docs/adr/ADR-010-distributed-kernel-ownership.md
+++ b/docs/adr/ADR-010-distributed-kernel-ownership.md
@@ -1,3 +1,14 @@
+---
+title: ADR-010: Distributed Kernel Ownership Model
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - adr
+see_also:
+  - README.md
+---
 # ADR-010: Distributed Kernel Ownership Model
 
 ## Status

--- a/docs/adr/ADR-011-structured-kernel-panic-and-diagnostics.md
+++ b/docs/adr/ADR-011-structured-kernel-panic-and-diagnostics.md
@@ -1,3 +1,14 @@
+---
+title: ADR 011: Structured Kernel Panic and Diagnostics
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - adr
+see_also:
+  - README.md
+---
 # ADR 011: Structured Kernel Panic and Diagnostics
 
 ## Status

--- a/docs/adr/ADR-012-can-subsystem-architecture.md
+++ b/docs/adr/ADR-012-can-subsystem-architecture.md
@@ -1,3 +1,14 @@
+---
+title: ADR-012: CAN Subsystem and Userspace Routing Architecture
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - adr
+see_also:
+  - README.md
+---
 # ADR-012: CAN Subsystem and Userspace Routing Architecture
 
 ## Status

--- a/docs/adr/ADR-012-interrupt-controller-evolution.md
+++ b/docs/adr/ADR-012-interrupt-controller-evolution.md
@@ -1,3 +1,14 @@
+---
+title: ADR-012: Interrupt Controller Evolution with Compatibility-First Core IRQ Model
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - adr
+see_also:
+  - README.md
+---
 # ADR-012: Interrupt Controller Evolution with Compatibility-First Core IRQ Model
 
 - **Status:** Accepted

--- a/docs/adr/ADR-013-multikernel-memory-protection-architecture.md
+++ b/docs/adr/ADR-013-multikernel-memory-protection-architecture.md
@@ -1,3 +1,14 @@
+---
+title: ADR-013: Multikernel Memory Protection Architecture (MPA)
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - adr
+see_also:
+  - README.md
+---
 # ADR-013: Multikernel Memory Protection Architecture (MPA)
 
 ## Status

--- a/docs/adr/ADR-allocation-classes.md
+++ b/docs/adr/ADR-allocation-classes.md
@@ -1,3 +1,14 @@
+---
+title: ADR: Allocation Classes
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - adr
+see_also:
+  - README.md
+---
 # ADR: Allocation Classes
 
 ## Context

--- a/docs/adr/ADR-boot-runtime-contract.md
+++ b/docs/adr/ADR-boot-runtime-contract.md
@@ -1,3 +1,14 @@
+---
+title: Architecture Decision Record: Boot and Runtime Lifecycle Contract
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - adr
+see_also:
+  - README.md
+---
 # Architecture Decision Record: Boot and Runtime Lifecycle Contract
 
 ### Contract Status

--- a/docs/adr/ADR-build-presets-for-memory-profiles.md
+++ b/docs/adr/ADR-build-presets-for-memory-profiles.md
@@ -1,3 +1,14 @@
+---
+title: ADR: Build Presets for Memory Profiles
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - adr
+see_also:
+  - README.md
+---
 # ADR: Build Presets for Memory Profiles
 
 ## Context

--- a/docs/adr/ADR-memory-core-vs-advanced-vm-split.md
+++ b/docs/adr/ADR-memory-core-vs-advanced-vm-split.md
@@ -1,3 +1,14 @@
+---
+title: ADR: Memory Core vs Advanced VM Split
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - adr
+see_also:
+  - README.md
+---
 # ADR: Memory Core vs Advanced VM Split
 
 ## Context

--- a/docs/adr/ADR-memory-hal-unification.md
+++ b/docs/adr/ADR-memory-hal-unification.md
@@ -1,3 +1,14 @@
+---
+title: ADR: Memory HAL Unification and Multikernel Memory Model
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - adr
+see_also:
+  - README.md
+---
 # ADR: Memory HAL Unification and Multikernel Memory Model
 
 ## Status

--- a/docs/adr/ADR-memory-profile-gating.md
+++ b/docs/adr/ADR-memory-profile-gating.md
@@ -1,3 +1,14 @@
+---
+title: ADR: Memory Profile Gating
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - adr
+see_also:
+  - README.md
+---
 # ADR: Memory Profile Gating
 
 ## Context

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,79 +1,84 @@
+---
+title: ADR Guide and Index
+status: Active
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - adr
+  - decision-log
+see_also:
+  - ../README.md
+  - ../architecture/contracts/naming-conventions.md
+---
+
 # ADR Guide and Index
 
-This directory (`docs/adr`) is the canonical location for Architecture Decision Records (ADRs) in Bharat-OS. This page provides guidelines on how to write and update an ADR, followed by the index of accepted decisions.
+`docs/adr/` is the canonical location for Bharat-OS Architecture Decision Records.
 
-If you have questions about the ADR process or need to propose a new one, please contact **Divyang Panchasara**.
+## ADR Lifecycle
 
-## How to Write and Update an ADR
-
-An ADR captures an important architectural decision made along with its context and consequences.
-
-### 1. Naming and Creating a New ADR
-- File name must follow the pattern `ADR-XXX-short-descriptive-title.md` (e.g., `ADR-014-new-subsystem.md`).
-- Continue the numeric ordering from the highest numbered ADR currently in the folder.
-
-### 2. Format / Template
-Each ADR should include YAML frontmatter and follow the standard structure:
-
-```markdown
----
-title: ADR-XXX Short Title
-status: Proposed | Accepted | Rejected | Superseded
-owner: Your Name
-reviewers: Reviewer Names
-version: 1.0
-last_updated: YYYY-MM-DD
-tags: tag1, tag2
----
-
-# ADR-XXX: Short Title
-
-## Context
-Describe the forces at play, the technological context, or the problem being solved. What is the current situation? Why is a decision necessary?
-
-## Decision
-What is the proposed change or decision? Write this in clear, assertive language.
-
-## Consequences
-What becomes easier or more difficult because of this change? Are there new risks or maintenance burdens? Are there performance or security implications?
+```mermaid
+stateDiagram-v2
+  [*] --> Proposed
+  Proposed --> Accepted: consensus + merge
+  Proposed --> Rejected: decision not adopted
+  Accepted --> Superseded: replaced by newer ADR
+  Rejected --> [*]
+  Superseded --> [*]
 ```
 
-### 3. Review and Update Process
-- **Drafting:** Create a pull request adding the ADR with a status of `Proposed`.
-- **Review:** Gather feedback from the team and stakeholders. Divyang Panchasara and other key reviewers should be tagged.
-- **Acceptance:** Once consensus is reached, the status is changed to `Accepted` and the PR is merged.
-- **Updates:** If an ADR becomes obsolete due to a newer decision, do not delete it. Instead, update its status to `Superseded` and link to the new ADR that replaces it.
+## ADR Template Contract
 
----
+Use this minimum structure for all new ADRs:
 
-## Accepted ADR Index
+| Section | Required | Notes |
+|---|---|---|
+| Frontmatter | Yes | `title`, `status`, `owner`, `last_updated`, `tags`, optional `see_also`. |
+| Context | Yes | What problem or force requires a decision? |
+| Decision | Yes | The chosen approach, stated clearly. |
+| Consequences | Yes | Trade-offs, risks, and follow-up work. |
+| References | Recommended | Links to related ADRs / architecture contracts. |
 
-1. [ADR-001: Microkernel vs Hybrid](ADR-001-microkernel-vs-hybrid.md)
-2. [ADR-002: Capability Model](ADR-002-capability-model.md)
-3. [ADR-003: Multikernel Messaging](ADR-003-multikernel-messaging.md)
-4. [ADR-004: Linux Personality First](ADR-004-linux-personality-first.md)
-5. [ADR-005: ML Stays Out of Ring 0](ADR-005-ml-stays-out-of-ring-0.md)
-6. [ADR-006: NUMA Awareness](ADR-006-numa-awareness.md)
-7. [ADR-007: Experimental Scope](ADR-007-experimental-scope.md)
-8. [ADR-008: Distributed VM Monitor and VM Spaces](008-distributed-vm-monitor-and-vm-spaces.md)
-   *(Also: [ADR-008: AI Scheduler Plugin Contract](ADR-008-ai-scheduler-plugin-contract.md))*
-9. [ADR-009: SDK Libc Strategy](009-sdk-libc-strategy.md)
-   *(Also: [ADR-009: Documentation Status and Claims](ADR-009-documentation-status-and-claims.md))*
-10. [ADR-010: Distributed Kernel Ownership](ADR-010-distributed-kernel-ownership.md)
-11. [ADR-011: Structured Kernel Panic and Diagnostics](ADR-011-structured-kernel-panic-and-diagnostics.md)
-12. [ADR-012: CAN Subsystem Architecture](ADR-012-can-subsystem-architecture.md)
-    *(Also: [ADR-012: Interrupt Controller Evolution](ADR-012-interrupt-controller-evolution.md))*
-13. [ADR-013: Multikernel Memory Protection Architecture](ADR-013-multikernel-memory-protection-architecture.md)
-14. [ADR-014: Library Layering and Data Structures](ADR-014-library-layering-and-data-structures.md)
-15. [ADR-015: Documentation Information Architecture and Archive Policy](ADR-015-documentation-information-architecture.md)
+## Naming Rules
 
-### Additional Architecture and Memory ADRs
-- [ADR: Allocation Classes](ADR-allocation-classes.md)
-- [ADR: Boot Runtime Contract](ADR-boot-runtime-contract.md)
-- [ADR: Build Presets for Memory Profiles](ADR-build-presets-for-memory-profiles.md)
-- [ADR: Cross-Core Thread Handoff](ADR-001-cross-core-thread-handoff.md)
-- [ADR: Memory Core vs Advanced VM Split](ADR-memory-core-vs-advanced-vm-split.md)
-- [ADR: Memory HAL Unification](ADR-memory-hal-unification.md)
-- [ADR: Memory Profile Gating](ADR-memory-profile-gating.md)
+- Preferred pattern: `ADR-XXX-short-title.md`.
+- Legacy files with alternate numbering are retained for traceability.
+- Do not renumber historical ADRs after merge.
 
-*(Note: Some ADR numbers overlap slightly from legacy tracking and are preserved here for historical context).*
+## ADR Index
+
+### Numbered ADRs
+
+| ADR | Title | File |
+|---|---|---|
+| ADR-001 | Microkernel vs Hybrid | [`ADR-001-microkernel-vs-hybrid.md`](ADR-001-microkernel-vs-hybrid.md) |
+| ADR-002 | Capability Model | [`ADR-002-capability-model.md`](ADR-002-capability-model.md) |
+| ADR-003 | Multikernel Messaging | [`ADR-003-multikernel-messaging.md`](ADR-003-multikernel-messaging.md) |
+| ADR-004 | Linux Personality First | [`ADR-004-linux-personality-first.md`](ADR-004-linux-personality-first.md) |
+| ADR-005 | ML Stays Out of Ring 0 | [`ADR-005-ml-stays-out-of-ring-0.md`](ADR-005-ml-stays-out-of-ring-0.md) |
+| ADR-006 | NUMA Awareness | [`ADR-006-numa-awareness.md`](ADR-006-numa-awareness.md) |
+| ADR-007 | Experimental Scope | [`ADR-007-experimental-scope.md`](ADR-007-experimental-scope.md) |
+| ADR-008 | Distributed VM Monitor and VM Spaces | [`008-distributed-vm-monitor-and-vm-spaces.md`](008-distributed-vm-monitor-and-vm-spaces.md) |
+| ADR-008 | AI Scheduler Plugin Contract | [`ADR-008-ai-scheduler-plugin-contract.md`](ADR-008-ai-scheduler-plugin-contract.md) |
+| ADR-009 | SDK Libc Strategy | [`009-sdk-libc-strategy.md`](009-sdk-libc-strategy.md) |
+| ADR-009 | Documentation Status and Claims | [`ADR-009-documentation-status-and-claims.md`](ADR-009-documentation-status-and-claims.md) |
+| ADR-010 | Distributed Kernel Ownership | [`ADR-010-distributed-kernel-ownership.md`](ADR-010-distributed-kernel-ownership.md) |
+| ADR-011 | Structured Kernel Panic and Diagnostics | [`ADR-011-structured-kernel-panic-and-diagnostics.md`](ADR-011-structured-kernel-panic-and-diagnostics.md) |
+| ADR-012 | CAN Subsystem Architecture | [`ADR-012-can-subsystem-architecture.md`](ADR-012-can-subsystem-architecture.md) |
+| ADR-012 | Interrupt Controller Evolution | [`ADR-012-interrupt-controller-evolution.md`](ADR-012-interrupt-controller-evolution.md) |
+| ADR-013 | Multikernel Memory Protection Architecture | [`ADR-013-multikernel-memory-protection-architecture.md`](ADR-013-multikernel-memory-protection-architecture.md) |
+| ADR-014 | Library Layering and Data Structures | [`ADR-014-library-layering-and-data-structures.md`](ADR-014-library-layering-and-data-structures.md) |
+| ADR-015 | Documentation Information Architecture | [`ADR-015-documentation-information-architecture.md`](ADR-015-documentation-information-architecture.md) |
+
+### Functional ADR Extensions
+
+| Topic | File |
+|---|---|
+| Allocation classes | [`ADR-allocation-classes.md`](ADR-allocation-classes.md) |
+| Boot/runtime contract | [`ADR-boot-runtime-contract.md`](ADR-boot-runtime-contract.md) |
+| Build presets by memory profile | [`ADR-build-presets-for-memory-profiles.md`](ADR-build-presets-for-memory-profiles.md) |
+| Cross-core thread handoff | [`ADR-001-cross-core-thread-handoff.md`](ADR-001-cross-core-thread-handoff.md) |
+| Memory core vs advanced VM split | [`ADR-memory-core-vs-advanced-vm-split.md`](ADR-memory-core-vs-advanced-vm-split.md) |
+| Memory HAL unification | [`ADR-memory-hal-unification.md`](ADR-memory-hal-unification.md) |
+| Memory profile gating | [`ADR-memory-profile-gating.md`](ADR-memory-profile-gating.md) |

--- a/docs/ai-agents/README.md
+++ b/docs/ai-agents/README.md
@@ -1,3 +1,14 @@
+---
+title: AI Agent & Skill Documentation Kit
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - ai-agents
+see_also:
+  - README.md
+---
 # AI Agent & Skill Documentation Kit
 
 This folder provides a **portable documentation structure** for code agents and IDE assistants, so teams can keep one source of truth and adapt it across tools such as:

--- a/docs/ai-agents/ide/antigravity.md
+++ b/docs/ai-agents/ide/antigravity.md
@@ -1,3 +1,15 @@
+---
+title: Antigravity IDE Integration Guide
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - ai-agents
+  - ide
+see_also:
+  - README.md
+---
 # Antigravity IDE Integration Guide
 
 ## Recommended Setup

--- a/docs/ai-agents/ide/vscode.md
+++ b/docs/ai-agents/ide/vscode.md
@@ -1,3 +1,15 @@
+---
+title: VS Code Integration Guide
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - ai-agents
+  - ide
+see_also:
+  - README.md
+---
 # VS Code Integration Guide
 
 ## Recommended Setup

--- a/docs/ai-agents/platforms/claude.md
+++ b/docs/ai-agents/platforms/claude.md
@@ -1,3 +1,15 @@
+---
+title: Claude Runtime Notes
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - ai-agents
+  - platforms
+see_also:
+  - README.md
+---
 # Claude Runtime Notes
 
 ## Recommended Inputs

--- a/docs/ai-agents/platforms/codex.md
+++ b/docs/ai-agents/platforms/codex.md
@@ -1,3 +1,15 @@
+---
+title: Codex Runtime Notes
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - ai-agents
+  - platforms
+see_also:
+  - README.md
+---
 # Codex Runtime Notes
 
 ## Recommended Files

--- a/docs/ai-agents/platforms/github-copilot.md
+++ b/docs/ai-agents/platforms/github-copilot.md
@@ -1,3 +1,15 @@
+---
+title: GitHub Copilot Runtime Notes
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - ai-agents
+  - platforms
+see_also:
+  - README.md
+---
 # GitHub Copilot Runtime Notes
 
 ## Recommended Inputs

--- a/docs/ai-agents/platforms/google-jules.md
+++ b/docs/ai-agents/platforms/google-jules.md
@@ -1,3 +1,15 @@
+---
+title: Google/Jules-Style Agent Notes
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - ai-agents
+  - platforms
+see_also:
+  - README.md
+---
 # Google/Jules-Style Agent Notes
 
 ## Recommended Inputs

--- a/docs/ai-agents/standards/AGENT.md
+++ b/docs/ai-agents/standards/AGENT.md
@@ -1,3 +1,15 @@
+---
+title: Agent Specification (Cross-Platform)
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - ai-agents
+  - standards
+see_also:
+  - README.md
+---
 # Agent Specification (Cross-Platform)
 
 Use this document as the shared baseline for any code agent operating in the repo.

--- a/docs/ai-agents/standards/GUARDRAILS.md
+++ b/docs/ai-agents/standards/GUARDRAILS.md
@@ -1,3 +1,15 @@
+---
+title: Agent Guardrails
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - ai-agents
+  - standards
+see_also:
+  - README.md
+---
 # Agent Guardrails
 
 Guardrails define hard boundaries and review gates for automated coding activity.

--- a/docs/ai-agents/standards/SKILL.md
+++ b/docs/ai-agents/standards/SKILL.md
@@ -1,3 +1,15 @@
+---
+title: Skill Specification (Cross-Platform)
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - ai-agents
+  - standards
+see_also:
+  - README.md
+---
 # Skill Specification (Cross-Platform)
 
 A skill is a reusable package of instructions + optional scripts/templates that an agent can invoke for a specific class of tasks.

--- a/docs/ai-agents/templates/AGENTS.template.md
+++ b/docs/ai-agents/templates/AGENTS.template.md
@@ -1,3 +1,15 @@
+---
+title: AGENTS.md Template
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - ai-agents
+  - templates
+see_also:
+  - README.md
+---
 # AGENTS.md Template
 
 ## Scope

--- a/docs/ai-agents/templates/SKILL.template.md
+++ b/docs/ai-agents/templates/SKILL.template.md
@@ -1,3 +1,15 @@
+---
+title: SKILL.md Template
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - ai-agents
+  - templates
+see_also:
+  - README.md
+---
 # SKILL.md Template
 
 ## Name

--- a/docs/architecture/000_KERNEL_ARCHITECTURE.md
+++ b/docs/architecture/000_KERNEL_ARCHITECTURE.md
@@ -1,3 +1,14 @@
+---
+title: `KERNEL_ARCHITECTURE.md`
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+see_also:
+  - README.md
+---
 Operating systems are strange beasts. They sit between **physics and abstraction**. On one side: electrons, buses, cache lines, interrupts. On the other: files, processes, sockets, GUIs. A good kernel architecture document is essentially a **map of that borderland**.
 
 For a serious OS repository like **Bharat-OS**, three documents anchor the project:

--- a/docs/architecture/AUTOMOTIVE_ARCHITECTURE.md
+++ b/docs/architecture/AUTOMOTIVE_ARCHITECTURE.md
@@ -1,3 +1,14 @@
+---
+title: Bharat-OS Automotive & Mobility Architecture
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+see_also:
+  - README.md
+---
 # Bharat-OS Automotive & Mobility Architecture
 
 ## 1. Purpose

--- a/docs/architecture/BOOT_SELFTEST_POLICY.md
+++ b/docs/architecture/BOOT_SELFTEST_POLICY.md
@@ -1,3 +1,14 @@
+---
+title: Bharat-OS Boot Self-Test Policy
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+see_also:
+  - README.md
+---
 # Bharat-OS Boot Self-Test Policy
 
 ## Purpose

--- a/docs/architecture/DISTRIBUTED_KERNEL_PLAN.md
+++ b/docs/architecture/DISTRIBUTED_KERNEL_PLAN.md
@@ -1,3 +1,14 @@
+---
+title: Distributed Kernel Ownership Plan
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+see_also:
+  - README.md
+---
 # Distributed Kernel Ownership Plan
 
 ## Objective

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,3 +1,14 @@
+---
+title: Architecture Documentation Index
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+see_also:
+  - README.md
+---
 # Architecture Documentation Index
 
 This index maps Bharat-OS architecture documentation to the current repository structure.

--- a/docs/architecture/SHAKTI_BHARAT_OS_IMPLEMENTATION_PLAN.md
+++ b/docs/architecture/SHAKTI_BHARAT_OS_IMPLEMENTATION_PLAN.md
@@ -1,3 +1,14 @@
+---
+title: SHAKTI Integration Plan for Bharat-OS
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+see_also:
+  - README.md
+---
 # SHAKTI Integration Plan for Bharat-OS
 
 This document defines a **clean-integration plan** for SHAKTI support in Bharat-OS without contaminating architecture-neutral kernel surfaces.

--- a/docs/architecture/arch-capability-matrix.md
+++ b/docs/architecture/arch-capability-matrix.md
@@ -1,3 +1,14 @@
+---
+title: Architecture Capability Matrix
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+see_also:
+  - README.md
+---
 # Architecture Capability Matrix
 
 This document defines the expected architecture capabilities for the runtime tiers.

--- a/docs/architecture/arm32-rv32-edge-tier-plan.md
+++ b/docs/architecture/arm32-rv32-edge-tier-plan.md
@@ -1,3 +1,14 @@
+---
+title: ARM32 + RV32 EDGE-Tier Architecture Expansion Plan
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+see_also:
+  - README.md
+---
 # ARM32 + RV32 EDGE-Tier Architecture Expansion Plan
 
 This document defines how Bharat-OS should add 32-bit architecture support without splitting into separate kernel personalities.

--- a/docs/architecture/bidl-v1.md
+++ b/docs/architecture/bidl-v1.md
@@ -1,3 +1,14 @@
+---
+title: Bharat-OS IDL (BIDL) v1 Grammar (Current Implementation Profile)
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+see_also:
+  - README.md
+---
 # Bharat-OS IDL (BIDL) v1 Grammar (Current Implementation Profile)
 
 ## 1. Purpose and Scope

--- a/docs/architecture/boot/BOOT_ARCHITECTURE.md
+++ b/docs/architecture/boot/BOOT_ARCHITECTURE.md
@@ -1,3 +1,15 @@
+---
+title: Bharat-OS Boot Architecture
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - boot
+see_also:
+  - README.md
+---
 # Bharat-OS Boot Architecture
 
 ## 1. Purpose

--- a/docs/architecture/boot/boot-status-and-roadmap.md
+++ b/docs/architecture/boot/boot-status-and-roadmap.md
@@ -1,3 +1,15 @@
+---
+title: Boot Architecture Status and Roadmap
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - boot
+see_also:
+  - README.md
+---
 # Boot Architecture Status and Roadmap
 
 ## Current Code Status (March 2026)

--- a/docs/architecture/boot/boot_contract.md
+++ b/docs/architecture/boot/boot_contract.md
@@ -1,3 +1,15 @@
+---
+title: Canonical Boot Contract
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - boot
+see_also:
+  - README.md
+---
 # Canonical Boot Contract
 
 ### Contract Status

--- a/docs/architecture/boot/boot_display_architecture.md
+++ b/docs/architecture/boot/boot_display_architecture.md
@@ -1,3 +1,15 @@
+---
+title: Boot Display Architecture
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - boot
+see_also:
+  - README.md
+---
 # Boot Display Architecture
 
 **Bharat-OS boot graphics is a user-space, capability-mediated, machine-discovered subsystem that selects the best available display path at boot, while preserving text/serial fallback and keeping GUI policy out of the kernel.**

--- a/docs/architecture/boot/boot_flow_riscv64.md
+++ b/docs/architecture/boot/boot_flow_riscv64.md
@@ -1,3 +1,15 @@
+---
+title: Boot Flow: RISC-V (64-bit)
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - boot
+see_also:
+  - README.md
+---
 # Boot Flow: RISC-V (64-bit)
 
 ## Overview

--- a/docs/architecture/boot/boot_flow_x86_64.md
+++ b/docs/architecture/boot/boot_flow_x86_64.md
@@ -1,3 +1,15 @@
+---
+title: Boot Flow: x86_64
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - boot
+see_also:
+  - README.md
+---
 # Boot Flow: x86_64
 
 ## Overview

--- a/docs/architecture/boot/boot_security.md
+++ b/docs/architecture/boot/boot_security.md
@@ -1,3 +1,15 @@
+---
+title: Boot Security Metadata
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - boot
+see_also:
+  - README.md
+---
 # Boot Security Metadata
 
 **Status**: Active

--- a/docs/architecture/boot/boot_sources.md
+++ b/docs/architecture/boot/boot_sources.md
@@ -1,3 +1,15 @@
+---
+title: Boot Source Adapters
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - boot
+see_also:
+  - README.md
+---
 # Boot Source Adapters
 
 **Status**: Active

--- a/docs/architecture/boot/boot_test_matrix.md
+++ b/docs/architecture/boot/boot_test_matrix.md
@@ -1,3 +1,15 @@
+---
+title: Boot Test Matrix
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - boot
+see_also:
+  - README.md
+---
 # Boot Test Matrix
 
 **Status**: Active

--- a/docs/architecture/boot/boot_validation.md
+++ b/docs/architecture/boot/boot_validation.md
@@ -1,3 +1,15 @@
+---
+title: Boot Validation Framework
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - boot
+see_also:
+  - README.md
+---
 # Boot Validation Framework
 
 **Status**: Active

--- a/docs/architecture/boot/memory-architecture-multikernel.md
+++ b/docs/architecture/boot/memory-architecture-multikernel.md
@@ -1,3 +1,15 @@
+---
+title: 1. Executive Summary
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - boot
+see_also:
+  - README.md
+---
 # 1. Executive Summary
 
 This document defines the **Bharat-OS Memory Architecture** aligned with:

--- a/docs/architecture/boot/v1-boot-definition.md
+++ b/docs/architecture/boot/v1-boot-definition.md
@@ -1,3 +1,15 @@
+---
+title: v1 Boot Definition
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - boot
+see_also:
+  - README.md
+---
 # v1 Boot Definition
 
 ## Purpose

--- a/docs/architecture/components/drivers-subcomponents-architecture.md
+++ b/docs/architecture/components/drivers-subcomponents-architecture.md
@@ -1,3 +1,15 @@
+---
+title: Drivers Subcomponents Architecture (Repository-Aligned Status + Roadmap)
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - components
+see_also:
+  - README.md
+---
 # Drivers Subcomponents Architecture (Repository-Aligned Status + Roadmap)
 
 This document maps driver domains to the **current `core/drivers/` folder tree** and captures concrete convergence tasks.

--- a/docs/architecture/components/kernel-subcomponents-architecture.md
+++ b/docs/architecture/components/kernel-subcomponents-architecture.md
@@ -1,3 +1,15 @@
+---
+title: Kernel Subcomponents Architecture (Repository-Aligned Status + Roadmap)
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - components
+see_also:
+  - README.md
+---
 # Kernel Subcomponents Architecture (Repository-Aligned Status + Roadmap)
 
 This document decomposes kernel subcomponents according to the **current `core/kernel/src` tree** and maps closure tasks.

--- a/docs/architecture/components/proposed-drivers.md
+++ b/docs/architecture/components/proposed-drivers.md
@@ -1,3 +1,15 @@
+---
+title: Proposed Drivers Architecture and Roadmap (Aligned to Current Tree)
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - components
+see_also:
+  - README.md
+---
 # Proposed Drivers Architecture and Roadmap (Aligned to Current Tree)
 
 This document tracks **what exists now** and the production-grade first slice implemented for network and CAN driver classes.

--- a/docs/architecture/components/services-subcomponents-architecture.md
+++ b/docs/architecture/components/services-subcomponents-architecture.md
@@ -1,3 +1,15 @@
+---
+title: Services Subcomponents Architecture (Repository-Aligned Status + Roadmap)
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - components
+see_also:
+  - README.md
+---
 # Services Subcomponents Architecture (Repository-Aligned Status + Roadmap)
 
 This document maps the service layer to the **current repository structure** and highlights consolidation work needed to align with `docs/architecture/folder_structure.md`.

--- a/docs/architecture/components/subsystem-subcomponents-architecture.md
+++ b/docs/architecture/components/subsystem-subcomponents-architecture.md
@@ -1,3 +1,15 @@
+---
+title: Subsystem Subcomponents Architecture (Repository-Aligned Status + Roadmap)
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - components
+see_also:
+  - README.md
+---
 # Subsystem Subcomponents Architecture (Repository-Aligned Status + Roadmap)
 
 This document tracks subsystem-level decomposition against the current repository layout (`core/personalities/`, `core/stacks/`, and core/kernel/service subsystem touchpoints).

--- a/docs/architecture/console/console_architecture.md
+++ b/docs/architecture/console/console_architecture.md
@@ -1,3 +1,15 @@
+---
+title: Console and Shell Architecture (Aligned Runtime Contract)
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - console
+see_also:
+  - README.md
+---
 # Console and Shell Architecture (Aligned Runtime Contract)
 
 This document defines the **current Bharat-OS console + shell architecture contract** and aligns it with the code that exists today.

--- a/docs/architecture/contracts/adr-002-personality-model.md
+++ b/docs/architecture/contracts/adr-002-personality-model.md
@@ -1,3 +1,15 @@
+---
+title: ADR 002: Personality Model Architecture
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - contracts
+see_also:
+  - README.md
+---
 # ADR 002: Personality Model Architecture
 
 ## 1. Status

--- a/docs/architecture/contracts/bidl-security-annotations.md
+++ b/docs/architecture/contracts/bidl-security-annotations.md
@@ -1,3 +1,15 @@
+---
+title: BIDL Security Annotations
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - contracts
+see_also:
+  - README.md
+---
 # BIDL Security Annotations
 
 BIDL serves as the declarative authority contract for Bharat-OS. The generated dispatcher runtimes rely on security annotations to enforce capability and lease boundaries automatically. Manual dispatcher bypasses are forbidden.

--- a/docs/architecture/contracts/naming-conventions.md
+++ b/docs/architecture/contracts/naming-conventions.md
@@ -1,3 +1,15 @@
+---
+title: Naming Conventions
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - contracts
+see_also:
+  - README.md
+---
 # Naming Conventions
 
 ## Naming Rules

--- a/docs/architecture/contracts/personality-contract-architecture.md
+++ b/docs/architecture/contracts/personality-contract-architecture.md
@@ -1,3 +1,15 @@
+---
+title: Personality Contract Architecture
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - contracts
+see_also:
+  - README.md
+---
 # Personality Contract Architecture
 
 ### Contract Status

--- a/docs/architecture/contracts/personality-implementation-roadmap.md
+++ b/docs/architecture/contracts/personality-implementation-roadmap.md
@@ -1,3 +1,15 @@
+---
+title: Personality Implementation Roadmap
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - contracts
+see_also:
+  - README.md
+---
 # Personality Implementation Roadmap
 
 ## Program Name

--- a/docs/architecture/contracts/personality-naming.md
+++ b/docs/architecture/contracts/personality-naming.md
@@ -1,3 +1,15 @@
+---
+title: Personality Naming and Vocabulary
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - contracts
+see_also:
+  - README.md
+---
 # Personality Naming and Vocabulary
 
 ## 1. Overview

--- a/docs/architecture/core/README.md
+++ b/docs/architecture/core/README.md
@@ -1,3 +1,15 @@
+---
+title: Core Architecture
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - core
+see_also:
+  - README.md
+---
 # Core Architecture
 
 This folder contains foundational architectural models for Bharat-OS.

--- a/docs/architecture/core/backend-telemetry-model.md
+++ b/docs/architecture/core/backend-telemetry-model.md
@@ -1,3 +1,15 @@
+---
+title: Backend Telemetry Model
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - core
+see_also:
+  - README.md
+---
 # Backend Telemetry Model
 
 ## Overview

--- a/docs/architecture/core/boot-runtime-lifecycle.md
+++ b/docs/architecture/core/boot-runtime-lifecycle.md
@@ -1,3 +1,15 @@
+---
+title: Boot and Runtime Lifecycle Contract
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - core
+see_also:
+  - README.md
+---
 # Boot and Runtime Lifecycle Contract
 
 ## 1. Purpose

--- a/docs/architecture/core/build-packaging-run-flash-debug-contract.md
+++ b/docs/architecture/core/build-packaging-run-flash-debug-contract.md
@@ -1,3 +1,15 @@
+---
+title: Build, Packaging, Run, Flash, and Debug Contract
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - core
+see_also:
+  - README.md
+---
 # Build, Packaging, Run, Flash, and Debug Contract
 
 This document outlines the manifest-driven target delivery pipeline architecture for Bharat-OS. The pipeline transforms declarative inputs (YAML targets or legacy JSON configs) into runnable or flashable artifacts while strictly decoupling the compilation, packaging, and execution phases.

--- a/docs/architecture/core/constraint-aware-execution.md
+++ b/docs/architecture/core/constraint-aware-execution.md
@@ -1,3 +1,15 @@
+---
+title: Constraint-Aware Execution Substrate
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - core
+see_also:
+  - README.md
+---
 # Constraint-Aware Execution Substrate
 
 This document outlines the core architecture for Bharat-OS constraint-aware execution.

--- a/docs/architecture/core/execution-mode-and-cpu-partitioning.md
+++ b/docs/architecture/core/execution-mode-and-cpu-partitioning.md
@@ -1,3 +1,15 @@
+---
+title: Execution Mode and CPU Partitioning Architecture
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - core
+see_also:
+  - README.md
+---
 # Execution Mode and CPU Partitioning Architecture
 
 This document describes the design and rationale for the execution mode and CPU partitioning framework in Bharat-OS.

--- a/docs/architecture/core/feature-class-taxonomy.md
+++ b/docs/architecture/core/feature-class-taxonomy.md
@@ -1,3 +1,15 @@
+---
+title: Feature Class Taxonomy
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - core
+see_also:
+  - README.md
+---
 # Feature Class Taxonomy
 
 ## Overview

--- a/docs/architecture/core/hardware-capability-model.md
+++ b/docs/architecture/core/hardware-capability-model.md
@@ -1,3 +1,15 @@
+---
+title: Hardware Capability Model
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - core
+see_also:
+  - README.md
+---
 # Hardware Capability Model
 
 ## Overview

--- a/docs/architecture/core/isa-capability-dispatch-analysis-and-implementation-plan.md
+++ b/docs/architecture/core/isa-capability-dispatch-analysis-and-implementation-plan.md
@@ -1,3 +1,15 @@
+---
+title: ISA Capability & Dispatch Analysis + Implementation Plan
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - core
+see_also:
+  - README.md
+---
 # ISA Capability & Dispatch Analysis + Implementation Plan
 
 ## Purpose

--- a/docs/architecture/core/kernel-alignment-and-gap-analysis.md
+++ b/docs/architecture/core/kernel-alignment-and-gap-analysis.md
@@ -1,3 +1,15 @@
+---
+title: 📘 Bharat-OS Core Architecture Alignment
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - core
+see_also:
+  - README.md
+---
 # 📘 Bharat-OS Core Architecture Alignment
 
 **File:** `docs/architecture/core/kernel-alignment-and-gap-analysis.md`

--- a/docs/architecture/core/process-scheduler-architecture.md
+++ b/docs/architecture/core/process-scheduler-architecture.md
@@ -1,3 +1,15 @@
+---
+title: Process & Scheduler Architecture in Bharat-OS
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - core
+see_also:
+  - README.md
+---
 # Process & Scheduler Architecture in Bharat-OS
 
 This document outlines the fundamental shift in how Bharat-OS handles processes, threads, and scheduling compared to traditional monolithic operating systems like Linux, Windows, macOS, iOS, and Android.

--- a/docs/architecture/core/profile-startup-matrix.md
+++ b/docs/architecture/core/profile-startup-matrix.md
@@ -1,3 +1,15 @@
+---
+title: Profile Startup Matrix
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - core
+see_also:
+  - README.md
+---
 # Profile Startup Matrix
 
 ## Overview

--- a/docs/architecture/core/service-identity-and-incarnation.md
+++ b/docs/architecture/core/service-identity-and-incarnation.md
@@ -1,3 +1,15 @@
+---
+title: Service Identity and Incarnation
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - core
+see_also:
+  - README.md
+---
 # Service Identity and Incarnation
 
 This document details the primitives governing service identity and restarting within the Bharat-OS multikernel.

--- a/docs/architecture/core/uapi-idl-ipc-boundary.md
+++ b/docs/architecture/core/uapi-idl-ipc-boundary.md
@@ -1,3 +1,15 @@
+---
+title: UAPI, IDL, and IPC Boundary
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - core
+see_also:
+  - README.md
+---
 # UAPI, IDL, and IPC Boundary
 
 This document explicitly defines the separation of concerns between UAPI, IDL, and IPC layers in Bharat-OS. Maintaining strict discipline around these boundaries is critical for a stable ABI, decoupled service interactions, and long-term architectural health.

--- a/docs/architecture/crypto-boundary.md
+++ b/docs/architecture/crypto-boundary.md
@@ -1,3 +1,14 @@
+---
+title: Crypto Boundary Architecture
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+see_also:
+  - README.md
+---
 # Crypto Boundary Architecture
 
 ## Kernel vs Service Responsibility Matrix

--- a/docs/architecture/device-manager-contract.md
+++ b/docs/architecture/device-manager-contract.md
@@ -1,3 +1,14 @@
+---
+title: Device Manager (devmgr) Contract
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+see_also:
+  - README.md
+---
 # Device Manager (devmgr) Contract
 
 ### Contract Status

--- a/docs/architecture/device-profiles-and-use-cases.md
+++ b/docs/architecture/device-profiles-and-use-cases.md
@@ -1,3 +1,14 @@
+---
+title: Device Profiles and Use-cases
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+see_also:
+  - README.md
+---
 # Device Profiles and Use-cases
 
 This document maps Bharat-OS architectural features to practical deployment classes and distinguishes **implemented baseline** vs **roadmap**.

--- a/docs/architecture/device-profiles.md
+++ b/docs/architecture/device-profiles.md
@@ -1,3 +1,14 @@
+---
+title: Device Profiles and Subsystem Matrix
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+see_also:
+  - README.md
+---
 # Device Profiles and Subsystem Matrix
 
 This document summarizes how Bharat-OS maps a common microkernel core to different device categories and deployment profiles.

--- a/docs/architecture/device_class_mapping.md
+++ b/docs/architecture/device_class_mapping.md
@@ -1,3 +1,14 @@
+---
+title: Device Class Registry Mapping
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+see_also:
+  - README.md
+---
 # Device Class Registry Mapping
 
 The `bharat_device_class_t` and `bharat_device_descriptor_t` defined in `include/bharat/interface/uapi/device/device_class.h` provide a normalized classification and descriptor contract across the system.

--- a/docs/architecture/display_subsystem.md
+++ b/docs/architecture/display_subsystem.md
@@ -1,3 +1,14 @@
+---
+title: Display and Output Architecture
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+see_also:
+  - README.md
+---
 # Display and Output Architecture
 
 The graphical and output presentation system in Bharat-OS defines multiple levels of abstraction. Unlike conventional OSes that treat the desktop compositor as the sole interface, we provide an intentionally layered approach that scales down to headless devices and up to complex multi-monitor desktop workstations.

--- a/docs/architecture/distributed-kernel-implementation-plan.md
+++ b/docs/architecture/distributed-kernel-implementation-plan.md
@@ -1,3 +1,14 @@
+---
+title: Distributed Kernel Implementation Plan (Automotive & Mobility)
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+see_also:
+  - README.md
+---
 # Distributed Kernel Implementation Plan (Automotive & Mobility)
 
 This plan converts the automotive architecture direction into an executable engineering program for Bharat-OS kernel, subsystem, and OS layers.

--- a/docs/architecture/driver-model-baseline.md
+++ b/docs/architecture/driver-model-baseline.md
@@ -1,3 +1,14 @@
+---
+title: Driver Model Baseline Architecture
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+see_also:
+  - README.md
+---
 # Driver Model Baseline Architecture
 
 ## Purpose

--- a/docs/architecture/driver-model.md
+++ b/docs/architecture/driver-model.md
@@ -1,3 +1,14 @@
+---
+title: Driver Model
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+see_also:
+  - README.md
+---
 # Driver Model
 
 ## Overview

--- a/docs/architecture/edge32-portability-audit.md
+++ b/docs/architecture/edge32-portability-audit.md
@@ -1,3 +1,14 @@
+---
+title: EDGE32 Portability Audit
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+see_also:
+  - README.md
+---
 # EDGE32 Portability Audit
 
 This document summarizes the current status of pointer-width inference and portability assumptions that must be addressed before the full arm32 and riscv32 (EDGE32 Tier 2) ports can be considered fully functional.

--- a/docs/architecture/footprint/footprint-tier-model.md
+++ b/docs/architecture/footprint/footprint-tier-model.md
@@ -1,3 +1,15 @@
+---
+title: Bharat-OS Footprint Tier Model
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - footprint
+see_also:
+  - README.md
+---
 # Bharat-OS Footprint Tier Model
 
 This document defines the **official footprint contract** for Bharat-OS targets.

--- a/docs/architecture/gui-strategy.md
+++ b/docs/architecture/gui-strategy.md
@@ -1,3 +1,14 @@
+---
+title: GUI Strategy — Bharat-OS
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+see_also:
+  - README.md
+---
 # GUI Strategy — Bharat-OS
 
 **Status:** Planned (user-space service, deferred post v1 kernel)

--- a/docs/architecture/hardware-abstraction-and-drivers-baseline.md
+++ b/docs/architecture/hardware-abstraction-and-drivers-baseline.md
@@ -1,3 +1,14 @@
+---
+title: Hardware Abstraction and Driver Baseline (v1)
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+see_also:
+  - README.md
+---
 # Hardware Abstraction and Driver Baseline (v1)
 
 This document captures the current HAL and driver-framework baseline in kernel space.

--- a/docs/architecture/interrupt/interrupt-architecture.md
+++ b/docs/architecture/interrupt/interrupt-architecture.md
@@ -1,3 +1,15 @@
+---
+title: Interrupt Architecture
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - interrupt
+see_also:
+  - README.md
+---
 # Interrupt Architecture
 
 ## Overview

--- a/docs/architecture/isa/triCore-rx-strategy.md
+++ b/docs/architecture/isa/triCore-rx-strategy.md
@@ -1,3 +1,15 @@
+---
+title: TriCore / Renesas RX Strategy
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - isa
+see_also:
+  - README.md
+---
 # TriCore / Renesas RX Strategy
 
 This note captures the selection posture for safety and industrial domains.

--- a/docs/architecture/kernel-functionality-tiers-v1.md
+++ b/docs/architecture/kernel-functionality-tiers-v1.md
@@ -1,3 +1,14 @@
+---
+title: Kernel Functionality Tiers (v1)
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+see_also:
+  - README.md
+---
 # Kernel Functionality Tiers (v1)
 
 ## Purpose

--- a/docs/architecture/kernel-object-model.md
+++ b/docs/architecture/kernel-object-model.md
@@ -1,3 +1,14 @@
+---
+title: Kernel Object Model
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+see_also:
+  - README.md
+---
 # Kernel Object Model
 
 ## Overview

--- a/docs/architecture/kernel-subcomponents-architecture.md
+++ b/docs/architecture/kernel-subcomponents-architecture.md
@@ -1,3 +1,14 @@
+---
+title: Kernel Subcomponents Architecture
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+see_also:
+  - README.md
+---
 
 ### Boot Subsystem Refactor
 The core boot flow has been heavily refactored:

--- a/docs/architecture/kernel/capabilities/README.md
+++ b/docs/architecture/kernel/capabilities/README.md
@@ -1,3 +1,15 @@
+---
+title: Capability Model
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - kernel
+see_also:
+  - README.md
+---
 # Capability Model
 
 **See also:**

--- a/docs/architecture/kernel/capabilities/access-control.md
+++ b/docs/architecture/kernel/capabilities/access-control.md
@@ -1,3 +1,15 @@
+---
+title: Access Control Model
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - kernel
+see_also:
+  - README.md
+---
 # Access Control Model
 
 ## Overview

--- a/docs/architecture/kernel/capabilities/capability-naming-and-terms.md
+++ b/docs/architecture/kernel/capabilities/capability-naming-and-terms.md
@@ -1,3 +1,15 @@
+---
+title: Capability Naming and Terms
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - kernel
+see_also:
+  - README.md
+---
 # Capability Naming and Terms
 
 This document specifies the canonical naming conventions for capability types, rights, and related distributed-consistency primitives in Bharat-OS.

--- a/docs/architecture/kernel/capabilities/capability-types.md
+++ b/docs/architecture/kernel/capabilities/capability-types.md
@@ -1,3 +1,15 @@
+---
+title: Capability Types
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - kernel
+see_also:
+  - README.md
+---
 # Capability Types
 
 ## Overview

--- a/docs/architecture/kernel/capabilities/comparison.md
+++ b/docs/architecture/kernel/capabilities/comparison.md
@@ -1,3 +1,15 @@
+---
+title: Comparison: POSIX vs. seL4 vs. Bharat-OS
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - kernel
+see_also:
+  - README.md
+---
 # Comparison: POSIX vs. seL4 vs. Bharat-OS
 
 ## Overview

--- a/docs/architecture/kernel/capabilities/cspace.md
+++ b/docs/architecture/kernel/capabilities/cspace.md
@@ -1,3 +1,15 @@
+---
+title: Capability Space (CSpace)
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - kernel
+see_also:
+  - README.md
+---
 # Capability Space (CSpace)
 
 ## Overview

--- a/docs/architecture/kernel/capabilities/derivation.md
+++ b/docs/architecture/kernel/capabilities/derivation.md
@@ -1,3 +1,15 @@
+---
+title: Derivation and Revocation
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - kernel
+see_also:
+  - README.md
+---
 # Derivation and Revocation
 
 ## Overview

--- a/docs/architecture/kernel/capabilities/roadmap.md
+++ b/docs/architecture/kernel/capabilities/roadmap.md
@@ -1,3 +1,15 @@
+---
+title: Capabilities Roadmap
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - kernel
+see_also:
+  - README.md
+---
 # Capabilities Roadmap
 
 ## Current Status (v1 Baseline)

--- a/docs/architecture/kernel/capabilities/sealing.md
+++ b/docs/architecture/kernel/capabilities/sealing.md
@@ -1,3 +1,15 @@
+---
+title: Sealing
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - kernel
+see_also:
+  - README.md
+---
 # Sealing
 
 ## Overview

--- a/docs/architecture/kernel/console/roadmap.md
+++ b/docs/architecture/kernel/console/roadmap.md
@@ -1,3 +1,15 @@
+---
+title: Console Subsystem Roadmap
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - kernel
+see_also:
+  - README.md
+---
 # Console Subsystem Roadmap
 
 This roadmap tracks the functional implementation of the Bharat-OS Console Subsystem.

--- a/docs/architecture/kernel/ipc/IPC_ARCHITECTURE.md
+++ b/docs/architecture/kernel/ipc/IPC_ARCHITECTURE.md
@@ -1,3 +1,15 @@
+---
+title: Kernel IPC Architecture
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - kernel
+see_also:
+  - README.md
+---
 # Kernel IPC Architecture
 
 This document aggregates the theoretical primitives for Inter-Process Communication (IPC) in Bharat-OS. The primary cross-core messaging mechanism moving forward is **URPC**. For details regarding that, see the `urpc/` directory. The primitives below define legacy or specialized IPC support.

--- a/docs/architecture/kernel/ipc/README.md
+++ b/docs/architecture/kernel/ipc/README.md
@@ -1,3 +1,15 @@
+---
+title: Bharat-OS IPC Architecture
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - kernel
+see_also:
+  - README.md
+---
 # Bharat-OS IPC Architecture
 
 This document describes the design and guarantees of the Inter-Process Communication (IPC) subsystems in Bharat-OS. The communication architecture is divided into a layered model spanning local interactions, asynchronous requests, and cross-core multikernel transports.

--- a/docs/architecture/kernel/ipc/ipc-performance.md
+++ b/docs/architecture/kernel/ipc/ipc-performance.md
@@ -1,3 +1,15 @@
+---
+title: IPC Performance
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - kernel
+see_also:
+  - README.md
+---
 # IPC Performance
 
 ## Overview

--- a/docs/architecture/kernel/ipc/roadmap.md
+++ b/docs/architecture/kernel/ipc/roadmap.md
@@ -1,3 +1,15 @@
+---
+title: IPC Roadmap
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - kernel
+see_also:
+  - README.md
+---
 # IPC Roadmap
 
 ## Current Status (v1 Baseline)

--- a/docs/architecture/kernel/process_thread.md
+++ b/docs/architecture/kernel/process_thread.md
@@ -1,3 +1,15 @@
+---
+title: Bharat-OS Process & Thread Management Architecture
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - kernel
+see_also:
+  - README.md
+---
 # Bharat-OS Process & Thread Management Architecture
 
 **Version:** v2.0 (Proposed - True Multikernel)

--- a/docs/architecture/kernel/process_thread_future_tasks.md
+++ b/docs/architecture/kernel/process_thread_future_tasks.md
@@ -1,3 +1,15 @@
+---
+title: Process & Thread Management Architecture - Future Implementation Plan
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - kernel
+see_also:
+  - README.md
+---
 # Process & Thread Management Architecture - Future Implementation Plan
 
 **Version:** v2.0 (Proposed - True Multikernel)

--- a/docs/architecture/kernel/scheduler/README.md
+++ b/docs/architecture/kernel/scheduler/README.md
@@ -1,3 +1,15 @@
+---
+title: Kernel Scheduler Documentation
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - kernel
+see_also:
+  - README.md
+---
 # Kernel Scheduler Documentation
 
 This folder is the single source of truth for scheduler architecture, implementation status, and roadmap.

--- a/docs/architecture/kernel/scheduler/ai-scheduler-overview.md
+++ b/docs/architecture/kernel/scheduler/ai-scheduler-overview.md
@@ -1,3 +1,15 @@
+---
+title: AI Scheduler Overview
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - kernel
+see_also:
+  - README.md
+---
 # AI Scheduler Overview
 
 ## Design intent

--- a/docs/architecture/kernel/scheduler/ai-scheduler-status-and-roadmap.md
+++ b/docs/architecture/kernel/scheduler/ai-scheduler-status-and-roadmap.md
@@ -1,3 +1,15 @@
+---
+title: AI Scheduler Status and Roadmap
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - kernel
+see_also:
+  - README.md
+---
 # AI Scheduler Status and Roadmap
 
 ## Current status (as implemented)

--- a/docs/architecture/kernel/scheduler/algorithms.md
+++ b/docs/architecture/kernel/scheduler/algorithms.md
@@ -1,3 +1,15 @@
+---
+title: Scheduler Algorithms
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - kernel
+see_also:
+  - README.md
+---
 # Scheduler Algorithms
 
 ## Active policy selector

--- a/docs/architecture/kernel/scheduler/cpu-affinity.md
+++ b/docs/architecture/kernel/scheduler/cpu-affinity.md
@@ -1,3 +1,15 @@
+---
+title: CPU Affinity & NUMA
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - kernel
+see_also:
+  - README.md
+---
 # CPU Affinity & NUMA
 
 ## Overview

--- a/docs/architecture/kernel/scheduler/invariants-and-router-contract.md
+++ b/docs/architecture/kernel/scheduler/invariants-and-router-contract.md
@@ -1,3 +1,15 @@
+---
+title: Scheduler Invariants and Router Contract
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - kernel
+see_also:
+  - README.md
+---
 # Scheduler Invariants and Router Contract
 
 ### Contract Status

--- a/docs/architecture/kernel/scheduler/preemption.md
+++ b/docs/architecture/kernel/scheduler/preemption.md
@@ -1,3 +1,15 @@
+---
+title: Preemption
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - kernel
+see_also:
+  - README.md
+---
 # Preemption
 
 ## Overview

--- a/docs/architecture/kernel/scheduler/priority.md
+++ b/docs/architecture/kernel/scheduler/priority.md
@@ -1,3 +1,15 @@
+---
+title: Priority & Priority Inversion
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - kernel
+see_also:
+  - README.md
+---
 # Priority & Priority Inversion
 
 ## Overview

--- a/docs/architecture/kernel/scheduler/realtime.md
+++ b/docs/architecture/kernel/scheduler/realtime.md
@@ -1,3 +1,15 @@
+---
+title: Real-Time Support
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - kernel
+see_also:
+  - README.md
+---
 # Real-Time Support
 
 ## Overview

--- a/docs/architecture/kernel/scheduler/roadmap.md
+++ b/docs/architecture/kernel/scheduler/roadmap.md
@@ -1,3 +1,15 @@
+---
+title: Scheduler Roadmap
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - kernel
+see_also:
+  - README.md
+---
 # Scheduler Roadmap
 
 ## Status snapshot (from current scheduler code)

--- a/docs/architecture/kernel/scheduler/runqueue.md
+++ b/docs/architecture/kernel/scheduler/runqueue.md
@@ -1,3 +1,15 @@
+---
+title: Runqueue Design
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - kernel
+see_also:
+  - README.md
+---
 # Runqueue Design
 
 ## Overview

--- a/docs/architecture/kernel/scheduler/scheduler-and-threading.md
+++ b/docs/architecture/kernel/scheduler/scheduler-and-threading.md
@@ -1,3 +1,15 @@
+---
+title: Scheduler and Threading Baseline
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - kernel
+see_also:
+  - README.md
+---
 # Scheduler and Threading Baseline
 
 This document reflects the scheduler/threading baseline from current kernel code under `core/kernel/src/sched/` and `core/kernel/include/sched/`.

--- a/docs/architecture/kernel/scheduler/scheduler-invariants-and-host-tests.md
+++ b/docs/architecture/kernel/scheduler/scheduler-invariants-and-host-tests.md
@@ -1,3 +1,15 @@
+---
+title: Scheduler Invariants and Host-Test Contract
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - kernel
+see_also:
+  - README.md
+---
 # Scheduler Invariants and Host-Test Contract
 
 ## Purpose

--- a/docs/architecture/kernel/scheduler/time-accounting.md
+++ b/docs/architecture/kernel/scheduler/time-accounting.md
@@ -1,3 +1,15 @@
+---
+title: Time Accounting
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - kernel
+see_also:
+  - README.md
+---
 # Time Accounting
 
 ## Overview

--- a/docs/architecture/kernel/scheduler_model.md
+++ b/docs/architecture/kernel/scheduler_model.md
@@ -1,3 +1,15 @@
+---
+title: Scheduler Architecture (Multikernel Model)
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - kernel
+see_also:
+  - README.md
+---
 # Scheduler Architecture (Multikernel Model)
 
 **Version:** v2.0 (Proposed - True Multikernel)

--- a/docs/architecture/kernel/status-code-contract.md
+++ b/docs/architecture/kernel/status-code-contract.md
@@ -1,3 +1,15 @@
+---
+title: Status Code and Error Unification Contract
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - kernel
+see_also:
+  - README.md
+---
 # Status Code and Error Unification Contract
 
 ### Contract Status

--- a/docs/architecture/kernel/tasks-threads/README.md
+++ b/docs/architecture/kernel/tasks-threads/README.md
@@ -1,3 +1,15 @@
+---
+title: Bharat-OS Task and Thread Model
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - kernel
+see_also:
+  - README.md
+---
 # Bharat-OS Task and Thread Model
 
 ## Overview

--- a/docs/architecture/kernel/tasks-threads/context-switch.md
+++ b/docs/architecture/kernel/tasks-threads/context-switch.md
@@ -1,3 +1,15 @@
+---
+title: Context Switch and Syscall/Trap Gates
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - kernel
+see_also:
+  - README.md
+---
 # Context Switch and Syscall/Trap Gates
 
 This document defines the current in-kernel context switch mechanism and syscall/trap gate contract, adapting our architecture to the multikernel Barrelfish/seL4 model.

--- a/docs/architecture/kernel/tasks-threads/fork-exec.md
+++ b/docs/architecture/kernel/tasks-threads/fork-exec.md
@@ -1,3 +1,15 @@
+---
+title: Fork and Exec
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - kernel
+see_also:
+  - README.md
+---
 # Fork and Exec
 
 ## Overview

--- a/docs/architecture/kernel/tasks-threads/kernel-threads.md
+++ b/docs/architecture/kernel/tasks-threads/kernel-threads.md
@@ -1,3 +1,15 @@
+---
+title: Kernel Threads
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - kernel
+see_also:
+  - README.md
+---
 # Kernel Threads
 
 ## Overview

--- a/docs/architecture/kernel/tasks-threads/lifecycle.md
+++ b/docs/architecture/kernel/tasks-threads/lifecycle.md
@@ -1,3 +1,15 @@
+---
+title: Thread Lifecycle and State Machine
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - kernel
+see_also:
+  - README.md
+---
 # Thread Lifecycle and State Machine
 
 ### Contract Status

--- a/docs/architecture/kernel/tasks-threads/roadmap.md
+++ b/docs/architecture/kernel/tasks-threads/roadmap.md
@@ -1,3 +1,15 @@
+---
+title: Tasks & Threads Roadmap
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - kernel
+see_also:
+  - README.md
+---
 # Tasks & Threads Roadmap
 
 ## Current Status (v1 Baseline)

--- a/docs/architecture/kernel/tasks-threads/synchronization.md
+++ b/docs/architecture/kernel/tasks-threads/synchronization.md
@@ -1,3 +1,15 @@
+---
+title: Synchronization
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - kernel
+see_also:
+  - README.md
+---
 # Synchronization
 
 ## Overview

--- a/docs/architecture/kernel/tasks-threads/task-model.md
+++ b/docs/architecture/kernel/tasks-threads/task-model.md
@@ -1,3 +1,15 @@
+---
+title: The Task Model
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - kernel
+see_also:
+  - README.md
+---
 # The Task Model
 
 ## Definition

--- a/docs/architecture/kernel/tasks-threads/thread-model.md
+++ b/docs/architecture/kernel/tasks-threads/thread-model.md
@@ -1,3 +1,15 @@
+---
+title: The Thread Model
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - kernel
+see_also:
+  - README.md
+---
 # The Thread Model
 
 ## Definition

--- a/docs/architecture/kernel/tasks-threads/tls.md
+++ b/docs/architecture/kernel/tasks-threads/tls.md
@@ -1,3 +1,15 @@
+---
+title: Thread Local Storage (TLS)
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - kernel
+see_also:
+  - README.md
+---
 # Thread Local Storage (TLS)
 
 ## Overview

--- a/docs/architecture/kernel/urpc/README.md
+++ b/docs/architecture/kernel/urpc/README.md
@@ -1,3 +1,15 @@
+---
+title: uRPC (User-level Remote Procedure Call)
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - kernel
+see_also:
+  - README.md
+---
 # uRPC (User-level Remote Procedure Call)
 
 ## Overview

--- a/docs/architecture/kernel/urpc/call-model.md
+++ b/docs/architecture/kernel/urpc/call-model.md
@@ -1,3 +1,15 @@
+---
+title: uRPC Call Model
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - kernel
+see_also:
+  - README.md
+---
 # uRPC Call Model
 
 ## Overview

--- a/docs/architecture/kernel/urpc/endpoint-design.md
+++ b/docs/architecture/kernel/urpc/endpoint-design.md
@@ -1,3 +1,15 @@
+---
+title: Endpoint Design
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - kernel
+see_also:
+  - README.md
+---
 # Endpoint Design
 
 ## Overview

--- a/docs/architecture/kernel/urpc/kernel-path.md
+++ b/docs/architecture/kernel/urpc/kernel-path.md
@@ -1,3 +1,15 @@
+---
+title: uRPC Kernel Path
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - kernel
+see_also:
+  - README.md
+---
 # uRPC Kernel Path
 
 ## Overview

--- a/docs/architecture/kernel/urpc/marshalling.md
+++ b/docs/architecture/kernel/urpc/marshalling.md
@@ -1,3 +1,15 @@
+---
+title: Bharat-OS Message Wire Format v1
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - kernel
+see_also:
+  - README.md
+---
 # Bharat-OS Message Wire Format v1
 
 ## 1. Overview

--- a/docs/architecture/kernel/urpc/roadmap.md
+++ b/docs/architecture/kernel/urpc/roadmap.md
@@ -1,3 +1,15 @@
+---
+title: uRPC Roadmap
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - kernel
+see_also:
+  - README.md
+---
 # uRPC Roadmap
 
 ## Current Status (v1 Baseline)

--- a/docs/architecture/kernel/urpc/userspace-stub.md
+++ b/docs/architecture/kernel/urpc/userspace-stub.md
@@ -1,3 +1,15 @@
+---
+title: User-space Stubs
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - kernel
+see_also:
+  - README.md
+---
 # User-space Stubs
 
 ## Overview

--- a/docs/architecture/kernel/urpc_model.md
+++ b/docs/architecture/kernel/urpc_model.md
@@ -1,3 +1,15 @@
+---
+title: uRPC Architecture (Multikernel Model)
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - kernel
+see_also:
+  - README.md
+---
 # uRPC Architecture (Multikernel Model)
 
 **Version:** v2.0 (Proposed - True Multikernel)

--- a/docs/architecture/low-footprint-design.md
+++ b/docs/architecture/low-footprint-design.md
@@ -1,3 +1,14 @@
+---
+title: Low-Footprint Design and Analysis
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+see_also:
+  - README.md
+---
 # Low-Footprint Design and Analysis
 
 This document details the strategies and analysis for running Bharat-OS on resource-constrained hardware, specifically focusing on the **Nano** and **RT (Real-Time)** profiles.

--- a/docs/architecture/memory/ai-adjacent-memory-accel-roadmap.md
+++ b/docs/architecture/memory/ai-adjacent-memory-accel-roadmap.md
@@ -1,3 +1,15 @@
+---
+title: AI-Adjacent Memory & Accelerator Primitive Roadmap
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - memory
+see_also:
+  - README.md
+---
 # AI-Adjacent Memory & Accelerator Primitive Roadmap
 
 ## 1. Goal and Position

--- a/docs/architecture/memory/dma-iommu-lifecycle.md
+++ b/docs/architecture/memory/dma-iommu-lifecycle.md
@@ -1,3 +1,15 @@
+---
+title: DMA and IOMMU Lifecycle Contract
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - memory
+see_also:
+  - README.md
+---
 # DMA and IOMMU Lifecycle Contract
 
 ### Contract Status

--- a/docs/architecture/memory/memory-architecture-comprehensive.md
+++ b/docs/architecture/memory/memory-architecture-comprehensive.md
@@ -1,3 +1,15 @@
+---
+title: Bharat-OS Comprehensive Memory Architecture
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - memory
+see_also:
+  - README.md
+---
 # Bharat-OS Comprehensive Memory Architecture
 
 ## 1. Executive Summary

--- a/docs/architecture/memory/memory-model-capability-matrix.md
+++ b/docs/architecture/memory/memory-model-capability-matrix.md
@@ -1,3 +1,15 @@
+---
+title: Bharat-OS Memory Architecture: Capability Model
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - memory
+see_also:
+  - README.md
+---
 # Bharat-OS Memory Architecture: Capability Model
 
 Bharat-OS supports a variety of target architectures with varying memory management hardware capabilities. Instead of forcing heavy virtual memory (VM) semantics onto all architectures, we have established a **canonical memory model capability matrix**.

--- a/docs/architecture/memory/memory-roadmap-consolidated.md
+++ b/docs/architecture/memory/memory-roadmap-consolidated.md
@@ -1,3 +1,15 @@
+---
+title: Memory Architecture Roadmap & State
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - memory
+see_also:
+  - README.md
+---
 # Memory Architecture Roadmap & State
 
 This roadmap tracks the convergence of the memory management subsystem in Bharat-OS toward a production-grade multikernel architecture.

--- a/docs/architecture/memory/vm-authority-path.md
+++ b/docs/architecture/memory/vm-authority-path.md
@@ -1,3 +1,15 @@
+---
+title: Virtual Memory Authority Path Contract
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - memory
+see_also:
+  - README.md
+---
 # Virtual Memory Authority Path Contract
 
 This document defines the authoritative path for Virtual Memory (VM) management in Bharat-OS. It outlines the strict sequence of authority from page fault down to hardware execution, identifying ownership boundaries, policy versus mechanism, and the treatment of legacy mapping paths.

--- a/docs/architecture/multiprocessor-and-numa-baseline.md
+++ b/docs/architecture/multiprocessor-and-numa-baseline.md
@@ -1,3 +1,14 @@
+---
+title: Multiprocessor and NUMA Baseline (v1)
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+see_also:
+  - README.md
+---
 # Multiprocessor and NUMA Baseline (v1)
 
 This document captures the current multiprocessor/NUMA baseline for Bharat-OS.

--- a/docs/architecture/network-architecture.md
+++ b/docs/architecture/network-architecture.md
@@ -1,3 +1,14 @@
+---
+title: Bharat-OS Network & Communications Architecture
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+see_also:
+  - README.md
+---
 # Bharat-OS Network & Communications Architecture
 
 ## 1. Overview

--- a/docs/architecture/network/edge-connectivity-profiles.md
+++ b/docs/architecture/network/edge-connectivity-profiles.md
@@ -1,3 +1,15 @@
+---
+title: Edge Connectivity Profiles Architecture
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - network
+see_also:
+  - README.md
+---
 # Edge Connectivity Profiles Architecture
 
 ## Overview

--- a/docs/architecture/placement.md
+++ b/docs/architecture/placement.md
@@ -1,3 +1,14 @@
+---
+title: Architecture Placement Contract
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+see_also:
+  - README.md
+---
 # Architecture Placement Contract
 
 Bharat-OS enforces strict architectural boundaries to keep the system modular, portable, and secure. Contributors must adhere to these placement rules.

--- a/docs/architecture/posix-compat-matrix.md
+++ b/docs/architecture/posix-compat-matrix.md
@@ -1,3 +1,14 @@
+---
+title: POSIX Compatibility Matrix
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+see_also:
+  - README.md
+---
 # POSIX Compatibility Matrix
 
 POSIX compatibility is a profile, not an all-or-nothing guarantee. In Bharat-OS, POSIX is implemented via a multi-tiered compatibility strategy aimed at fast bring-up, deterministic edge deployment, and minimal monolithic assumptions in the core kernel.

--- a/docs/architecture/pr-spec-driver-baseline.md
+++ b/docs/architecture/pr-spec-driver-baseline.md
@@ -1,3 +1,14 @@
+---
+title: PR Spec: Driver Core Baseline, Device Manager Contract, and Edge I/O Production Slice
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+see_also:
+  - README.md
+---
 # PR Spec: Driver Core Baseline, Device Manager Contract, and Edge I/O Production Slice
 
 ## 1. Goal and Non-Goals

--- a/docs/architecture/primitive-matrix-roadmap.md
+++ b/docs/architecture/primitive-matrix-roadmap.md
@@ -1,3 +1,14 @@
+---
+title: Bharat-OS Primitive Matrix and Execution Roadmap
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+see_also:
+  - README.md
+---
 # Bharat-OS Primitive Matrix and Execution Roadmap
 
 ## Governing rule

--- a/docs/architecture/profile-driven-storage-network-subsystems.md
+++ b/docs/architecture/profile-driven-storage-network-subsystems.md
@@ -1,3 +1,14 @@
+---
+title: Profile-Driven Storage and Network Subsystems
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+see_also:
+  - README.md
+---
 # Profile-Driven Storage and Network Subsystems
 
 This note defines how Bharat-OS selects storage and networking capabilities from:

--- a/docs/architecture/profiles/extended_device_profiles.md
+++ b/docs/architecture/profiles/extended_device_profiles.md
@@ -1,3 +1,15 @@
+---
+title: Extended Device Profiles and Use Cases Matrix
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - profiles
+see_also:
+  - README.md
+---
 # Extended Device Profiles and Use Cases Matrix
 
 This document defines the comprehensive matrix of target deployment profiles for Bharat-OS, spanning edge microcontrollers to data center servers. It details the required memory models, scheduler mixes, hardware subsystems (BUS, SoC, DMA, Accelerators), and the future roadmap for distributed kernel connectivity.

--- a/docs/architecture/realtime-automotive-robotics-subsystems.md
+++ b/docs/architecture/realtime-automotive-robotics-subsystems.md
@@ -1,3 +1,14 @@
+---
+title: Real-time / Automotive / Robotics Specific Subsystems
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+see_also:
+  - README.md
+---
 # Real-time / Automotive / Robotics Specific Subsystems
 
 This document defines subsystem contracts for EV, drone, robotics, and industrial Bharat-OS deployments.

--- a/docs/architecture/sdk-libc-architecture.md
+++ b/docs/architecture/sdk-libc-architecture.md
@@ -1,3 +1,14 @@
+---
+title: Bharat-OS SDK and Libc Architecture
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+see_also:
+  - README.md
+---
 # Bharat-OS SDK and Libc Architecture
 
 For edge devices, drones, gateways, robotics nodes, and appliance-class systems, the winning move is not "full desktop POSIX first". The winning move is:

--- a/docs/architecture/sdk-libc-plan.md
+++ b/docs/architecture/sdk-libc-plan.md
@@ -1,3 +1,14 @@
+---
+title: Bharat-OS SDK and Libc Implementation Plan
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+see_also:
+  - README.md
+---
 # Bharat-OS SDK and Libc Implementation Plan
 
 This document outlines the phased implementation plan for the Bharat-OS SDK and libc layer, transforming the kernel into a testable OS platform.

--- a/docs/architecture/secure-boot-fast-boot-profiles.md
+++ b/docs/architecture/secure-boot-fast-boot-profiles.md
@@ -1,3 +1,14 @@
+---
+title: Secure Boot + Fast Boot Profiles (Automotive/RTOS/Robot/Drone)
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+see_also:
+  - README.md
+---
 # Secure Boot + Fast Boot Profiles (Automotive/RTOS/Robot/Drone)
 
 ## What this adds

--- a/docs/architecture/security/init_service_architecture_and_delivery_plan.md
+++ b/docs/architecture/security/init_service_architecture_and_delivery_plan.md
@@ -1,3 +1,15 @@
+---
+title: Bharat-OS `core/services/init` Deep Analysis and Implementation Plan
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - security
+see_also:
+  - README.md
+---
 # Bharat-OS `core/services/init` Deep Analysis and Implementation Plan
 
 ## 1) Executive Summary

--- a/docs/architecture/services/init_architecture.md
+++ b/docs/architecture/services/init_architecture.md
@@ -1,3 +1,15 @@
+---
+title: Bharat-OS Init Service Architecture (`core/services/init`)
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - services
+see_also:
+  - README.md
+---
 # Bharat-OS Init Service Architecture (`core/services/init`)
 
 ## 1. Overview and Core Philosophy

--- a/docs/architecture/services/init_bootstrap_contract.md
+++ b/docs/architecture/services/init_bootstrap_contract.md
@@ -1,3 +1,15 @@
+---
+title: Bharat-OS `core/services/init` — Design Principles & Architecture
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - services
+see_also:
+  - README.md
+---
 # Bharat-OS `core/services/init` — Design Principles & Architecture
 
 ## 1. Purpose

--- a/docs/architecture/services/init_profile_implementation_tasks.md
+++ b/docs/architecture/services/init_profile_implementation_tasks.md
@@ -1,3 +1,15 @@
+---
+title: Bharat-OS `core/services/init` — Profile Implementation Task Plan
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - services
+see_also:
+  - README.md
+---
 # Bharat-OS `core/services/init` — Profile Implementation Task Plan
 
 ## 1. Purpose

--- a/docs/architecture/services/process_manager.md
+++ b/docs/architecture/services/process_manager.md
@@ -1,3 +1,15 @@
+---
+title: Process Manager Service Architecture
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - services
+see_also:
+  - README.md
+---
 # Process Manager Service Architecture
 
 **Version:** v1.0 (Proposed)

--- a/docs/architecture/services/runtime_lifecycle_contract.md
+++ b/docs/architecture/services/runtime_lifecycle_contract.md
@@ -1,3 +1,15 @@
+---
+title: Service Runtime Lifecycle Contract
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - services
+see_also:
+  - README.md
+---
 # Service Runtime Lifecycle Contract
 
 ### Contract Status

--- a/docs/architecture/services/service-lifecycle-contract.md
+++ b/docs/architecture/services/service-lifecycle-contract.md
@@ -1,3 +1,15 @@
+---
+title: Service Lifecycle Contract
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - services
+see_also:
+  - README.md
+---
 # Service Lifecycle Contract
 
 ### Contract Status

--- a/docs/architecture/services/system/boot_displayd.md
+++ b/docs/architecture/services/system/boot_displayd.md
@@ -1,3 +1,15 @@
+---
+title: Boot Display Service (`core/services/system/boot_displayd`)
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - services
+see_also:
+  - README.md
+---
 # Boot Display Service (`core/services/system/boot_displayd`)
 
 ## Overview

--- a/docs/architecture/services/system/diag.md
+++ b/docs/architecture/services/system/diag.md
@@ -1,3 +1,15 @@
+---
+title: Diagnostic Service (`core/services/system/diag`)
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - services
+see_also:
+  - README.md
+---
 # Diagnostic Service (`core/services/system/diag`)
 
 ## Overview

--- a/docs/architecture/shared/lib_architecture.md
+++ b/docs/architecture/shared/lib_architecture.md
@@ -1,3 +1,15 @@
+---
+title: Bharat-OS Library Layering Architecture
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - shared
+see_also:
+  - README.md
+---
 # Bharat-OS Library Layering Architecture
 
 ## Purpose and Principles

--- a/docs/architecture/shared/lib_roadmap.md
+++ b/docs/architecture/shared/lib_roadmap.md
@@ -1,3 +1,15 @@
+---
+title: Bharat-OS Library Layering and Migration Roadmap
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - shared
+see_also:
+  - README.md
+---
 # Bharat-OS Library Layering and Migration Roadmap
 
 ## Current State Findings

--- a/docs/architecture/storage-and-sandbox-strategy.md
+++ b/docs/architecture/storage-and-sandbox-strategy.md
@@ -1,3 +1,14 @@
+---
+title: Storage & Filesystem Strategy (Advanced)
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+see_also:
+  - README.md
+---
 # Storage & Filesystem Strategy (Advanced)
 
 > Consolidation note: normative storage/filesystem architecture now lives in `docs/architecture/storage/` (`vfs-and-filesystem-architecture.md`, `file-system-detailed-design.md`, `sandbox-policy.md`, `roadmap.md`). This document remains an advanced strategy companion for long-horizon ideas and must not be read as current-state or normative contract.

--- a/docs/architecture/storage/README.md
+++ b/docs/architecture/storage/README.md
@@ -1,3 +1,15 @@
+---
+title: Storage & Filesystem Architecture (Canonical Index)
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - storage
+see_also:
+  - README.md
+---
 # Storage & Filesystem Architecture (Canonical Index)
 
 This directory is the **canonical home** for Bharat-OS storage and filesystem architecture.

--- a/docs/architecture/storage/file-system-detailed-design.md
+++ b/docs/architecture/storage/file-system-detailed-design.md
@@ -1,3 +1,15 @@
+---
+title: Storage and Filesystem Detailed Design (Current Implementation State)
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - storage
+see_also:
+  - README.md
+---
 # Storage and Filesystem Detailed Design (Current Implementation State)
 
 ## 1. Purpose

--- a/docs/architecture/storage/roadmap.md
+++ b/docs/architecture/storage/roadmap.md
@@ -1,3 +1,15 @@
+---
+title: Storage & Filesystem Roadmap (Delivery Sequencing)
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - storage
+see_also:
+  - README.md
+---
 # Storage & Filesystem Roadmap (Delivery Sequencing)
 
 ## Status legend

--- a/docs/architecture/storage/sandbox-policy.md
+++ b/docs/architecture/storage/sandbox-policy.md
@@ -1,3 +1,15 @@
+---
+title: Storage Sandbox Policy (Canonical)
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - storage
+see_also:
+  - README.md
+---
 # Storage Sandbox Policy (Canonical)
 
 ## 1. Purpose

--- a/docs/architecture/storage/vfs-and-filesystem-architecture.md
+++ b/docs/architecture/storage/vfs-and-filesystem-architecture.md
@@ -1,3 +1,15 @@
+---
+title: Storage and Filesystem Architecture Contract (Normative)
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - storage
+see_also:
+  - README.md
+---
 # Storage and Filesystem Architecture Contract (Normative)
 
 ## 1. Purpose and scope

--- a/docs/architecture/subsystems_gap_analysis.md
+++ b/docs/architecture/subsystems_gap_analysis.md
@@ -1,3 +1,14 @@
+---
+title: Subsystems Architecture Review & Gap Analysis
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+see_also:
+  - README.md
+---
 # Subsystems Architecture Review & Gap Analysis
 
 ## 1. Overview & Goal

--- a/docs/architecture/syscall/syscall-abi-boundary.md
+++ b/docs/architecture/syscall/syscall-abi-boundary.md
@@ -1,3 +1,15 @@
+---
+title: Syscall ABI Boundary Hardening
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - syscall
+see_also:
+  - README.md
+---
 # Syscall ABI Boundary Hardening
 
 This document explains the architecture and governance of the Bharat-OS native syscall boundary.

--- a/docs/architecture/system/shell-architecture.md
+++ b/docs/architecture/system/shell-architecture.md
@@ -1,3 +1,15 @@
+---
+title: Shell Architecture and Production Contract
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - system
+see_also:
+  - README.md
+---
 # Shell Architecture and Production Contract
 
 ## Purpose

--- a/docs/architecture/system/shell-profile-matrix.md
+++ b/docs/architecture/system/shell-profile-matrix.md
@@ -1,3 +1,15 @@
+---
+title: Shell Profile Matrix
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - system
+see_also:
+  - README.md
+---
 # Shell Profile Matrix
 
 This matrix maps Bharat-OS product profiles to shell class, access mode, and operational policy.

--- a/docs/architecture/threat-model-and-mac.md
+++ b/docs/architecture/threat-model-and-mac.md
@@ -1,3 +1,14 @@
+---
+title: Bharat-OS Threat Model and Mandatory Access Control (MAC) Baseline
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+see_also:
+  - README.md
+---
 # Bharat-OS Threat Model and Mandatory Access Control (MAC) Baseline
 
 This document defines the minimum security model expected for production Bharat-OS kernels.

--- a/docs/architecture/ui/ui_execution_roadmap.md
+++ b/docs/architecture/ui/ui_execution_roadmap.md
@@ -1,3 +1,15 @@
+---
+title: Bharat-OS UI/Display Roadmap (Ticket-Oriented, Production-Grade)
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - ui
+see_also:
+  - README.md
+---
 # Bharat-OS UI/Display Roadmap (Ticket-Oriented, Production-Grade)
 
 **Status:** Wave 1 completed; Wave 2 implementation in progress  

--- a/docs/architecture/usb-subsystem-roadmap.md
+++ b/docs/architecture/usb-subsystem-roadmap.md
@@ -1,3 +1,14 @@
+---
+title: USB Subsystem Roadmap
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+see_also:
+  - README.md
+---
 # USB Subsystem Roadmap
 
 ## Purpose

--- a/docs/architecture/verification-scope.md
+++ b/docs/architecture/verification-scope.md
@@ -1,3 +1,14 @@
+---
+title: Formal Verification Scope
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+see_also:
+  - README.md
+---
 # Formal Verification Scope
 
 ## Overview

--- a/docs/architecture/vfs-storage-architecture.md
+++ b/docs/architecture/vfs-storage-architecture.md
@@ -1,3 +1,14 @@
+---
+title: Legacy VFS & Storage Architecture Note
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+see_also:
+  - README.md
+---
 # Legacy VFS & Storage Architecture Note
 
 This file is retained for compatibility with old references.

--- a/docs/archive/README.md
+++ b/docs/archive/README.md
@@ -1,3 +1,14 @@
+---
+title: Documentation Archive
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - archive
+see_also:
+  - README.md
+---
 # Documentation Archive
 
 This folder stores superseded or low-signal documents that are kept for historical traceability, not as active guidance.

--- a/docs/archive/architecture/boot/boot_console_uart_gui_brainstorm.md
+++ b/docs/archive/architecture/boot/boot_console_uart_gui_brainstorm.md
@@ -1,3 +1,15 @@
+---
+title: Boot-Level Display, Console, UART, and Basic GUI: Architecture Brainstorm
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - archive
+  - architecture
+see_also:
+  - README.md
+---
 # Boot-Level Display, Console, UART, and Basic GUI: Architecture Brainstorm
 
 ## 1) Problem Statement and Goals

--- a/docs/archive/architecture/v2_fix_archived.md
+++ b/docs/archive/architecture/v2_fix_archived.md
@@ -1,3 +1,15 @@
+---
+title: Address-Translation Architecture Redesign (v2_fix)
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - archive
+  - architecture
+see_also:
+  - README.md
+---
 # Address-Translation Architecture Redesign (v2_fix)
 
 This document serves as the master plan for refactoring the Bharat-OS page-table and virtual memory subsystems into a robust, multi-tier address-translation architecture.

--- a/docs/boards/shakti/README.md
+++ b/docs/boards/shakti/README.md
@@ -1,3 +1,15 @@
+---
+title: SHAKTI Board Support Notes
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - boards
+  - shakti
+see_also:
+  - README.md
+---
 # SHAKTI Board Support Notes
 
 This folder tracks SHAKTI board-specific support status for Bharat-OS.

--- a/docs/cleanup-tasks.md
+++ b/docs/cleanup-tasks.md
@@ -1,3 +1,14 @@
+---
+title: Bharat-OS Cleanup and Structural Alignment Tasks
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - general
+see_also:
+  - README.md
+---
 # Bharat-OS Cleanup and Structural Alignment Tasks
 
 This document outlines the required cleanup tasks and folder structure improvements needed to bring the repository fully in line with the architectural boundaries defined in `docs/architecture/folder_structure.md`.

--- a/docs/dev/BENCHMARK_FRAMEWORK_GUIDE.md
+++ b/docs/dev/BENCHMARK_FRAMEWORK_GUIDE.md
@@ -1,3 +1,14 @@
+---
+title: Bharat-OS Benchmark Framework Guide
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - dev
+see_also:
+  - README.md
+---
 # Bharat-OS Benchmark Framework Guide
 
 ## 1. Goals

--- a/docs/dev/bharat-native-standard-surface-and-compat-boundary.md
+++ b/docs/dev/bharat-native-standard-surface-and-compat-boundary.md
@@ -1,3 +1,14 @@
+---
+title: Bharat Native Standard Surface and Compatibility Boundary
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - dev
+see_also:
+  - README.md
+---
 # Bharat Native Standard Surface and Compatibility Boundary
 
 ## Purpose

--- a/docs/dev/boot-artifact-matrix.md
+++ b/docs/dev/boot-artifact-matrix.md
@@ -1,0 +1,11 @@
+---
+title: Boot Artifact Matrix
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - dev
+see_also:
+  - README.md
+---

--- a/docs/dev/boot-console-milestone-and-followups.md
+++ b/docs/dev/boot-console-milestone-and-followups.md
@@ -1,3 +1,14 @@
+---
+title: Boot-console milestone and follow-up task set (2026-04-15)
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - dev
+see_also:
+  - README.md
+---
 # Boot-console milestone and follow-up task set (2026-04-15)
 
 ## Milestone committed in this phase

--- a/docs/dev/build/BUILD_ARM64.md
+++ b/docs/dev/build/BUILD_ARM64.md
@@ -1,3 +1,15 @@
+---
+title: ARM64 Build Quickstart
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - dev
+  - build
+see_also:
+  - README.md
+---
 # ARM64 Build Quickstart
 
 ## Build only

--- a/docs/dev/build/BUILD_RISCV64.md
+++ b/docs/dev/build/BUILD_RISCV64.md
@@ -1,3 +1,15 @@
+---
+title: RISC-V64 Build Quickstart
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - dev
+  - build
+see_also:
+  - README.md
+---
 # RISC-V64 Build Quickstart
 
 ## Build only

--- a/docs/dev/build/BUILD_X86_64.md
+++ b/docs/dev/build/BUILD_X86_64.md
@@ -1,3 +1,15 @@
+---
+title: x86_64 Build Quickstart
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - dev
+  - build
+see_also:
+  - README.md
+---
 # x86_64 Build Quickstart
 
 ## Build only

--- a/docs/dev/build/ENV_PREP.md
+++ b/docs/dev/build/ENV_PREP.md
@@ -1,3 +1,15 @@
+---
+title: Environment Preparation for Build + Test + Run
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - dev
+  - build
+see_also:
+  - README.md
+---
 # Environment Preparation for Build + Test + Run
 
 This guide is for the current Bharat-OS build system (`tools/build.py` + wrappers).

--- a/docs/dev/build/HOST_BUILD_TEST_RUN_GUIDE.md
+++ b/docs/dev/build/HOST_BUILD_TEST_RUN_GUIDE.md
@@ -1,3 +1,15 @@
+---
+title: Build System Guide (Authoritative)
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - dev
+  - build
+see_also:
+  - README.md
+---
 # Build System Guide (Authoritative)
 
 This is the current, code-aligned guide for Bharat-OS build tooling.

--- a/docs/dev/build/HOST_BUILD_TEST_RUN_PLAN.md
+++ b/docs/dev/build/HOST_BUILD_TEST_RUN_PLAN.md
@@ -1,3 +1,15 @@
+---
+title: Build/Test/Run Modernization Plan
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - dev
+  - build
+see_also:
+  - README.md
+---
 # Build/Test/Run Modernization Plan
 
 This plan tracks migration to a YAML-target-first, preset-driven build workflow.

--- a/docs/dev/cmake-governance-and-agent-rules.md
+++ b/docs/dev/cmake-governance-and-agent-rules.md
@@ -1,3 +1,14 @@
+---
+title: CMake Governance, Versioning, and Agent/Developer Rules
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - dev
+see_also:
+  - README.md
+---
 # CMake Governance, Versioning, and Agent/Developer Rules
 
 This document defines mandatory build-system governance for Bharat-OS contributors (human and code agents).

--- a/docs/dev/compiler-safety-and-optimization.md
+++ b/docs/dev/compiler-safety-and-optimization.md
@@ -1,3 +1,14 @@
+---
+title: Compiler Safety and Optimization
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - dev
+see_also:
+  - README.md
+---
 # Compiler Safety and Optimization
 
 In kernel code, the optimization order must be:

--- a/docs/dev/current-code-status.md
+++ b/docs/dev/current-code-status.md
@@ -1,3 +1,14 @@
+---
+title: Bharat-OS Current Code Status (March 2026)
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - dev
+see_also:
+  - README.md
+---
 # Bharat-OS Current Code Status (March 2026)
 
 This document summarizes **what is actually implemented in code today** versus what is scaffolded.

--- a/docs/dev/developer_guidelines.md
+++ b/docs/dev/developer_guidelines.md
@@ -1,3 +1,14 @@
+---
+title: Bharat-OS Developer Guidelines
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - dev
+see_also:
+  - README.md
+---
 # Bharat-OS Developer Guidelines
 
 This document outlines the modern C guidelines for kernel and embedded development within the Bharat-OS project, focusing heavily on the **C23 standard (ISO/IEC 9899:2024)**. For embedded, OS, and kernel development, these features are essential for memory safety, compile-time optimization, and hardware-level bit manipulation.

--- a/docs/dev/driver-contributor-rules.md
+++ b/docs/dev/driver-contributor-rules.md
@@ -1,3 +1,14 @@
+---
+title: Driver Contributor Rules
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - dev
+see_also:
+  - README.md
+---
 # Driver Contributor Rules
 
 ## Purpose

--- a/docs/dev/execution-mode-build-and-preset-guide.md
+++ b/docs/dev/execution-mode-build-and-preset-guide.md
@@ -1,3 +1,14 @@
+---
+title: Execution Mode Build and Preset Guide
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - dev
+see_also:
+  - README.md
+---
 # Execution Mode Build and Preset Guide
 
 This document explains the CMake integration and the provided presets for configuring Bharat-OS with the Execution Mode and CPU Partitioning framework.

--- a/docs/dev/footprint-enforcement.md
+++ b/docs/dev/footprint-enforcement.md
@@ -1,3 +1,14 @@
+---
+title: Footprint Enforcement
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - dev
+see_also:
+  - README.md
+---
 # Footprint Enforcement
 
 Footprint enforcement is performed as part of target validation.

--- a/docs/dev/hardware-feature-placement-rules.md
+++ b/docs/dev/hardware-feature-placement-rules.md
@@ -1,3 +1,14 @@
+---
+title: Hardware Feature Placement and Ownership Rules
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - dev
+see_also:
+  - README.md
+---
 # Hardware Feature Placement and Ownership Rules
 
 ## Overview

--- a/docs/dev/ipc-contract-hardening.md
+++ b/docs/dev/ipc-contract-hardening.md
@@ -1,3 +1,14 @@
+---
+title: IPC/URPC Contract Hardening (Developer Branch)
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - dev
+see_also:
+  - README.md
+---
 # IPC/URPC Contract Hardening (Developer Branch)
 
 ### Contract Status

--- a/docs/dev/kernel-boundary-abi-freeze-plan.md
+++ b/docs/dev/kernel-boundary-abi-freeze-plan.md
@@ -1,3 +1,14 @@
+---
+title: Kernel Boundary + Syscall ABI Freeze Plan
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - dev
+see_also:
+  - README.md
+---
 # Kernel Boundary + Syscall ABI Freeze Plan
 
 ## Purpose

--- a/docs/dev/migrating-from-build-config-json.md
+++ b/docs/dev/migrating-from-build-config-json.md
@@ -1,3 +1,14 @@
+---
+title: Migrating from build_config.json
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - dev
+see_also:
+  - README.md
+---
 # Migrating from build_config.json
 
 This document explains the transition from the legacy `build_config.json` to the new declarative Target YAML pipeline.

--- a/docs/dev/power_thermal_phase1_tasks.md
+++ b/docs/dev/power_thermal_phase1_tasks.md
@@ -1,3 +1,14 @@
+---
+title: Phase 1 Implementation Task Pack: Power and Thermal Governance
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - dev
+see_also:
+  - README.md
+---
 # Phase 1 Implementation Task Pack: Power and Thermal Governance
 
 This document outlines the Phase 1 implementation tasks for the Power and Thermal Governance subsystem in Bharat-OS. The tasks are designed to build out the minimal kernel framework and null backends, enabling a stable foundation for advanced policy services in later phases.

--- a/docs/dev/profile-boot-config.md
+++ b/docs/dev/profile-boot-config.md
@@ -1,3 +1,14 @@
+---
+title: Developer Reference: Profile Boot Configuration
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - dev
+see_also:
+  - README.md
+---
 # Developer Reference: Profile Boot Configuration
 
 ## Overview

--- a/docs/dev/project-structure-migration-status.md
+++ b/docs/dev/project-structure-migration-status.md
@@ -1,3 +1,14 @@
+---
+title: Project Structure Migration Status
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - dev
+see_also:
+  - README.md
+---
 # Project Structure Migration Status
 
 This tracker is the execution companion for `project-structure-refactor-plan.md`.

--- a/docs/dev/release-versioning.md
+++ b/docs/dev/release-versioning.md
@@ -1,3 +1,14 @@
+---
+title: Bharat-OS Release and Versioning Policy
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - dev
+see_also:
+  - README.md
+---
 # Bharat-OS Release and Versioning Policy
 
 Bharat-OS uses a manifest-driven release identity system. A single version is not applied monolithically to all services. Instead, the OS uses a component-based versioning approach, combining multiple independently versioned artifacts into a defined release structure.

--- a/docs/dev/sdk_guide.md
+++ b/docs/dev/sdk_guide.md
@@ -1,3 +1,14 @@
+---
+title: Bharat-OS SDK Guide
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - dev
+see_also:
+  - README.md
+---
 # Bharat-OS SDK Guide
 
 ## Purpose

--- a/docs/dev/sdk_toolchain_gap_analysis.md
+++ b/docs/dev/sdk_toolchain_gap_analysis.md
@@ -1,3 +1,14 @@
+---
+title: SDK & Toolchain Roadmap (Gap Analysis)
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - dev
+see_also:
+  - README.md
+---
 # SDK & Toolchain Roadmap (Gap Analysis)
 
 ## Current Maturity Level

--- a/docs/dev/shell-contributor-guide.md
+++ b/docs/dev/shell-contributor-guide.md
@@ -1,3 +1,14 @@
+---
+title: Shell Contributor Guide
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - dev
+see_also:
+  - README.md
+---
 # Shell Contributor Guide
 
 This guide defines contribution rules for Bharat-OS shell work. Follow this before opening implementation PRs.

--- a/docs/dev/shell-testing.md
+++ b/docs/dev/shell-testing.md
@@ -1,3 +1,14 @@
+---
+title: System Shell Testing Guide
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - dev
+see_also:
+  - README.md
+---
 # System Shell Testing Guide
 
 ## Scope

--- a/docs/dev/target-yaml-authoring-guide.md
+++ b/docs/dev/target-yaml-authoring-guide.md
@@ -1,3 +1,14 @@
+---
+title: Target YAML Authoring Guide
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - dev
+see_also:
+  - README.md
+---
 # Target YAML Authoring Guide
 
 This guide explains how to define declarative targets for the Bharat-OS build and execution pipeline. Target YAML files describe the full lifecycle of a target: how it is built, packaged, run, flashed, and debugged.

--- a/docs/dev/toolchain_guide.md
+++ b/docs/dev/toolchain_guide.md
@@ -1,3 +1,14 @@
+---
+title: Bharat-OS Toolchain Guide
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - dev
+see_also:
+  - README.md
+---
 # Bharat-OS Toolchain Guide
 
 ## Purpose

--- a/docs/dev/unified-policy-uapi-contracts.md
+++ b/docs/dev/unified-policy-uapi-contracts.md
@@ -1,3 +1,14 @@
+---
+title: Unified Policy UAPI Contracts (interface/uapi/policy)
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - dev
+see_also:
+  - README.md
+---
 # Unified Policy UAPI Contracts (interface/uapi/policy)
 
 ## Scope

--- a/docs/dev/verification_guide.md
+++ b/docs/dev/verification_guide.md
@@ -1,3 +1,14 @@
+---
+title: Local Multi-Architecture Verification Guide
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - dev
+see_also:
+  - README.md
+---
 # Local Multi-Architecture Verification Guide
 
 This guide describes how to verify Bharat-OS across all supported architectures and profiles using local tools.

--- a/docs/exp_to_support_various_board.md
+++ b/docs/exp_to_support_various_board.md
@@ -1,3 +1,14 @@
+---
+title: Bharat-OS: Experimental Support Strategy for Various Boards
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - general
+see_also:
+  - README.md
+---
 # Bharat-OS: Experimental Support Strategy for Various Boards
 
 ## Purpose

--- a/docs/profiles/device_profiles.md
+++ b/docs/profiles/device_profiles.md
@@ -1,3 +1,14 @@
+---
+title: Device Profiles
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - profiles
+see_also:
+  - README.md
+---
 # Device Profiles
 
 Bharat-OS supports multiple interaction models and required subsystems based on the specific device class. Instead of forcing a one-size-fits-all binary, we define these device profiles. Each profile establishes the base functionality required, ensuring optimal performance for its given domain.

--- a/docs/research_doc/deep-research-report.md
+++ b/docs/research_doc/deep-research-report.md
@@ -1,3 +1,14 @@
+---
+title: Kernel and OS-Level Integration Across Hardware Architectures and Accelerators
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - research_doc
+see_also:
+  - README.md
+---
 # Kernel and OS-Level Integration Across Hardware Architectures and Accelerators
 
 ## Executive summary

--- a/docs/research_doc/papers.md
+++ b/docs/research_doc/papers.md
@@ -1,3 +1,14 @@
+---
+title: Foundational Research Papers
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - research_doc
+see_also:
+  - README.md
+---
 # Foundational Research Papers
 
 Bharat-OS draws heavy inspiration from several foundational operating systems and academic works. The following papers provide the canonical design guidance and architectural underpinnings for the OS.

--- a/docs/reviews/architecture_authority_lifecycle_failure_review_2026-04-21.md
+++ b/docs/reviews/architecture_authority_lifecycle_failure_review_2026-04-21.md
@@ -1,3 +1,14 @@
+---
+title: Bharat-OS Architecture Review Refresh: Authority, Lifecycle, and Failure Containment
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - reviews
+see_also:
+  - README.md
+---
 # Bharat-OS Architecture Review Refresh: Authority, Lifecycle, and Failure Containment
 
 **Date:** 2026-04-21  

--- a/docs/reviews/architecture_review_enhancement_plan.md
+++ b/docs/reviews/architecture_review_enhancement_plan.md
@@ -1,3 +1,14 @@
+---
+title: Architecture Review and Enhancement Plan
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - reviews
+see_also:
+  - README.md
+---
 # Architecture Review and Enhancement Plan
 
 ## Executive Summary

--- a/docs/reviews/code-quality-and-production-gap-analysis_2026-04-24.md
+++ b/docs/reviews/code-quality-and-production-gap-analysis_2026-04-24.md
@@ -1,3 +1,14 @@
+---
+title: Bharat-OS Deep Code Review & Production Gap Analysis (2026-04-24)
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - reviews
+see_also:
+  - README.md
+---
 # Bharat-OS Deep Code Review & Production Gap Analysis (2026-04-24)
 
 ## 1) Review objective

--- a/docs/reviews/context-switching-hw-optimization-review.md
+++ b/docs/reviews/context-switching-hw-optimization-review.md
@@ -1,3 +1,14 @@
+---
+title: Context Switching Review: Kernel + Subsystem (revalidated)
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - reviews
+see_also:
+  - README.md
+---
 # Context Switching Review: Kernel + Subsystem (revalidated)
 
 ## Scope

--- a/docs/reviews/current-implementation-review.md
+++ b/docs/reviews/current-implementation-review.md
@@ -1,3 +1,14 @@
+---
+title: Current Implementation Review (Status + Remaining Gaps)
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - reviews
+see_also:
+  - README.md
+---
 # Current Implementation Review (Status + Remaining Gaps)
 
 This review tracks the implementation state of Bharat-OS and prioritizes what remains for production readiness.

--- a/docs/reviews/gap_analysis/algorithm_improvement/code_improvement_audit.md
+++ b/docs/reviews/gap_analysis/algorithm_improvement/code_improvement_audit.md
@@ -1,3 +1,15 @@
+---
+title: Algorithm Improvement Code Audit (Validated Against Current Tree)
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - reviews
+  - gap_analysis
+see_also:
+  - README.md
+---
 # Algorithm Improvement Code Audit (Validated Against Current Tree)
 
 This audit cross-checks the gap-analysis notes in this folder against the *current* codebase and lists the concrete algorithmic hotspots still worth improving.

--- a/docs/reviews/gap_analysis/algorithm_improvement/crypto_and_hashing.md
+++ b/docs/reviews/gap_analysis/algorithm_improvement/crypto_and_hashing.md
@@ -1,3 +1,15 @@
+---
+title: Cryptography and Hashing Inefficiencies
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - reviews
+  - gap_analysis
+see_also:
+  - README.md
+---
 # Cryptography and Hashing Inefficiencies
 
 This document tracks where cryptography or hashing logic currently operates in software and flags opportunities to substitute these with hardware offloading or hardware-accelerated CPU instructions.

--- a/docs/reviews/gap_analysis/algorithm_improvement/memory_operations.md
+++ b/docs/reviews/gap_analysis/algorithm_improvement/memory_operations.md
@@ -1,3 +1,15 @@
+---
+title: Memory Operations Inefficiencies
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - reviews
+  - gap_analysis
+see_also:
+  - README.md
+---
 # Memory Operations Inefficiencies
 
 This document tracks where the codebase relies heavily on slow, generic software implementations of `memcpy` and `memset` in critical paths, and lists opportunities for hardware optimizations.

--- a/docs/reviews/gap_analysis/algorithm_improvement/network_checksums.md
+++ b/docs/reviews/gap_analysis/algorithm_improvement/network_checksums.md
@@ -1,3 +1,15 @@
+---
+title: Network Checksums and CRC Inefficiencies
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - reviews
+  - gap_analysis
+see_also:
+  - README.md
+---
 # Network Checksums and CRC Inefficiencies
 
 This document tracks where software computation is used for Checksum validation, Generation, and Cyclic Redundancy Checks (CRCs). These are typically expensive operations per-packet or per-message, making them prime candidates for hardware offloading.

--- a/docs/reviews/gap_analysis/algorithm_improvement/search_and_iteration.md
+++ b/docs/reviews/gap_analysis/algorithm_improvement/search_and_iteration.md
@@ -1,3 +1,15 @@
+---
+title: Search and Iteration Inefficiencies
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - reviews
+  - gap_analysis
+see_also:
+  - README.md
+---
 # Search and Iteration Inefficiencies
 
 This document identifies areas in the codebase where inefficient $O(n)$ search algorithms and linear array iterations are used instead of more optimal data structures (like hash maps or trees) or hardware-assisted search mechanisms.

--- a/docs/reviews/gap_analysis/interrupt_controller_architecture_plan.md
+++ b/docs/reviews/gap_analysis/interrupt_controller_architecture_plan.md
@@ -1,3 +1,15 @@
+---
+title: Interrupt Controller Architecture Analysis & Evolution Plan
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - reviews
+  - gap_analysis
+see_also:
+  - README.md
+---
 # Interrupt Controller Architecture Analysis & Evolution Plan
 
 ## Scope and target architectures

--- a/docs/reviews/gap_analysis/latest_gap_analysis.md
+++ b/docs/reviews/gap_analysis/latest_gap_analysis.md
@@ -1,3 +1,15 @@
+---
+title: Bharat-OS – Critical Gap Analysis & Execution Roadmap
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - reviews
+  - gap_analysis
+see_also:
+  - README.md
+---
 # Bharat-OS – Critical Gap Analysis & Execution Roadmap
 
 ## 1. Executive Summary

--- a/docs/reviews/gap_analysis/layer_reference_gap_analysis_2026-04-19.md
+++ b/docs/reviews/gap_analysis/layer_reference_gap_analysis_2026-04-19.md
@@ -1,3 +1,15 @@
+---
+title: Layer Reference Gap Analysis — Kernel/HAL/Arch/Platform/Services/Stacks/User-SDK/UIPC
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - reviews
+  - gap_analysis
+see_also:
+  - README.md
+---
 # Layer Reference Gap Analysis — Kernel/HAL/Arch/Platform/Services/Stacks/User-SDK/UIPC
 
 _Date:_ 2026-04-19  

--- a/docs/reviews/gap_analysis/runtime_isa_extension_production_tasklist.md
+++ b/docs/reviews/gap_analysis/runtime_isa_extension_production_tasklist.md
@@ -1,3 +1,15 @@
+---
+title: Runtime ISA Extension Strategy → Production Tasklist
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - reviews
+  - gap_analysis
+see_also:
+  - README.md
+---
 # Runtime ISA Extension Strategy → Production Tasklist
 
 **Date:** 2026-04-25

--- a/docs/reviews/gap_analysis/runtime_isa_extension_strategy.md
+++ b/docs/reviews/gap_analysis/runtime_isa_extension_strategy.md
@@ -1,3 +1,15 @@
+---
+title: Runtime ISA Extension Leverage in Core Kernel: Gap Analysis (x86_64, arm64, riscv64)
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - reviews
+  - gap_analysis
+see_also:
+  - README.md
+---
 # Runtime ISA Extension Leverage in Core Kernel: Gap Analysis (x86_64, arm64, riscv64)
 
 **Date:** 2026-03-19  

--- a/docs/reviews/gap_analysis_merged_review_2026-04-22.md
+++ b/docs/reviews/gap_analysis_merged_review_2026-04-22.md
@@ -1,3 +1,14 @@
+---
+title: Merged Review: `docs/reviews/gap_analysis` + `docs/reviews`
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - reviews
+see_also:
+  - README.md
+---
 # Merged Review: `docs/reviews/gap_analysis` + `docs/reviews`
 
 Date: 2026-04-22  

--- a/docs/reviews/host-testing-and-qemu-runner-review_2026-04-21.md
+++ b/docs/reviews/host-testing-and-qemu-runner-review_2026-04-21.md
@@ -1,3 +1,14 @@
+---
+title: Host Testing & QEMU Runner Review (2026-04-21)
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - reviews
+see_also:
+  - README.md
+---
 # Host Testing & QEMU Runner Review (2026-04-21)
 
 ## Scope

--- a/docs/reviews/ipc_architecture_profile_readiness_review_2026-03-21.md
+++ b/docs/reviews/ipc_architecture_profile_readiness_review_2026-03-21.md
@@ -1,3 +1,14 @@
+---
+title: IPC Architecture Critical Review (March 21, 2026)
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - reviews
+see_also:
+  - README.md
+---
 # IPC Architecture Critical Review (March 21, 2026)
 
 This review evaluates `docs/IPC_ARCHITECTURE.md` against the current implementation and assesses readiness across:

--- a/docs/reviews/main-branch-gap-validation_2026-04-21.md
+++ b/docs/reviews/main-branch-gap-validation_2026-04-21.md
@@ -1,3 +1,14 @@
+---
+title: Main branch gap validation (refresh)
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - reviews
+see_also:
+  - README.md
+---
 # Main branch gap validation (refresh)
 
 Date: 2026-04-21  

--- a/docs/reviews/memory-and-fileop-layer-placement-review_2026-04-20.md
+++ b/docs/reviews/memory-and-fileop-layer-placement-review_2026-04-20.md
@@ -1,3 +1,14 @@
+---
+title: Memory + File Operation Layer Placement Review (memset/memcpy/memmove/open/openat)
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - reviews
+see_also:
+  - README.md
+---
 # Memory + File Operation Layer Placement Review (memset/memcpy/memmove/open/openat)
 
 Date: 2026-04-20  

--- a/docs/reviews/modern_primitives_personality_impact_review_2026-04-20.md
+++ b/docs/reviews/modern_primitives_personality_impact_review_2026-04-20.md
@@ -1,3 +1,14 @@
+---
+title: Bharat-OS Review: Modern Primitives, Risk, and Personality Impact (Linux/Android)
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - reviews
+see_also:
+  - README.md
+---
 # Bharat-OS Review: Modern Primitives, Risk, and Personality Impact (Linux/Android)
 
 **Date:** 2026-04-20

--- a/docs/reviews/scaffold_todo_and_arch_separation_review_2026-04-22.md
+++ b/docs/reviews/scaffold_todo_and_arch_separation_review_2026-04-22.md
@@ -1,3 +1,14 @@
+---
+title: Bharat-OS – Scaffold, TODO, and Architecture-Separation Review
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - reviews
+see_also:
+  - README.md
+---
 # Bharat-OS – Scaffold, TODO, and Architecture-Separation Review
 **Date:** 2026-04-22  
 **Branch reviewed:** `developer`  

--- a/docs/testing/e2e-testing.md
+++ b/docs/testing/e2e-testing.md
@@ -1,3 +1,14 @@
+---
+title: End-to-End Testing
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - testing
+see_also:
+  - README.md
+---
 # End-to-End Testing
 
 Bharat-OS uses a two-layer E2E testing approach focusing on QEMU CI matrices and manual hardware testing paths. Due to the profile-driven architecture of the OS, the test matrix validates combinations of architecture and device/personality profiles.

--- a/docs/testing/run-matrix.md
+++ b/docs/testing/run-matrix.md
@@ -1,3 +1,14 @@
+---
+title: Unified Multi-Arch SMP Run Matrix
+status: Draft
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - testing
+see_also:
+  - README.md
+---
 # Unified Multi-Arch SMP Run Matrix
 
 Bharat-OS supports a systematic execution matrix to test Single-core (UP) and Multi-core (SMP) operations across varying architectures and execution profiles.


### PR DESCRIPTION
### Motivation
- Bring uniform, machine-readable metadata to the entire `docs/` corpus so tooling, search, and cross-references can rely on stable frontmatter. 
- Improve discoverability and information architecture for contributors by consolidating top-level hub pages (`docs/README.md`, `docs/adr/README.md`) with IA diagrams and clear precedence rules. 
- Normalize ADR and agent templates to make ADR lifecycle, naming, and agent/skill guidance explicit and consistent. 

### Description
- Added YAML frontmatter (`title`, `status`, `owner`, `last_updated`, `tags`, `see_also`) to Markdown files that lacked it across `docs/` (263 files updated). 
- Reworked `docs/README.md` into a documentation hub with a Mermaid IA diagram, source-of-truth precedence table, directory map, status vocabulary, and quick-start links. 
- Reworked `docs/adr/README.md` to include an ADR lifecycle diagram, template contract, naming rules, and a normalized ADR index; updated ADR files to match metadata format. 
- Standardized metadata and small index/content improvements across `docs/architecture/`, `docs/ai-agents/`, `docs/dev/`, `docs/testing/`, and related doc folders to align with the document contract. 
- Committed the changes as `docs: standardize documentation metadata and IA indexes` (263 files changed). 

### Testing
- Ran a repository scan that enforces frontmatter presence via: `python - <<'PY' ...` which reported `missing 0`, confirming every `docs/*.md` now starts with frontmatter (success). 
- Inspected repository diff summary with `git diff --stat` which showed scope and magnitude (`263 files changed, 3174 insertions(+), 127 deletions(-)`) and reviewed selected updated index files. 
- Created a commit with `git commit -m "docs: standardize documentation metadata and IA indexes"` and generated the PR entry; the commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec55dcb90483208c05837d42a92b47)