### PR TITLE
Fix x86_64 headless shell build and syscall linkage

### DIFF
--- a/core/lib/syscall/syscall_stubs.c
+++ b/core/lib/syscall/syscall_stubs.c
@@ -24,3 +24,7 @@ long bharat_syscall(long sysno,
 
     return bharat_syscall_arch(sysno, arg1, arg2, arg3, arg4, arg5, arg6);
 }
+
+long bh_syscall(long sysno, long arg1, long arg2, long arg3, long arg4, long arg5, long arg6) {
+    return bharat_syscall(sysno, arg1, arg2, arg3, arg4, arg5, arg6);
+}

--- a/core/services/system/shell/CMakeLists.txt
+++ b/core/services/system/shell/CMakeLists.txt
@@ -28,6 +28,8 @@ target_link_libraries(system_shell PRIVATE
 target_include_directories(system_shell PRIVATE
     include
     ../../../lib
+    ../../../lib/runtime/include
+    ${CMAKE_SOURCE_DIR}/interface
 )
 
 if(CONFIG_SHELL_MINI)

--- a/core/services/system/shell/src/shell_dispatch.c
+++ b/core/services/system/shell/src/shell_dispatch.c
@@ -2,8 +2,6 @@
 
 #include "shell_string.h"
 
-#include <sys/time.h>
-
 #include "shell_auth.h"
 #include "shell_registry.h"
 
@@ -77,14 +75,15 @@ static size_t command_token_count(const char* command) {
     return count;
 }
 
-static uint64_t monotonic_ms(void) {
-    struct timeval tv;
-
-    if (gettimeofday(&tv, NULL) != 0) {
+static uint64_t monotonic_ms(const shell_backend_api_t* backend) {
+    uint64_t now = 0;
+    if (!backend || !backend->get_uptime_ms) {
         return 0u;
     }
-
-    return ((uint64_t)tv.tv_sec * 1000u) + ((uint64_t)tv.tv_usec / 1000u);
+    if (backend->get_uptime_ms(&now) != 0) {
+        return 0u;
+    }
+    return now;
 }
 
 shell_response_t shell_dispatch(shell_session_t* session,
@@ -128,9 +127,9 @@ shell_response_t shell_dispatch(shell_session_t* session,
         return mk(access, "access denied", matched->command);
     }
 
-    start_ms = monotonic_ms();
+    start_ms = monotonic_ms(backend);
     response = matched->handler(session, backend, argv);
-    end_ms = monotonic_ms();
+    end_ms = monotonic_ms(backend);
 
     if (matched->timeout_ms > 0u) {
         if (end_ms > start_ms && (end_ms - start_ms) > matched->timeout_ms) {

--- a/core/services/system/shell/src/shell_service.c
+++ b/core/services/system/shell/src/shell_service.c
@@ -2,14 +2,14 @@
 
 #include "shell_string.h"
 
-#include <stdio.h>
-
 #include "shell_dispatch.h"
 #include "shell_output.h"
 #include "shell_parser.h"
 #include "shell_session.h"
 
-#ifndef SHELL_NO_MAIN
+#if defined(BHARAT_HOST_TEST) && !defined(SHELL_NO_MAIN)
+#include <stdio.h>
+
 static void trim_line_end(char* line) {
     size_t len;
 
@@ -73,7 +73,7 @@ shell_status_code_t shell_process_line(shell_session_t* session,
     return response.code;
 }
 
-#ifndef SHELL_NO_MAIN
+#if defined(BHARAT_HOST_TEST) && !defined(SHELL_NO_MAIN)
 int main(void) {
     shell_session_t session;
     const shell_backend_api_t* backend = shell_default_backend();
@@ -92,5 +92,26 @@ int main(void) {
     }
 
     return 0;
+}
+#elif !defined(SHELL_NO_MAIN)
+int main(void) {
+    shell_session_t session;
+    const shell_backend_api_t* backend = shell_default_backend();
+    char out[SHELL_MAX_OUTPUT_LEN];
+
+    shell_session_init(&session,
+                       SHELL_MODE_DEV,
+                       SHELL_CAP_DIAG | SHELL_CAP_REBOOT | SHELL_CAP_SVC_WRITE | SHELL_CAP_FACTORY);
+
+    for (;;) {
+        shell_response_t idle = {
+            .code = SHELL_RC_OK,
+            .message = "shell service idle",
+            .payload = NULL,
+        };
+        shell_format_response(session.output_mode, &idle, out, sizeof(out));
+        (void)backend;
+        (void)out;
+    }
 }
 #endif


### PR DESCRIPTION
### Motivation
- Cross-target/freestanding x86_64 builds were failing: userspace shell referenced host-only headers (`stdio.h`, `sys/time.h`) and linker errors reported an undefined `bh_syscall` symbol.

### Description
- Add compatibility wrapper `bh_syscall(...)` that forwards to `bharat_syscall(...)` to satisfy existing runtime/crt0 callers (file: `core/lib/syscall/syscall_stubs.c`).
- Remove direct dependency on `<sys/time.h>` and `gettimeofday()` from the shell dispatch path and switch to the shell backend uptime API (`backend->get_uptime_ms`) for command timing (file: `core/services/system/shell/src/shell_dispatch.c`).
- Restrict inclusion of `<stdio.h>` and the interactive `stdin`/`stdout` `main()` to host-test builds (`BHARAT_HOST_TEST`), and add a non-host idle `main()` path for target builds so the shell target no longer requires host stdio headers (file: `core/services/system/shell/src/shell_service.c`).
- Add required include directories for the shell target so runtime/uapi headers resolve during cross builds: `../../../lib/runtime/include` and `${CMAKE_SOURCE_DIR}/interface` (file: `core/services/system/shell/CMakeLists.txt`).

### Testing
- Built the system shell target with `cmake --build --preset=x86_64-dev --target system_shell -j4`, which succeeded. ✅
- Built the demo app with `cmake --build --preset=x86_64-dev --target app_demo -j4`, which succeeded. ✅
- Attempted full cross build with `cmake --build --preset=x86_64-dev -j4`, which failed in this environment due to missing host libc headers for the cross toolchain (`bits/libc-header-start.h`) while compiling unrelated CRT/runtime host stubs; this failure is environmental and not caused by the changes in this patch. ⚠️

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec7010192c8320a12052a2d8e791be)