### PR TITLE
Implement architecture-backed userspace syscall dispatch

### DIFF
--- a/core/lib/syscall/syscall_stubs.c
+++ b/core/lib/syscall/syscall_stubs.c
@@ -1,4 +1,15 @@
 #include <bharat/uapi/syscall_nr.h>
+#include <bharat/uapi/sys_errno.h>
+
+#if defined(__x86_64__)
+#include <bharat/uapi/arch/x86_64/syscall.h>
+#elif defined(__aarch64__)
+#include <bharat/uapi/arch/arm64/syscall.h>
+#elif defined(__riscv)
+#include <bharat/uapi/arch/riscv64/syscall.h>
+#else
+#error "Unsupported architecture"
+#endif
 
 long bharat_syscall(long sysno,
                     long arg1,
@@ -7,12 +18,9 @@ long bharat_syscall(long sysno,
                     long arg4,
                     long arg5,
                     long arg6) {
-    (void)sysno;
-    (void)arg1;
-    (void)arg2;
-    (void)arg3;
-    (void)arg4;
-    (void)arg5;
-    (void)arg6;
-    return -1;
+    if (sysno < 0 || (unsigned long)sysno > (unsigned long)SYSCALL_MAX) {
+        return -(long)SYS_ENOSYS;
+    }
+
+    return bharat_syscall_arch(sysno, arg1, arg2, arg3, arg4, arg5, arg6);
 }


### PR DESCRIPTION
### Motivation

- Userspace `bharat_syscall` was a placeholder that always returned `-1`, preventing real syscall traps into the kernel and breaking userspace behavior such as the shell.

### Description

- Replaced the stub implementation in `core/lib/syscall/syscall_stubs.c` with an architecture-backed dispatch that includes the ABI headers for `x86_64`, `arm64`, and `riscv64` and calls `bharat_syscall_arch`.
- Added syscall-number bounds validation and return `-SYS_ENOSYS` for out-of-range syscall IDs before performing the architecture trap.

### Testing

- Ran configuration with `cmake -S . -B build`, which completed successfully.
- Built the syscall library with `cmake --build build --target bharat_syscall -j4`, which succeeded and produced `libbharat_syscall.a`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec6a70e52883209748e8b6c0ca19b3)