### PR TITLE
Capability Validation Framework Baseline (Phase K3-S0)

### DIFF
--- a/core/kernel/include/capability.h
+++ b/core/kernel/include/capability.h
@@ -268,6 +268,26 @@ kstatus_t cap_lookup_thread(const capability_table_t *table, uint32_t cap_id, ca
 kstatus_t cap_lookup_process(const capability_table_t *table, uint32_t cap_id, cap_rights_mask_t required_rights, bh_process_object_t *out);
 kstatus_t cap_lookup_memory(const capability_table_t *table, uint32_t cap_id, cap_rights_mask_t required_rights, bh_memory_object_t *out);
 
+typedef struct cap_validation_request {
+    uint32_t cap_id;
+    cap_type_t expected_object_type;
+    cap_rights_mask_t required_rights;
+    uint32_t requester_pid;
+    uint64_t expected_generation;
+} cap_validation_request_t;
+
+/**
+ * @brief Canonical fail-closed capability validation.
+ *
+ * @param table Pointer to the capability table.
+ * @param req Validation request parameters.
+ * @param out_entry Optional output pointer to receive the validated entry.
+ * @return K_OK on success, or an appropriate K_ERR_* on failure.
+ */
+kstatus_t cap_validate_ex(capability_table_t *table,
+                          const cap_validation_request_t *req,
+                          capability_entry_t **out_entry);
+
 /*@
   requires src != \null;
   requires dst != \null;

--- a/core/kernel/include/kernel/status.h
+++ b/core/kernel/include/kernel/status.h
@@ -64,6 +64,7 @@ typedef int32_t kstatus_t;
 #define K_ERR_CAP_OWNERSHIP     ((kstatus_t)-772)
 #define K_ERR_LABEL_VIOLATION   ((kstatus_t)-773)
 #define K_ERR_SANDBOX_VIOLATION ((kstatus_t)-774)
+#define K_ERR_CAP_STALE         ((kstatus_t)-775)
 
 /* ── IPC / URPC ───────────────── -1024 .. -1279 */
 #define K_ERR_IPC_NO_ENDPOINT   ((kstatus_t)-1024)

--- a/core/kernel/src/capability.c
+++ b/core/kernel/src/capability.c
@@ -965,3 +965,101 @@ kstatus_t cap_lookup_memory(const capability_table_t *table, uint32_t cap_id, ca
     out->flags = e.flags;
     return K_OK;
 }
+
+static kstatus_t cap_validate_rights_internal(cap_rights_mask_t entry_rights, cap_rights_mask_t required_rights) {
+    if ((entry_rights & required_rights) != required_rights) {
+        return K_ERR_CAP_DENIED;
+    }
+    return K_OK;
+}
+
+static kstatus_t cap_validate_object_type_internal(cap_type_t entry_type, cap_type_t expected_type) {
+    if (expected_type != CAP_TYPE_NONE && entry_type != expected_type) {
+        return K_ERR_CAP_WRONG_TYPE;
+    }
+    return K_OK;
+}
+
+static kstatus_t cap_validate_scope_internal(const capability_table_t *table, uint32_t requester_pid) {
+    // If requester_pid is 0, we assume scope check is not requested or it's a kernel internal caller
+    if (requester_pid == 0) {
+        return K_OK;
+    }
+
+    if (table->owner_pid != 0 && table->owner_pid != requester_pid) {
+        return K_ERR_CAP_DENIED;
+    }
+    return K_OK;
+}
+
+static kstatus_t cap_validate_generation_internal(uint32_t entry_gen, uint64_t expected_gen) {
+    if (expected_gen != 0 && (uint32_t)expected_gen != entry_gen) {
+        return K_ERR_CAP_STALE;
+    }
+    return K_OK;
+}
+
+kstatus_t cap_validate_ex(capability_table_t *table,
+                          const cap_validation_request_t *req,
+                          capability_entry_t **out_entry) {
+    if (!table || !req) {
+        return K_ERR_INVALID_ARG;
+    }
+
+    if (out_entry) {
+        *out_entry = NULL;
+    }
+
+    uint32_t id_only = req->cap_id & 0xFFFF;
+    uint32_t handle_gen = req->cap_id >> 16;
+
+    kstatus_t status = K_ERR_NOT_FOUND;
+    capability_entry_t *found_entry = NULL;
+
+    spin_lock(&table->lock);
+
+    for (size_t i = 0; i < BHARAT_ARRAY_SIZE(table->entries); ++i) {
+        capability_entry_t *e = &table->entries[i];
+        if (e->in_use != 0U && e->id == id_only) {
+            // 1. Generation check (handle vs entry)
+            if (handle_gen != 0 && e->generation != handle_gen) {
+                status = K_ERR_CAP_STALE;
+                break;
+            }
+
+            // 2. Expected generation check (request vs entry)
+            status = cap_validate_generation_internal(e->generation, req->expected_generation);
+            if (status != K_OK) break;
+
+            // 3. State check
+            if (e->state != CAP_STATE_LIVE) {
+                status = K_ERR_CAP_REVOKED;
+                break;
+            }
+
+            // 4. Object type check
+            status = cap_validate_object_type_internal(e->type, req->expected_object_type);
+            if (status != K_OK) break;
+
+            // 5. Rights check
+            status = cap_validate_rights_internal(e->rights, req->required_rights);
+            if (status != K_OK) break;
+
+            // 6. Scope check
+            status = cap_validate_scope_internal(table, req->requester_pid);
+            if (status != K_OK) break;
+
+            found_entry = e;
+            status = K_OK;
+            break;
+        }
+    }
+
+    spin_unlock(&table->lock);
+
+    if (status == K_OK && out_entry) {
+        *out_entry = found_entry;
+    }
+
+    return status;
+}

--- a/core/kernel/src/tests/ktest_capability.c
+++ b/core/kernel/src/tests/ktest_capability.c
@@ -260,6 +260,97 @@ static int test_cap_rights_attenuation(void) {
     return 0;
 }
 
+static int test_cap_validate_framework(void) {
+    capability_table_t* table = cap_table_create();
+    ASSERT_RET(table != NULL, -1);
+    table->owner_pid = 100;
+
+    uint32_t cap_id;
+    int status_grant = cap_table_grant(table, CAP_TYPE_MEMORY, 0x8000, CAP_RIGHT_MEMORY_MAP | CAP_RIGHT_MEMORY_SHARE, &cap_id);
+    ASSERT_RET(status_grant == 0, -2);
+
+    capability_entry_t *entry = NULL;
+    cap_validation_request_t req = {
+        .cap_id = cap_id,
+        .expected_object_type = CAP_TYPE_MEMORY,
+        .required_rights = CAP_RIGHT_MEMORY_MAP,
+        .requester_pid = 100,
+        .expected_generation = 0
+    };
+
+    // 1. Success case
+    kstatus_t status = cap_validate_ex(table, &req, &entry);
+    ASSERT_RET(status == K_OK, -3);
+    ASSERT_RET(entry != NULL, -4);
+    ASSERT_RET(entry->id == (cap_id & 0xFFFF), -5);
+
+    // 2. Success case - return entry optional
+    status = cap_validate_ex(table, &req, NULL);
+    ASSERT_RET(status == K_OK, -6);
+
+    // 3. Invalid handle ID
+    req.cap_id = cap_id + 1;
+    status = cap_validate_ex(table, &req, &entry);
+    ASSERT_RET(status == K_ERR_NOT_FOUND, -7);
+    ASSERT_RET(entry == NULL, -8);
+    req.cap_id = cap_id;
+
+    // 4. Wrong object type
+    req.expected_object_type = CAP_TYPE_ENDPOINT;
+    status = cap_validate_ex(table, &req, &entry);
+    ASSERT_RET(status == K_ERR_CAP_WRONG_TYPE, -9);
+    req.expected_object_type = CAP_TYPE_MEMORY;
+
+    // 5. Missing rights
+    req.required_rights = CAP_RIGHT_MEMORY_UNMAP;
+    status = cap_validate_ex(table, &req, &entry);
+    ASSERT_RET(status == K_ERR_CAP_DENIED, -10);
+    req.required_rights = CAP_RIGHT_MEMORY_MAP;
+
+    // 6. Wrong requester PID (Scope)
+    req.requester_pid = 101;
+    status = cap_validate_ex(table, &req, &entry);
+    ASSERT_RET(status == K_ERR_CAP_DENIED, -11);
+    req.requester_pid = 100;
+
+    // 7. Stale generation in handle
+    uint32_t stale_handle = (cap_id & 0xFFFF) | (0x55 << 16);
+    req.cap_id = stale_handle;
+    status = cap_validate_ex(table, &req, &entry);
+    ASSERT_RET(status == K_ERR_CAP_STALE, -12);
+    req.cap_id = cap_id;
+
+    // 8. Stale generation in request
+    req.expected_generation = 0x99;
+    status = cap_validate_ex(table, &req, &entry);
+    ASSERT_RET(status == K_ERR_CAP_STALE, -13);
+    req.expected_generation = (cap_id >> 16); // match actual
+    status = cap_validate_ex(table, &req, &entry);
+    ASSERT_RET(status == K_OK, -14);
+    req.expected_generation = 0;
+
+    // 9. Revoked capability (manually set state to test the path)
+    spin_lock(&table->lock);
+    for (size_t i = 0; i < 64; i++) {
+        if (table->entries[i].in_use && table->entries[i].id == (cap_id & 0xFFFF)) {
+            table->entries[i].state = CAP_STATE_REVOKED;
+            break;
+        }
+    }
+    spin_unlock(&table->lock);
+    status = cap_validate_ex(table, &req, &entry);
+    ASSERT_RET(status == K_ERR_CAP_REVOKED, -15);
+
+    // 10. Null table or request
+    status = cap_validate_ex(NULL, &req, &entry);
+    ASSERT_RET(status == K_ERR_INVALID_ARG, -16);
+    status = cap_validate_ex(table, NULL, &entry);
+    ASSERT_RET(status == K_ERR_INVALID_ARG, -17);
+
+    cap_table_destroy(table);
+    return 0;
+}
+
 static int test_cap_stale_handle(void) {
     capability_table_t* table = cap_table_create();
     ASSERT_RET(table != NULL, -1);
@@ -369,6 +460,10 @@ static int ktest_cap_run(void) {
 
     hal_serial_write("  [TEST] test_cap_stale_handle... ");
     if (test_cap_stale_handle() != 0) return -1;
+    hal_serial_write("PASSED\n");
+
+    hal_serial_write("  [TEST] test_cap_validate_framework... ");
+    if (test_cap_validate_framework() != 0) return -1;
     hal_serial_write("PASSED\n");
 
     hal_serial_write("  [TEST] test_cap_policy_semantics... ");

--- a/docs/architecture/kernel/capability-validation-contract.md
+++ b/docs/architecture/kernel/capability-validation-contract.md
@@ -1,0 +1,64 @@
+# Capability Validation Framework Contract
+
+## Overview
+The Capability Validation Framework provides a reusable, strict, and fail-closed validation layer for Bharat-OS capabilities. It is designed to be the canonical entry point for checking capability validity at security boundaries such as system calls and IPC entry points.
+
+## Goals
+- **Fail-Closed**: Any validation failure results in immediate denial of access.
+- **Canonical**: Centralized validation logic to prevent ad-hoc check bypasses.
+- **Strict**: Validates object type, rights, scope, and generation.
+- **Reusable**: Independent of specific syscall or IPC logic.
+
+## Validation Components
+
+### 1. Object Type Validation
+Ensures that the capability being used matches the expected kernel object type (e.g., Endpoint, Memory, Thread).
+
+### 2. Rights Validation
+Verifies that the capability possesses all the rights required for the requested operation.
+
+### 3. Scope Validation
+Validates that the requester has the authority to use the capability. In Phase K3-S0, this is primarily based on the `owner_pid` of the capability table.
+
+### 4. Generation & Stale Handle Validation
+Prevents "use-after-revocation" or "use-after-reallocation" by checking generation numbers.
+- Handles containing a non-zero generation are checked against the entry.
+- Explicitly requested `expected_generation` is strictly enforced.
+
+### 5. Revocation State
+Ensures that the capability is in the `CAP_STATE_LIVE` state.
+
+## API Specification
+
+```c
+typedef struct cap_validation_request {
+    uint32_t cap_id;                 // The capability handle/ID to validate
+    cap_type_t expected_object_type; // The required type, or CAP_TYPE_NONE to skip
+    cap_rights_mask_t required_rights;// Bitmask of required rights
+    uint32_t requester_pid;          // PID of the requester for scope check
+    uint64_t expected_generation;    // Optional strict generation check
+} cap_validation_request_t;
+
+kstatus_t cap_validate_ex(capability_table_t *table,
+                          const cap_validation_request_t *req,
+                          capability_entry_t **out_entry);
+```
+
+## Error Codes
+- `K_OK`: Validation successful.
+- `K_ERR_NOT_FOUND`: Capability ID does not exist in the table.
+- `K_ERR_CAP_WRONG_TYPE`: Capability exists but is of the wrong type.
+- `K_ERR_CAP_DENIED`: Missing required rights or scope mismatch.
+- `K_ERR_CAP_STALE`: Generation mismatch (stale handle or stale request).
+- `K_ERR_CAP_REVOKED`: Capability has been revoked and is no longer live.
+- `K_ERR_INVALID_ARG`: Null table or request pointer.
+
+## Current Limitations (Phase K3-S0)
+- **Rollout**: Not yet wired into every syscall boundary.
+- **Scope Model**: Minimal security-domain model (PID-based only).
+- **Revocation**: Distributed revocation semantics are still being matured.
+
+## Future Evolution
+- Integration into all syscall dispatch paths.
+- Extension of the scope model to support security domains and services.
+- Audit logging for denied capability access attempts.

--- a/docs/dev/current-code-status.md
+++ b/docs/dev/current-code-status.md
@@ -83,7 +83,29 @@ Use these labels consistently across status docs and roadmap updates:
 
 ---
 
-## 3) Networking implementation details
+## 3) Core Subsystem implementation details
+
+### Capability Validation Framework
+**Status: Partial / Phase K3-S0 baseline**
+
+A reusable, strict, fail-closed capability validation framework has been introduced to the kernel. This serves as the canonical validation path for object types, rights, scope (PID-based), and generation/stale-handle checks.
+
+**Current progress:**
+- Canonical `cap_validate_ex()` implementation.
+- Internal helpers for granular validation (rights, type, scope, generation).
+- Rich internal error mapping via `kstatus_t` (e.g., `K_ERR_CAP_STALE`, `K_ERR_CAP_REVOKED`).
+- Comprehensive negative-path unit tests in `ktest_capability`.
+- Initial contract documentation in `docs/architecture/kernel/capability-validation-contract.md`.
+
+**Current limitations:**
+- Not yet wired into every syscall boundary.
+- Not yet enforced across all IPC/service entry points.
+- Capability lifecycle revocation semantics are still partial.
+- Security-domain scope model is intentionally minimal (PID-only) in this phase.
+
+---
+
+## 4) Networking implementation details
 
 *Note: The legacy `net` monolithic service is deprecated and transitional. `netmgr` and `netstack` represent the canonical forward path.*
 
@@ -116,14 +138,14 @@ Current limitations:
 
 ---
 
-## 4) Gap summary (docs-to-code)
+## 5) Gap summary (docs-to-code)
 
 1. **Status precision gap**: several services are buildable but still lifecycle scaffolds.
-2. **Enforcement gap**: capability checks in some manager paths were historically placeholder-permissive; however, the major `netmgr` bypass has been closed (fail-closed shim). Full capability routing is still needed.
+2. **Enforcement gap**: capability checks in some manager paths were historically placeholder-permissive; however, the major `netmgr` bypass has been closed (fail-closed shim). Full capability routing is still needed. The Phase K3-S0 validation framework provides the tools to close this gap.
 3. **Runtime wiring gap**: multiple daemons initialize state but do not yet run complete production event loops.
 4. **Hardening gap**: observability, failure semantics, and profile-specific guarantees need deeper closure.
 
-## 4.1) Security production gate (explicit blocker)
+## 5.1) Security production gate (explicit blocker)
 
 To avoid status inflation, this repository treats capability enforcement maturity as a hard release gate:
 
@@ -134,7 +156,7 @@ To avoid status inflation, this repository treats capability enforcement maturit
 
 ---
 
-## 5) Contributor update rules
+## 6) Contributor update rules
 
 When updating this document:
 
@@ -144,7 +166,7 @@ When updating this document:
 4. If architecture docs are more aspirational, retain them, but record the current reality here.
 
 
-## 6) Component architecture drill-down docs
+## 7) Component architecture drill-down docs
 
 For diagram-based decomposition and roadmap mapping by domain, see:
 
@@ -153,13 +175,13 @@ For diagram-based decomposition and roadmap mapping by domain, see:
 - `docs/architecture/components/services-subcomponents-architecture.md`
 - `docs/architecture/components/drivers-subcomponents-architecture.md`
 
-## 7) Memory hardening roadmap
+## 8) Memory hardening roadmap
 
 For the current memory production hardening plan and profile/architecture acceptance matrix, see:
 
 - `docs/architecture/memory/memory-roadmap-consolidated.md`
 
-## 8) Service Deployment Profiles
+## 9) Service Deployment Profiles
 
 Services in Bharat-OS are not universally mandatory. They are deployed via three primary profile tiers to accommodate hardware constraints:
 


### PR DESCRIPTION
Implemented the Capability Validation Framework Baseline (Phase K3-S0). This includes the core validation logic in `cap_validate_ex`, new error codes, comprehensive tests, and architectural documentation. The framework is designed to be the single source of truth for capability security checks at syscall and IPC boundaries.

---
*PR created automatically by Jules for task [18274788929055608017](https://jules.google.com/task/18274788929055608017) started by @divyang4481*