### PR TITLE
Add missing HAL MM hooks, fix header name collision, and update runtime include paths

### DIFF
--- a/core/arch/hal/arm/arm64/hal_mm.c
+++ b/core/arch/hal/arm/arm64/hal_mm.c
@@ -1,5 +1,6 @@
 #include <stdbool.h>
 #include "hal/hal_capabilities.h"
+#include "hal/hal_mm.h"
 #include "hal/hal_mmu.h"
 #include <string.h>
 
@@ -23,6 +24,27 @@ int hal_mem_get_caps(hal_mem_caps_t *caps) {
     caps->supports_iommu = true; // SMMU
 
     return 0;
+}
+
+void hal_mm_get_zone_limits(hal_mm_zone_limits_t *out) {
+    if (!out) return;
+    out->dma_low_start = 0;
+    out->dma_low_end = 0x00FFFFFFu;     /* first 16 MiB */
+    out->dma32_start = 0;
+    out->dma32_end = 0xFFFFFFFFu;       /* first 4 GiB */
+    out->normal_start = 0x100000000ULL; /* above 4 GiB */
+    out->normal_end = (uintptr_t)-1;
+    out->flags = 0;
+}
+
+void hal_mm_backend_caps(hal_mm_backend_caps_t *out) {
+    if (!out) return;
+    out->kind = HAL_MM_BACKEND_MMU_FULL;
+    out->map_granule = 4096;
+    out->protect_granule = 4096;
+    out->alloc_granule = 4096;
+    out->max_regions = 0;
+    out->flags = 1;
 }
 
 static const hal_arch_capabilities_t g_arm64_caps = {

--- a/core/arch/hal/riscv/riscv64/hal_mm.c
+++ b/core/arch/hal/riscv/riscv64/hal_mm.c
@@ -1,6 +1,28 @@
 #include <stdbool.h>
 #include "hal/hal_capabilities.h"
 #include "hal/hal_mm.h"
+#include "hal/hal_mmu.h"
+#include <string.h>
+
+int hal_mem_get_caps(hal_mem_caps_t *caps) {
+    if (!caps) return -1;
+
+    memset(caps, 0, sizeof(hal_mem_caps_t));
+    caps->model = HAL_MEMORY_MODEL_MMU_FULL;
+    caps->va_bits = 48;
+    caps->pa_bits = 56;
+    caps->page_sizes_mask = HAL_PAGE_SIZE_4K | HAL_PAGE_SIZE_2M | HAL_PAGE_SIZE_1G;
+    caps->supports_nx = true;
+    caps->supports_asid = true;
+    caps->supports_global = true;
+    caps->supports_user_mode = true;
+    caps->supports_write_protect = true;
+    caps->supports_iommu = false;
+    caps->supports_hugepages = true;
+    caps->supports_dirty_accessed = true;
+    caps->max_mpu_regions = 0;
+    return 0;
+}
 
 void hal_mm_get_zone_limits(hal_mm_zone_limits_t *out) {
     if (!out) return;
@@ -34,11 +56,20 @@ void hal_mm_backend_caps(hal_mm_backend_caps_t *out) {
 }
 
 const hal_arch_capabilities_t *hal_get_arch_capabilities(void) {
-#if __riscv_xlen == 32
-    extern const hal_arch_capabilities_t *hal_get_arch_capabilities_riscv32(void);
-    return hal_get_arch_capabilities_riscv32();
-#else
-    extern const hal_arch_capabilities_t *hal_get_arch_capabilities_riscv64(void);
-    return hal_get_arch_capabilities_riscv64();
-#endif
+    static const hal_arch_capabilities_t g_riscv64_caps = {
+        .arch_name = "riscv64",
+        .arch_bits = 64,
+        .support_level = BH_ARCH_SUPPORT_RUNTIME_SUPPORTED,
+        .memory_model = BH_MEMORY_MODEL_MMU_FULL,
+        .has_smp = true,
+        .has_irq_controller = true,
+        .has_monotonic_timer = true,
+        .has_cycle_counter = true,
+        .has_dma = true,
+        .has_iommu = false,
+        .has_cache_ops = true,
+        .has_tlb_ops = true,
+        .max_supported_cores = 64
+    };
+    return &g_riscv64_caps;
 }

--- a/core/arch/hal/x86/x86_64/hal_mm.c
+++ b/core/arch/hal/x86/x86_64/hal_mm.c
@@ -1,5 +1,6 @@
 #include <stdbool.h>
 #include "hal/hal_capabilities.h"
+#include "hal/hal_mm.h"
 #include "hal/hal_mmu.h"
 #include <string.h>
 
@@ -26,6 +27,27 @@ int hal_mem_get_caps(hal_mem_caps_t *caps) {
     caps->supports_iommu = true;
 
     return 0;
+}
+
+void hal_mm_get_zone_limits(hal_mm_zone_limits_t *out) {
+    if (!out) return;
+    out->dma_low_start = 0;
+    out->dma_low_end = 0x00FFFFFFu;     /* first 16 MiB */
+    out->dma32_start = 0;
+    out->dma32_end = 0xFFFFFFFFu;       /* first 4 GiB */
+    out->normal_start = 0x100000000ULL; /* above 4 GiB */
+    out->normal_end = (uintptr_t)-1;
+    out->flags = 0;
+}
+
+void hal_mm_backend_caps(hal_mm_backend_caps_t *out) {
+    if (!out) return;
+    out->kind = HAL_MM_BACKEND_MMU_FULL;
+    out->map_granule = 4096;
+    out->protect_granule = 4096;
+    out->alloc_granule = 4096;
+    out->max_regions = 0;
+    out->flags = 1;
 }
 
 static const hal_arch_capabilities_t g_x86_64_caps = {

--- a/core/arch/hal/x86/x86_64/hal_pt_x86_64.c
+++ b/core/arch/hal/x86/x86_64/hal_pt_x86_64.c
@@ -34,7 +34,6 @@ const size_t g_kernel_physmap_size = 0x8000000000ULL; // 512GB
 static void x86_tlb_flush_page_local(virt_addr_t vaddr);
 void x86_pt_caps_init(void);
 bool g_x86_mmu_finalized = false;
-static bool g_x86_pcid_supported = false;
 extern const virt_addr_t g_kernel_virt_offset;
 
 static void* x86_phys_to_virt(phys_addr_t phys) { 

--- a/core/hal/include/hal/hal_mmu.h
+++ b/core/hal/include/hal/hal_mmu.h
@@ -26,14 +26,6 @@ enum hal_memory_model {
  * Detailed hardware features reported by the architecture/platform.
  */
 
-/* Supported page-size mask bits for hal_mem_caps_t.page_sizes_mask */
-enum hal_page_size_bits {
-    HAL_PAGE_SIZE_4K = (1u << 0),
-    HAL_PAGE_SIZE_2M = (1u << 1),
-    HAL_PAGE_SIZE_1G = (1u << 2),
-    HAL_PAGE_SIZE_4M = (1u << 3),
-};
-
 typedef struct hal_mem_caps {
     enum hal_memory_model model;
 

--- a/core/lib/runtime/CMakeLists.txt
+++ b/core/lib/runtime/CMakeLists.txt
@@ -3,7 +3,12 @@ project(BharatOS_Lib_Runtime C ASM)
 
 # Create crt0 as an OBJECT library so it can be explicitly linked into every binary
 add_library(bharat_crt0 OBJECT src/crt0.c)
-target_include_directories(bharat_crt0 PUBLIC include ${CMAKE_SOURCE_DIR}/core/lib)
+target_include_directories(bharat_crt0 PUBLIC
+    include
+    ${CMAKE_SOURCE_DIR}/core/lib
+    ${CMAKE_SOURCE_DIR}/interface
+    ${CMAKE_SOURCE_DIR}/interface/include
+)
 target_link_libraries(bharat_crt0 PUBLIC bharat_freestanding bharat_syscall)
 
 # Add the lib/runtime static library
@@ -30,6 +35,8 @@ bharat_configure_userspace_library(bharat_runtime_tensor)
 # Set the public include directory
 target_include_directories(bharat_libruntime PUBLIC
     include
+    ${CMAKE_SOURCE_DIR}/interface
+    ${CMAKE_SOURCE_DIR}/interface/include
     ${CMAKE_SOURCE_DIR}/interface/uapi/runtime
     ${CMAKE_SOURCE_DIR}/core/kernel/include
 )

--- a/docs/reviews/syscall_conflict_analysis_2026-04-26.md
+++ b/docs/reviews/syscall_conflict_analysis_2026-04-26.md
@@ -1,0 +1,73 @@
+# Syscall / Kernel / SDK / Lib Conflict Analysis (2026-04-26)
+
+## Scope
+
+This review covered:
+- Kernel build and syscall integration paths
+- SDK and userspace syscall stubs
+- Headless cross-arch builds requested (`x86_64_desktop_headless`, `arm64_desktop_headless`, `riscv64_desktop_headless`)
+- User library and base test app compile status (`bharat_syscall`, `bharatsys`, `bharatc`, `app_test`)
+
+## What was fixed during this pass
+
+1. **HAL page-size macro/enum name collision (hard compiler break).**
+   - `core/hal/include/hal/hal_mmu.h` defined both preprocessor macros and enum members with the same names (`HAL_PAGE_SIZE_4K`, etc.), causing compile errors.
+   - Resolved by keeping the macro constants as the single source in that header.
+
+2. **x86_64 HAL duplicate symbol definition (hard compiler break).**
+   - `core/arch/hal/x86/x86_64/hal_pt_x86_64.c` had duplicate file-scope definitions of `g_x86_pcid_supported`.
+   - Removed duplicate to restore one-definition correctness.
+
+3. **Runtime include-path mismatch between old/new UAPI header layouts.**
+   - `core/lib/runtime` targets were missing include paths needed by legacy `<uapi/...>` includes used by runtime SDK sources.
+   - Added `${CMAKE_SOURCE_DIR}/interface` and `${CMAKE_SOURCE_DIR}/interface/include` to runtime target include paths.
+
+4. **Cross-arch HAL/MM linkage coverage (x86_64/arm64/riscv64).**
+   - Added missing `hal_mm_get_zone_limits()` and `hal_mm_backend_caps()` in x86_64 and arm64 HAL MM backends.
+   - Added missing `hal_mem_get_caps()` implementation and concrete `hal_get_arch_capabilities()` return path in riscv64 HAL MM backend.
+
+## Build and validation outcome
+
+### QEMU toolchains
+QEMU packages were installed and verified:
+- `qemu-system-x86_64`
+- `qemu-system-aarch64`
+- `qemu-system-riscv64`
+
+### Requested headless builds
+- `./build.sh all --target x86_64_desktop_headless` -> **PASS** (build + package + QEMU boot marker observed).
+- `./build.sh all --target arm64_desktop_headless` -> **PASS** (build + package + QEMU boot marker observed).
+- `./build.sh all --target riscv64_desktop_headless` -> **FAIL** (build + package succeed, QEMU run times out before boot marker).
+
+Status: link-time HAL/MM symbol blockers are fixed for x86_64/arm64/riscv64. Remaining execution blocker is RISC-V runtime boot progress (OpenSBI handoff occurs, kernel boot marker not emitted within runner timeout).
+
+### User lib/base test app compile status
+For all configured presets, these targets build successfully:
+- `bharat_syscall`
+- `bharatsys`
+- `bharatc`
+- `app_test`
+
+Command used:
+- `cmake --build --preset=<preset> --target bharat_syscall bharatsys bharatc app_test`
+
+## High-risk syscall contract finding (important)
+
+There are currently **two syscall number header families** active in-tree:
+
+1. `interface/include/bharat/uapi/syscall_nr.h`
+   - Canonical table driven by `syscall_table.def` (newer ABI surface).
+
+2. `interface/uapi/syscall/syscall_nr.h`
+   - Legacy macro table (contains calls like `SYSCALL_MEM_ALLOC`, `SYSCALL_THREAD_EXIT`, `SYSCALL_IPC_CALL`, etc.).
+
+Current runtime and SDK wrapper code still references legacy names in several places. This can create silent ABI drift depending on include paths and target configuration.
+
+## Recommended next steps to fully stabilize syscall work
+
+1. **Declare a single canonical syscall source-of-truth** (prefer `interface/include/bharat/uapi/syscall_table.def`).
+2. **Add explicit compatibility alias policy** (temporary aliases in one place) or migrate all callsites in one sweep.
+3. **Add a CI check** that rejects dual-source syscall definitions and unknown syscall identifiers in SDK/runtime wrappers.
+4. **Fix kernel HAL/MM link breakage** (`hal_mm_backend_caps`, `hal_mm_get_zone_limits`, etc.) so QEMU boot verification can run.
+5. **After link fixes**, run headless QEMU smoke tests per arch with syscall-focused app/test payloads.
+


### PR DESCRIPTION
### Motivation
- Resolve link-time and build failures caused by missing HAL memory backend hooks and duplicate/conflicting definitions across architectures.
- Expose consistent MM capability/query APIs for `x86_64`, `arm64`, and `riscv64` so the kernel/userspace can query memory topology and backend features.
- Restore runtime SDK build compatibility with legacy UAPI header layout by adding missing include directories.

### Description
- Implemented `hal_mm_get_zone_limits()` and `hal_mm_backend_caps()` for `x86_64` and `arm64` and added `hal_mem_get_caps()` for `riscv64`, and provided a concrete `hal_get_arch_capabilities()` path for `riscv64`.
- Fixed a header macro/enum collision in `core/hal/include/hal/hal_mmu.h` by removing the duplicate enum definitions and keeping the macro page-size constants as the canonical definitions.
- Removed duplicate file-scope definition of `g_x86_pcid_supported` in `core/arch/hal/x86/x86_64/hal_pt_x86_64.c` to eliminate one-definition violations.
- Updated `core/lib/runtime/CMakeLists.txt` to add `${CMAKE_SOURCE_DIR}/interface` and `${CMAKE_SOURCE_DIR}/interface/include` to public include paths so legacy `<uapi/...>` includes resolve.
- Added a review document `docs/reviews/syscall_conflict_analysis_2026-04-26.md` that documents the findings and remediation steps related to syscall header conflicts and HAL/MM fixes.

### Testing
- Performed headless cross-arch builds and boot checks using the project build scripts and QEMU; `x86_64_desktop_headless` build+QEMU boot marker: `PASS`.
- `arm64_desktop_headless` build+QEMU boot marker: `PASS`.
- `riscv64_desktop_headless` build and package succeeded but QEMU timed out before the kernel boot marker: `FAIL` (runtime boot progress issue remains).
- Built user/runtime artifacts `bharat_syscall`, `bharatsys`, `bharatc`, and `app_test` via `cmake --build --preset=<preset> --target ...` and observed successful compilation for all configured presets.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed8dd151408320b4138c77bc75448a)