### PR TITLE
SCHED1: Execution Mode & CPU Partition Admission Contract

### DIFF
--- a/core/kernel/include/sched/sched_admission.h
+++ b/core/kernel/include/sched/sched_admission.h
@@ -1,0 +1,68 @@
+#ifndef BHARAT_KERNEL_SCHED_ADMISSION_H
+#define BHARAT_KERNEL_SCHED_ADMISSION_H
+
+#include <kernel/status.h>
+#include <bharat/uapi/system/execution_mode.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Check if a CPU supports a specific scheduler class.
+ *
+ * @param cpu_id The ID of the CPU.
+ * @param class_mask The class mask to check.
+ * @return K_OK if allowed, K_ERR_DENIED if not allowed, or other error code.
+ */
+kstatus_t sched_admission_allows_class(
+    uint32_t cpu_id,
+    bharat_sched_class_mask_t class_mask
+);
+
+/**
+ * @brief Select the first eligible CPU for a specific scheduler class.
+ *
+ * This implementation is deterministic and intentionally simple: it chooses
+ * the first eligible CPU in ascending order of CPU ID.
+ *
+ * @param class_mask The class mask required.
+ * @param out_cpu_id Pointer to store the selected CPU ID.
+ * @return K_OK on success, K_ERR_NOT_FOUND if no eligible CPU exists.
+ */
+kstatus_t sched_admission_select_cpu(
+    bharat_sched_class_mask_t class_mask,
+    uint32_t *out_cpu_id
+);
+
+/**
+ * @brief Validate the current CPU partition configuration.
+ *
+ * Reports errors if the configuration violates scheduler invariants:
+ * - At least one SYSTEM CPU must exist.
+ * - RT and FAIR/GP must not be collapsed on the same CPU in multi-core systems.
+ * - Single-core systems must use TEMPORAL strategy.
+ *
+ * @return K_OK on success, error code otherwise.
+ */
+kstatus_t sched_admission_validate_partitions(void);
+
+/**
+ * @brief Convert execution mode to human-readable string.
+ * @param mode The execution mode.
+ * @return A stable non-NULL string.
+ */
+const char *sched_admission_mode_to_string(bharat_execution_mode_t mode);
+
+/**
+ * @brief Convert partition strategy to human-readable string.
+ * @param strategy The partition strategy.
+ * @return A stable non-NULL string.
+ */
+const char *sched_admission_partition_to_string(bharat_partition_strategy_t strategy);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // BHARAT_KERNEL_SCHED_ADMISSION_H

--- a/core/kernel/src/sched/cpu_partition.c
+++ b/core/kernel/src/sched/cpu_partition.c
@@ -56,6 +56,31 @@ int cpu_partition_init(bharat_execution_config_t *config) {
                 config->cpu_partitions[i].allowed_sched_classes = BHARAT_SCHED_CLASS_SYSTEM | BHARAT_SCHED_CLASS_FAIR;
             }
         }
+    } else if (config->active_cpu_count == 3) {
+        if (config->execution_mode == BHARAT_EXEC_MODE_GENERAL_PURPOSE) {
+            for (int i = 0; i < 3; i++) {
+                config->cpu_partitions[i].role = BHARAT_CPU_PARTITION_SYSTEM;
+                config->cpu_partitions[i].allowed_sched_classes = BHARAT_SCHED_CLASS_SYSTEM | BHARAT_SCHED_CLASS_FAIR;
+            }
+        } else if (config->execution_mode == BHARAT_EXEC_MODE_REALTIME) {
+            config->cpu_partitions[0].role = BHARAT_CPU_PARTITION_SYSTEM;
+            config->cpu_partitions[0].allowed_sched_classes = BHARAT_SCHED_CLASS_SYSTEM;
+
+            config->cpu_partitions[1].role = BHARAT_CPU_PARTITION_REALTIME;
+            config->cpu_partitions[1].allowed_sched_classes = BHARAT_SCHED_CLASS_FIFO_RT;
+
+            config->cpu_partitions[2].role = BHARAT_CPU_PARTITION_SPARE;
+            config->cpu_partitions[2].allowed_sched_classes = BHARAT_SCHED_CLASS_NONE;
+        } else if (config->execution_mode == BHARAT_EXEC_MODE_MIXED_CRITICAL) {
+            config->cpu_partitions[0].role = BHARAT_CPU_PARTITION_SYSTEM;
+            config->cpu_partitions[0].allowed_sched_classes = BHARAT_SCHED_CLASS_SYSTEM;
+
+            config->cpu_partitions[1].role = BHARAT_CPU_PARTITION_REALTIME;
+            config->cpu_partitions[1].allowed_sched_classes = BHARAT_SCHED_CLASS_FIFO_RT;
+
+            config->cpu_partitions[2].role = BHARAT_CPU_PARTITION_BEST_EFFORT;
+            config->cpu_partitions[2].allowed_sched_classes = BHARAT_SCHED_CLASS_FAIR;
+        }
     } else if (config->active_cpu_count >= 4) {
         // Spatial Mapping (example base rules)
         if (config->execution_mode == BHARAT_EXEC_MODE_MIXED_CRITICAL) {

--- a/core/kernel/src/sched/sched_admission.c
+++ b/core/kernel/src/sched/sched_admission.c
@@ -1,0 +1,141 @@
+#include <sched/sched_admission.h>
+#include <sched/cpu_partition.h>
+#include <profile/execution_mode.h>
+#include <stddef.h>
+
+kstatus_t sched_admission_allows_class(
+    uint32_t cpu_id,
+    bharat_sched_class_mask_t class_mask
+) {
+    if (cpu_partition_allows_class(cpu_id, class_mask)) {
+        return K_OK;
+    }
+    return K_ERR_DENIED;
+}
+
+kstatus_t sched_admission_select_cpu(
+    bharat_sched_class_mask_t class_mask,
+    uint32_t *out_cpu_id
+) {
+    const bharat_execution_config_t *cfg = bharat_execution_mode_get_config();
+    if (!cfg || !out_cpu_id) {
+        return K_ERR_INVALID_ARG;
+    }
+
+    /*
+     * SCHED1 selection is deterministic and intentionally simple:
+     * choose the first eligible CPU. Load-aware selection belongs to a
+     * later scheduler-balancing phase.
+     */
+    for (uint32_t i = 0; i < cfg->active_cpu_count; i++) {
+        if (cpu_partition_allows_class(i, class_mask)) {
+            *out_cpu_id = i;
+            return K_OK;
+        }
+    }
+
+    return K_ERR_NOT_FOUND;
+}
+
+kstatus_t sched_admission_validate_partitions(void) {
+    const bharat_execution_config_t *cfg = bharat_execution_mode_get_config();
+    if (!cfg) {
+        return K_ERR_BAD_STATE;
+    }
+
+    if (cfg->active_cpu_count == 0) {
+        return K_ERR_INVALID_ARG;
+    }
+
+    if (cfg->active_cpu_count > BHARAT_MAX_CPU_PARTITIONS) {
+        return K_ERR_OVERFLOW;
+    }
+
+    if (cfg->execution_mode == BHARAT_EXEC_MODE_UNKNOWN) {
+        return K_ERR_BAD_STATE;
+    }
+
+    // 1. One SYSTEM CPU must exist
+    bool has_system = false;
+    for (uint32_t i = 0; i < cfg->active_cpu_count; i++) {
+        if (cfg->cpu_partitions[i].role == BHARAT_CPU_PARTITION_SYSTEM) {
+            has_system = true;
+            break;
+        }
+    }
+    if (!has_system) {
+        return K_ERR_DENIED;
+    }
+
+    // 2. Single-core mode must use TEMPORAL strategy
+    if (cfg->active_cpu_count == 1) {
+        if (cfg->partition_strategy != BHARAT_PARTITION_STRATEGY_TEMPORAL) {
+            return K_ERR_BAD_STATE;
+        }
+    } else {
+        // 3. Multi-core mode should use SPATIAL strategy
+        if (cfg->partition_strategy != BHARAT_PARTITION_STRATEGY_SPATIAL) {
+            return K_ERR_BAD_STATE;
+        }
+
+        // 4. MIX mode must not collapse RT and FAIR on multi-core
+        if (cfg->execution_mode == BHARAT_EXEC_MODE_MIXED_CRITICAL) {
+            bool has_rt = false;
+            bool has_fair = false;
+            for (uint32_t i = 0; i < cfg->active_cpu_count; i++) {
+                uint32_t mask = cfg->cpu_partitions[i].allowed_sched_classes;
+                if (mask & BHARAT_SCHED_CLASS_FIFO_RT) has_rt = true;
+                if (mask & BHARAT_SCHED_CLASS_FAIR) has_fair = true;
+
+                if ((mask & BHARAT_SCHED_CLASS_FIFO_RT) && (mask & BHARAT_SCHED_CLASS_FAIR)) {
+                    return K_ERR_BAD_STATE;
+                }
+            }
+            if (!has_rt || !has_fair) {
+                return K_ERR_BAD_STATE;
+            }
+        }
+
+        // 5. RT mode must have at least one RT-capable CPU
+        if (cfg->execution_mode == BHARAT_EXEC_MODE_REALTIME) {
+            bool has_rt = false;
+            for (uint32_t i = 0; i < cfg->active_cpu_count; i++) {
+                if (cfg->cpu_partitions[i].allowed_sched_classes & BHARAT_SCHED_CLASS_FIFO_RT) {
+                    has_rt = true;
+                    break;
+                }
+            }
+            if (!has_rt) {
+                return K_ERR_BAD_STATE;
+            }
+        }
+    }
+
+    return K_OK;
+}
+
+const char *sched_admission_mode_to_string(bharat_execution_mode_t mode) {
+    switch (mode) {
+        case BHARAT_EXEC_MODE_REALTIME:
+            return "RT";
+        case BHARAT_EXEC_MODE_GENERAL_PURPOSE:
+            return "GP";
+        case BHARAT_EXEC_MODE_MIXED_CRITICAL:
+            return "MIX";
+        case BHARAT_EXEC_MODE_UNKNOWN:
+        default:
+            return "UNKNOWN";
+    }
+}
+
+const char *sched_admission_partition_to_string(bharat_partition_strategy_t strategy) {
+    switch (strategy) {
+        case BHARAT_PARTITION_STRATEGY_SPATIAL:
+            return "SPATIAL";
+        case BHARAT_PARTITION_STRATEGY_TEMPORAL:
+            return "TEMPORAL";
+        case BHARAT_PARTITION_STRATEGY_NONE:
+        default:
+            return "UNKNOWN";
+    }
+}

--- a/docs/architecture/kernel/scheduler/execution-mode-and-cpu-partition-contract.md
+++ b/docs/architecture/kernel/scheduler/execution-mode-and-cpu-partition-contract.md
@@ -1,0 +1,67 @@
+# Execution Mode & CPU Partition Admission Contract
+
+## Overview
+
+Bharat-OS enforces a strict admission and partitioning contract for scheduler execution. This contract ensures that workload types (System, Realtime, Fair/GP) are routed to appropriate CPU cores based on the system's execution mode and hardware topology.
+
+The goal is to provide predictable isolation for realtime tasks while maintaining general-purpose throughput where applicable, and supporting single-core temporal sharing for small devices.
+
+## Partitioning Strategies
+
+### 1. Temporal Partitioning (Single-Core)
+Used when `active_cpu_count == 1`.
+- All classes (SYSTEM, FIFO_RT, FAIR) coexist on CPU0.
+- Separation is handled by scheduler class priority (RT wins over GP).
+- No cross-core migration or remote routing.
+
+### 2. Spatial Partitioning (Multi-Core)
+Used when `active_cpu_count > 1`.
+- Roles are assigned per CPU (SYSTEM, REALTIME, BEST_EFFORT, SPARE).
+- Specific classes are admitted only on allowed CPUs.
+
+## Execution Modes
+
+### General Purpose (GP)
+Focuses on broad throughput across all cores.
+- All CPUs allow `SYSTEM | FAIR` classes.
+- RT classes are typically rejected unless explicitly configured.
+
+### Realtime (RT)
+Focuses on strict RT isolation.
+- `CPU0` is dedicated to `SYSTEM` tasks.
+- `CPU1..N` are dedicated to `REALTIME` tasks.
+- GP/FAIR tasks are generally rejected or routed to a `SPARE` core if available.
+
+### Mixed-Criticality (MIX)
+Balancing RT performance and GP throughput.
+- Enforces separation of RT and FAIR workloads on multi-core systems.
+- For 2 cores: `CPU0 = SYSTEM | RT`, `CPU1 = FAIR`.
+- For 3+ cores: Explicitly separates `SYSTEM`, `RT`, and `FAIR` cores.
+
+## Admission Rules by Core Count
+
+| Mode | CPU Count | Strategy | CPU0 Role | CPU1 Role | CPU2 Role | CPU3..N Role |
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+| **Small** | 1 | Temporal | SYSTEM | - | - | - |
+| **GP** | 2+ | Spatial | SYSTEM | SYSTEM | SYSTEM | SYSTEM |
+| **RT** | 2 | Spatial | SYSTEM+RT | SPARE | - | - |
+| **RT** | 3 | Spatial | SYSTEM | RT | SPARE | - |
+| **RT** | 4+ | Spatial | SYSTEM | RT | RT | RT |
+| **MIX** | 2 | Spatial | SYSTEM+RT | FAIR | - | - |
+| **MIX** | 3 | Spatial | SYSTEM | RT | FAIR | - |
+| **MIX** | 4+ | Spatial | SYSTEM | RT | RT | FAIR |
+
+## Admission API
+
+The admission layer provides deterministic helpers for the scheduler router:
+
+- `sched_admission_allows_class(cpu_id, class_mask)`: Checks if a specific class is permitted on a CPU.
+- `sched_admission_select_cpu(class_mask, out_cpu_id)`: Selects the first eligible CPU for a workload.
+- `sched_admission_validate_partitions()`: Verifies that the current configuration meets invariant requirements (e.g., at least one SYSTEM CPU, no RT+FAIR collapse on multi-core).
+
+## Invariants
+
+1. **At least one SYSTEM CPU** must exist to ensure kernel health and housekeeping.
+2. **Deterministic Selection**: In the absence of load balancing, CPU selection for admission must be deterministic (ascending CPU ID order).
+3. **No RT+FAIR Collapse**: On systems with multiple cores in MIX mode, Realtime and Fair workloads must not be assigned to the same core to prevent GP interference with RT timing.
+4. **Fail-Closed**: Invalid configurations (unknown modes, invalid CPU IDs, or violating invariants) must be rejected by the admission layer.

--- a/quality/tests/host/CMakeLists.txt
+++ b/quality/tests/host/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-include(delivery/cmake/test_component_policy.cmake)
+include(cmake/test_component_policy.cmake)
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Generic")
     # This file shouldn't be processed if we are building the kernel (cross-compiling)
@@ -135,6 +135,14 @@ add_executable(test_sched test_sched.c host_stubs.c ../../core/lib/rbtree/rbtree
 target_include_directories(test_sched PRIVATE ../../kernel/include ../../include ../../core/lib/include)
 
 add_test(NAME host_test_sched COMMAND test_sched)
+
+add_executable(test_sched_admission test_sched_admission.c ../../core/kernel/src/sched/sched_admission.c ../../core/kernel/src/sched/cpu_partition.c)
+target_include_directories(test_sched_admission PRIVATE
+    ../../core/kernel/include
+    ../../interface/include
+    ../../core/lib/include
+)
+add_test(NAME host_test_sched_admission COMMAND test_sched_admission)
 
 add_executable(test_lib_string test_lib_string.c ../../core/lib/string/string.c)
 add_test(NAME host_test_lib_string COMMAND test_lib_string)

--- a/quality/tests/host/test_sched_admission.c
+++ b/quality/tests/host/test_sched_admission.c
@@ -1,0 +1,189 @@
+#include <sched/sched_admission.h>
+#include <sched/cpu_partition.h>
+#include <profile/execution_mode.h>
+#include <kernel/status.h>
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+// Mock the execution mode config getter to control tests
+static bharat_execution_config_t mock_config;
+static bool use_mock_config = false;
+
+const bharat_execution_config_t* bharat_execution_mode_get_config(void) {
+    if (use_mock_config) {
+        return &mock_config;
+    }
+    // Fallback to real if available, though for host tests we usually mock
+    return NULL;
+}
+
+static void setup_mock(uint32_t cpu_count, bharat_execution_mode_t mode) {
+    memset(&mock_config, 0, sizeof(mock_config));
+    mock_config.active_cpu_count = cpu_count;
+    mock_config.execution_mode = mode;
+    int rc = cpu_partition_init(&mock_config);
+    assert(rc == 0);
+    use_mock_config = true;
+}
+
+static void test_one_core_temporal_allows_system_rt_fair(void) {
+    setup_mock(1, BHARAT_EXEC_MODE_MIXED_CRITICAL);
+
+    assert(mock_config.partition_strategy == BHARAT_PARTITION_STRATEGY_TEMPORAL);
+    assert(sched_admission_allows_class(0, BHARAT_SCHED_CLASS_SYSTEM) == K_OK);
+    assert(sched_admission_allows_class(0, BHARAT_SCHED_CLASS_FIFO_RT) == K_OK);
+    assert(sched_admission_allows_class(0, BHARAT_SCHED_CLASS_FAIR) == K_OK);
+
+    uint32_t selected_cpu;
+    assert(sched_admission_select_cpu(BHARAT_SCHED_CLASS_SYSTEM, &selected_cpu) == K_OK);
+    assert(selected_cpu == 0);
+    assert(sched_admission_select_cpu(BHARAT_SCHED_CLASS_FIFO_RT, &selected_cpu) == K_OK);
+    assert(selected_cpu == 0);
+    assert(sched_admission_select_cpu(BHARAT_SCHED_CLASS_FAIR, &selected_cpu) == K_OK);
+    assert(selected_cpu == 0);
+
+    assert(sched_admission_validate_partitions() == K_OK);
+
+    printf("PASS: test_one_core_temporal_allows_system_rt_fair\n");
+}
+
+static void test_two_core_gp_maps_both_system_fair(void) {
+    setup_mock(2, BHARAT_EXEC_MODE_GENERAL_PURPOSE);
+
+    assert(mock_config.partition_strategy == BHARAT_PARTITION_STRATEGY_SPATIAL);
+    assert(sched_admission_allows_class(0, BHARAT_SCHED_CLASS_SYSTEM) == K_OK);
+    assert(sched_admission_allows_class(0, BHARAT_SCHED_CLASS_FAIR) == K_OK);
+    assert(sched_admission_allows_class(1, BHARAT_SCHED_CLASS_SYSTEM) == K_OK);
+    assert(sched_admission_allows_class(1, BHARAT_SCHED_CLASS_FAIR) == K_OK);
+
+    // RT should be rejected in GP mode unless explicitly enabled (it's not in our current init)
+    assert(sched_admission_allows_class(0, BHARAT_SCHED_CLASS_FIFO_RT) == K_ERR_DENIED);
+
+    uint32_t selected_cpu;
+    // Selection should be deterministic: first eligible
+    assert(sched_admission_select_cpu(BHARAT_SCHED_CLASS_FAIR, &selected_cpu) == K_OK);
+    assert(selected_cpu == 0);
+
+    assert(sched_admission_validate_partitions() == K_OK);
+
+    printf("PASS: test_two_core_gp_maps_both_system_fair\n");
+}
+
+static void test_two_core_rt_maps_cpu0_system_rt_cpu1_spare(void) {
+    setup_mock(2, BHARAT_EXEC_MODE_REALTIME);
+
+    assert(sched_admission_allows_class(0, BHARAT_SCHED_CLASS_SYSTEM) == K_OK);
+    assert(sched_admission_allows_class(0, BHARAT_SCHED_CLASS_FIFO_RT) == K_OK);
+    assert(sched_admission_allows_class(0, BHARAT_SCHED_CLASS_FAIR) == K_ERR_DENIED);
+
+    // CPU1 is SPARE
+    assert(mock_config.cpu_partitions[1].role == BHARAT_CPU_PARTITION_SPARE);
+    assert(sched_admission_allows_class(1, BHARAT_SCHED_CLASS_SYSTEM) == K_ERR_DENIED);
+    assert(sched_admission_allows_class(1, BHARAT_SCHED_CLASS_FIFO_RT) == K_ERR_DENIED);
+    assert(sched_admission_allows_class(1, BHARAT_SCHED_CLASS_FAIR) == K_ERR_DENIED);
+
+    uint32_t selected_cpu;
+    assert(sched_admission_select_cpu(BHARAT_SCHED_CLASS_FIFO_RT, &selected_cpu) == K_OK);
+    assert(selected_cpu == 0);
+    assert(sched_admission_select_cpu(BHARAT_SCHED_CLASS_FAIR, &selected_cpu) == K_ERR_NOT_FOUND);
+
+    assert(sched_admission_validate_partitions() == K_OK);
+
+    printf("PASS: test_two_core_rt_maps_cpu0_system_rt_cpu1_spare\n");
+}
+
+static void test_three_core_mix_has_system_rt_and_fair(void) {
+    setup_mock(3, BHARAT_EXEC_MODE_MIXED_CRITICAL);
+
+    // CPU0: SYSTEM, CPU1: RT, CPU2: FAIR
+    assert(mock_config.cpu_partitions[0].role == BHARAT_CPU_PARTITION_SYSTEM);
+    assert(mock_config.cpu_partitions[1].role == BHARAT_CPU_PARTITION_REALTIME);
+    assert(mock_config.cpu_partitions[2].role == BHARAT_CPU_PARTITION_BEST_EFFORT);
+
+    assert(sched_admission_allows_class(0, BHARAT_SCHED_CLASS_SYSTEM) == K_OK);
+    assert(sched_admission_allows_class(0, BHARAT_SCHED_CLASS_FIFO_RT) == K_ERR_DENIED);
+
+    assert(sched_admission_allows_class(1, BHARAT_SCHED_CLASS_FIFO_RT) == K_OK);
+    assert(sched_admission_allows_class(1, BHARAT_SCHED_CLASS_SYSTEM) == K_ERR_DENIED);
+
+    assert(sched_admission_allows_class(2, BHARAT_SCHED_CLASS_FAIR) == K_OK);
+    assert(sched_admission_allows_class(2, BHARAT_SCHED_CLASS_FIFO_RT) == K_ERR_DENIED);
+
+    assert(sched_admission_validate_partitions() == K_OK);
+
+    printf("PASS: test_three_core_mix_has_system_rt_and_fair\n");
+}
+
+static void test_four_core_mixed_has_system_rt_and_fair(void) {
+    setup_mock(4, BHARAT_EXEC_MODE_MIXED_CRITICAL);
+
+    assert(mock_config.partition_strategy == BHARAT_PARTITION_STRATEGY_SPATIAL);
+    assert(mock_config.cpu_partitions[0].role == BHARAT_CPU_PARTITION_SYSTEM);
+    assert(mock_config.cpu_partitions[1].role == BHARAT_CPU_PARTITION_REALTIME);
+    assert(mock_config.cpu_partitions[2].role == BHARAT_CPU_PARTITION_REALTIME);
+    assert(mock_config.cpu_partitions[3].role == BHARAT_CPU_PARTITION_BEST_EFFORT);
+
+    assert(sched_admission_allows_class(0, BHARAT_SCHED_CLASS_SYSTEM) == K_OK);
+    assert(sched_admission_allows_class(1, BHARAT_SCHED_CLASS_FIFO_RT) == K_OK);
+    assert(sched_admission_allows_class(2, BHARAT_SCHED_CLASS_FIFO_RT) == K_OK);
+    assert(sched_admission_allows_class(3, BHARAT_SCHED_CLASS_FAIR) == K_OK);
+
+    assert(sched_admission_validate_partitions() == K_OK);
+
+    printf("PASS: test_four_core_mixed_has_system_rt_and_fair\n");
+}
+
+static void test_rt_class_rejected_on_fair_only_cpu(void) {
+    setup_mock(4, BHARAT_EXEC_MODE_MIXED_CRITICAL);
+    assert(sched_admission_allows_class(3, BHARAT_SCHED_CLASS_FIFO_RT) == K_ERR_DENIED);
+    printf("PASS: test_rt_class_rejected_on_fair_only_cpu\n");
+}
+
+static void test_fair_class_rejected_on_rt_only_cpu(void) {
+    setup_mock(4, BHARAT_EXEC_MODE_MIXED_CRITICAL);
+    assert(sched_admission_allows_class(1, BHARAT_SCHED_CLASS_FAIR) == K_ERR_DENIED);
+    printf("PASS: test_fair_class_rejected_on_rt_only_cpu\n");
+}
+
+static void test_unknown_execution_mode_fails_closed(void) {
+    setup_mock(2, BHARAT_EXEC_MODE_GENERAL_PURPOSE);
+    mock_config.execution_mode = BHARAT_EXEC_MODE_UNKNOWN;
+
+    assert(sched_admission_validate_partitions() == K_ERR_BAD_STATE);
+
+    printf("PASS: test_unknown_execution_mode_fails_closed\n");
+}
+
+static void test_invalid_cpu_id_rejected(void) {
+    setup_mock(1, BHARAT_EXEC_MODE_GENERAL_PURPOSE);
+    assert(sched_admission_allows_class(1, BHARAT_SCHED_CLASS_SYSTEM) == K_ERR_DENIED);
+    printf("PASS: test_invalid_cpu_id_rejected\n");
+}
+
+static void test_string_helpers(void) {
+    assert(strcmp(sched_admission_mode_to_string(BHARAT_EXEC_MODE_GENERAL_PURPOSE), "GP") == 0);
+    assert(strcmp(sched_admission_mode_to_string(BHARAT_EXEC_MODE_REALTIME), "RT") == 0);
+    assert(strcmp(sched_admission_mode_to_string(BHARAT_EXEC_MODE_MIXED_CRITICAL), "MIX") == 0);
+    assert(strcmp(sched_admission_mode_to_string(BHARAT_EXEC_MODE_UNKNOWN), "UNKNOWN") == 0);
+
+    assert(strcmp(sched_admission_partition_to_string(BHARAT_PARTITION_STRATEGY_SPATIAL), "SPATIAL") == 0);
+    assert(strcmp(sched_admission_partition_to_string(BHARAT_PARTITION_STRATEGY_TEMPORAL), "TEMPORAL") == 0);
+    assert(strcmp(sched_admission_partition_to_string(BHARAT_PARTITION_STRATEGY_NONE), "UNKNOWN") == 0);
+
+    printf("PASS: test_string_helpers\n");
+}
+
+int main(void) {
+    test_one_core_temporal_allows_system_rt_fair();
+    test_two_core_gp_maps_both_system_fair();
+    test_two_core_rt_maps_cpu0_system_rt_cpu1_spare();
+    test_three_core_mix_has_system_rt_and_fair();
+    test_four_core_mixed_has_system_rt_and_fair();
+    test_rt_class_rejected_on_fair_only_cpu();
+    test_fair_class_rejected_on_rt_only_cpu();
+    test_unknown_execution_mode_fails_closed();
+    test_invalid_cpu_id_rejected();
+    test_string_helpers();
+    return 0;
+}


### PR DESCRIPTION
Implemented the SCHED1 task, which establishes a clear admission contract for the scheduler based on execution modes and CPU partitioning. This includes the admission API, 3-core specific behavior, multi-core spatial isolation rules, and a validation layer to ensure system invariants are met at boot. Added tests and documentation.

---
*PR created automatically by Jules for task [10937437427550796448](https://jules.google.com/task/10937437427550796448) started by @divyang4481*