### PR TITLE
IPC0 — IPC/URPC Reliability Contract Baseline

### DIFF
--- a/core/kernel/include/bharat/urpc.h
+++ b/core/kernel/include/bharat/urpc.h
@@ -5,6 +5,7 @@
 #include <stdbool.h>
 #include "urpc/urpc_bootstrap.h"
 #include "ipc/ipc_profile_policy.h"
+#include <bharat/uapi/ipc/status.h>
 
 // Define standard URPC message types
 typedef enum {
@@ -68,9 +69,10 @@ typedef enum {
     URPC_CHANNEL_ERROR
 } urpc_channel_state_t;
 
-int urpc_channel_bind(uint32_t target_core);
-int urpc_channel_accept(uint32_t source_core);
-int urpc_channel_close(uint32_t target_core);
+bool urpc_channel_transition_allowed(urpc_channel_state_t from, urpc_channel_state_t to);
+bharat_status_t urpc_channel_bind(uint32_t target_core);
+bharat_status_t urpc_channel_accept(uint32_t source_core);
+bharat_status_t urpc_channel_close(uint32_t target_core);
 urpc_channel_state_t urpc_channel_get_state(uint32_t target_core);
 int urpc_channel_can_route(ipc_traffic_type_t traffic, uint32_t payload_len, bool cross_core);
 

--- a/core/kernel/include/ipc/contract_validate.h
+++ b/core/kernel/include/ipc/contract_validate.h
@@ -4,6 +4,7 @@
 #include <bharat/uapi/ipc/contract.h>
 #include <bharat/uapi/ipc/status.h>
 #include <stddef.h>
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -14,8 +15,28 @@ extern "C" {
  * @brief Helper functions to validate IPC contract headers.
  */
 
+typedef struct ipc_contract_rules {
+    uint32_t expected_version;
+    uint32_t min_opcode;
+    uint32_t max_opcode;
+    uint32_t max_payload_size;
+    uint32_t required_flags;
+    uint32_t allowed_flags;
+    bool allow_variable_payload;
+    uint32_t payload_alignment; // 0 or power of 2
+} ipc_contract_rules_t;
+
 /**
- * Validates the core structure of an IPC contract header.
+ * Validates the core structure of an IPC contract header against a set of rules.
+ * @param hdr The header to validate.
+ * @param rules The rules to validate against.
+ * @return BHARAT_IPC_STATUS_OK on success, or a canonical IPC status error code.
+ */
+int bharat_ipc_contract_validate_ex(const bharat_ipc_contract_header_t *hdr,
+                                    const ipc_contract_rules_t *rules);
+
+/**
+ * Validates the core structure of an IPC contract header. (Legacy wrapper)
  * @param hdr The header to validate.
  * @param expected_version The interface version expected by the handler.
  * @param min_opcode Minimum valid opcode.

--- a/core/kernel/include/ipc/ipc_status.h
+++ b/core/kernel/include/ipc/ipc_status.h
@@ -1,0 +1,26 @@
+#ifndef BHARAT_IPC_STATUS_H
+#define BHARAT_IPC_STATUS_H
+
+#include <bharat/uapi/ipc/status.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @file ipc_status.h
+ * @brief Human-readable status mapping for IPC error codes.
+ */
+
+/**
+ * Returns a human-readable string representation of a bharat_status_t code.
+ * @param status The status code to map.
+ * @return A constant string describing the status.
+ */
+const char *bharat_ipc_status_to_string(bharat_status_t status);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // BHARAT_IPC_STATUS_H

--- a/core/kernel/include/ipc/ipc_traffic.h
+++ b/core/kernel/include/ipc/ipc_traffic.h
@@ -1,0 +1,33 @@
+#ifndef BHARAT_IPC_TRAFFIC_H
+#define BHARAT_IPC_TRAFFIC_H
+
+#include <bharat/uapi/ipc/status.h>
+#include "ipc_endpoint.h"
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct ipc_route_admission {
+    bool accepted;
+    bharat_status_t reason;
+    uint32_t available_slots;
+    uint32_t max_payload;
+} ipc_route_admission_t;
+
+/**
+ * Validates if a specific message route is admissible under traffic, payload,
+ * and backpressure constraints.
+ */
+bharat_status_t ipc_route_admit(
+    ipc_traffic_type_t traffic,
+    uint32_t payload_len,
+    bool cross_core,
+    ipc_route_admission_t *out);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // BHARAT_IPC_TRAFFIC_H

--- a/core/kernel/src/ipc/contract_validate.c
+++ b/core/kernel/src/ipc/contract_validate.c
@@ -2,7 +2,67 @@
 #include <stddef.h>
 
 /**
- * Validates the core structure of an IPC contract header.
+ * Validates the core structure of an IPC contract header against a set of rules.
+ */
+int bharat_ipc_contract_validate_ex(const bharat_ipc_contract_header_t *hdr,
+                                    const ipc_contract_rules_t *rules)
+{
+    if (hdr == NULL || rules == NULL) {
+        return BHARAT_IPC_STATUS_ERR_DECODE;
+    }
+
+    /* Validate header version */
+    if (hdr->header_version != BHARAT_IPC_HEADER_VERSION_V1) {
+        return BHARAT_IPC_STATUS_ERR_VERSION;
+    }
+
+    /* Validate interface version */
+    if (hdr->interface_version != rules->expected_version) {
+        return BHARAT_IPC_STATUS_ERR_VERSION;
+    }
+
+    /* Validate opcode range */
+    if (hdr->opcode < rules->min_opcode || hdr->opcode > rules->max_opcode) {
+        return BHARAT_IPC_STATUS_ERR_OPCODE;
+    }
+
+    /* Validate payload size */
+    if (rules->allow_variable_payload) {
+        if (rules->max_payload_size > 0 && hdr->payload_size > rules->max_payload_size) {
+            return BHARAT_IPC_STATUS_ERR_LENGTH;
+        }
+    } else {
+        if (rules->max_payload_size > 0 && hdr->payload_size != rules->max_payload_size) {
+            return BHARAT_IPC_STATUS_ERR_LENGTH;
+        }
+    }
+
+    /* Validate flags */
+    if ((hdr->flags & rules->required_flags) != rules->required_flags) {
+        return BHARAT_IPC_STATUS_ERR_FLAGS;
+    }
+
+    if ((hdr->flags & ~rules->allowed_flags) != 0) {
+        return BHARAT_IPC_STATUS_ERR_FLAGS;
+    }
+
+    /* Reserved flags check: Reject any bits outside the defined V1 flags */
+    if (hdr->flags & ~BHARAT_IPC_FLAGS_ALL_V1) {
+        return BHARAT_IPC_STATUS_ERR_FLAGS;
+    }
+
+    /* Payload alignment check */
+    if (rules->payload_alignment > 1) {
+        if (hdr->payload_size % rules->payload_alignment != 0) {
+            return BHARAT_IPC_STATUS_ERR_DECODE;
+        }
+    }
+
+    return BHARAT_IPC_STATUS_OK;
+}
+
+/**
+ * Validates the core structure of an IPC contract header. (Legacy wrapper)
  */
 int bharat_ipc_contract_validate(const bharat_ipc_contract_header_t *hdr,
                                  uint32_t expected_version,
@@ -10,29 +70,16 @@ int bharat_ipc_contract_validate(const bharat_ipc_contract_header_t *hdr,
                                  uint32_t max_opcode,
                                  uint32_t expected_payload_size)
 {
-    if (hdr == NULL) {
-        return BHARAT_IPC_STATUS_ERR_DECODE;
-    }
+    ipc_contract_rules_t rules = {
+        .expected_version = expected_version,
+        .min_opcode = min_opcode,
+        .max_opcode = max_opcode,
+        .max_payload_size = expected_payload_size,
+        .required_flags = 0,
+        .allowed_flags = BHARAT_IPC_FLAGS_ALL_V1,
+        .allow_variable_payload = (expected_payload_size == 0),
+        .payload_alignment = 0,
+    };
 
-    /* Validate version */
-    if (hdr->interface_version != expected_version) {
-        return BHARAT_IPC_STATUS_ERR_VERSION;
-    }
-
-    /* Validate opcode range */
-    if (hdr->opcode < min_opcode || hdr->opcode > max_opcode) {
-        return BHARAT_IPC_STATUS_ERR_OPCODE;
-    }
-
-    /* Validate payload size (if a specific size is expected)
-     * For ops that allow a variable size payload within bounds,
-     * the caller can set expected_payload_size=0 and do its own check.
-     */
-    if (expected_payload_size > 0 && hdr->payload_size != expected_payload_size) {
-        return BHARAT_IPC_STATUS_ERR_DECODE;
-    }
-
-    /* In the future, flags checks might be added here */
-
-    return BHARAT_IPC_STATUS_OK;
+    return bharat_ipc_contract_validate_ex(hdr, &rules);
 }

--- a/core/kernel/src/ipc/ipc_status.c
+++ b/core/kernel/src/ipc/ipc_status.c
@@ -1,0 +1,32 @@
+#include <ipc/ipc_status.h>
+#include <stddef.h>
+
+const char *bharat_ipc_status_to_string(bharat_status_t status)
+{
+    switch (status) {
+        case BHARAT_IPC_STATUS_OK:
+            return "IPC_OK";
+        case BHARAT_IPC_STATUS_ERR_DECODE:
+            return "IPC_ERR_DECODE";
+        case BHARAT_IPC_STATUS_ERR_VERSION:
+            return "IPC_ERR_VERSION";
+        case BHARAT_IPC_STATUS_ERR_OPCODE:
+            return "IPC_ERR_OPCODE";
+        case BHARAT_IPC_STATUS_ERR_PERM:
+            return "IPC_ERR_PERMISSION";
+        case BHARAT_IPC_STATUS_ERR_NOT_FOUND:
+            return "IPC_ERR_NOT_FOUND";
+        case BHARAT_IPC_STATUS_ERR_UNSUPPORTED:
+            return "IPC_ERR_UNSUPPORTED";
+        case BHARAT_IPC_STATUS_ERR_INTERNAL:
+            return "IPC_ERR_INTERNAL";
+        case BHARAT_IPC_STATUS_ERR_TRUNCATED:
+            return "IPC_ERR_TRUNCATED";
+        case BHARAT_IPC_STATUS_ERR_LENGTH:
+            return "IPC_ERR_LENGTH";
+        case BHARAT_IPC_STATUS_ERR_FLAGS:
+            return "IPC_ERR_FLAGS";
+        default:
+            return "IPC_ERR_UNKNOWN";
+    }
+}

--- a/core/kernel/src/ipc/ipc_traffic.c
+++ b/core/kernel/src/ipc/ipc_traffic.c
@@ -1,4 +1,7 @@
 #include "ipc_endpoint.h"
+#include "ipc/ipc_traffic.h"
+#include "ipc/ipc_profile_policy.h"
+#include <stddef.h>
 
 static const char *k_ipc_traffic_names[] = {
     [IPC_TRAFFIC_UNSPECIFIED] = "UNSPECIFIED",
@@ -15,4 +18,41 @@ const char *ipc_traffic_type_name(ipc_traffic_type_t type) {
         return k_ipc_traffic_names[type];
     }
     return "UNKNOWN";
+}
+
+bharat_status_t ipc_route_admit(
+    ipc_traffic_type_t traffic,
+    uint32_t payload_len,
+    bool cross_core,
+    ipc_route_admission_t *out)
+{
+    if (out == NULL) {
+        return BHARAT_IPC_STATUS_ERR_INTERNAL;
+    }
+
+    out->accepted = false;
+    out->available_slots = 0; // Placeholder until full backpressure implemented
+
+    ipc_profile_policy_t p = ipc_profile_policy_current();
+    ipc_transport_t transport = ipc_profile_select_transport(traffic, cross_core);
+
+    if (cross_core) {
+        out->max_payload = (transport == IPC_TRANSPORT_URPC) ?
+                            p.max_cross_core_payload : p.endpoint_payload_max;
+    } else {
+        out->max_payload = p.endpoint_payload_max;
+    }
+
+    if (!ipc_profile_payload_supported(traffic, payload_len, cross_core)) {
+        out->reason = BHARAT_IPC_STATUS_ERR_LENGTH;
+        return BHARAT_IPC_STATUS_ERR_LENGTH;
+    }
+
+    // Baseline backpressure: for now, we always admit if payload is valid.
+    // In IPC1, this will check actual ring/buffer availability.
+    out->accepted = true;
+    out->reason = BHARAT_IPC_STATUS_OK;
+    out->available_slots = 1; // At least one slot available if accepted
+
+    return BHARAT_IPC_STATUS_OK;
 }

--- a/core/kernel/src/urpc/urpc_channel.c
+++ b/core/kernel/src/urpc/urpc_channel.c
@@ -4,10 +4,37 @@
 // Define channel states per core
 static urpc_channel_state_t g_urpc_states[BHARAT_MAX_CPUS];
 
+// Validate state transitions
+bool urpc_channel_transition_allowed(urpc_channel_state_t from, urpc_channel_state_t to) {
+    if (from == to) return true;
+
+    switch (from) {
+        case URPC_CHANNEL_CLOSED:
+            return (to == URPC_CHANNEL_BINDING) || (to == URPC_CHANNEL_BOUND);
+        case URPC_CHANNEL_BINDING:
+            return (to == URPC_CHANNEL_BOUND) || (to == URPC_CHANNEL_ERROR) || (to == URPC_CHANNEL_CLOSED);
+        case URPC_CHANNEL_BOUND:
+            return (to == URPC_CHANNEL_CLOSED) || (to == URPC_CHANNEL_ERROR);
+        case URPC_CHANNEL_ERROR:
+            return (to == URPC_CHANNEL_CLOSED); // Must reset to closed before retry
+        default:
+            return false;
+    }
+}
+
 // Send a command to a target core to initiate binding
-int urpc_channel_bind(uint32_t target_core) {
-    if (target_core >= BHARAT_MAX_CPUS) return -1;
-    if (target_core == hal_cpu_get_id()) return -2; // Can't bind to self
+bharat_status_t urpc_channel_bind(uint32_t target_core) {
+    if (target_core >= BHARAT_MAX_CPUS) return BHARAT_IPC_STATUS_ERR_NOT_FOUND;
+    if (target_core == hal_cpu_get_id()) return BHARAT_IPC_STATUS_ERR_UNSUPPORTED; // Can't bind to self
+
+    urpc_channel_state_t current = g_urpc_states[target_core];
+    if (current == URPC_CHANNEL_BINDING || current == URPC_CHANNEL_BOUND) {
+        return BHARAT_IPC_STATUS_ERR_INTERNAL; // Already in progress or bound (Busy)
+    }
+
+    if (!urpc_channel_transition_allowed(current, URPC_CHANNEL_BINDING)) {
+        return BHARAT_IPC_STATUS_ERR_INTERNAL;
+    }
 
     // Pack a BIND_REQ message
     uint64_t msg = urpc_pack_msg(URPC_BIND_REQ, 0);
@@ -19,16 +46,21 @@ int urpc_channel_bind(uint32_t target_core) {
     int ret = urpc_bootstrap_send(target_core, msg);
     if (ret != 0) {
         g_urpc_states[target_core] = URPC_CHANNEL_ERROR;
-        return ret;
+        return BHARAT_IPC_STATUS_ERR_INTERNAL;
     }
 
-    return 0;
+    return BHARAT_IPC_STATUS_OK;
 }
 
 // Accept a binding request from a source core
-int urpc_channel_accept(uint32_t source_core) {
-    if (source_core >= BHARAT_MAX_CPUS) return -1;
-    if (source_core == hal_cpu_get_id()) return -2; // Can't accept from self
+bharat_status_t urpc_channel_accept(uint32_t source_core) {
+    if (source_core >= BHARAT_MAX_CPUS) return BHARAT_IPC_STATUS_ERR_NOT_FOUND;
+    if (source_core == hal_cpu_get_id()) return BHARAT_IPC_STATUS_ERR_UNSUPPORTED; // Can't accept from self
+
+    urpc_channel_state_t current = g_urpc_states[source_core];
+    if (!urpc_channel_transition_allowed(current, URPC_CHANNEL_BOUND)) {
+        return BHARAT_IPC_STATUS_ERR_INTERNAL;
+    }
 
     // Pack a BIND_ACK message
     uint64_t msg = urpc_pack_msg(URPC_BIND_ACK, 0);
@@ -37,19 +69,36 @@ int urpc_channel_accept(uint32_t source_core) {
     g_urpc_states[source_core] = URPC_CHANNEL_BOUND;
     urpc_mark_ready(source_core); // Signal bootstrap layer that channel is ready
 
-    return urpc_bootstrap_send(source_core, msg);
+    int ret = urpc_bootstrap_send(source_core, msg);
+    if (ret != 0) {
+        g_urpc_states[source_core] = URPC_CHANNEL_ERROR;
+        return BHARAT_IPC_STATUS_ERR_INTERNAL;
+    }
+
+    return BHARAT_IPC_STATUS_OK;
 }
 
 // Close a bound channel
-int urpc_channel_close(uint32_t target_core) {
-    if (target_core >= BHARAT_MAX_CPUS) return -1;
+bharat_status_t urpc_channel_close(uint32_t target_core) {
+    if (target_core >= BHARAT_MAX_CPUS) return BHARAT_IPC_STATUS_ERR_NOT_FOUND;
+
+    urpc_channel_state_t current = g_urpc_states[target_core];
+    if (!urpc_channel_transition_allowed(current, URPC_CHANNEL_CLOSED)) {
+        return BHARAT_IPC_STATUS_ERR_INTERNAL;
+    }
 
     // Pack a CLOSE message
     uint64_t msg = urpc_pack_msg(URPC_CLOSE, 0);
 
     g_urpc_states[target_core] = URPC_CHANNEL_CLOSED;
 
-    return urpc_bootstrap_send(target_core, msg);
+    int ret = urpc_bootstrap_send(target_core, msg);
+    if (ret != 0) {
+         // Even if send fails, we are logically closed locally
+         return BHARAT_IPC_STATUS_ERR_INTERNAL;
+    }
+
+    return BHARAT_IPC_STATUS_OK;
 }
 
 // Get the state of a channel

--- a/docs/architecture/kernel/ipc-urpc-reliability-contract.md
+++ b/docs/architecture/kernel/ipc-urpc-reliability-contract.md
@@ -1,0 +1,44 @@
+# IPC/URPC Reliability Contract
+
+Status: Partial / IPC0 baseline
+
+## Goals
+- Explicit validation contract for IPC messages.
+- Deterministic error/status results for IPC operations.
+- Safe URPC channel state transitions with validation.
+- Minimal backpressure admission control based on payload and traffic type.
+
+## Non-goals
+- No syscall changes.
+- No scheduler changes.
+- No full cross-node routing.
+- No full distributed message broker.
+- No capability enforcement rollout.
+
+## IPC Contract Validation
+The IPC contract validator (`bharat_ipc_contract_validate_ex`) enforces:
+- Proper header and interface versioning.
+- Opcode range validation.
+- Payload size and optional alignment constraints.
+- Mandatory and allowed flag bitmasks.
+- Rejection of reserved or unsupported flags.
+
+## IPC Status Mapping
+A canonical mapping from `bharat_status_t` to human-readable strings is provided via `bharat_ipc_status_to_string()`. This ensures consistent logging and debugging across the kernel and userspace services.
+
+## URPC Channel Reliability
+The URPC channel layer now enforces a strict state machine for channel lifecycles:
+- **CLOSED -> BINDING/BOUND**: Initiation of a channel.
+- **BINDING -> BOUND/ERROR/CLOSED**: Result of a binding request.
+- **BOUND -> CLOSED/ERROR**: Termination or failure of a bound channel.
+- **ERROR -> CLOSED**: Mandatory reset before retry.
+
+Transitions are validated via `urpc_channel_transition_allowed()`. Self-bind and duplicate bind attempts are explicitly rejected.
+
+## IPC Route Admission
+The `ipc_route_admit()` function provides an early-rejection mechanism for IPC traffic. It evaluates whether a message can be admitted based on:
+- Traffic type (Control, Bulk, etc.)
+- Payload size relative to transport limits (Endpoint vs. URPC).
+- Core routing (Local vs. Cross-core).
+
+This serves as the foundation for full backpressure support in future IPC iterations.

--- a/interface/include/bharat/uapi/ipc/contract.h
+++ b/interface/include/bharat/uapi/ipc/contract.h
@@ -37,6 +37,10 @@ enum {
     BHARAT_IPC_FLAG_CAP_TRANSFER   = (1u << 2),
 };
 
+#define BHARAT_IPC_FLAGS_ALL_V1 (BHARAT_IPC_FLAG_REPLY | \
+                                 BHARAT_IPC_FLAG_NONBLOCK | \
+                                 BHARAT_IPC_FLAG_CAP_TRANSFER)
+
 #ifdef __cplusplus
 }
 #endif

--- a/quality/tests/host/CMakeLists.txt
+++ b/quality/tests/host/CMakeLists.txt
@@ -144,6 +144,10 @@ add_executable(test_ipc_profile test_ipc_profile.c ../../kernel/src/profile/prof
 target_include_directories(test_ipc_profile PRIVATE ../../kernel/include ../../include ../../core/lib/include)
 add_test(NAME host_test_ipc_profile COMMAND test_ipc_profile)
 
+add_executable(test_ipc_urpc_reliability test_ipc_urpc_reliability.c ../../kernel/src/ipc/contract_validate.c ../../kernel/src/ipc/ipc_status.c ../../kernel/src/ipc/ipc_traffic.c ../../kernel/src/urpc/urpc_channel.c ../../kernel/src/ipc/ipc_profile_policy.c ../../kernel/src/mm/mem_model.c ../../kernel/src/profile/profile.c)
+target_include_directories(test_ipc_urpc_reliability PRIVATE ../../kernel/include ../../include ../../core/lib/include)
+add_test(NAME host_test_ipc_urpc_reliability COMMAND test_ipc_urpc_reliability)
+
 add_executable(test_ipc_urpc_policy_rt_mpu test_ipc_urpc_policy_matrix.c ../../kernel/src/ipc/ipc_profile_policy.c ../../kernel/src/mm/mem_model.c ../../kernel/src/profile/profile.c)
 target_include_directories(test_ipc_urpc_policy_rt_mpu PRIVATE ../../kernel/include ../../include ../../core/lib/include)
 target_compile_definitions(test_ipc_urpc_policy_rt_mpu PRIVATE CONFIG_PROFILE_AUTOMOBILE=1 CONFIG_MEM_MODEL_MPU=1 BHARAT_KERNEL_PROFILE_RT=1 EXPECT_PREFER_URPC=1 EXPECT_ALLOW_BULK_IPC=0 EXPECT_URPC_MAX=32 EXPECT_CONTROL_TRANSPORT=IPC_TRANSPORT_URPC EXPECT_BULK_TRANSPORT=IPC_TRANSPORT_URPC)

--- a/quality/tests/host/test_ipc_urpc_reliability.c
+++ b/quality/tests/host/test_ipc_urpc_reliability.c
@@ -1,0 +1,159 @@
+#include <stdio.h>
+#include <assert.h>
+#include <string.h>
+
+#include "ipc/contract_validate.h"
+#include "ipc/ipc_status.h"
+#include "ipc/ipc_traffic.h"
+#include "bharat/urpc.h"
+#include "hal/hal.h"
+
+// Mock hal_cpu_get_id
+uint32_t hal_cpu_get_id(void) {
+    return 0;
+}
+
+// Mock urpc_bootstrap_send
+int urpc_bootstrap_send(uint32_t target_core, uint64_t msg) {
+    return 0;
+}
+
+// Mock urpc_mark_ready
+void urpc_mark_ready(uint32_t source_core) {
+}
+
+static void test_ipc_contract_validation(void) {
+    bharat_ipc_contract_header_t hdr = {
+        .header_version = BHARAT_IPC_HEADER_VERSION_V1,
+        .interface_version = 1,
+        .opcode = 10,
+        .payload_size = 64,
+        .flags = 0
+    };
+
+    ipc_contract_rules_t rules = {
+        .expected_version = 1,
+        .min_opcode = 1,
+        .max_opcode = 100,
+        .max_payload_size = 128,
+        .required_flags = 0,
+        .allowed_flags = BHARAT_IPC_FLAG_REPLY | BHARAT_IPC_FLAG_NONBLOCK,
+        .allow_variable_payload = true,
+        .payload_alignment = 8
+    };
+
+    // Valid header
+    assert(bharat_ipc_contract_validate_ex(&hdr, &rules) == BHARAT_IPC_STATUS_OK);
+
+    // Invalid header version
+    hdr.header_version = 0;
+    assert(bharat_ipc_contract_validate_ex(&hdr, &rules) == BHARAT_IPC_STATUS_ERR_VERSION);
+    hdr.header_version = BHARAT_IPC_HEADER_VERSION_V1;
+
+    // Invalid interface version
+    hdr.interface_version = 2;
+    assert(bharat_ipc_contract_validate_ex(&hdr, &rules) == BHARAT_IPC_STATUS_ERR_VERSION);
+    hdr.interface_version = 1;
+
+    // Invalid opcode (too low)
+    hdr.opcode = 0;
+    assert(bharat_ipc_contract_validate_ex(&hdr, &rules) == BHARAT_IPC_STATUS_ERR_OPCODE);
+    hdr.opcode = 10;
+
+    // Invalid opcode (too high)
+    hdr.opcode = 101;
+    assert(bharat_ipc_contract_validate_ex(&hdr, &rules) == BHARAT_IPC_STATUS_ERR_OPCODE);
+    hdr.opcode = 10;
+
+    // Payload too large
+    hdr.payload_size = 129;
+    assert(bharat_ipc_contract_validate_ex(&hdr, &rules) == BHARAT_IPC_STATUS_ERR_LENGTH);
+    hdr.payload_size = 64;
+
+    // Payload alignment mismatch
+    hdr.payload_size = 60;
+    assert(bharat_ipc_contract_validate_ex(&hdr, &rules) == BHARAT_IPC_STATUS_ERR_DECODE);
+    hdr.payload_size = 64;
+
+    // Invalid flags (not allowed)
+    hdr.flags = 0x10; // Reserved/unsupported
+    assert(bharat_ipc_contract_validate_ex(&hdr, &rules) == BHARAT_IPC_STATUS_ERR_FLAGS);
+    hdr.flags = 0;
+
+    // Required flags missing
+    rules.required_flags = BHARAT_IPC_FLAG_REPLY;
+    assert(bharat_ipc_contract_validate_ex(&hdr, &rules) == BHARAT_IPC_STATUS_ERR_FLAGS);
+    hdr.flags = BHARAT_IPC_FLAG_REPLY;
+    assert(bharat_ipc_contract_validate_ex(&hdr, &rules) == BHARAT_IPC_STATUS_OK);
+    rules.required_flags = 0;
+    hdr.flags = 0;
+
+    // Fixed payload size
+    rules.allow_variable_payload = false;
+    rules.max_payload_size = 64;
+    assert(bharat_ipc_contract_validate_ex(&hdr, &rules) == BHARAT_IPC_STATUS_OK);
+    hdr.payload_size = 32;
+    assert(bharat_ipc_contract_validate_ex(&hdr, &rules) == BHARAT_IPC_STATUS_ERR_LENGTH);
+
+    printf("test_ipc_contract_validation passed\n");
+}
+
+static void test_ipc_status_strings(void) {
+    assert(strcmp(bharat_ipc_status_to_string(BHARAT_IPC_STATUS_OK), "IPC_OK") == 0);
+    assert(strcmp(bharat_ipc_status_to_string(BHARAT_IPC_STATUS_ERR_VERSION), "IPC_ERR_VERSION") == 0);
+    assert(strcmp(bharat_ipc_status_to_string(BHARAT_IPC_STATUS_ERR_FLAGS), "IPC_ERR_FLAGS") == 0);
+    assert(strcmp(bharat_ipc_status_to_string((bharat_status_t)999), "IPC_ERR_UNKNOWN") == 0);
+    printf("test_ipc_status_strings passed\n");
+}
+
+static void test_urpc_channel_validation(void) {
+    // Test state transitions
+    assert(urpc_channel_transition_allowed(URPC_CHANNEL_CLOSED, URPC_CHANNEL_BINDING) == true);
+    assert(urpc_channel_transition_allowed(URPC_CHANNEL_CLOSED, URPC_CHANNEL_BOUND) == true);
+    assert(urpc_channel_transition_allowed(URPC_CHANNEL_CLOSED, URPC_CHANNEL_ERROR) == false);
+
+    assert(urpc_channel_transition_allowed(URPC_CHANNEL_BINDING, URPC_CHANNEL_BOUND) == true);
+    assert(urpc_channel_transition_allowed(URPC_CHANNEL_BINDING, URPC_CHANNEL_ERROR) == true);
+    assert(urpc_channel_transition_allowed(URPC_CHANNEL_BINDING, URPC_CHANNEL_CLOSED) == true);
+
+    assert(urpc_channel_transition_allowed(URPC_CHANNEL_ERROR, URPC_CHANNEL_CLOSED) == true);
+    assert(urpc_channel_transition_allowed(URPC_CHANNEL_ERROR, URPC_CHANNEL_BINDING) == false);
+
+    // Test bind rejections
+    assert(urpc_channel_bind(0) == BHARAT_IPC_STATUS_ERR_UNSUPPORTED); // Self-bind (mocked CPU ID is 0)
+    assert(urpc_channel_bind(999) == BHARAT_IPC_STATUS_ERR_NOT_FOUND); // Invalid core
+
+    assert(urpc_channel_bind(1) == BHARAT_IPC_STATUS_OK); // OK
+    assert(urpc_channel_bind(1) == BHARAT_IPC_STATUS_ERR_INTERNAL); // Duplicate bind (already binding)
+
+    // Test close
+    assert(urpc_channel_close(1) == BHARAT_IPC_STATUS_OK);
+    assert(urpc_channel_get_state(1) == URPC_CHANNEL_CLOSED);
+
+    printf("test_urpc_channel_validation passed\n");
+}
+
+static void test_ipc_route_admission(void) {
+    ipc_route_admission_t out;
+
+    // Normal case (GP profile defaults)
+    assert(ipc_route_admit(IPC_TRAFFIC_CONTROL, 16, false, &out) == BHARAT_IPC_STATUS_OK);
+    assert(out.accepted == true);
+    assert(out.reason == BHARAT_IPC_STATUS_OK);
+
+    // Payload too large for endpoint
+    assert(ipc_route_admit(IPC_TRAFFIC_BULK, 1024, false, &out) == BHARAT_IPC_STATUS_ERR_LENGTH);
+    assert(out.accepted == false);
+    assert(out.reason == BHARAT_IPC_STATUS_ERR_LENGTH);
+
+    printf("test_ipc_route_admission passed\n");
+}
+
+int main(void) {
+    test_ipc_contract_validation();
+    test_ipc_status_strings();
+    test_urpc_channel_validation();
+    test_ipc_route_admission();
+    printf("All IPC/URPC reliability tests passed.\n");
+    return 0;
+}


### PR DESCRIPTION
This change addresses the IPC0 — IPC/URPC Reliability Contract Baseline task. It strengthens the IPC/URPC behavior by adding explicit validation contracts, canonical error mapping, and hardened state transitions.

Key changes:
- `core/kernel/src/ipc/contract_validate.c`: Implemented `bharat_ipc_contract_validate_ex`.
- `core/kernel/src/ipc/ipc_status.c`: Added human-readable status mapping.
- `core/kernel/src/urpc/urpc_channel.c`: Hardened channel lifecycle and state transitions.
- `core/kernel/src/ipc/ipc_traffic.c`: Implemented `ipc_route_admit` for traffic validation.
- `quality/tests/host/test_ipc_urpc_reliability.c`: Added comprehensive unit tests.
- `docs/architecture/kernel/ipc-urpc-reliability-contract.md`: Documented the new contract.


---
*PR created automatically by Jules for task [11454496446789545770](https://jules.google.com/task/11454496446789545770) started by @divyang4481*