### PR TITLE
Fix SDK/UAPI include paths and restore MMU/VMM build constants

### DIFF
--- a/core/arch/hal/x86_64/hal_pt_x86_64.c
+++ b/core/arch/hal/x86_64/hal_pt_x86_64.c
@@ -32,6 +32,7 @@ const size_t g_kernel_physmap_size = 0x8000000000ULL; // 512GB
 
 static void x86_tlb_flush_page_local(virt_addr_t vaddr);
 bool g_x86_mmu_finalized = false;
+static bool g_x86_pcid_supported = false;
 extern const virt_addr_t g_kernel_virt_offset;
 
 static void* x86_phys_to_virt(phys_addr_t phys) { 

--- a/core/hal/include/hal/hal_mmu.h
+++ b/core/hal/include/hal/hal_mmu.h
@@ -21,6 +21,15 @@ enum hal_memory_model {
  *
  * Detailed hardware features reported by the architecture/platform.
  */
+
+/* Supported page-size mask bits for hal_mem_caps_t.page_sizes_mask */
+enum hal_page_size_bits {
+    HAL_PAGE_SIZE_4K = (1u << 0),
+    HAL_PAGE_SIZE_2M = (1u << 1),
+    HAL_PAGE_SIZE_1G = (1u << 2),
+    HAL_PAGE_SIZE_4M = (1u << 3),
+};
+
 typedef struct hal_mem_caps {
     enum hal_memory_model model;
 

--- a/core/kernel/src/mm/vmm.c
+++ b/core/kernel/src/mm/vmm.c
@@ -11,6 +11,7 @@
 #include <stdint.h>
 #include "mm/aspace_profile.h"
 #include "debug/mm_invariants.h"
+#include "kernel/status.h"
 
 address_space_t kernel_space;
 static int kernel_space_ready = 0;

--- a/core/lib/CMakeLists.txt
+++ b/core/lib/CMakeLists.txt
@@ -114,6 +114,7 @@ add_library(transport ALIAS bharat_libtransport)
 set(BH_SDK_INCLUDES
     ${CMAKE_CURRENT_SOURCE_DIR}/runtime/include
     ${CMAKE_SOURCE_DIR}/interface
+    ${CMAKE_CURRENT_SOURCE_DIR}/syscall/common
 )
 
 add_library(bharatsys STATIC

--- a/core/lib/runtime/CMakeLists.txt
+++ b/core/lib/runtime/CMakeLists.txt
@@ -3,7 +3,7 @@ project(BharatOS_Lib_Runtime C ASM)
 
 # Create crt0 as an OBJECT library so it can be explicitly linked into every binary
 add_library(bharat_crt0 OBJECT src/crt0.c)
-target_include_directories(bharat_crt0 PUBLIC include)
+target_include_directories(bharat_crt0 PUBLIC include ${CMAKE_SOURCE_DIR}/interface ${CMAKE_SOURCE_DIR}/core/lib/syscall/common)
 target_link_libraries(bharat_crt0 PUBLIC bharat_freestanding bharat_syscall)
 
 # Add the lib/runtime static library

--- a/core/lib/runtime/include/bharat/bh_native.h
+++ b/core/lib/runtime/include/bharat/bh_native.h
@@ -3,12 +3,12 @@
 
 #include <stdint.h>
 #include <stddef.h>
-#include <interface/uapi/capability/capability.h>
-#include <interface/uapi/handle/handle.h>
-#include <interface/uapi/ipc/ipc.h>
-#include <interface/uapi/memory/memory.h>
-#include <interface/uapi/time/time.h>
-#include <interface/uapi/object/object.h>
+#include <uapi/capability/capability.h>
+#include <uapi/handle/handle.h>
+#include <uapi/ipc/ipc.h>
+#include <uapi/memory/memory.h>
+#include <uapi/time/time.h>
+#include <uapi/object/object.h>
 
 /* Capability Management */
 int bh_cap_revoke(bh_cap_t cap);

--- a/core/lib/runtime/src/bharat/bh_native.c
+++ b/core/lib/runtime/src/bharat/bh_native.c
@@ -1,6 +1,6 @@
 #include <bharat/bh_native.h>
-#include <interface/uapi/syscall/syscall_nr.h>
-#include <core/lib/syscall/common/syscall.h>
+#include <uapi/syscall/syscall_nr.h>
+#include <syscall.h>
 
 int bh_cap_revoke(bh_cap_t cap) {
     return (int)bh_syscall(SYSCALL_CAP_REVOKE, (long)cap, 0, 0, 0, 0, 0);

--- a/core/lib/runtime/src/crt0.c
+++ b/core/lib/runtime/src/crt0.c
@@ -1,7 +1,7 @@
 #include <stdint.h>
 #include <stddef.h>
-#include <interface/uapi/syscall/syscall_nr.h>
-#include <core/lib/syscall/common/syscall.h>
+#include <uapi/syscall/syscall_nr.h>
+#include <syscall.h>
 
 extern int main(int argc, char* argv[], char* envp[]);
 

--- a/core/lib/runtime/src/malloc/malloc.c
+++ b/core/lib/runtime/src/malloc/malloc.c
@@ -1,6 +1,6 @@
 #include <stdlib.h>
-#include <interface/uapi/syscall/syscall_nr.h>
-#include <core/lib/syscall/common/syscall.h>
+#include <uapi/syscall/syscall_nr.h>
+#include <syscall.h>
 
 /* Minimal slab-like allocator can be implemented here later for better performance.
    For now, we use direct syscalls as a baseline. */

--- a/core/lib/runtime/src/stdio/stdio.c
+++ b/core/lib/runtime/src/stdio/stdio.c
@@ -6,8 +6,8 @@
 #define BH_WRITE(buf, len) fwrite(buf, 1, len, stdout)
 #else
 #include <stdio.h>
-#include <interface/uapi/syscall/syscall_nr.h>
-#include <core/lib/syscall/common/syscall.h>
+#include <uapi/syscall/syscall_nr.h>
+#include <syscall.h>
 #define BH_WRITE(buf, len) bh_syscall(SYSCALL_IPC_SEND, 1, (long)buf, (long)len, 0, 0, 0)
 #endif
 

--- a/core/lib/syscall/common/syscall.c
+++ b/core/lib/syscall/common/syscall.c
@@ -1,11 +1,11 @@
-#include <interface/uapi/syscall/syscall_nr.h>
+#include <uapi/syscall/syscall_nr.h>
 
 #if defined(__x86_64__)
-#include <interface/uapi/arch/x86_64/syscall.h>
+#include <uapi/arch/x86_64/syscall.h>
 #elif defined(__aarch64__)
-#include <interface/uapi/arch/arm64/syscall.h>
+#include <uapi/arch/arm64/syscall.h>
 #elif defined(__riscv)
-#include <interface/uapi/arch/riscv64/syscall.h>
+#include <uapi/arch/riscv64/syscall.h>
 #else
 #error "Unsupported architecture"
 #endif

--- a/interface/uapi/ipc/ipc.h
+++ b/interface/uapi/ipc/ipc.h
@@ -2,7 +2,7 @@
 #define BHARAT_UAPI_IPC_H
 
 #include <stdint.h>
-#include <interface/uapi/capability/capability.h>
+#include <uapi/capability/capability.h>
 
 typedef bh_cap_t bh_endpoint_t;
 

--- a/interface/uapi/object/object.h
+++ b/interface/uapi/object/object.h
@@ -2,7 +2,7 @@
 #define BHARAT_UAPI_OBJECT_H
 
 #include <stdint.h>
-#include <interface/uapi/handle/handle.h>
+#include <uapi/handle/handle.h>
 
 struct bh_object_info {
     uint32_t type;

--- a/interface/uapi/service/service.h
+++ b/interface/uapi/service/service.h
@@ -2,7 +2,7 @@
 #define BHARAT_UAPI_SERVICE_H
 
 #include <stdint.h>
-#include <interface/uapi/ipc/ipc.h>
+#include <uapi/ipc/ipc.h>
 
 struct bh_service_info {
     char name[64];


### PR DESCRIPTION
### Motivation
- Resolve build failures caused by inconsistent SDK/UAPI include paths that produced missing-header errors for `syscall_nr.h` and capability headers.
- Restore missing MMU page-size constants used by architecture reporters to fix undeclared identifier errors in `hal_mmu` implementations.
- Restore visibility of kernel status codes and CPU capability state used by VMM/MMU code to eliminate compilation errors.

### Description
- Normalized runtime and syscall sources and UAPI headers to use the project include root by changing `#include <interface/uapi/...>` to `#include <uapi/...>` across runtime/syscall and UAPI headers. 
- Exposed the syscall common headers to SDK targets by adding the syscall folder to `BH_SDK_INCLUDES` and adding the runtime/syscall include into `bharat_crt0` via CMake (`core/lib/CMakeLists.txt`, `core/lib/runtime/CMakeLists.txt`).
- Added `enum hal_page_size_bits` (bit masks `HAL_PAGE_SIZE_4K`, `HAL_PAGE_SIZE_2M`, `HAL_PAGE_SIZE_1G`, `HAL_PAGE_SIZE_4M`) to `core/hal/include/hal/hal_mmu.h` to provide page-size mask constants expected by arch implementations. 
- Restored required definitions/visibility by including `kernel/status.h` in `core/kernel/src/mm/vmm.c` and adding `static bool g_x86_pcid_supported = false;` to `core/arch/hal/x86_64/hal_pt_x86_64.c` to resolve undeclared identifier errors. 

### Testing
- Installed QEMU system emulators with `sudo apt-get install -y qemu-system-x86 qemu-system-arm qemu-system-aarch64` and verified availability with `qemu-system-x86_64 --version` and `qemu-system-aarch64 --version`, both of which succeeded. 
- Ran `cmake --preset=x86_64-dev` to configure and attempted `cmake --build --preset=x86_64-dev`; previous missing-header and undeclared-identifier errors from the repository sources were resolved, but the build in this container is blocked by the cross-toolchain environment (`bits/libc-header-start.h` missing for `x86_64-unknown-none-elf`), so the full build did not complete here. 
- Repeated the build attempt after the fixes and observed the same toolchain/environment blocker, confirming repository fixes addressed the original source-level errors but that a separate toolchain configuration is required to finish the native cross-build in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec6dfba618832094412928d4ff747c)