### PR TITLE
shell: add interactive runtime loop and harden dispatch path

### DIFF
--- a/core/services/system/shell/src/shell_dispatch.c
+++ b/core/services/system/shell/src/shell_dispatch.c
@@ -2,6 +2,8 @@
 
 #include "shell_string.h"
 
+#include <sys/time.h>
+
 #include "shell_auth.h"
 #include "shell_registry.h"
 
@@ -10,29 +12,48 @@ static shell_response_t mk(shell_status_code_t code, const char* msg, const char
     return r;
 }
 
+static bool tokens_equal(const char* token, const char* command_token, size_t len) {
+    size_t i;
+    if (!token || !command_token) {
+        return false;
+    }
+    for (i = 0; i < len; ++i) {
+        if (token[i] != command_token[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+
 static bool command_matches(const char* command, const shell_argv_t* argv) {
-    char buf[32];
     size_t i = 0;
     size_t token_idx = 0;
-    size_t out = 0;
+    size_t token_start = 0;
+    size_t token_len;
 
     if (!command || !argv) {
         return false;
     }
 
-    while (command[i] != '\0' && token_idx < argv->count) {
-        size_t token_len = shell_strlen(argv->tokens[token_idx]);
-        if (out + token_len + 1u >= sizeof(buf)) {
+    while (command[i] != '\0') {
+        if (token_idx >= argv->count) {
             return false;
         }
-        shell_memcpy(&buf[out], argv->tokens[token_idx], token_len);
-        out += token_len;
-
+        token_start = i;
         while (command[i] != '\0' && command[i] != ' ') {
             ++i;
         }
+        token_len = i - token_start;
+
+        if (shell_strlen(argv->tokens[token_idx]) != token_len) {
+            return false;
+        }
+        if (token_len > 0u &&
+            !tokens_equal(argv->tokens[token_idx], &command[token_start], token_len)) {
+            return false;
+        }
+
         if (command[i] == ' ') {
-            buf[out++] = ' ';
             while (command[i] == ' ') {
                 ++i;
             }
@@ -42,8 +63,7 @@ static bool command_matches(const char* command, const shell_argv_t* argv) {
         break;
     }
 
-    buf[out] = '\0';
-    return shell_strcmp(buf, command) == 0;
+    return true;
 }
 
 static size_t command_token_count(const char* command) {
@@ -57,6 +77,16 @@ static size_t command_token_count(const char* command) {
     return count;
 }
 
+static uint64_t monotonic_ms(void) {
+    struct timeval tv;
+
+    if (gettimeofday(&tv, NULL) != 0) {
+        return 0u;
+    }
+
+    return ((uint64_t)tv.tv_sec * 1000u) + ((uint64_t)tv.tv_usec / 1000u);
+}
+
 shell_response_t shell_dispatch(shell_session_t* session,
                                 const shell_backend_api_t* backend,
                                 const shell_argv_t* argv) {
@@ -66,6 +96,8 @@ shell_response_t shell_dispatch(shell_session_t* session,
     size_t i;
     shell_status_code_t access;
     shell_response_t response;
+    uint64_t start_ms;
+    uint64_t end_ms;
 
     if (!session || !argv || argv->count == 0) {
         return mk(SHELL_RC_INVALID_ARG, "invalid input", NULL);
@@ -96,7 +128,19 @@ shell_response_t shell_dispatch(shell_session_t* session,
         return mk(access, "access denied", matched->command);
     }
 
+    start_ms = monotonic_ms();
     response = matched->handler(session, backend, argv);
+    end_ms = monotonic_ms();
+
+    if (matched->timeout_ms > 0u) {
+        if (end_ms > start_ms && (end_ms - start_ms) > matched->timeout_ms) {
+            if (backend && backend->audit_event) {
+                backend->audit_event("timeout", matched->command, SHELL_RC_TIMEOUT);
+            }
+            return mk(SHELL_RC_TIMEOUT, "command timeout", matched->command);
+        }
+    }
+
     shell_session_auth_success(session);
     if (backend && backend->audit_event && response.code != SHELL_RC_OK) {
         backend->audit_event("failed", matched->command, response.code);

--- a/core/services/system/shell/src/shell_service.c
+++ b/core/services/system/shell/src/shell_service.c
@@ -2,10 +2,28 @@
 
 #include "shell_string.h"
 
+#include <stdio.h>
+
 #include "shell_dispatch.h"
 #include "shell_output.h"
 #include "shell_parser.h"
 #include "shell_session.h"
+
+#ifndef SHELL_NO_MAIN
+static void trim_line_end(char* line) {
+    size_t len;
+
+    if (!line) {
+        return;
+    }
+
+    len = shell_strlen(line);
+    while (len > 0u && (line[len - 1u] == '\n' || line[len - 1u] == '\r')) {
+        line[len - 1u] = '\0';
+        --len;
+    }
+}
+#endif
 
 shell_status_code_t shell_process_line(shell_session_t* session,
                                        const shell_backend_api_t* backend,
@@ -55,6 +73,24 @@ shell_status_code_t shell_process_line(shell_session_t* session,
     return response.code;
 }
 
+#ifndef SHELL_NO_MAIN
 int main(void) {
+    shell_session_t session;
+    const shell_backend_api_t* backend = shell_default_backend();
+    char line[SHELL_MAX_INPUT_LEN];
+    char out[SHELL_MAX_OUTPUT_LEN];
+
+    shell_session_init(&session,
+                       SHELL_MODE_DEV,
+                       SHELL_CAP_DIAG | SHELL_CAP_REBOOT | SHELL_CAP_SVC_WRITE | SHELL_CAP_FACTORY);
+
+    while (fgets(line, sizeof(line), stdin) != NULL) {
+        trim_line_end(line);
+        (void)shell_process_line(&session, backend, line, out, sizeof(out));
+        puts(out);
+        fflush(stdout);
+    }
+
     return 0;
 }
+#endif

--- a/docs/architecture/system/shell-architecture.md
+++ b/docs/architecture/system/shell-architecture.md
@@ -56,6 +56,21 @@ Shell handlers must use service contracts/backend APIs and must not access kerne
 - No full shell↔console daemon wiring for true end-to-end TTY/session path.
 - Remote/script/compat modes are build-flag placeholders today.
 
+## Implementation work items (tracked from this architecture)
+
+### Completed in current shell code
+
+- Added an interactive shell runtime loop in `shell_service.c` with bounded line input (`SHELL_MAX_INPUT_LEN`) and explicit stdout flush behavior.
+- Hardened command matching to avoid fixed-size command reconstruction buffers during multi-token lookup.
+- Added elapsed-time timeout enforcement using command metadata (`timeout_ms`) and timeout audit events.
+
+### Remaining for full production contract
+
+- Replace stub backend (`shell_backend_stub.c`) with service IPC backend wiring to console daemon transport.
+- Introduce explicit session bootstrap/auth handshake prior to enabling privileged command catalogs.
+- Wire cancellation-aware timeout path into backend/service calls instead of post-handler elapsed checks.
+- Add QEMU run-stage evidence collection once cross-tree build blockers are resolved (currently failing at missing `core/lib/syscall/syscall_stubs.c` during target configure).
+
 ## Security and capability model
 
 Mandatory controls:


### PR DESCRIPTION
### Motivation

- Provide a real interactive shell runtime so the service can be exercised from stdin/console and produce flushed output for emulator/CI validation.
- Remove fragile fixed-size command reconstruction in dispatch to eliminate buffer coupling and improve correctness for multi-token commands.
- Enforce per-command timeout metadata and emit audit events to start hardening execution/observability requirements for production readiness.

### Description

- Add an interactive `main` loop to `core/services/system/shell/src/shell_service.c` that reads bounded lines (`SHELL_MAX_INPUT_LEN`), trims CR/LF, calls `shell_process_line`, prints and flushes responses, and is guarded by `#ifndef SHELL_NO_MAIN` to preserve host tests. 
- Replace fixed-buffer command reconstruction with token-by-token comparison in `core/services/system/shell/src/shell_dispatch.c` using a new `tokens_equal` helper and a robust `command_matches` implementation. 
- Add elapsed-time measurement (`monotonic_ms` backed by `gettimeofday`) and wrap handler invocation with start/end timestamps to enforce `timeout_ms` per-command, returning `SHELL_RC_TIMEOUT` and emitting a timeout audit via `backend->audit_event` on expiry. 
- Update `docs/architecture/system/shell-architecture.md` with a short checklist of implemented hardening items and remaining work (IPC backend wiring, auth bootstrap, cancellation-aware timeouts, QEMU evidence collection).

### Testing

- Compiled and executed all shell unit tests by building host test binaries with `-DSHELL_NO_MAIN=1` and running each `core/services/system/shell/tests/test_shell_*.c`; all tests passed. 
- Installed Python YAML deps required by the build runner with `python3 -m pip install --user pyyaml jsonschema` (succeeded). 
- Attempted cross-tree QEMU target builds via `python3 tools/build.py build --target-yaml ...` for x86_64/arm64/riscv64 and they failed at CMake configure due to a missing `core/lib/syscall/syscall_stubs.c` (blocking E2E QEMU validation); installing host `qemu-system-*` packages was also blocked by an external apt repository error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec673711c48320b744c707610b1e88)