### PR TITLE
M0 — Memory Profile Runtime Validator

### DIFF
--- a/core/kernel/include/mm/mem_model.h
+++ b/core/kernel/include/mm/mem_model.h
@@ -4,6 +4,10 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include "bharat/mem_class.h"
+#include "kernel/status.h"
+
+// Forward declaration for HAL capabilities
+struct hal_mem_caps;
 
 /**
  * Memory Model Architectures
@@ -36,6 +40,41 @@ typedef uint64_t mpa_caps_t;
 #define MEM_CAP_PER_CORE_PMM_CACHE   (1ULL << 9)
 
 /**
+ * Memory Runtime Capabilities (Kernel-normalized)
+ */
+typedef struct mem_runtime_caps {
+    bool supports_mmu;
+    bool supports_mmu_lite;
+    bool supports_mpu;
+
+    bool supports_demand_paging;
+    bool supports_page_protection;
+    bool supports_region_protection;
+    bool supports_shared_memory;
+
+    bool supports_dma_map;
+    bool supports_iommu;
+    bool supports_numa;
+    bool supports_hugepage;
+} mem_runtime_caps_t;
+
+/**
+ * Memory Profile Contract
+ */
+typedef struct mem_profile_contract {
+    mem_model_t model;
+
+    bool require_demand_paging;
+    bool require_page_protection;
+    bool require_region_protection;
+    bool require_shared_memory;
+    bool require_dma_isolation;
+    bool require_iommu;
+    bool require_numa;
+    bool require_hugepage;
+} mem_profile_contract_t;
+
+/**
  * API Contract for Unsupported Operations:
  *
  * - Any operation requesting a feature not supported by the current memory model
@@ -49,6 +88,16 @@ typedef uint64_t mpa_caps_t;
  * Get the current canonical memory model.
  */
 mem_model_t mem_model_get_current(void);
+
+/**
+ * Normalizes HAL capabilities into kernel runtime capabilities.
+ */
+kstatus_t mem_runtime_caps_from_hal(const struct hal_mem_caps *hal_caps, mem_runtime_caps_t *out_caps);
+
+/**
+ * Derives the memory profile contract from the current build configuration.
+ */
+kstatus_t mem_profile_contract_from_build(mem_profile_contract_t *out_contract);
 
 /**
  * Query the capability bits of the current memory model.

--- a/core/kernel/include/mm/mem_validator.h
+++ b/core/kernel/include/mm/mem_validator.h
@@ -16,4 +16,19 @@ int mm_validate_model(void);
  */
 mem_model_t mm_get_validated_model(void);
 
+/**
+ * Validates the runtime capabilities against the memory profile contract.
+ *
+ * @param caps Detected hardware/runtime capabilities.
+ * @param contract Requested memory profile contract.
+ * @return K_OK on success, K_ERR_PROFILE_RESTRICTED or other error on mismatch.
+ */
+kstatus_t mem_runtime_validate_profile(const mem_runtime_caps_t *caps,
+                                        const mem_profile_contract_t *contract);
+
+/**
+ * Converts a validation status code to a human-readable string.
+ */
+const char* mem_runtime_validation_status_to_string(kstatus_t status);
+
 #endif /* BHARAT_MM_VALIDATOR_H */

--- a/core/kernel/src/mm/mem_model.c
+++ b/core/kernel/src/mm/mem_model.c
@@ -1,4 +1,6 @@
 #include "mm/mem_model.h"
+#include "hal/hal_mmu.h"
+#include <string.h>
 
 // For now we map the current memory model based on build configuration.
 mem_model_t mem_model_get_current(void) {
@@ -11,6 +13,70 @@ mem_model_t mem_model_get_current(void) {
 #else
     return MEM_MODEL_MMU_FULL;
 #endif
+}
+
+kstatus_t mem_runtime_caps_from_hal(const struct hal_mem_caps *hal_caps, mem_runtime_caps_t *out_caps) {
+    if (!hal_caps || !out_caps) return K_ERR_INVALID_ARG;
+
+    memset(out_caps, 0, sizeof(mem_runtime_caps_t));
+
+    out_caps->supports_mmu = (hal_caps->model == HAL_MEMORY_MODEL_MMU_FULL);
+    out_caps->supports_mmu_lite = (hal_caps->model == HAL_MEMORY_MODEL_MMU_LITE ||
+                                   hal_caps->model == HAL_MEMORY_MODEL_MMU_FULL);
+    out_caps->supports_mpu = (hal_caps->model == HAL_MEMORY_MODEL_MPU ||
+                               hal_caps->model == HAL_MEMORY_MODEL_MMU_LITE ||
+                               hal_caps->model == HAL_MEMORY_MODEL_MMU_FULL);
+
+    out_caps->supports_demand_paging = (hal_caps->model == HAL_MEMORY_MODEL_MMU_FULL);
+    out_caps->supports_page_protection = hal_caps->supports_write_protect;
+    out_caps->supports_region_protection = (hal_caps->model >= HAL_MEMORY_MODEL_MPU);
+    out_caps->supports_shared_memory = (hal_caps->model >= HAL_MEMORY_MODEL_MMU_LITE);
+
+    out_caps->supports_dma_map = true; // Baseline assumption for M0
+    out_caps->supports_iommu = hal_caps->supports_iommu;
+    out_caps->supports_numa = false; // Not yet reported by HAL
+    out_caps->supports_hugepage = hal_caps->supports_hugepages;
+
+    return K_OK;
+}
+
+kstatus_t mem_profile_contract_from_build(mem_profile_contract_t *out_contract) {
+    if (!out_contract) return K_ERR_INVALID_ARG;
+
+    memset(out_contract, 0, sizeof(mem_profile_contract_t));
+    out_contract->model = mem_model_get_current();
+
+    switch (out_contract->model) {
+        case MEM_MODEL_MMU_FULL:
+            out_contract->require_page_protection = true;
+            out_contract->require_region_protection = true;
+            out_contract->require_shared_memory = true;
+#ifdef CONFIG_DEMAND_PAGING_REQUIRED
+            out_contract->require_demand_paging = true;
+#endif
+#ifdef CONFIG_IOMMU_REQUIRED
+            out_contract->require_iommu = true;
+#endif
+            break;
+
+        case MEM_MODEL_MMU_LITE:
+            out_contract->require_region_protection = true;
+            out_contract->require_page_protection = true;
+            out_contract->require_shared_memory = true;
+            out_contract->require_demand_paging = false;
+            break;
+
+        case MEM_MODEL_MPU:
+            out_contract->require_region_protection = true;
+            out_contract->require_page_protection = false;
+            out_contract->require_demand_paging = false;
+            break;
+
+        default:
+            break;
+    }
+
+    return K_OK;
 }
 
 uint64_t mem_model_get_caps(void) {

--- a/core/kernel/src/mm/mem_validator.c
+++ b/core/kernel/src/mm/mem_validator.c
@@ -17,65 +17,91 @@ static const char* model_to_str(enum hal_memory_model model) {
     }
 }
 
-int mm_validate_model(void) {
-    hal_mem_caps_t caps;
-    int ret = hal_mem_get_caps(&caps);
+kstatus_t mem_runtime_validate_profile(const mem_runtime_caps_t *caps,
+                                        const mem_profile_contract_t *contract) {
+    if (!caps || !contract) return K_ERR_INVALID_ARG;
 
-    if (ret != 0) {
-        console_log(CONSOLE_LEVEL_PANIC, "MEM: Failed to retrieve HAL memory capabilities!\n");
-        return K_ERR_FAULT;
-    }
-
-    mem_model_t requested = mem_model_get_current();
-
-    console_log(CONSOLE_LEVEL_INFO, "MEM: Initializing memory model validation...\n");
-    console_log(CONSOLE_LEVEL_INFO, "MEM: Detected Hardware Model: %s\n", model_to_str(caps.model));
-    console_log(CONSOLE_LEVEL_INFO, "MEM: Requested Software Model: %s\n",
-                model_to_str((enum hal_memory_model)requested));
-
-    /*
-     * Validation Logic:
-     * The hardware must support at least the level of the requested software model.
-     */
-    bool compatible = false;
-    switch (requested) {
-        case MEM_MODEL_NONE:
-            compatible = true;
-            break;
-        case MEM_MODEL_MPU:
-            compatible = (caps.model >= HAL_MEMORY_MODEL_MPU);
+    // 1. Fundamental Model Check
+    bool model_compatible = false;
+    switch (contract->model) {
+        case MEM_MODEL_MMU_FULL:
+            model_compatible = caps->supports_mmu;
             break;
         case MEM_MODEL_MMU_LITE:
-            compatible = (caps.model >= HAL_MEMORY_MODEL_MMU_LITE);
+            model_compatible = caps->supports_mmu_lite;
             break;
-        case MEM_MODEL_MMU_FULL:
-            compatible = (caps.model == HAL_MEMORY_MODEL_MMU_FULL);
+        case MEM_MODEL_MPU:
+            model_compatible = caps->supports_mpu;
+            break;
+        case MEM_MODEL_NONE:
+            model_compatible = true;
             break;
         default:
-            compatible = false;
-            break;
+            return K_ERR_PROFILE_RESTRICTED;
     }
 
-    if (!compatible) {
-        console_log(CONSOLE_LEVEL_PANIC, "MEM: CRITICAL - Hardware model %s does not support requested %s!\n",
-                    model_to_str(caps.model), model_to_str((enum hal_memory_model)requested));
-        return K_ERR_PROFILE_RESTRICTED;
+    if (!model_compatible) return K_ERR_PROFILE_RESTRICTED;
+
+    // 2. Feature Guarantee Check
+    if (contract->require_demand_paging && !caps->supports_demand_paging) return K_ERR_PROFILE_RESTRICTED;
+    if (contract->require_page_protection && !caps->supports_page_protection) return K_ERR_PROFILE_RESTRICTED;
+    if (contract->require_region_protection && !caps->supports_region_protection) return K_ERR_PROFILE_RESTRICTED;
+    if (contract->require_shared_memory && !caps->supports_shared_memory) return K_ERR_PROFILE_RESTRICTED;
+    if (contract->require_iommu && !caps->supports_iommu) return K_ERR_PROFILE_RESTRICTED;
+    if (contract->require_numa && !caps->supports_numa) return K_ERR_PROFILE_RESTRICTED;
+    if (contract->require_hugepage && !caps->supports_hugepage) return K_ERR_PROFILE_RESTRICTED;
+
+    return K_OK;
+}
+
+const char* mem_runtime_validation_status_to_string(kstatus_t status) {
+    switch (status) {
+        case K_OK: return "PASS";
+        case K_ERR_PROFILE_RESTRICTED: return "FAIL: Profile Mismatch";
+        case K_ERR_INVALID_ARG: return "FAIL: Invalid Arguments";
+        case K_ERR_UNSUPPORTED: return "FAIL: Unsupported";
+        default: return "FAIL: Unknown Error";
+    }
+}
+
+int mm_validate_model(void) {
+    hal_mem_caps_t hal_caps;
+    mem_runtime_caps_t runtime_caps;
+    mem_profile_contract_t contract;
+    kstatus_t status;
+
+    status = hal_mem_get_caps(&hal_caps);
+    if (status != K_OK) {
+        console_log(CONSOLE_LEVEL_PANIC, "MEM: Failed to retrieve HAL memory capabilities!\n");
+        return status;
     }
 
-#ifdef CONFIG_IOMMU_REQUIRED
-    if (!caps.supports_iommu) {
-        console_log(CONSOLE_LEVEL_PANIC, "MEM: CRITICAL - IOMMU required by profile but not detected in HAL!\n");
-        return K_ERR_PROFILE_RESTRICTED;
+    status = mem_runtime_caps_from_hal(&hal_caps, &runtime_caps);
+    if (status != K_OK) {
+        console_log(CONSOLE_LEVEL_PANIC, "MEM: Failed to normalize memory capabilities!\n");
+        return status;
     }
-#else
-    if (caps.supports_iommu) {
-        console_log(CONSOLE_LEVEL_INFO, "MEM: IOMMU detected and available.\n");
-    } else {
-        console_log(CONSOLE_LEVEL_WARN, "MEM: IOMMU not detected. System will operate in degraded DMA mode.\n");
-    }
-#endif
 
-    validated_model = requested;
+    status = mem_profile_contract_from_build(&contract);
+    if (status != K_OK) {
+        console_log(CONSOLE_LEVEL_PANIC, "MEM: Failed to derive build profile contract!\n");
+        return status;
+    }
+
+    console_log(CONSOLE_LEVEL_INFO, "MEM: Initializing memory model validation...\n");
+    console_log(CONSOLE_LEVEL_INFO, "MEM: Detected Hardware Model: %s\n", model_to_str(hal_caps.model));
+    console_log(CONSOLE_LEVEL_INFO, "MEM: Requested Software Model: %s\n",
+                model_to_str((enum hal_memory_model)contract.model));
+
+    status = mem_runtime_validate_profile(&runtime_caps, &contract);
+
+    if (status != K_OK) {
+        console_log(CONSOLE_LEVEL_PANIC, "MEM: CRITICAL - Runtime profile validation %s!\n",
+                    mem_runtime_validation_status_to_string(status));
+        return status;
+    }
+
+    validated_model = contract.model;
     validation_complete = true;
 
     console_log(CONSOLE_LEVEL_INFO, "MEM: Memory model validation successful.\n");

--- a/docs/architecture/memory/runtime-memory-profile-validation.md
+++ b/docs/architecture/memory/runtime-memory-profile-validation.md
@@ -1,0 +1,52 @@
+# Runtime Memory Profile Validation
+
+## Status
+Partial / M0 baseline
+
+## Problem
+Compile-time memory model selection is not enough. The kernel must verify at boot that detected hardware capabilities satisfy the selected memory contract.
+
+## Goals
+- Validate detected HAL memory capabilities.
+- Validate selected memory model/profile contract.
+- Fail closed on impossible combinations.
+- Keep validation kernel-internal for now.
+
+## Non-Goals
+- No PMM per-core magazines.
+- No TLB shootdown redesign.
+- No VM lifecycle rewrite.
+- No UAPI exposure.
+- No full IOMMU implementation.
+
+## Capability Sources
+- HAL/architecture reports `hal_mem_caps_t`.
+- Kernel normalizes to `mem_runtime_caps_t`.
+- Build/profile derives `mem_profile_contract_t`.
+
+## Validation Rules
+### MMU_FULL
+- Requires `supports_mmu`.
+- Requires `supports_page_protection`.
+- Requires `supports_region_protection`.
+- Requires `supports_shared_memory`.
+- Optionally requires `supports_demand_paging` if `CONFIG_DEMAND_PAGING_REQUIRED` is set.
+- Optionally requires `supports_iommu` if `CONFIG_IOMMU_REQUIRED` is set.
+
+### MMU_LITE
+- Requires `supports_mmu_lite`.
+- Requires `supports_page_protection`.
+- Requires `supports_region_protection`.
+- Requires `supports_shared_memory`.
+
+### MPU_ONLY
+- Requires `supports_mpu`.
+- Requires `supports_region_protection`.
+- Rejects `require_demand_paging`.
+
+## Failure Policy
+Invalid combinations fail closed during boot validation, resulting in a kernel panic.
+
+## Test Requirements
+- Unit tests for synthetic capability/contract combinations.
+- Boot logs should indicate the success or failure of the validation.

--- a/docs/dev/current-code-status.md
+++ b/docs/dev/current-code-status.md
@@ -83,7 +83,22 @@ Use these labels consistently across status docs and roadmap updates:
 
 ---
 
-## 3) Networking implementation details
+## 3) Memory runtime validation details
+
+### Runtime Memory Profile Validation
+Status: **Partial** / M0 baseline
+
+The kernel now has a boot/runtime validation path that checks detected memory capabilities against the selected memory model/profile contract. This does not complete PMM ownership, TLB shootdown, VM lifecycle, DMA/IOMMU, or full memory production hardening.
+
+Implemented features include:
+- `hal_mem_caps_t` normalization into kernel `mem_runtime_caps_t`.
+- `mem_profile_contract_t` derivation from build configuration.
+- `mem_runtime_validate_profile()` implementation with fail-closed rules.
+- Integration into `mm_validate_model()` during early boot.
+
+---
+
+## 4) Networking implementation details
 
 *Note: The legacy `net` monolithic service is deprecated and transitional. `netmgr` and `netstack` represent the canonical forward path.*
 
@@ -116,14 +131,14 @@ Current limitations:
 
 ---
 
-## 4) Gap summary (docs-to-code)
+## 5) Gap summary (docs-to-code)
 
 1. **Status precision gap**: several services are buildable but still lifecycle scaffolds.
 2. **Enforcement gap**: capability checks in some manager paths were historically placeholder-permissive; however, the major `netmgr` bypass has been closed (fail-closed shim). Full capability routing is still needed.
 3. **Runtime wiring gap**: multiple daemons initialize state but do not yet run complete production event loops.
 4. **Hardening gap**: observability, failure semantics, and profile-specific guarantees need deeper closure.
 
-## 4.1) Security production gate (explicit blocker)
+## 5.1) Security production gate (explicit blocker)
 
 To avoid status inflation, this repository treats capability enforcement maturity as a hard release gate:
 
@@ -134,7 +149,7 @@ To avoid status inflation, this repository treats capability enforcement maturit
 
 ---
 
-## 5) Contributor update rules
+## 6) Contributor update rules
 
 When updating this document:
 
@@ -144,7 +159,7 @@ When updating this document:
 4. If architecture docs are more aspirational, retain them, but record the current reality here.
 
 
-## 6) Component architecture drill-down docs
+## 7) Component architecture drill-down docs
 
 For diagram-based decomposition and roadmap mapping by domain, see:
 
@@ -153,13 +168,13 @@ For diagram-based decomposition and roadmap mapping by domain, see:
 - `docs/architecture/components/services-subcomponents-architecture.md`
 - `docs/architecture/components/drivers-subcomponents-architecture.md`
 
-## 7) Memory hardening roadmap
+## 8) Memory hardening roadmap
 
 For the current memory production hardening plan and profile/architecture acceptance matrix, see:
 
 - `docs/architecture/memory/memory-roadmap-consolidated.md`
 
-## 8) Service Deployment Profiles
+## 9) Service Deployment Profiles
 
 Services in Bharat-OS are not universally mandatory. They are deployed via three primary profile tiers to accommodate hardware constraints:
 

--- a/quality/tests/host/test_mem_validator.c
+++ b/quality/tests/host/test_mem_validator.c
@@ -13,16 +13,16 @@
 /* Mocks and Stubs */
 static hal_mem_caps_t mock_caps;
 static int mock_caps_ret = 0;
-static mem_model_t mock_requested_model = MEM_MODEL_NONE;
 
 int hal_mem_get_caps(hal_mem_caps_t *caps) {
     if (caps) *caps = mock_caps;
     return mock_caps_ret;
 }
 
-mem_model_t mem_model_get_current(void) {
-    return mock_requested_model;
-}
+/*
+ * Note: mem_model_get_current() is provided by mem_model.c
+ * and its return value is controlled by BHARAT_PROFILE_* defines.
+ */
 
 void console_log(int level, const char *fmt, ...) {
     va_list args;
@@ -35,57 +35,129 @@ void console_log(int level, const char *fmt, ...) {
 /* Test Cases */
 void test_valid_mmu_full() {
     printf("Running test_valid_mmu_full...\n");
+    memset(&mock_caps, 0, sizeof(mock_caps));
     mock_caps.model = HAL_MEMORY_MODEL_MMU_FULL;
     mock_caps.supports_iommu = true;
+    mock_caps.supports_write_protect = true;
     mock_caps_ret = 0;
-    mock_requested_model = MEM_MODEL_MMU_FULL;
 
     int ret = mm_validate_model();
+    // Default model is MMU_FULL if no PROFILE define is set
     assert(ret == K_OK);
     assert(mm_get_validated_model() == MEM_MODEL_MMU_FULL);
 }
 
 void test_invalid_mmu_full_on_mpu() {
     printf("Running test_invalid_mmu_full_on_mpu...\n");
+    memset(&mock_caps, 0, sizeof(mock_caps));
     mock_caps.model = HAL_MEMORY_MODEL_MPU;
     mock_caps_ret = 0;
-    mock_requested_model = MEM_MODEL_MMU_FULL;
+
+    int ret = mm_validate_model();
+    // Default model is MMU_FULL, so it should fail on MPU
+    assert(ret == K_ERR_PROFILE_RESTRICTED);
+}
+
+void test_valid_mmu_lite_on_full_synthetic() {
+    printf("Running test_valid_mmu_lite_on_full_synthetic...\n");
+    mem_runtime_caps_t caps = {0};
+    caps.supports_mmu_lite = true;
+    caps.supports_page_protection = true;
+    caps.supports_region_protection = true;
+    caps.supports_shared_memory = true;
+
+    mem_profile_contract_t contract = {0};
+    contract.model = MEM_MODEL_MMU_LITE;
+    contract.require_page_protection = true;
+    contract.require_region_protection = true;
+    contract.require_shared_memory = true;
+
+    kstatus_t status = mem_runtime_validate_profile(&caps, &contract);
+    assert(status == K_OK);
+}
+
+void test_mmu_full_requires_page_prot() {
+    printf("Running test_mmu_full_requires_page_prot...\n");
+    memset(&mock_caps, 0, sizeof(mock_caps));
+    mock_caps.model = HAL_MEMORY_MODEL_MMU_FULL;
+    mock_caps.supports_write_protect = false; // Missing page protection
+    mock_caps_ret = 0;
 
     int ret = mm_validate_model();
     assert(ret == K_ERR_PROFILE_RESTRICTED);
 }
 
-void test_valid_mmu_lite_on_full() {
-    printf("Running test_valid_mmu_lite_on_full...\n");
-    mock_caps.model = HAL_MEMORY_MODEL_MMU_FULL;
-    mock_caps_ret = 0;
-    mock_requested_model = MEM_MODEL_MMU_LITE;
+void test_mpu_only_rejects_demand_paging() {
+    printf("Running test_mpu_only_rejects_demand_paging...\n");
+    mem_runtime_caps_t caps = {0};
+    caps.supports_mpu = true;
+    caps.supports_region_protection = true;
 
-    int ret = mm_validate_model();
-    assert(ret == K_OK);
+    mem_profile_contract_t contract = {0};
+    contract.model = MEM_MODEL_MPU;
+    contract.require_demand_paging = true;
+
+    kstatus_t status = mem_runtime_validate_profile(&caps, &contract);
+    assert(status == K_ERR_PROFILE_RESTRICTED);
 }
 
-void test_iommu_required_fail() {
-    printf("Running test_iommu_required_fail...\n");
-    mock_caps.model = HAL_MEMORY_MODEL_MMU_FULL;
-    mock_caps.supports_iommu = false;
-    mock_caps_ret = 0;
-    mock_requested_model = MEM_MODEL_MMU_FULL;
+void test_iommu_required_fail_synthetic() {
+    printf("Running test_iommu_required_fail_synthetic...\n");
+    mem_runtime_caps_t caps = {0};
+    caps.supports_mmu = true;
+    caps.supports_page_protection = true;
+    caps.supports_region_protection = true;
+    caps.supports_shared_memory = true;
+    caps.supports_iommu = false; // Missing IOMMU
 
-    /*
-     * In a real build, CONFIG_IOMMU_REQUIRED would be a macro.
-     * For this test, we can only verify the branch if we could recompile.
-     * But we can at least verify the basic model validation works.
-     */
-    int ret = mm_validate_model();
-    assert(ret == K_OK); // Since CONFIG_IOMMU_REQUIRED is likely not defined for host test
+    mem_profile_contract_t contract = {0};
+    contract.model = MEM_MODEL_MMU_FULL;
+    contract.require_page_protection = true;
+    contract.require_iommu = true;
+
+    kstatus_t status = mem_runtime_validate_profile(&caps, &contract);
+    assert(status == K_ERR_PROFILE_RESTRICTED);
+}
+
+void test_optional_numa_hugepage_accepted() {
+    printf("Running test_optional_numa_hugepage_accepted...\n");
+    mem_runtime_caps_t caps = {0};
+    caps.supports_mmu = true;
+    caps.supports_page_protection = true;
+    caps.supports_region_protection = true;
+    caps.supports_shared_memory = true;
+    caps.supports_numa = false;
+    caps.supports_hugepage = false;
+
+    mem_profile_contract_t contract = {0};
+    contract.model = MEM_MODEL_MMU_FULL;
+    contract.require_page_protection = true;
+    contract.require_numa = false; // Optional
+    contract.require_hugepage = false; // Optional
+
+    kstatus_t status = mem_runtime_validate_profile(&caps, &contract);
+    assert(status == K_OK);
+}
+
+void test_unknown_caps_fail_closed() {
+    printf("Running test_unknown_caps_fail_closed...\n");
+    mem_runtime_caps_t caps = {0}; // All false
+    mem_profile_contract_t contract = {0};
+    contract.model = (mem_model_t)99; // Unknown model
+
+    kstatus_t status = mem_runtime_validate_profile(&caps, &contract);
+    assert(status == K_ERR_PROFILE_RESTRICTED);
 }
 
 int main() {
     test_valid_mmu_full();
     test_invalid_mmu_full_on_mpu();
-    test_valid_mmu_lite_on_full();
-    test_iommu_required_fail();
+    test_valid_mmu_lite_on_full_synthetic();
+    test_mmu_full_requires_page_prot();
+    test_mpu_only_rejects_demand_paging();
+    test_iommu_required_fail_synthetic();
+    test_optional_numa_hugepage_accepted();
+    test_unknown_caps_fail_closed();
 
     printf("All mem_validator host tests passed!\n");
     return 0;


### PR DESCRIPTION
Implemented the M0 baseline for Memory Profile Runtime Validation. This change ensures that Bharat-OS validates at boot time that the detected hardware capabilities from the HAL satisfy the requested software memory model and profile guarantees (e.g., MMU support, page protection, demand paging). It introduces kernel-normalized capability and contract structures, integrates them into the existing early boot validation path, and provides comprehensive host-side unit tests to verify the fail-closed behavior on mismatches.

---
*PR created automatically by Jules for task [2658437410420880689](https://jules.google.com/task/2658437410420880689) started by @divyang4481*