### PR TITLE
docs(shell): define production build variants and QEMU shell validation matrix

### DIFF
--- a/docs/architecture/system/shell-architecture.md
+++ b/docs/architecture/system/shell-architecture.md
@@ -100,6 +100,87 @@ The shell and console are considered aligned only when:
 - `CONFIG_SHELL_SCRIPT`
 - `CONFIG_SHELL_COMPAT_POSIX` (deferred)
 
+## Production build profiles (shell-focused)
+
+The shell service is compiled under `core/services/system/shell/` and currently defaults to:
+
+- `CONFIG_SHELL_ADMIN=ON`
+- `CONFIG_SHELL_RECOVERY=ON`
+- `CONFIG_SHELL_MINI=OFF`
+- `CONFIG_SHELL_REMOTE=OFF`
+- `CONFIG_SHELL_SCRIPT=OFF`
+- `CONFIG_SHELL_COMPAT_POSIX=OFF`
+
+For production-grade shell rollout, define explicit build variants rather than relying on ad-hoc local toggles.
+
+### Recommended CMake variants
+
+```bash
+# 1) Recovery-first mini shell (small footprint)
+cmake --preset=x86_64-dev \
+  -DCONFIG_SHELL_MINI=ON \
+  -DCONFIG_SHELL_ADMIN=OFF \
+  -DCONFIG_SHELL_RECOVERY=ON \
+  -DCONFIG_SHELL_REMOTE=OFF \
+  -DCONFIG_SHELL_SCRIPT=OFF
+
+# 2) Operator/admin shell (default operational profile)
+cmake --preset=x86_64-dev \
+  -DCONFIG_SHELL_MINI=OFF \
+  -DCONFIG_SHELL_ADMIN=ON \
+  -DCONFIG_SHELL_RECOVERY=ON \
+  -DCONFIG_SHELL_REMOTE=OFF \
+  -DCONFIG_SHELL_SCRIPT=OFF
+
+# 3) Extended diagnostics shell (lab only, not fleet default)
+cmake --preset=x86_64-dev \
+  -DCONFIG_SHELL_MINI=OFF \
+  -DCONFIG_SHELL_ADMIN=ON \
+  -DCONFIG_SHELL_RECOVERY=ON \
+  -DCONFIG_SHELL_REMOTE=ON \
+  -DCONFIG_SHELL_SCRIPT=ON
+```
+
+`CONFIG_SHELL_COMPAT_POSIX` remains deferred and must not be used as a blocker for core system shell production readiness.
+
+## QEMU validation builds and run flow
+
+To validate shell + console behavior on emulator targets, use the delivery target specs and the unified build runner:
+
+```bash
+# x86_64 baseline
+python3 tools/build.py all --target-yaml delivery/targets/qemu/x86_64_desktop_headless.yaml
+
+# arm64 baseline
+python3 tools/build.py all --target-yaml delivery/targets/qemu/arm64_desktop_headless.yaml
+
+# riscv64 baseline
+python3 tools/build.py all --target-yaml delivery/targets/qemu/riscv64_desktop_headless.yaml
+```
+
+If `all` is too slow for iteration, split the stages:
+
+```bash
+python3 tools/build.py build --target-yaml delivery/targets/qemu/x86_64_desktop_headless.yaml
+python3 tools/build.py package --target-yaml delivery/targets/qemu/x86_64_desktop_headless.yaml
+python3 tools/build.py run --target-yaml delivery/targets/qemu/x86_64_desktop_headless.yaml
+```
+
+## Interactive shell acceptance criteria (QEMU)
+
+A QEMU run is considered shell-ready only when all checks pass:
+
+1. Boot reaches stable serial console output in `-nographic` mode.
+2. Shell session can receive typed input and return output over console stream.
+3. Read-only commands succeed (`help`, `version`, `status`, `uptime`).
+4. One privileged command path is validated in both states:
+   - denied path in restricted mode (expected),
+   - allowed path with required capability in permitted mode.
+5. Structured output (`mode kv`) emits machine-parsable response contract.
+6. Negative-path checks: malformed command, unknown command, backend unavailable.
+
+Until full shell↔console IPC is landed, keep these as mandatory milestone gates with explicit “expected gap” notes in release evidence.
+
 ## Near-term roadmap
 
 ### Phase 1 — Integration completion

--- a/docs/architecture/system/shell-profile-matrix.md
+++ b/docs/architecture/system/shell-profile-matrix.md
@@ -67,6 +67,44 @@ This matrix maps Bharat-OS product profiles to shell class, access mode, and ope
 | `CONFIG_SHELL_SCRIPT` | off | off | optional | off/restricted | optional |
 | `CONFIG_SHELL_COMPAT_POSIX` | n/a | n/a | n/a | n/a | deferred |
 
+## QEMU build matrix for shell bring-up
+
+Use these delivery targets for repeatable build+run validation of shell behavior:
+
+| Validation lane | Target YAML | Primary intent | Expected shell profile |
+|---|---|---|---|
+| x86_64 headless | `delivery/targets/qemu/x86_64_desktop_headless.yaml` | Fastest developer bring-up and command-path checks | Admin + recovery |
+| arm64 headless | `delivery/targets/qemu/arm64_desktop_headless.yaml` | Cross-arch parity checks for console/shell path | Admin + recovery |
+| riscv64 headless | `delivery/targets/qemu/riscv64_desktop_headless.yaml` | RISC-V parity and regression guardrail | Admin + recovery |
+
+Canonical command shape:
+
+```bash
+python3 tools/build.py all --target-yaml <one-of-the-targets-above>
+```
+
+## Minimum shell command test set per build
+
+Each QEMU lane should execute at least the following command sequence after boot:
+
+1. `help`
+2. `version`
+3. `status`
+4. `uptime`
+5. `mode kv`
+6. `sys info`
+7. `svc list`
+8. `reboot` (or another privileged command) with explicit policy expectation:
+   - deny in restricted/prod session without capability,
+   - allow only when capability + mode policy permit.
+
+This command set proves:
+
+- Input path works (interactive command ingestion),
+- Output path works (human + machine-readable),
+- Registry resolution works for single-token and multi-token commands,
+- Capability/mode policy enforcement works for mutating operations.
+
 ## Command policy baseline
 
 | Command class | Dev | Prod | Factory | Recovery | Safety-critical runtime |
@@ -87,3 +125,4 @@ When adding a new profile, document:
 4. Mutating command policy and required capabilities.
 5. Audit and rate-limit requirements.
 6. Safety restrictions (if applicable).
+7. QEMU validation lane and shell command test set evidence.


### PR DESCRIPTION
### Motivation
- Provide a concrete, repeatable path to produce QEMU-run artifacts and validate interactive shell I/O and policy behavior because the architecture docs described design but lacked runnable validation steps.
- Define minimal acceptance criteria and a canonical command test set so shell/console alignment can be objectively measured across architectures.

### Description
- Add a "Production build profiles (shell-focused)" section to `docs/architecture/system/shell-architecture.md` that documents current default CMake options and three recommended CMake variants with example invocations.
- Add QEMU validation build/run guidance and an "Interactive shell acceptance criteria (QEMU)" checklist to `docs/architecture/system/shell-architecture.md` showing `tools/build.py` usage for headless validation.
- Extend `docs/architecture/system/shell-profile-matrix.md` with a QEMU validation lane table for `x86_64`, `arm64`, and `riscv64`, a canonical `python3 tools/build.py` invocation, a minimum shell command test sequence to run after boot, and a review checklist entry requiring QEMU evidence.
- This is a documentation-only change and does not modify runtime code or behavior.

### Testing
- Performed structural validation and diffs of the updated Markdown files and confirmed referenced delivery target YAMLs exist under `delivery/targets/qemu/`, which succeeded.
- Sanity-checked rendered sections and example commands by printing the updated ranges with `sed`/`nl` to ensure the Markdown layout and code snippets are intact and readable.
- No unit tests or QEMU runtime builds were executed in this change; CI/runtime validation is intended to follow using the documented `python3 tools/build.py` flows.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec644457408320830d6beb5da7bed8)