### PR TITLE
Harden architecture boundary and document production gaps

### DIFF
--- a/core/arch/arm/arm64/accel_caps.c
+++ b/core/arch/arm/arm64/accel_caps.c
@@ -1,0 +1,24 @@
+#include "arch/common/accel_caps_publish.h"
+#include <stdint.h>
+
+void arch_accel_caps_publish_target_impl(accel_discovery_t *accel,
+                                    const arch_cpu_caps_record_t *caps_all,
+                                    const arch_cpu_caps_record_t *caps_any) {
+    accel_set_mask(&accel->raw_all_mask, HAL_ACCEL_FEAT_ARM64_SVE,
+                   &caps_all->raw, ARCH_CPU_FEAT_ARM64_SVE);
+    accel_set_mask(&accel->raw_any_mask, HAL_ACCEL_FEAT_ARM64_SVE,
+                   &caps_any->raw, ARCH_CPU_FEAT_ARM64_SVE);
+    accel_set_mask(&accel->usable_all_mask, HAL_ACCEL_FEAT_ARM64_SVE,
+                   &caps_all->usable, ARCH_CPU_FEAT_ARM64_SVE);
+    accel_set_mask(&accel->usable_any_mask, HAL_ACCEL_FEAT_ARM64_SVE,
+                   &caps_any->usable, ARCH_CPU_FEAT_ARM64_SVE);
+
+    accel_set_mask(&accel->raw_all_mask, HAL_ACCEL_FEAT_ARM64_SVE2,
+                   &caps_all->raw, ARCH_CPU_FEAT_ARM64_SVE2);
+    accel_set_mask(&accel->raw_any_mask, HAL_ACCEL_FEAT_ARM64_SVE2,
+                   &caps_any->raw, ARCH_CPU_FEAT_ARM64_SVE2);
+    accel_set_mask(&accel->usable_all_mask, HAL_ACCEL_FEAT_ARM64_SVE2,
+                   &caps_all->usable, ARCH_CPU_FEAT_ARM64_SVE2);
+    accel_set_mask(&accel->usable_any_mask, HAL_ACCEL_FEAT_ARM64_SVE2,
+                   &caps_any->usable, ARCH_CPU_FEAT_ARM64_SVE2);
+}

--- a/core/arch/common/accel_caps_publish.c
+++ b/core/arch/common/accel_caps_publish.c
@@ -2,14 +2,11 @@
 
 #include <stdint.h>
 
-static inline void accel_set_mask(uint64_t *mask, hal_accel_feature_t feat,
-                                  const arch_cpu_caps_t *caps, int arch_feat) {
-    if (feat >= HAL_ACCEL_FEAT__COUNT) {
-        return;
-    }
-    if (arch_cpu_caps_test(caps, arch_feat)) {
-        *mask |= (1ULL << (uint32_t)feat);
-    }
+// Weak stub for arch-specific publish logic
+void __attribute__((weak)) arch_accel_caps_publish_target_impl(accel_discovery_t *accel,
+                                    const arch_cpu_caps_record_t *caps_all,
+                                    const arch_cpu_caps_record_t *caps_any) {
+    (void)accel; (void)caps_all; (void)caps_any;
 }
 
 void arch_accel_caps_publish_target(accel_discovery_t *accel,
@@ -19,104 +16,5 @@ void arch_accel_caps_publish_target(accel_discovery_t *accel,
         return;
     }
 
-#if defined(__x86_64__)
-    accel_set_mask(&accel->raw_all_mask, HAL_ACCEL_FEAT_X86_AVX,
-                   &caps_all->raw, ARCH_CPU_FEAT_X86_AVX);
-    accel_set_mask(&accel->raw_any_mask, HAL_ACCEL_FEAT_X86_AVX,
-                   &caps_any->raw, ARCH_CPU_FEAT_X86_AVX);
-    accel_set_mask(&accel->usable_all_mask, HAL_ACCEL_FEAT_X86_AVX,
-                   &caps_all->usable, ARCH_CPU_FEAT_X86_AVX);
-    accel_set_mask(&accel->usable_any_mask, HAL_ACCEL_FEAT_X86_AVX,
-                   &caps_any->usable, ARCH_CPU_FEAT_X86_AVX);
-
-    accel_set_mask(&accel->raw_all_mask, HAL_ACCEL_FEAT_X86_AVX2,
-                   &caps_all->raw, ARCH_CPU_FEAT_X86_AVX2);
-    accel_set_mask(&accel->raw_any_mask, HAL_ACCEL_FEAT_X86_AVX2,
-                   &caps_any->raw, ARCH_CPU_FEAT_X86_AVX2);
-    accel_set_mask(&accel->usable_all_mask, HAL_ACCEL_FEAT_X86_AVX2,
-                   &caps_all->usable, ARCH_CPU_FEAT_X86_AVX2);
-    accel_set_mask(&accel->usable_any_mask, HAL_ACCEL_FEAT_X86_AVX2,
-                   &caps_any->usable, ARCH_CPU_FEAT_X86_AVX2);
-
-    accel_set_mask(&accel->raw_all_mask, HAL_ACCEL_FEAT_X86_FMA,
-                   &caps_all->raw, ARCH_CPU_FEAT_X86_FMA);
-    accel_set_mask(&accel->raw_any_mask, HAL_ACCEL_FEAT_X86_FMA,
-                   &caps_any->raw, ARCH_CPU_FEAT_X86_FMA);
-    accel_set_mask(&accel->usable_all_mask, HAL_ACCEL_FEAT_X86_FMA,
-                   &caps_all->usable, ARCH_CPU_FEAT_X86_FMA);
-    accel_set_mask(&accel->usable_any_mask, HAL_ACCEL_FEAT_X86_FMA,
-                   &caps_any->usable, ARCH_CPU_FEAT_X86_FMA);
-
-    accel_set_mask(&accel->raw_all_mask, HAL_ACCEL_FEAT_X86_PCLMUL,
-                   &caps_all->raw, ARCH_CPU_FEAT_X86_PCLMUL);
-    accel_set_mask(&accel->raw_any_mask, HAL_ACCEL_FEAT_X86_PCLMUL,
-                   &caps_any->raw, ARCH_CPU_FEAT_X86_PCLMUL);
-    accel_set_mask(&accel->usable_all_mask, HAL_ACCEL_FEAT_X86_PCLMUL,
-                   &caps_all->usable, ARCH_CPU_FEAT_X86_PCLMUL);
-    accel_set_mask(&accel->usable_any_mask, HAL_ACCEL_FEAT_X86_PCLMUL,
-                   &caps_any->usable, ARCH_CPU_FEAT_X86_PCLMUL);
-#elif defined(__aarch64__)
-    accel_set_mask(&accel->raw_all_mask, HAL_ACCEL_FEAT_ARM64_SVE,
-                   &caps_all->raw, ARCH_CPU_FEAT_ARM64_SVE);
-    accel_set_mask(&accel->raw_any_mask, HAL_ACCEL_FEAT_ARM64_SVE,
-                   &caps_any->raw, ARCH_CPU_FEAT_ARM64_SVE);
-    accel_set_mask(&accel->usable_all_mask, HAL_ACCEL_FEAT_ARM64_SVE,
-                   &caps_all->usable, ARCH_CPU_FEAT_ARM64_SVE);
-    accel_set_mask(&accel->usable_any_mask, HAL_ACCEL_FEAT_ARM64_SVE,
-                   &caps_any->usable, ARCH_CPU_FEAT_ARM64_SVE);
-
-    accel_set_mask(&accel->raw_all_mask, HAL_ACCEL_FEAT_ARM64_SVE2,
-                   &caps_all->raw, ARCH_CPU_FEAT_ARM64_SVE2);
-    accel_set_mask(&accel->raw_any_mask, HAL_ACCEL_FEAT_ARM64_SVE2,
-                   &caps_any->raw, ARCH_CPU_FEAT_ARM64_SVE2);
-    accel_set_mask(&accel->usable_all_mask, HAL_ACCEL_FEAT_ARM64_SVE2,
-                   &caps_all->usable, ARCH_CPU_FEAT_ARM64_SVE2);
-    accel_set_mask(&accel->usable_any_mask, HAL_ACCEL_FEAT_ARM64_SVE2,
-                   &caps_any->usable, ARCH_CPU_FEAT_ARM64_SVE2);
-#elif defined(__riscv)
-    accel_set_mask(&accel->raw_all_mask, HAL_ACCEL_FEAT_RISCV_V,
-                   &caps_all->raw, ARCH_CPU_FEAT_RISCV_V);
-    accel_set_mask(&accel->raw_any_mask, HAL_ACCEL_FEAT_RISCV_V,
-                   &caps_any->raw, ARCH_CPU_FEAT_RISCV_V);
-    accel_set_mask(&accel->usable_all_mask, HAL_ACCEL_FEAT_RISCV_V,
-                   &caps_all->usable, ARCH_CPU_FEAT_RISCV_V);
-    accel_set_mask(&accel->usable_any_mask, HAL_ACCEL_FEAT_RISCV_V,
-                   &caps_any->usable, ARCH_CPU_FEAT_RISCV_V);
-
-    accel_set_mask(&accel->raw_all_mask, HAL_ACCEL_FEAT_RISCV_ZBA,
-                   &caps_all->raw, ARCH_CPU_FEAT_RISCV_ZBA);
-    accel_set_mask(&accel->raw_any_mask, HAL_ACCEL_FEAT_RISCV_ZBA,
-                   &caps_any->raw, ARCH_CPU_FEAT_RISCV_ZBA);
-    accel_set_mask(&accel->usable_all_mask, HAL_ACCEL_FEAT_RISCV_ZBA,
-                   &caps_all->usable, ARCH_CPU_FEAT_RISCV_ZBA);
-    accel_set_mask(&accel->usable_any_mask, HAL_ACCEL_FEAT_RISCV_ZBA,
-                   &caps_any->usable, ARCH_CPU_FEAT_RISCV_ZBA);
-
-    accel_set_mask(&accel->raw_all_mask, HAL_ACCEL_FEAT_RISCV_ZBB,
-                   &caps_all->raw, ARCH_CPU_FEAT_RISCV_ZBB);
-    accel_set_mask(&accel->raw_any_mask, HAL_ACCEL_FEAT_RISCV_ZBB,
-                   &caps_any->raw, ARCH_CPU_FEAT_RISCV_ZBB);
-    accel_set_mask(&accel->usable_all_mask, HAL_ACCEL_FEAT_RISCV_ZBB,
-                   &caps_all->usable, ARCH_CPU_FEAT_RISCV_ZBB);
-    accel_set_mask(&accel->usable_any_mask, HAL_ACCEL_FEAT_RISCV_ZBB,
-                   &caps_any->usable, ARCH_CPU_FEAT_RISCV_ZBB);
-
-    accel_set_mask(&accel->raw_all_mask, HAL_ACCEL_FEAT_RISCV_ZBC,
-                   &caps_all->raw, ARCH_CPU_FEAT_RISCV_ZBC);
-    accel_set_mask(&accel->raw_any_mask, HAL_ACCEL_FEAT_RISCV_ZBC,
-                   &caps_any->raw, ARCH_CPU_FEAT_RISCV_ZBC);
-    accel_set_mask(&accel->usable_all_mask, HAL_ACCEL_FEAT_RISCV_ZBC,
-                   &caps_all->usable, ARCH_CPU_FEAT_RISCV_ZBC);
-    accel_set_mask(&accel->usable_any_mask, HAL_ACCEL_FEAT_RISCV_ZBC,
-                   &caps_any->usable, ARCH_CPU_FEAT_RISCV_ZBC);
-
-    accel_set_mask(&accel->raw_all_mask, HAL_ACCEL_FEAT_RISCV_ZBS,
-                   &caps_all->raw, ARCH_CPU_FEAT_RISCV_ZBS);
-    accel_set_mask(&accel->raw_any_mask, HAL_ACCEL_FEAT_RISCV_ZBS,
-                   &caps_any->raw, ARCH_CPU_FEAT_RISCV_ZBS);
-    accel_set_mask(&accel->usable_all_mask, HAL_ACCEL_FEAT_RISCV_ZBS,
-                   &caps_all->usable, ARCH_CPU_FEAT_RISCV_ZBS);
-    accel_set_mask(&accel->usable_any_mask, HAL_ACCEL_FEAT_RISCV_ZBS,
-                   &caps_any->usable, ARCH_CPU_FEAT_RISCV_ZBS);
-#endif
+    arch_accel_caps_publish_target_impl(accel, caps_all, caps_any);
 }

--- a/core/arch/hal/arm32/hal_cpu.c
+++ b/core/arch/hal/arm32/hal_cpu.c
@@ -5,6 +5,11 @@
 
 void hal_cpu_init(void) {}
 
+bool hal_cpu_is_syscall(const void *trap_frame) {
+    (void)trap_frame;
+    return false;
+}
+
 bool hal_cpu_is_page_fault(const void *trap_frame) {
     (void)trap_frame;
     return false;

--- a/core/arch/hal/arm32/hal_pt_arm32.c
+++ b/core/arch/hal/arm32/hal_pt_arm32.c
@@ -301,6 +301,8 @@ static const hal_pt_caps_t arm32_pt_caps = {
     .supports_linear_physmap = false,
 };
 
+extern hal_tlb_ops_t arm32_hal_tlb_ops;
+
 hal_pt_ops_t arm32_hal_pt_ops = {
     .backend_type          = TRANSLATE_BACKEND_MMU,
     .caps                  = &arm32_pt_caps,
@@ -315,6 +317,10 @@ hal_pt_ops_t arm32_hal_pt_ops = {
     .protect_range         = NULL,
     .query_mapping         = NULL,
 };
+
+void arch_hal_pt_init(void) {
+    hal_pt_register_ops(&arm32_hal_pt_ops, &arm32_hal_tlb_ops);
+}
 
 static void arm32_tlb_flush_page_local(virt_addr_t vaddr) {
     asm volatile("mcr p15, 0, %0, c8, c7, 1" : : "r" (vaddr));

--- a/core/arch/hal/arm64/hal_cpu.c
+++ b/core/arch/hal/arm64/hal_cpu.c
@@ -37,6 +37,14 @@ void hal_cpu_reboot(void) {
 // TODO: Needs refactor: #include directive placed mid-file for dependency/order compatibility.
 #include "trap.h"
 
+bool hal_cpu_is_syscall(const void *trap_frame) {
+    if (!trap_frame) return false;
+    const trap_frame_t *tf = (const trap_frame_t *)trap_frame;
+    if (tf->type != TRAP_TYPE_SYNC) return false;
+    uint64_t ec = tf->cause >> 26;
+    return (ec == 0x15); // SVC instruction in AArch64
+}
+
 bool hal_cpu_is_page_fault(const void *trap_frame) {
     if (!trap_frame) return false;
     const trap_frame_t *tf = (const trap_frame_t *)trap_frame;

--- a/core/arch/hal/arm64/hal_pt_arm64.c
+++ b/core/arch/hal/arm64/hal_pt_arm64.c
@@ -610,6 +610,8 @@ static const hal_pt_caps_t arm64_pt_caps = {
     .supports_linear_physmap = true,
 };
 
+extern hal_tlb_ops_t arm64_hal_tlb_ops;
+
 hal_pt_ops_t arm64_hal_pt_ops = {
     .backend_type          = TRANSLATE_BACKEND_MMU,
     .caps                  = &arm64_pt_caps,
@@ -624,6 +626,10 @@ hal_pt_ops_t arm64_hal_pt_ops = {
     .protect_range         = arm64_pt_protect_range,
     .query_mapping         = arm64_pt_query_mapping,
 };
+
+void arch_hal_pt_init(void) {
+    hal_pt_register_ops(&arm64_hal_pt_ops, &arm64_hal_tlb_ops);
+}
 
 static const hal_tlb_caps_t arm64_tlb_caps = {
     .supports_page_flush = true,

--- a/core/arch/hal/riscv/hal_cpu.c
+++ b/core/arch/hal/riscv/hal_cpu.c
@@ -72,6 +72,12 @@ void hal_cpu_reboot(void) {
 // TODO: Needs refactor: #include directive placed mid-file for dependency/order compatibility.
 #include "trap.h"
 
+bool hal_cpu_is_syscall(const void *trap_frame) {
+    if (!trap_frame) return false;
+    const trap_frame_t *tf = (const trap_frame_t *)trap_frame;
+    return (tf->cause == 8); // Environment call from U-mode
+}
+
 bool hal_cpu_is_page_fault(const void *trap_frame) {
     if (!trap_frame) return false;
     const trap_frame_t *tf = (const trap_frame_t *)trap_frame;

--- a/core/arch/hal/riscv32/hal_pt_riscv32.c
+++ b/core/arch/hal/riscv32/hal_pt_riscv32.c
@@ -253,6 +253,8 @@ static const hal_pt_caps_t riscv32_pt_caps = {
     .supports_linear_physmap = false,
 };
 
+extern hal_tlb_ops_t riscv32_hal_tlb_ops;
+
 hal_pt_ops_t riscv32_hal_pt_ops = {
     .backend_type          = TRANSLATE_BACKEND_MMU,
     .caps                  = &riscv32_pt_caps,
@@ -267,6 +269,10 @@ hal_pt_ops_t riscv32_hal_pt_ops = {
     .protect_range         = NULL,
     .query_mapping         = NULL,
 };
+
+void arch_hal_pt_init(void) {
+    hal_pt_register_ops(&riscv32_hal_pt_ops, &riscv32_hal_tlb_ops);
+}
 
 static void riscv32_tlb_flush_page_local(virt_addr_t vaddr) {
     asm volatile(

--- a/core/arch/hal/riscv64/hal_pt_riscv64.c
+++ b/core/arch/hal/riscv64/hal_pt_riscv64.c
@@ -361,6 +361,8 @@ static const hal_pt_caps_t riscv64_pt_caps = {
     .supports_linear_physmap = true,
 };
 
+extern hal_tlb_ops_t riscv64_hal_tlb_ops;
+
 hal_pt_ops_t riscv64_hal_pt_ops = {
     .backend_type          = TRANSLATE_BACKEND_MMU,
     .caps                  = &riscv64_pt_caps,
@@ -375,6 +377,10 @@ hal_pt_ops_t riscv64_hal_pt_ops = {
     .protect_range         = riscv64_pt_protect_range,
     .query_mapping         = riscv64_pt_query_mapping,
 };
+
+void arch_hal_pt_init(void) {
+    hal_pt_register_ops(&riscv64_hal_pt_ops, &riscv64_hal_tlb_ops);
+}
 
 static const hal_tlb_caps_t riscv64_tlb_caps = {
     .supports_page_flush = true,

--- a/core/arch/hal/x86_64/hal_cpu.c
+++ b/core/arch/hal/x86_64/hal_cpu.c
@@ -75,6 +75,12 @@ void hal_cpu_reboot(void) {
 // TODO: Needs refactor: #include directive placed mid-file for dependency/order compatibility.
 #include "trap.h"
 
+bool hal_cpu_is_syscall(const void *trap_frame) {
+    if (!trap_frame) return false;
+    const trap_frame_t *tf = (const trap_frame_t *)trap_frame;
+    return (tf->cause == 0x80U); // x86_64 uses INT 0x80 for legacy or custom
+}
+
 bool hal_cpu_is_page_fault(const void *trap_frame) {
     if (!trap_frame) return false;
     const trap_frame_t *tf = (const trap_frame_t *)trap_frame;

--- a/core/arch/hal/x86_64/hal_pt_x86_64.c
+++ b/core/arch/hal/x86_64/hal_pt_x86_64.c
@@ -31,6 +31,7 @@ const size_t g_kernel_physmap_size = 0x8000000000ULL; // 512GB
 #define X86_LARGE_2M_SIZE (1ULL << 21)
 
 static void x86_tlb_flush_page_local(virt_addr_t vaddr);
+void x86_pt_caps_init(void);
 bool g_x86_mmu_finalized = false;
 static bool g_x86_pcid_supported = false;
 extern const virt_addr_t g_kernel_virt_offset;
@@ -547,6 +548,8 @@ static hal_pt_caps_t x86_pt_caps = {
     .supports_linear_physmap = true,
 };
 
+extern hal_tlb_ops_t x86_hal_tlb_ops;
+
 hal_pt_ops_t x86_hal_pt_ops = {
     .backend_type          = TRANSLATE_BACKEND_MMU,
     .caps                  = &x86_pt_caps,
@@ -561,6 +564,12 @@ hal_pt_ops_t x86_hal_pt_ops = {
     .protect_range         = x86_pt_protect_range,
     .query_mapping         = x86_pt_query_mapping,
 };
+
+void arch_hal_pt_init(void) {
+    x86_pt_caps_init();
+    x86_pt_set_mmu_finalized(true);
+    hal_pt_register_ops(&x86_hal_pt_ops, &x86_hal_tlb_ops);
+}
 
 // --- x86_64 TLB Operations ---
 

--- a/core/arch/riscv/riscv32/boot/entry.c
+++ b/core/arch/riscv/riscv32/boot/entry.c
@@ -15,15 +15,11 @@ void kernel_main(uint64_t hart_id, uintptr_t fdt_ptr) {
     hal_riscv_set_boot_info(hart_id, (uint64_t)fdt_ptr);
 
     if (fdt_ptr == 0 || !fdt_is_valid((void*)fdt_ptr)) {
-        fdt_ptr = 0x40000000;
+        kernel_panic("FDT missing or invalid: boot contract violation");
     }
 
     extern void riscv_fdt_parse_common(boot_info_t *boot, const void *fdt_ptr);
-    if (fdt_is_valid((void*)fdt_ptr)) {
-        riscv_fdt_parse_common(&boot, (const void*)fdt_ptr);
-    } else {
-        kernel_panic("FDT NOT FOUND AT FALLBACK!");
-    }
+    riscv_fdt_parse_common(&boot, (const void*)fdt_ptr);
 
     kernel_main_common(&boot);
 }

--- a/core/arch/riscv/riscv64/accel_caps.c
+++ b/core/arch/riscv/riscv64/accel_caps.c
@@ -1,0 +1,51 @@
+#include "arch/common/accel_caps_publish.h"
+#include <stdint.h>
+
+void arch_accel_caps_publish_target_impl(accel_discovery_t *accel,
+                                    const arch_cpu_caps_record_t *caps_all,
+                                    const arch_cpu_caps_record_t *caps_any) {
+    accel_set_mask(&accel->raw_all_mask, HAL_ACCEL_FEAT_RISCV_V,
+                   &caps_all->raw, ARCH_CPU_FEAT_RISCV_V);
+    accel_set_mask(&accel->raw_any_mask, HAL_ACCEL_FEAT_RISCV_V,
+                   &caps_any->raw, ARCH_CPU_FEAT_RISCV_V);
+    accel_set_mask(&accel->usable_all_mask, HAL_ACCEL_FEAT_RISCV_V,
+                   &caps_all->usable, ARCH_CPU_FEAT_RISCV_V);
+    accel_set_mask(&accel->usable_any_mask, HAL_ACCEL_FEAT_RISCV_V,
+                   &caps_any->usable, ARCH_CPU_FEAT_RISCV_V);
+
+    accel_set_mask(&accel->raw_all_mask, HAL_ACCEL_FEAT_RISCV_ZBA,
+                   &caps_all->raw, ARCH_CPU_FEAT_RISCV_ZBA);
+    accel_set_mask(&accel->raw_any_mask, HAL_ACCEL_FEAT_RISCV_ZBA,
+                   &caps_any->raw, ARCH_CPU_FEAT_RISCV_ZBA);
+    accel_set_mask(&accel->usable_all_mask, HAL_ACCEL_FEAT_RISCV_ZBA,
+                   &caps_all->usable, ARCH_CPU_FEAT_RISCV_ZBA);
+    accel_set_mask(&accel->usable_any_mask, HAL_ACCEL_FEAT_RISCV_ZBA,
+                   &caps_any->usable, ARCH_CPU_FEAT_RISCV_ZBA);
+
+    accel_set_mask(&accel->raw_all_mask, HAL_ACCEL_FEAT_RISCV_ZBB,
+                   &caps_all->raw, ARCH_CPU_FEAT_RISCV_ZBB);
+    accel_set_mask(&accel->raw_any_mask, HAL_ACCEL_FEAT_RISCV_ZBB,
+                   &caps_any->raw, ARCH_CPU_FEAT_RISCV_ZBB);
+    accel_set_mask(&accel->usable_all_mask, HAL_ACCEL_FEAT_RISCV_ZBB,
+                   &caps_all->usable, ARCH_CPU_FEAT_RISCV_ZBB);
+    accel_set_mask(&accel->usable_any_mask, HAL_ACCEL_FEAT_RISCV_ZBB,
+                   &caps_any->usable, ARCH_CPU_FEAT_RISCV_ZBB);
+
+    accel_set_mask(&accel->raw_all_mask, HAL_ACCEL_FEAT_RISCV_ZBC,
+                   &caps_all->raw, ARCH_CPU_FEAT_RISCV_ZBC);
+    accel_set_mask(&accel->raw_any_mask, HAL_ACCEL_FEAT_RISCV_ZBC,
+                   &caps_any->raw, ARCH_CPU_FEAT_RISCV_ZBC);
+    accel_set_mask(&accel->usable_all_mask, HAL_ACCEL_FEAT_RISCV_ZBC,
+                   &caps_all->usable, ARCH_CPU_FEAT_RISCV_ZBC);
+    accel_set_mask(&accel->usable_any_mask, HAL_ACCEL_FEAT_RISCV_ZBC,
+                   &caps_any->usable, ARCH_CPU_FEAT_RISCV_ZBC);
+
+    accel_set_mask(&accel->raw_all_mask, HAL_ACCEL_FEAT_RISCV_ZBS,
+                   &caps_all->raw, ARCH_CPU_FEAT_RISCV_ZBS);
+    accel_set_mask(&accel->raw_any_mask, HAL_ACCEL_FEAT_RISCV_ZBS,
+                   &caps_any->raw, ARCH_CPU_FEAT_RISCV_ZBS);
+    accel_set_mask(&accel->usable_all_mask, HAL_ACCEL_FEAT_RISCV_ZBS,
+                   &caps_all->usable, ARCH_CPU_FEAT_RISCV_ZBS);
+    accel_set_mask(&accel->usable_any_mask, HAL_ACCEL_FEAT_RISCV_ZBS,
+                   &caps_any->usable, ARCH_CPU_FEAT_RISCV_ZBS);
+}

--- a/core/arch/riscv/riscv64/boot/entry.c
+++ b/core/arch/riscv/riscv64/boot/entry.c
@@ -21,14 +21,7 @@ void kernel_main(uint64_t hart_id, uintptr_t fdt_ptr) {
     hal_serial_write("\n");
 
     if (fdt_ptr == 0 || !fdt_is_valid((void*)fdt_ptr)) {
-        /* Fallback for QEMU virt: FDT at end of 256MB RAM */
-        fdt_ptr = 0x8fe00000;
-        hal_serial_write("Probing FDT at fallback: ");
-        hal_serial_write_hex(fdt_ptr);
-        hal_serial_write("\n");
-        if (!fdt_is_valid((void*)fdt_ptr)) {
-            kernel_panic("FDT not provided by bootloader and fallback failed");
-        }
+        kernel_panic("FDT missing or invalid: boot contract violation");
     }
 
     hal_riscv_set_boot_info(hart_id, (uint64_t)fdt_ptr);

--- a/core/arch/x86/x86_64/accel_caps.c
+++ b/core/arch/x86/x86_64/accel_caps.c
@@ -1,0 +1,42 @@
+#include "arch/common/accel_caps_publish.h"
+#include <stdint.h>
+
+void arch_accel_caps_publish_target_impl(accel_discovery_t *accel,
+                                    const arch_cpu_caps_record_t *caps_all,
+                                    const arch_cpu_caps_record_t *caps_any) {
+    accel_set_mask(&accel->raw_all_mask, HAL_ACCEL_FEAT_X86_AVX,
+                   &caps_all->raw, ARCH_CPU_FEAT_X86_AVX);
+    accel_set_mask(&accel->raw_any_mask, HAL_ACCEL_FEAT_X86_AVX,
+                   &caps_any->raw, ARCH_CPU_FEAT_X86_AVX);
+    accel_set_mask(&accel->usable_all_mask, HAL_ACCEL_FEAT_X86_AVX,
+                   &caps_all->usable, ARCH_CPU_FEAT_X86_AVX);
+    accel_set_mask(&accel->usable_any_mask, HAL_ACCEL_FEAT_X86_AVX,
+                   &caps_any->usable, ARCH_CPU_FEAT_X86_AVX);
+
+    accel_set_mask(&accel->raw_all_mask, HAL_ACCEL_FEAT_X86_AVX2,
+                   &caps_all->raw, ARCH_CPU_FEAT_X86_AVX2);
+    accel_set_mask(&accel->raw_any_mask, HAL_ACCEL_FEAT_X86_AVX2,
+                   &caps_any->raw, ARCH_CPU_FEAT_X86_AVX2);
+    accel_set_mask(&accel->usable_all_mask, HAL_ACCEL_FEAT_X86_AVX2,
+                   &caps_all->usable, ARCH_CPU_FEAT_X86_AVX2);
+    accel_set_mask(&accel->usable_any_mask, HAL_ACCEL_FEAT_X86_AVX2,
+                   &caps_any->usable, ARCH_CPU_FEAT_X86_AVX2);
+
+    accel_set_mask(&accel->raw_all_mask, HAL_ACCEL_FEAT_X86_FMA,
+                   &caps_all->raw, ARCH_CPU_FEAT_X86_FMA);
+    accel_set_mask(&accel->raw_any_mask, HAL_ACCEL_FEAT_X86_FMA,
+                   &caps_any->raw, ARCH_CPU_FEAT_X86_FMA);
+    accel_set_mask(&accel->usable_all_mask, HAL_ACCEL_FEAT_X86_FMA,
+                   &caps_all->usable, ARCH_CPU_FEAT_X86_FMA);
+    accel_set_mask(&accel->usable_any_mask, HAL_ACCEL_FEAT_X86_FMA,
+                   &caps_any->usable, ARCH_CPU_FEAT_X86_FMA);
+
+    accel_set_mask(&accel->raw_all_mask, HAL_ACCEL_FEAT_X86_PCLMUL,
+                   &caps_all->raw, ARCH_CPU_FEAT_X86_PCLMUL);
+    accel_set_mask(&accel->raw_any_mask, HAL_ACCEL_FEAT_X86_PCLMUL,
+                   &caps_any->raw, ARCH_CPU_FEAT_X86_PCLMUL);
+    accel_set_mask(&accel->usable_all_mask, HAL_ACCEL_FEAT_X86_PCLMUL,
+                   &caps_all->usable, ARCH_CPU_FEAT_X86_PCLMUL);
+    accel_set_mask(&accel->usable_any_mask, HAL_ACCEL_FEAT_X86_PCLMUL,
+                   &caps_any->usable, ARCH_CPU_FEAT_X86_PCLMUL);
+}

--- a/core/arch/x86/x86_64/boot/entry.c
+++ b/core/arch/x86/x86_64/boot/entry.c
@@ -45,8 +45,16 @@ void kernel_main(uint32_t magic, multiboot_information_t *mb_info) {
         kernel_panic("Invalid Multiboot magic number!");
     }
 
+    if (mb_info == NULL) {
+        kernel_panic("Multiboot information pointer is NULL");
+    }
+
     // Parse multiboot into platform and generic boot info
     x86_64_parse_multiboot(magic, mb_info, &plat, &boot);
+
+    if (boot.mem_region_count == 0) {
+        kernel_panic("No memory regions detected via Multiboot");
+    }
 
     // Provide generic hints
     boot.source = BOOT_SOURCE_MULTIBOOT2;

--- a/core/hal/hal_pt.c
+++ b/core/hal/hal_pt.c
@@ -12,53 +12,23 @@ static inline bool is_page_aligned_u64(uint64_t val) {
     return (val & (PAGE_SIZE - 1U)) == 0U;
 }
 
-#if defined(__x86_64__) || defined(_M_X64)
-extern hal_pt_ops_t x86_hal_pt_ops;
-extern hal_tlb_ops_t x86_hal_tlb_ops;
-__attribute__((weak)) void x86_pt_set_mmu_finalized(bool finalized) { (void)finalized; }
-#elif defined(__aarch64__) || defined(_M_ARM64)
-extern hal_pt_ops_t arm64_hal_pt_ops;
-extern hal_tlb_ops_t arm64_hal_tlb_ops;
-#elif defined(__arm__)
-extern hal_pt_ops_t arm32_hal_pt_ops;
-extern hal_tlb_ops_t arm32_hal_tlb_ops;
-#elif defined(__riscv) && __riscv_xlen == 64
-extern hal_pt_ops_t riscv64_hal_pt_ops;
-extern hal_tlb_ops_t riscv64_hal_tlb_ops;
-#elif defined(__riscv) && __riscv_xlen == 32
-extern hal_pt_ops_t riscv32_hal_pt_ops;
-extern hal_tlb_ops_t riscv32_hal_tlb_ops;
-#endif
+void hal_pt_register_ops(hal_pt_ops_t *ops, hal_tlb_ops_t *tlb_ops) {
+    if (ops) active_hal_pt = ops;
+    if (tlb_ops) active_hal_tlb = tlb_ops;
+}
 
-#if defined(BHARAT_PROFILE_MPU_ONLY) || defined(PROFILE_MPU_ONLY)
-extern hal_pt_ops_t mpu_hal_pt_ops;
-extern hal_tlb_ops_t mpu_hal_tlb_ops;
-#endif
+// Architecture-specific initialization will call hal_pt_register_ops.
+// This weak stub handles cases where no registration happens early.
+void __attribute__((weak)) arch_hal_pt_init(void) {}
 
 void hal_pt_init(void) {
-#if defined(__x86_64__) || defined(_M_X64)
-    void __attribute__((weak)) x86_pt_caps_init(void);
-    if (x86_pt_caps_init) {
-        x86_pt_caps_init();
+    if (!active_hal_pt) {
+        arch_hal_pt_init();
     }
-    x86_pt_set_mmu_finalized(true);
-    active_hal_pt = &x86_hal_pt_ops;
-    active_hal_tlb = &x86_hal_tlb_ops;
-#elif defined(__aarch64__) || defined(_M_ARM64)
-    active_hal_pt = &arm64_hal_pt_ops;
-    active_hal_tlb = &arm64_hal_tlb_ops;
-#elif defined(__arm__)
-    active_hal_pt = &arm32_hal_pt_ops;
-    active_hal_tlb = &arm32_hal_tlb_ops;
-#elif defined(__riscv) && __riscv_xlen == 64
-    active_hal_pt = &riscv64_hal_pt_ops;
-    active_hal_tlb = &riscv64_hal_tlb_ops;
-#elif defined(__riscv) && __riscv_xlen == 32
-    active_hal_pt = &riscv32_hal_pt_ops;
-    active_hal_tlb = &riscv32_hal_tlb_ops;
-#endif
 
 #if defined(BHARAT_PROFILE_MPU_ONLY) || defined(PROFILE_MPU_ONLY)
+    extern hal_pt_ops_t mpu_hal_pt_ops;
+    extern hal_tlb_ops_t mpu_hal_tlb_ops;
     // Overrides arch-specific setups for bare-metal MPU configs
     active_hal_pt = &mpu_hal_pt_ops;
     active_hal_tlb = &mpu_hal_tlb_ops;
@@ -96,7 +66,21 @@ int hal_pt_map_range(phys_addr_t root_pt, virt_addr_t vaddr, phys_addr_t paddr, 
     if (!active_hal_pt) {
         hal_pt_init();
     }
-    if (!active_hal_pt || size == 0U || !is_page_aligned_u64(vaddr) || !is_page_aligned_u64(paddr) || !is_page_aligned_u64(size)) {
+    if (!active_hal_pt) {
+        return -1;
+    }
+
+    if (size == 0U) {
+        return 0;
+    }
+
+    if (!is_page_aligned_u64(vaddr) || !is_page_aligned_u64(paddr) || !is_page_aligned_u64(size)) {
+        kernel_panic("hal_pt_map_range: unaligned parameters");
+        return -1;
+    }
+
+    // Basic flag validation - ensure at least some permissions or special flags are set
+    if (flags == 0) {
         return -1;
     }
 
@@ -122,7 +106,16 @@ int hal_pt_unmap_range(phys_addr_t root_pt, virt_addr_t vaddr, size_t size) {
     if (!active_hal_pt) {
         hal_pt_init();
     }
-    if (!active_hal_pt || size == 0U || !is_page_aligned_u64(vaddr) || !is_page_aligned_u64(size)) {
+    if (!active_hal_pt) {
+        return -1;
+    }
+
+    if (size == 0U) {
+        return 0;
+    }
+
+    if (!is_page_aligned_u64(vaddr) || !is_page_aligned_u64(size)) {
+        kernel_panic("hal_pt_unmap_range: unaligned parameters");
         return -1;
     }
 

--- a/core/kernel/include/arch/common/accel_caps_publish.h
+++ b/core/kernel/include/arch/common/accel_caps_publish.h
@@ -8,4 +8,14 @@ void arch_accel_caps_publish_target(accel_discovery_t *accel,
                                     const arch_cpu_caps_record_t *caps_all,
                                     const arch_cpu_caps_record_t *caps_any);
 
+static inline void accel_set_mask(uint64_t *mask, hal_accel_feature_t feat,
+                                  const arch_cpu_caps_t *caps, int arch_feat) {
+    if (feat >= HAL_ACCEL_FEAT__COUNT) {
+        return;
+    }
+    if (arch_cpu_caps_test(caps, arch_feat)) {
+        *mask |= (1ULL << (uint32_t)feat);
+    }
+}
+
 #endif // BHARAT_ARCH_COMMON_ACCEL_CAPS_PUBLISH_H

--- a/core/kernel/include/generated/bharat_config.h
+++ b/core/kernel/include/generated/bharat_config.h
@@ -1,0 +1,93 @@
+#ifndef BHARAT_CONFIG_H
+#define BHARAT_CONFIG_H
+
+/* AUTO-GENERATED VIA CMAKE configure_file(bharat_config.h.in -> generated/bharat_config.h). */
+/* Edit bharat_config.h.in, not generated/bharat_config.h. */
+/* Architecture Family */
+#define BHARAT_ARCH_X86 1
+/* #undef BHARAT_ARCH_ARM */
+/* #undef BHARAT_ARCH_RISCV */
+
+/* Architecture Bitness */
+/* #undef BHARAT_ARCH_32BIT */
+#define BHARAT_ARCH_64BIT 1
+
+/* Architecture Variant */
+#define BHARAT_ARCH_VARIANT_GENERIC 1
+/* #undef BHARAT_ARCH_VARIANT_SHAKTI */
+
+/* Device Profile */
+#define BHARAT_PROFILE_DESKTOP 1
+/* #undef BHARAT_PROFILE_MOBILE */
+/* #undef BHARAT_PROFILE_EDGE */
+/* #undef BHARAT_PROFILE_DATACENTER */
+/* #undef BHARAT_PROFILE_NETWORK_APPLIANCE */
+/* #undef BHARAT_PROFILE_DRONE */
+/* #undef BHARAT_PROFILE_ROBOT */
+/* #undef BHARAT_PROFILE_RTOS */
+/* #undef BHARAT_PROFILE_AUTOMOTIVE_ECU */
+/* #undef BHARAT_PROFILE_AUTOMOTIVE_INFOTAINMENT */
+
+/* Kernel Execution Profile */
+/* #undef BHARAT_KERNEL_PROFILE_RT */
+#define BHARAT_KERNEL_PROFILE_GP 1
+/* #undef BHARAT_KERNEL_PROFILE_MIX */
+
+/* IRQ Dispatch Mode */
+#define BHARAT_IRQ_DISPATCH_GENERIC 1
+/* #undef BHARAT_IRQ_DISPATCH_MIXED */
+/* #undef BHARAT_IRQ_DISPATCH_RT */
+
+/* Personality Profile */
+#define BHARAT_PERSONALITY_NATIVE 1
+/* #undef BHARAT_PERSONALITY_LINUX */
+/* #undef BHARAT_PERSONALITY_WINDOWS */
+/* #undef BHARAT_PERSONALITY_MAC */
+
+/* ISA Baseline */
+/* #undef BHARAT_ISA_BASELINE_X86_64_V2 */
+/* #undef BHARAT_ISA_BASELINE_RV64GC */
+/* ... add more baselines as needed ... */
+
+/* ISA Features (Dynamic based on CMake lists) */
+/* The build system will pass these as compile definitions */
+/* For example: -DBHARAT_ISA_FEATURE_AVX2=1 */
+
+/* Hardware Accelerators (Dynamic based on CMake lists) */
+/* For example: -DBHARAT_ACCEL_GPU=1 */
+
+/* Memory Capabilities */
+#define BHARAT_ENABLE_MMU 1
+/* #undef BHARAT_ENABLE_MPU */
+#define BHARAT_ENABLE_ADVANCED_VM 1
+#define BHARAT_ENABLE_IOMMU 1
+#define BHARAT_ENABLE_DMA_MAP 1
+#define BHARAT_ENABLE_COW 1
+#define BHARAT_ENABLE_DEMAND_PAGING 1
+#define BHARAT_ENABLE_SHARED_MEMORY 1
+/* #undef BHARAT_ENABLE_NUMA */
+#define BHARAT_ENABLE_ALLOC_CLASSES 1
+#define BHARAT_ENABLE_MEMORY_STATS 1
+
+#define MAX_SUPPORTED_CORES 32
+#define BHARAT_CONFIG_CAP_REVOKE_MAX 256
+
+/* Platform Firmware */
+/* #undef BHARAT_PLATFORM_ACPI */
+/* #undef BHARAT_PLATFORM_FDT */
+
+
+/* Multikernel & URPC Configuration */
+#define CONFIG_MULTIKERNEL 1
+#define CONFIG_HETEROGENEOUS_CPU 1
+#define CONFIG_URPC 1
+
+#ifndef BHARAT_CACHE_LINE_SIZE
+#define BHARAT_CACHE_LINE_SIZE 64
+#endif
+
+#ifndef BHARAT_ALIGNED_CACHE
+#define BHARAT_ALIGNED_CACHE __attribute__((aligned(BHARAT_CACHE_LINE_SIZE)))
+#endif
+
+#endif /* BHARAT_CONFIG_H */

--- a/core/kernel/include/hal/hal.h
+++ b/core/kernel/include/hal/hal.h
@@ -21,6 +21,7 @@ uint64_t hal_cpu_get_fault_address(const void *trap_frame);
 // Exception classification
 // TODO: Needs refactor: #include directive placed mid-file for dependency/order compatibility.
 #include <stdbool.h>
+bool hal_cpu_is_syscall(const void *trap_frame);
 bool hal_cpu_is_page_fault(const void *trap_frame);
 bool hal_cpu_is_access_fault(const void *trap_frame);
 bool hal_cpu_is_fp_simd_fault(const void *trap_frame);

--- a/core/kernel/include/hal/hal_pt.h
+++ b/core/kernel/include/hal/hal_pt.h
@@ -120,9 +120,12 @@ typedef struct hal_pt_ops {
     int         (*query_mapping)(phys_addr_t root_pt, virt_addr_t vaddr, phys_addr_t *paddr, size_t *mapped_size, uint32_t *flags);
 } hal_pt_ops_t;
 
+#include "../../include/hal/hal_tlb.h"
+
 extern hal_pt_ops_t *active_hal_pt;
 
 void hal_pt_init(void);
+void hal_pt_register_ops(hal_pt_ops_t *ops, hal_tlb_ops_t *tlb_ops);
 
 phys_addr_t hal_pt_create_address_space(phys_addr_t kernel_root_table);
 void hal_pt_destroy_address_space(phys_addr_t root_pt);

--- a/core/kernel/src/trap/trap.c
+++ b/core/kernel/src/trap/trap.c
@@ -450,15 +450,7 @@ long trap_handle(trap_frame_t *frame) {
   if (frame->type == TRAP_TYPE_IRQ) {
     info.trap_class = TRAP_CLASS_INTERRUPT;
   } else {
-#if defined(__x86_64__)
-    uintptr_t trap_cause_syscall = 0x80U;
-#elif defined(__riscv)
-    uintptr_t trap_cause_syscall = 8U;
-#else
-    uintptr_t trap_cause_syscall = 0xFFFFU;
-#endif
-
-    if (frame->cause == trap_cause_syscall) {
+    if (hal_cpu_is_syscall(frame)) {
       info.trap_class = TRAP_CLASS_SYSCALL;
     } else if (hal_cpu_is_page_fault(frame)) {
       info.trap_class = TRAP_CLASS_PAGE_FAULT;

--- a/docs/architecture/components/kernel-subcomponents-architecture.md
+++ b/docs/architecture/components/kernel-subcomponents-architecture.md
@@ -46,7 +46,7 @@ graph TD
 | Keep policy out of kernel | `core/kernel/src/profile/*`, `core/kernel/src/subsystem/linux` | Partial | Some profile/personality-like concerns still reside under kernel tree. |
 | Capability + IPC primitives | `cap`, `ipc`, `urpc` | Strong | Matches architecture direction. |
 | Memory authority and isolation | `mm/{vm,pt,pmm,dma,iommu,tlb}` | Strong | Good decomposition for MM evolution. |
-| Hardware abstraction usage | via `core/hal/*` and arch paths | Partial | HAL tree still includes arch-specific directories, conflicting with strict abstraction guidance. |
+| Hardware abstraction usage | via `core/hal/*` and arch paths | Baseline | Arch-specific `ops` registration is now pushed into arch directories, keeping `core/hal` clean of `#ifdef` leakage. |
 
 ## Kernel status matrix
 
@@ -56,7 +56,7 @@ graph TD
 | IPC + URPC | Partial | `core/kernel/src/ipc`, `core/kernel/src/urpc` | Unify backpressure/error contracts and cross-node routing semantics. | Phase 1, Phase 3 |
 | Capability core | Partial | `core/kernel/src/cap` | Add formal derivation/revocation invariant checks in host tests. | Phase 1, Phase 4 |
 | Scheduler | Partial | `core/kernel/src/sched` | Improve admission control + deterministic RT isolation proofs. | Phase 1, Phase 2 |
-| Trap/syscall path | Partial | `core/kernel/src/trap`, `core/kernel/src/sys` | Tighten ABI surface to `interface/uapi/` and remove internal header leakage. | Phase 1 |
+| Trap/syscall path | Baseline | `core/kernel/src/trap`, `core/kernel/src/sys` | Unified syscall detection via `hal_cpu_is_syscall` contract. Hardened boot contract validation and PT alignment checks. | Phase 1 |
 | Subsystem/personality hooks | Partial | `core/kernel/src/subsystem/linux`, `core/kernel/src/profile/*` | Move policy-heavy profile logic toward `core/services/` or `core/personalities/` where possible. | Phase 2, Phase 4 |
 
 ## Coding tasks identified

--- a/docs/reviews/core_arch_production_grade_review_2026-04-25.md
+++ b/docs/reviews/core_arch_production_grade_review_2026-04-25.md
@@ -1,0 +1,37 @@
+# Core Arch Production Grade Review - 2026-04-25
+
+## Files Reviewed
+- `core/arch/x86/x86_64/boot/entry.c`
+- `core/arch/arm/arm64/boot/entry.c`
+- `core/arch/riscv/riscv64/boot/entry.c`
+- `core/arch/x86/x86_64/boot/multiboot_parse.c`
+- `core/hal/hal_pt.c`
+- `core/hal/hal_mmu_caps.c`
+- `core/arch/common/accel_caps_publish.c`
+- `core/kernel/src/trap/trap.c`
+
+## Issues Found
+
+| ID | Severity | File | Issue | Production Risk | Status |
+|---|---|---|---|---|---|
+| 01 | P0 | `riscv64/boot/entry.c` | Hardcoded FDT fallback address (`0x8fe00000`). | Booting on incorrect DTB if loader fails to provide one. | Fixed |
+| 02 | P1 | `core/hal/hal_pt.c` | Arch-specific `#ifdef` leakage for PT ops registration. | Violates 6-layer architecture and portability. | Fixed |
+| 03 | P1 | `core/arch/common/accel_caps_publish.c` | Arch-specific `#ifdef` leakage in common code. | Maintenance burden and portability risk. | Fixed |
+| 04 | P2 | `core/hal/hal_pt.c` | Weak alignment and flag validation in range operations. | Potential for kernel memory corruption or invalid PTEs. | Fixed |
+| 05 | P2 | `x86_64/boot/entry.c` | Minimal validation of Multiboot structures after magic check. | Booting on corrupt bootloader data. | Fixed |
+| 06 | P3 | `core/kernel/src/trap/trap.c` | Mixed arch-specific constants for syscall trap cause. | Minor cleanup needed for consistency. | Fixed |
+
+## Build/Run Result Table
+
+| Target | Build | QEMU headless | Boot marker | Notes |
+|---|---:|---:|---|---|
+| x86_64_desktop_headless | PASS | PASS | `Bharat-OS` | Verified hardened boot flow. |
+| arm64_desktop_headless | PASS | PASS | `Bharat-OS` | Verified hardened boot flow. |
+| riscv64_desktop_headless | PASS | PASS | `Bharat-OS` | Verified hardened boot flow. |
+| arm32_mmu_lite_headless | PASS | FAIL | N/A | Build successful, but QEMU fails to produce output (Partial status). |
+| riscv32_mmu_lite_headless | PASS | FAIL | N/A | Build successful, but QEMU fails due to missing OpenSBI binary. |
+
+## Next Recommended Refactor Slice
+- Unify Trap/Exception handling registration across architectures (similar to PT ops).
+- Implement more robust CPU feature detection using the new `accel_caps` contract.
+- Standardize IPI and TLB shootdown mechanisms to avoid unbounded waits.


### PR DESCRIPTION
This patch improves the production-readiness of the architecture and HAL layers by:
- Enforcing strict boot contract validation (FDT/Multiboot) and removing unsafe fallbacks.
- Hardening MMU operations with strict alignment and flag checks.
- Refactoring the HAL/Arch boundary to eliminate architecture-specific `#ifdef` leakage from common code.
- Generalizing syscall detection in the core trap handler.
- Documenting identified gaps and verified status across major architectures.

---
*PR created automatically by Jules for task [226440260045566730](https://jules.google.com/task/226440260045566730) started by @divyang4481*