### PR TITLE
Fix EDF scheduler admission and sorting logic

### DIFF
--- a/core/kernel/include/sched/sched.h
+++ b/core/kernel/include/sched/sched.h
@@ -43,6 +43,8 @@ typedef enum {
 #define SCHED_MAX_PRIORITY 31U
 #define MAX_PRIORITY_LEVELS (SCHED_MAX_PRIORITY + 1U)
 
+#define BH_THREAD_FLAG_IDLE (1U << 0)
+
 typedef struct arch_ext_state arch_ext_state_t;
 
 typedef struct {
@@ -198,6 +200,8 @@ struct bh_thread {
     // Fault state
     thread_fault_t pending_fault;
     bool fault_pending;
+
+    uint32_t flags;
 };
 
 int thread_raise_fault(bh_thread_t *thread, thread_fault_t fault);

--- a/core/kernel/src/sched/constraint_apply.c
+++ b/core/kernel/src/sched/constraint_apply.c
@@ -6,11 +6,10 @@ bool sched_is_core_admissible(bh_thread_t *t, int cpu_id)
 {
     if (!t) return false;
 
-    // Use a simpler check rather than fully dereferencing internal rq state
-    // since g_active_core_count is static to sched.c.
-    // The idle thread has thread_id 0 implicitly or we can just rely on the sched core loops.
-    // If it's the idle thread, its mask is typically 0xFFFFFFFF anyway, but let's be safe.
-    if (t->thread_id == 0) return true; // Boot/Idle thread
+    // Explicitly allow idle threads on any core.
+    if ((t->flags & BH_THREAD_FLAG_IDLE) != 0) {
+        return true;
+    }
 
     return (t->constraints.cpu_mask & (1u << cpu_id)) != 0;
 }

--- a/core/kernel/src/sched/sched.c
+++ b/core/kernel/src/sched/sched.c
@@ -451,6 +451,10 @@ static bh_thread_t *sched_create_bootstrap_thread(bh_process_t *parent,
   list_init(&slot->run_node);
   list_init(&slot->wait_node);
 
+  if (kind == SCHED_BOOTSTRAP_IDLE) {
+    slot->thread.flags |= BH_THREAD_FLAG_IDLE;
+  }
+
   if (enqueue != 0U) {
     (void)sched_enqueue(&slot->thread, core);
   }
@@ -551,6 +555,22 @@ bh_thread_t *thread_create_detached(bh_process_t *parent, void (*entry_point)(vo
   slot->thread.preferred_numa_node = 0U;
   slot->thread.bound_core_id = sched_clamp_core(hal_cpu_get_id());
   slot->thread.affinity_mask = SCHED_AFFINITY_ANY;
+
+  // Initialize constraints with sane defaults
+  slot->thread.constraints.cpu_mask = SCHED_AFFINITY_ANY;
+  slot->thread.constraints.flags = 0;
+  slot->thread.constraints.latency_class = 0;
+  slot->thread.constraints.energy_class = 0;
+
+  slot->thread.priority = 1U; // Default priority
+  slot->thread.base_priority = 1U;
+  slot->thread.absolute_deadline_ms = 0; // 0 indicates no absolute deadline set yet
+
+  // RT attributes defaults
+  slot->thread.rt_attr.wcet_ms = 0;
+  slot->thread.rt_attr.period_ms = 0;
+  slot->thread.rt_attr.deadline_ms = 0;
+
   slot->thread.wake_deadline_ms = 0U;
   slot->thread.context_switch_count = 0U;
   slot->creation_core_id = sched_clamp_core(hal_cpu_get_id());

--- a/core/kernel/src/sched/sched_rt.c
+++ b/core/kernel/src/sched/sched_rt.c
@@ -12,8 +12,23 @@ void sched_edf_enqueue(sched_rq_t *rq, bh_thread_t *thread) {
 
         if (absolute_deadline < entry->absolute_deadline_ms) {
             link = &parent->rb_left;
-        } else {
+        } else if (absolute_deadline > entry->absolute_deadline_ms) {
             link = &parent->rb_right;
+        } else {
+            // Tie-breaker: higher priority first (lower value in Bharat is higher priority?
+            // Actually SCHED_MAX_PRIORITY is 31, so higher value is higher priority)
+            if (thread->priority > entry->priority) {
+                link = &parent->rb_left;
+            } else if (thread->priority < entry->priority) {
+                link = &parent->rb_right;
+            } else {
+                // Second tie-breaker: lower thread ID first
+                if (thread->thread_id < entry->thread_id) {
+                    link = &parent->rb_left;
+                } else {
+                    link = &parent->rb_right;
+                }
+            }
         }
     }
 
@@ -29,7 +44,7 @@ void sched_edf_dequeue(sched_rq_t *rq, bh_thread_t *thread) {
 }
 
 int sched_admission_edf(bh_thread_t *thread, uint64_t wcet_ms, uint64_t period_ms, uint64_t deadline_ms) {
-    if (!thread || period_ms == 0 || wcet_ms > period_ms) {
+    if (!thread || period_ms == 0 || wcet_ms == 0 || wcet_ms > deadline_ms || deadline_ms > period_ms) {
         return -1;
     }
 
@@ -39,7 +54,7 @@ int sched_admission_edf(bh_thread_t *thread, uint64_t wcet_ms, uint64_t period_m
     thread->rt_attr.deadline_ms = deadline_ms;
     thread->absolute_deadline_ms = 0; // calculated on enqueue
 
-    // Calculate bandwidth contribution
+    // Calculate bandwidth contribution (utilization * 1000)
     uint64_t bandwidth_needed = (wcet_ms * 1000) / period_ms;
 
     uint32_t core = thread->bound_core_id;


### PR DESCRIPTION
Fixed the EDF scheduler admission and sorting logic to resolve the `rt_sched` self-test failure. Introduced explicit idle thread detection, sane default thread constraints, and a robust EDF comparator with tie-breakers.

---
*PR created automatically by Jules for task [13996034615327568900](https://jules.google.com/task/13996034615327568900) started by @divyang4481*