### PR TITLE
Kernel Algorithmic Foundations: Naming, Placement, and Primitives

### DIFF
--- a/core/kernel/include/bharat/kernel/ds/bh_bitmap.h
+++ b/core/kernel/include/bharat/kernel/ds/bh_bitmap.h
@@ -1,0 +1,64 @@
+#ifndef BHARAT_KERNEL_DS_BH_BITMAP_H
+#define BHARAT_KERNEL_DS_BH_BITMAP_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <kernel/status.h>
+
+/**
+ * @file bh_bitmap.h
+ * @brief Fixed-size bitmap over caller-owned storage
+ */
+
+typedef struct bh_bitmap {
+    uint8_t *bits;
+    size_t size_bits;
+} bh_bitmap_t;
+
+/**
+ * @brief Initialize a bitmap with caller-provided storage
+ *
+ * @param bitmap Pointer to bitmap structure
+ * @param storage Pointer to storage buffer
+ * @param size_bits Size of bitmap in bits
+ * @return kstatus_t K_OK on success
+ */
+kstatus_t bh_bitmap_init(bh_bitmap_t *bitmap, void *storage, size_t size_bits);
+
+/**
+ * @brief Set a bit in the bitmap
+ */
+kstatus_t bh_bitmap_set(bh_bitmap_t *bitmap, size_t bit);
+
+/**
+ * @brief Clear a bit in the bitmap
+ */
+kstatus_t bh_bitmap_clear(bh_bitmap_t *bitmap, size_t bit);
+
+/**
+ * @brief Test if a bit is set
+ */
+bool bh_bitmap_test(const bh_bitmap_t *bitmap, size_t bit);
+
+/**
+ * @brief Find first clear bit
+ */
+kstatus_t bh_bitmap_find_first_clear(const bh_bitmap_t *bitmap, size_t *out_bit);
+
+/**
+ * @brief Find first set bit
+ */
+kstatus_t bh_bitmap_find_first_set(const bh_bitmap_t *bitmap, size_t *out_bit);
+
+/**
+ * @brief Set a range of bits
+ */
+kstatus_t bh_bitmap_set_range(bh_bitmap_t *bitmap, size_t start, size_t count);
+
+/**
+ * @brief Clear a range of bits
+ */
+kstatus_t bh_bitmap_clear_range(bh_bitmap_t *bitmap, size_t start, size_t count);
+
+#endif // BHARAT_KERNEL_DS_BH_BITMAP_H

--- a/core/kernel/include/bharat/kernel/ds/bh_handle_table.h
+++ b/core/kernel/include/bharat/kernel/ds/bh_handle_table.h
@@ -1,0 +1,76 @@
+#ifndef BHARAT_KERNEL_DS_BH_HANDLE_TABLE_H
+#define BHARAT_KERNEL_DS_BH_HANDLE_TABLE_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <kernel/status.h>
+
+/**
+ * @file bh_handle_table.h
+ * @brief Fixed-capacity generation handles
+ */
+
+typedef uint64_t bh_handle_t;
+
+typedef struct bh_handle_slot {
+    uint32_t generation;
+    uint32_t type;
+    void *object;
+    uint64_t rights;
+    bool active;
+} bh_handle_slot_t;
+
+typedef struct bh_handle_table {
+    bh_handle_slot_t *slots;
+    size_t capacity;
+    size_t count;
+} bh_handle_table_t;
+
+/**
+ * @brief Initialize a handle table
+ */
+kstatus_t bh_handle_table_init(bh_handle_table_t *table, void *storage, size_t capacity);
+
+/**
+ * @brief Allocate a handle for an object
+ */
+kstatus_t bh_handle_alloc(bh_handle_table_t *table, void *object, uint32_t type, uint64_t rights, bh_handle_t *out_handle);
+
+/**
+ * @brief Lookup an object by handle
+ */
+kstatus_t bh_handle_lookup(const bh_handle_table_t *table, bh_handle_t handle, uint32_t expected_type, void **out_object, uint64_t *out_rights);
+
+/**
+ * @brief Revoke a handle
+ */
+kstatus_t bh_handle_revoke(bh_handle_table_t *table, bh_handle_t handle);
+
+/**
+ * @brief Validate a handle (checks generation and active status)
+ */
+bool bh_handle_validate(const bh_handle_table_t *table, bh_handle_t handle);
+
+/**
+ * Helper to construct a handle from index and generation
+ */
+static inline bh_handle_t bh_handle_make(uint32_t index, uint32_t generation) {
+    return ((uint64_t)generation << 32) | index;
+}
+
+/**
+ * Helper to extract index from handle
+ */
+static inline uint32_t bh_handle_index(bh_handle_t handle) {
+    return (uint32_t)(handle & 0xFFFFFFFF);
+}
+
+/**
+ * Helper to extract generation from handle
+ */
+static inline uint32_t bh_handle_generation(bh_handle_t handle) {
+    return (uint32_t)(handle >> 32);
+}
+
+#endif // BHARAT_KERNEL_DS_BH_HANDLE_TABLE_H

--- a/core/kernel/include/bharat/kernel/ds/bh_list.h
+++ b/core/kernel/include/bharat/kernel/ds/bh_list.h
@@ -1,0 +1,92 @@
+#ifndef BHARAT_KERNEL_DS_BH_LIST_H
+#define BHARAT_KERNEL_DS_BH_LIST_H
+
+#include <stddef.h>
+#include <stdbool.h>
+
+/**
+ * @file bh_list.h
+ * @brief Canonical Kernel Intrusive Doubly-Linked List
+ */
+
+typedef struct bh_list_node {
+    struct bh_list_node *next;
+    struct bh_list_node *prev;
+} bh_list_node_t;
+
+#define BH_LIST_HEAD_INIT(name) { &(name), &(name) }
+
+#define BH_LIST_HEAD(name) \
+    bh_list_node_t name = BH_LIST_HEAD_INIT(name)
+
+#ifndef BH_CONTAINER_OF
+#define BH_CONTAINER_OF(ptr, type, member) \
+    ((type *)((char *)(ptr) - offsetof(type, member)))
+#endif
+
+static inline void bh_list_init(bh_list_node_t *head) {
+    head->next = head;
+    head->prev = head;
+}
+
+static inline bool bh_list_is_empty(const bh_list_node_t *head) {
+    return head->next == head;
+}
+
+static inline void bh_list_insert_after(bh_list_node_t *prev, bh_list_node_t *node) {
+    node->next = prev->next;
+    node->prev = prev;
+    prev->next->prev = node;
+    prev->next = node;
+}
+
+static inline void bh_list_insert_before(bh_list_node_t *next, bh_list_node_t *node) {
+    node->prev = next->prev;
+    node->next = next;
+    next->prev->next = node;
+    next->prev = node;
+}
+
+static inline void bh_list_push_front(bh_list_node_t *head, bh_list_node_t *node) {
+    bh_list_insert_after(head, node);
+}
+
+static inline void bh_list_push_back(bh_list_node_t *head, bh_list_node_t *node) {
+    bh_list_insert_before(head, node);
+}
+
+static inline void bh_list_remove(bh_list_node_t *node) {
+    node->next->prev = node->prev;
+    node->prev->next = node->next;
+    node->next = NULL;
+    node->prev = NULL;
+}
+
+static inline bh_list_node_t *bh_list_pop_front(bh_list_node_t *head) {
+    if (bh_list_is_empty(head)) {
+        return NULL;
+    }
+    bh_list_node_t *node = head->next;
+    bh_list_remove(node);
+    return node;
+}
+
+static inline bh_list_node_t *bh_list_pop_back(bh_list_node_t *head) {
+    if (bh_list_is_empty(head)) {
+        return NULL;
+    }
+    bh_list_node_t *node = head->prev;
+    bh_list_remove(node);
+    return node;
+}
+
+#define bh_list_entry(ptr, type, member) BH_CONTAINER_OF(ptr, type, member)
+
+#define bh_list_foreach(pos, head) \
+    for (pos = (head)->next; pos != (head); pos = pos->next)
+
+#define bh_list_foreach_safe(pos, n, head) \
+    for (pos = (head)->next, n = pos->next; pos != (head); \
+         pos = n, n = pos->next)
+
+#endif // BHARAT_KERNEL_DS_BH_LIST_H

--- a/core/kernel/src/ds/CMakeLists.txt
+++ b/core/kernel/src/ds/CMakeLists.txt
@@ -5,6 +5,8 @@ add_library(k_ds OBJECT
     bh_range_tree.c
     bh_ring.c
     bh_seqlock.c
+    bh_bitmap.c
+    bh_handle_table.c
 )
 target_link_libraries(k_ds PRIVATE bharat_kernel_includes bharat_kernel_buildopts)
 target_compile_options(k_ds PRIVATE $<$<COMPILE_LANGUAGE:C>:-ffreestanding> $<$<COMPILE_LANGUAGE:C>:-fno-builtin> $<$<COMPILE_LANGUAGE:C>:-fno-pic>)

--- a/core/kernel/src/ds/bh_bitmap.c
+++ b/core/kernel/src/ds/bh_bitmap.c
@@ -1,0 +1,75 @@
+#include <bharat/kernel/ds/bh_bitmap.h>
+#include <string.h>
+
+kstatus_t bh_bitmap_init(bh_bitmap_t *bitmap, void *storage, size_t size_bits) {
+    if (!bitmap || !storage) {
+        return K_ERR_INVALID_ARG;
+    }
+    bitmap->bits = (uint8_t *)storage;
+    bitmap->size_bits = size_bits;
+    memset(storage, 0, (size_bits + 7) / 8);
+    return K_OK;
+}
+
+kstatus_t bh_bitmap_set(bh_bitmap_t *bitmap, size_t bit) {
+    if (bit >= bitmap->size_bits) {
+        return K_ERR_INVALID_ARG;
+    }
+    bitmap->bits[bit / 8] |= (1 << (bit % 8));
+    return K_OK;
+}
+
+kstatus_t bh_bitmap_clear(bh_bitmap_t *bitmap, size_t bit) {
+    if (bit >= bitmap->size_bits) {
+        return K_ERR_INVALID_ARG;
+    }
+    bitmap->bits[bit / 8] &= ~(1 << (bit % 8));
+    return K_OK;
+}
+
+bool bh_bitmap_test(const bh_bitmap_t *bitmap, size_t bit) {
+    if (bit >= bitmap->size_bits) {
+        return false;
+    }
+    return (bitmap->bits[bit / 8] & (1 << (bit % 8))) != 0;
+}
+
+kstatus_t bh_bitmap_find_first_clear(const bh_bitmap_t *bitmap, size_t *out_bit) {
+    for (size_t i = 0; i < bitmap->size_bits; i++) {
+        if (!bh_bitmap_test(bitmap, i)) {
+            *out_bit = i;
+            return K_OK;
+        }
+    }
+    return K_ERR_NOT_FOUND;
+}
+
+kstatus_t bh_bitmap_find_first_set(const bh_bitmap_t *bitmap, size_t *out_bit) {
+    for (size_t i = 0; i < bitmap->size_bits; i++) {
+        if (bh_bitmap_test(bitmap, i)) {
+            *out_bit = i;
+            return K_OK;
+        }
+    }
+    return K_ERR_NOT_FOUND;
+}
+
+kstatus_t bh_bitmap_set_range(bh_bitmap_t *bitmap, size_t start, size_t count) {
+    if (start + count > bitmap->size_bits) {
+        return K_ERR_INVALID_ARG;
+    }
+    for (size_t i = 0; i < count; i++) {
+        bh_bitmap_set(bitmap, start + i);
+    }
+    return K_OK;
+}
+
+kstatus_t bh_bitmap_clear_range(bh_bitmap_t *bitmap, size_t start, size_t count) {
+    if (start + count > bitmap->size_bits) {
+        return K_ERR_INVALID_ARG;
+    }
+    for (size_t i = 0; i < count; i++) {
+        bh_bitmap_clear(bitmap, start + i);
+    }
+    return K_OK;
+}

--- a/core/kernel/src/ds/bh_handle_table.c
+++ b/core/kernel/src/ds/bh_handle_table.c
@@ -1,0 +1,107 @@
+#include <bharat/kernel/ds/bh_handle_table.h>
+#include <string.h>
+
+kstatus_t bh_handle_table_init(bh_handle_table_t *table, void *storage, size_t capacity) {
+    if (!table || !storage || capacity == 0) {
+        return K_ERR_INVALID_ARG;
+    }
+    table->slots = (bh_handle_slot_t *)storage;
+    table->capacity = capacity;
+    table->count = 0;
+    memset(storage, 0, capacity * sizeof(bh_handle_slot_t));
+    return K_OK;
+}
+
+kstatus_t bh_handle_alloc(bh_handle_table_t *table, void *object, uint32_t type, uint64_t rights, bh_handle_t *out_handle) {
+    if (!table || !object || !out_handle) {
+        return K_ERR_INVALID_ARG;
+    }
+
+    for (size_t i = 0; i < table->capacity; i++) {
+        if (!table->slots[i].active) {
+            table->slots[i].active = true;
+            table->slots[i].object = object;
+            table->slots[i].type = type;
+            table->slots[i].rights = rights;
+            // Increment generation to invalidate old handles to this slot
+            table->slots[i].generation++;
+
+            *out_handle = bh_handle_make((uint32_t)i, table->slots[i].generation);
+            table->count++;
+            return K_OK;
+        }
+    }
+
+    return K_ERR_NO_MEMORY; // Or K_ERR_LIMIT_EXCEEDED
+}
+
+kstatus_t bh_handle_lookup(const bh_handle_table_t *table, bh_handle_t handle, uint32_t expected_type, void **out_object, uint64_t *out_rights) {
+    if (!table || !out_object) {
+        return K_ERR_INVALID_ARG;
+    }
+
+    uint32_t index = bh_handle_index(handle);
+    uint32_t generation = bh_handle_generation(handle);
+
+    if (index >= table->capacity) {
+        return K_ERR_INVALID_ARG;
+    }
+
+    bh_handle_slot_t *slot = &table->slots[index];
+
+    if (!slot->active || slot->generation != generation) {
+        return K_ERR_NOT_FOUND; // Stale or invalid handle
+    }
+
+    if (expected_type != 0 && slot->type != expected_type) {
+        return K_ERR_CAP_WRONG_TYPE;
+    }
+
+    *out_object = slot->object;
+    if (out_rights) {
+        *out_rights = slot->rights;
+    }
+
+    return K_OK;
+}
+
+kstatus_t bh_handle_revoke(bh_handle_table_t *table, bh_handle_t handle) {
+    if (!table) {
+        return K_ERR_INVALID_ARG;
+    }
+
+    uint32_t index = bh_handle_index(handle);
+    uint32_t generation = bh_handle_generation(handle);
+
+    if (index >= table->capacity) {
+        return K_ERR_INVALID_ARG;
+    }
+
+    bh_handle_slot_t *slot = &table->slots[index];
+
+    if (!slot->active || slot->generation != generation) {
+        return K_ERR_NOT_FOUND;
+    }
+
+    slot->active = false;
+    slot->object = NULL;
+    table->count--;
+
+    return K_OK;
+}
+
+bool bh_handle_validate(const bh_handle_table_t *table, bh_handle_t handle) {
+    if (!table) {
+        return false;
+    }
+
+    uint32_t index = bh_handle_index(handle);
+    uint32_t generation = bh_handle_generation(handle);
+
+    if (index >= table->capacity) {
+        return false;
+    }
+
+    bh_handle_slot_t *slot = &table->slots[index];
+    return slot->active && slot->generation == generation;
+}

--- a/docs/architecture/kernel/kernel-algorithmic-foundations.md
+++ b/docs/architecture/kernel/kernel-algorithmic-foundations.md
@@ -10,260 +10,160 @@ tags:
   - algorithms
 ---
 
-# Epic E3-X — Kernel Algorithmic Foundations
+# Bharat-OS Kernel Algorithmic Foundations
 
-## Objective
+## 1. Purpose
+
 Introduce production-grade kernel algorithms and verification foundations required for scalable VM, object indexing, read-mostly metadata, safe hooks, storage metadata, and memory-safe kernel coding.
 
----
+## 2. Core Principle: Algorithm Placement Follows Ownership
 
-## E3-X-S1 — VM range index replacement strategy
+Algorithm is not selected because it is advanced. Algorithm is selected because it matches the ownership, latency, memory, and security boundary of that subsystem.
 
-### Objective
-Replace linear or ad-hoc VM region lookup with a scalable range index suitable for address-space regions.
+Bharat-OS must not place algorithms only by convenience. Every algorithm must be placed according to ownership, latency criticality, architecture dependency, and policy weight.
 
-**Recommended algorithm direction:**
-Maple-tree style range index or augmented interval tree.
-*Recommendation:* Maple-tree-inspired range index for VM regions, because it is optimized for range lookups and dense virtual address layouts. If implementation complexity is too high, start with an augmented red-black interval tree and keep the API compatible with a future Maple-style backend.
+- **Mechanism** belongs in the kernel, HAL, or drivers.
+- **Policy** belongs in services, stacks, or personalities.
 
-### Likely code areas
-- `core/kernel/include/ds/`
-- `core/kernel/src/ds/`
-- `core/kernel/src/mm/vm/`
-- `core/kernel/include/mm/`
-- `quality/tests/host/`
-- `docs/architecture/memory/`
+## 3. Current Repository Path Mapping
 
-### Tasks
-1. Define `vm_range_index` API contract.
-2. Compare interval tree vs Maple-style range tree.
-3. Define lookup, insert, remove, split, merge behavior.
-4. Define concurrency model: lock-based first, RCU-read later.
-5. Define migration plan from existing VM region lookup.
-6. Add benchmark requirements for region lookup scale.
+The canonical locations for kernel algorithmic foundations are:
 
-### Acceptance criteria
-- Roadmap defines chosen first implementation strategy.
-- API supports lookup by address and range-overlap query.
-- API does not expose internal tree representation.
-- Migration plan avoids touching active VM logic in this story.
+| Component | Repository Path |
+|---|---|
+| Core Kernel Sources | `core/kernel/src/` |
+| Kernel DS Headers | `core/kernel/include/bharat/kernel/ds/` |
+| Kernel DS Sources | `core/kernel/src/ds/` |
+| Scheduler | `core/kernel/src/sched/` |
+| Memory Management | `core/kernel/src/mm/` |
+| Capabilities | `core/kernel/src/cap/` |
+| IPC / uRPC | `core/kernel/src/ipc/`, `core/kernel/src/urpc/` |
+| System Services | `core/services/system/` |
 
-### Verification strategy
-- Unit tests for insert/remove/overlap.
-- Fuzz tests for random region maps.
-- Benchmark: lookup performance across 10, 100, 1k, 10k regions.
-- Invariant checks: no overlap unless explicitly allowed.
+## 4. Algorithm Placement Matrix
 
----
+| Algorithm Type | Correct Location | Reason |
+|---|---|---|
+| Per-core run queues, priority queues, deadline queues | `core/kernel/src/sched/` | Scheduler mechanism; latency-critical |
+| TLB shootdown queue/ring, ack bitmap, timeout tracking | `core/kernel/src/mm/` + HAL contract | Cross-core memory correctness |
+| Page allocator magazines, free lists, bitmap allocators | `core/kernel/src/mm/pmm/` | Core memory mechanism |
+| VM region lookup tree | `core/kernel/src/mm/vm/` | Address-space mechanism |
+| Capability lookup table, generation counters, revoke list | `core/kernel/src/cap/` | Security-critical authority path |
+| IPC/URPC ring buffer, message queue, endpoint registry | `core/kernel/src/ipc/`, `core/kernel/src/urpc/` | Cross-core/service mechanism |
+| Driver/device matching tables | `core/drivers/registry/`, `core/drivers/core/` | Driver-owned discovery/matching |
+| Network route table, ARP/neighbor cache, packet queues | `core/services/network/` or `core/stacks/net/` | Networking stack/policy, not core kernel |
+| Filesystem path tree, mount namespace, fd table policy | `core/services/system/filesystem/` | VFS policy belongs outside kernel |
+| Generic reusable structures | `core/kernel/src/ds/` | Shared building blocks |
 
-## E3-X-S2 — Kernel RCU/read-mostly primitive
+## 5. Canonical Kernel Data-Structure Primitives
 
-### Objective
-Introduce a minimal kernel read-mostly synchronization primitive for data that is frequently read and rarely updated.
+### 1. Intrusive Doubly Linked List (`bh_list.h`)
+Use for: scheduler runnable queues, wait queues, timer buckets, object lifecycle lists.
+- `bh_list_node_t`
+- `bh_list_init`
+- `bh_list_push_back`
+- `bh_list_remove`
 
-**Recommended direction:**
-RCU-lite first, full preemptible RCU later.
-For Bharat-OS, start small:
-- non-preemptible or cooperative RCU-lite
-- per-core read-side nesting
-- epoch/grace-period tracking
-- deferred callback queue
+### 2. Bitmap Allocator (`bh_bitmap.h`)
+Use for: small ID allocation, CPU masks, page-frame availability map, capability slot availability.
+- `bh_bitmap_t`
+- `bh_bitmap_find_first_clear`
+- `bh_bitmap_set_range`
 
-### Likely code areas
-- `core/kernel/include/sync/`
-- `core/kernel/src/sync/`
-- `core/kernel/src/sched/`
-- `core/kernel/src/ipc/`
-- `quality/tests/host/`
+### 3. Ring Buffer (`bh_ring.h`)
+Use for: IPC/URPC queues, TLB shootdown requests, telemetry event buffers.
+- `bh_ring_t`
+- `bh_ring_push`
+- `bh_ring_pop`
 
-### Tasks
-1. Define `rcu_read_lock()`/`rcu_read_unlock()` contract.
-2. Define `synchronize_rcu()` baseline behavior.
-3. Define `call_rcu()` deferred free contract.
-4. Define UP behavior: read lock is mostly compiler/barrier discipline.
-5. Define SMP behavior: grace period requires all cores to pass quiescent state.
-6. Document RT constraints and non-goals.
+### 4. Generation-Based Handle Table (`bh_handle_table.h`)
+Use for: capability handles, process/thread handles, IPC endpoint handles.
+Purpose: prevent stale handle reuse, support revoke and lifecycle validation.
+- `bh_handle_table_t`
+- `bh_handle_alloc`
+- `bh_handle_lookup`
+- `bh_handle_revoke`
 
-### Acceptance criteria
-- Roadmap clearly separates RCU-lite from full production RCU.
-- UP and SMP behavior are both defined.
-- RT-mode limitations are documented.
-- No scheduler implementation is changed in this story.
+### 5. Red-Black Tree / Ordered Tree
+Use for: VM region lookup, timer deadline ordering, ordered memory ranges.
+- `bh_rbtree_t`
+- `bh_rbtree_insert`
+- `bh_rbtree_find_le`
 
-### Verification strategy
-- Host model tests for epoch transitions.
-- Simulated multi-core quiescent-state tests.
-- Negative test: object not reclaimed before grace period.
-- Stress test plan for read-mostly object table.
+### 6. Radix Tree / Trie
+Use for: page-table-like sparse indexes, object ID namespace.
+- `bh_radix_t`
+- `bh_radix_insert`
+- `bh_radix_lookup`
 
----
+## 6. Naming Convention
 
-## E3-X-S3 — XArray/radix-style object index
+### Global Rule
+Use `bh_` for internal Bharat-OS primitives.
+Use `bharat_` only for stable UAPI/ABI-facing names where readability and external identity matter.
 
-### Objective
-Create a scalable object index for kernel objects such as handles, capabilities, VM objects, endpoints, devices, or file descriptors.
+### Type Naming
+| Kind | Format | Example |
+|---|---|---|
+| Struct typedef | `bh_<noun>_t` | `bh_ring_t` |
+| Enum typedef | `bh_<domain>_<noun>_t` | `bh_sched_class_t` |
+| Enum value | `BH_<DOMAIN>_<VALUE>` | `BH_MEM_CLASS_DMA` |
+| Function | `bh_<module>_<verb>` | `bh_ring_push` |
+| Static helper | `<module>_<verb>_local` | `ring_push_local` |
+| Constants | `BH_<MODULE>_<NAME>` | `BH_RING_MIN_CAPACITY` |
 
-**Recommended direction:**
-XArray/radix-tree inspired sparse integer-key index.
+## 7. Hot-Path Rules
+- Avoid heap allocation.
+- Prefer intrusive structures.
+- Prefer per-core ownership.
+- Avoid global locks.
+- Name lock-aware APIs clearly: `_locked`, `_nolock`, `_try`, `_irqsave`.
 
-### Likely code areas
-- `core/kernel/include/ds/`
-- `core/kernel/src/ds/`
-- `core/kernel/src/capability/`
-- `core/kernel/src/ipc/`
-- `core/kernel/src/mm/`
-- `quality/tests/host/`
+## 8. Small-Device, MMU-Lite, and MPU-Only Constraints
+- Provide fixed-capacity or compile-time bounded mode.
+- Avoid unbounded dynamic growth.
+- If a primitive requires an MMU, document the restriction.
 
-### Tasks
-1. Define `kobject_index` API.
-2. Support insert, lookup, remove, reserve ID, allocate next ID.
-3. Define ID generation and stale-ID avoidance strategy.
-4. Define RCU-read compatibility for future.
-5. Define memory allocation constraints for small-device builds.
+## 9. Code-Agent Checklist
 
-### Acceptance criteria
-- Roadmap defines object-index API without coupling to capabilities.
-- Sparse ID space support is required.
-- Future RCU-read compatibility is documented.
-- Small-device memory limits are considered.
+Before adding a new algorithm, answer:
 
-### Verification strategy
-- Unit tests for sparse inserts/removes.
-- Duplicate ID rejection.
-- Reuse-after-remove generation test plan.
-- Fuzz test with random insert/remove/lookup.
+1. **Is this mechanism or policy?** Mechanism lives in kernel/lib/drivers. Policy lives in services/stacks/personalities.
+2. **Is this architecture-specific?** If yes, implementation belongs in `arch/`, contract in `hal/include/`.
+3. **Is this reusable across kernel subsystems?** If yes, put it in `core/kernel/src/ds/`.
+4. **Does it touch user-visible ABI?** If yes, put stable types in `uapi/`.
+5. **Does it run on hot path?** Optimize for no locks, no heap, per-core data.
+6. **Does it support small devices?** Use fixed-capacity or bounded growth.
+7. **Does it have tests?** Host test for data structures is mandatory.
 
----
+## 10. Immediate Implementation Backlog
 
-## E3-X-S4 — Verified kernel hook prototype
+The following priorities define the roadmap for applying these foundations:
 
-### Objective
-Introduce a safe kernel hook mechanism for observability, policy callbacks, and future verified extensions without arbitrary function-pointer chaos.
-
-**Recommended direction:**
-typed hook table + static registration + verifier rules.
-Not dynamic eBPF yet. Start with verified static hooks.
-
-### Likely code areas
-- `core/kernel/include/verify/`
-- `core/kernel/src/verify/`
-- `core/kernel/include/hooks/` (if existing)
-- `core/kernel/src/init/`
-- `quality/tests/host/`
-- `docs/architecture/kernel/`
-
-### Tasks
-1. Define hook type descriptor.
-2. Define allowed hook points.
-3. Define registration-time validation.
-4. Define no-blocking / no-allocation / bounded-time rules.
-5. Define future path to bytecode/eBPF-like verification.
-
-### Acceptance criteria
-- Hook prototype is typed and bounded.
-- Invalid hook signature is rejected.
-- Hook registration is static or early-boot only.
-- No runtime dynamic loading in this phase.
-
-### Verification strategy
-- Compile-time signature tests where possible.
-- Registration validation tests.
-- Negative tests for invalid hook point.
-- Documentation of safety rules.
+1. **PMM per-core magazines**: Per-core magazine cache + remote free queue.
+2. **TLB shootdown**: Ring queue + request ID + ack bitmap + timeout.
+3. **Capability table**: Generation-based handle table + rights bitmap.
+4. **Scheduler runnable queues**: Intrusive list or priority bucket queues.
+5. **VM region lookup**: Ordered tree/rbtree first; maple-tree-like structure later.
 
 ---
 
-## E3-X-S5 — Storage metadata tree strategy
+## E3-X Stories (Preserved Roadmap)
 
-### Objective
-Define the metadata tree strategy for future production-grade storage and filesystem layers.
+### E3-X-S1 — VM range index replacement strategy
+Replace linear or ad-hoc VM region lookup with a scalable range index (Maple-tree style or Red-Black).
 
-**Recommended direction:**
-B+tree or copy-on-write B-tree depending on storage profile.
+### E3-X-S2 — Kernel RCU/read-mostly primitive
+Introduce RCU-lite for read-mostly synchronization (non-preemptible first).
 
-*For small devices:*
-littlefs-style log/tree metadata strategy.
+### E3-X-S3 — XArray/radix-style object index
+Scalable sparse integer-key index for handles, capabilities, etc.
 
-*For desktop/cloud:*
-B+tree / extent tree / COW metadata option.
+### E3-X-S4 — Verified kernel hook prototype
+Typed hook table + static registration for safe observability.
 
-### Likely code areas
-- `core/stacks/storage/`
-- `core/stacks/storage/metadata/`
-- `core/kernel/include/ds/`
-- `core/kernel/src/ds/`
-- `core/drivers/storage/`
-- `docs/architecture/storage/`
-- `quality/tests/host/`
+### E3-X-S5 — Storage metadata tree strategy
+B+tree or COW B-tree for filesystem layers.
 
-### Tasks
-1. Define storage metadata tree requirements.
-2. Separate kernel DS primitives from storage policy.
-3. Define extent-index requirements.
-4. Define crash-consistency expectations.
-5. Define small-device vs full-storage strategy.
-
-### Acceptance criteria
-- Roadmap does not put filesystem policy into kernel.
-- Shared DS primitives can live under `core/kernel/ds` only if policy-free.
-- Storage metadata policy belongs under `core/stacks/storage/metadata`.
-- Small-device and desktop/cloud profiles have different strategies.
-
-### Verification strategy
-- Metadata tree model tests.
-- Crash simulation plan.
-- Extent lookup benchmark plan.
-- Small-device memory budget analysis.
-
----
-
-## E3-X-S6 — Memory-safe kernel abstraction layer
-
-### Objective
-Reduce kernel memory-safety bugs by introducing safer abstractions for slices, spans, checked arithmetic, bounded copies, and typed ownership.
-
-**Recommended direction:**
-C-safe abstraction layer with optional future Rust exploration.
-Bharat-OS remains C-first for kernel baseline work. E3-X-S6 introduces memory-safe C abstractions such as checked arithmetic, span/slice types, bounded copies, ownership annotations, and static-analysis hooks. Rust may be evaluated later for selected isolated components, but this story is not a Rust rewrite.
-
-### Likely code areas
-- `core/kernel/include/ds/`
-- `core/kernel/include/verify/`
-- `core/kernel/src/ds/`
-- `core/kernel/src/verify/`
-- `core/kernel/include/lib/`
-- `quality/tests/host/`
-- `docs/dev/`
-
-### Tasks
-1. Define kernel span/slice type.
-2. Define checked arithmetic helpers.
-3. Define safe copy/move wrappers.
-4. Define ownership annotation macros.
-5. Define compiler-safety rules for freestanding kernel builds.
-6. Define static-analysis/lint hooks.
-
-### Acceptance criteria
-- Roadmap defines memory-safe abstractions without forcing broad migration.
-- Existing memops are not replaced in this story.
-- Checked arithmetic and span APIs are proposed as opt-in first.
-- Static-analysis path is documented.
-
-### Verification strategy
-- Unit tests for checked arithmetic overflow.
-- Unit tests for span bounds checks.
-- Compile-time tests for annotation macros where possible.
-- Future CI lint plan.
-
----
-
-## Implementation Status
-
-| Primitive | Header | Implementation | Tests | Integrated With | Status |
-|---|---|---|---|---|---|
-| RCU stub | `bh_rcu.h` | `bh_rcu_stub.c` | `test_bh_rcu_stub.c` | none | baseline |
-| Seqlock | `bh_seqlock.h` | `bh_seqlock.c` | `test_bh_seqlock.c` | none | baseline |
-| ID allocator | `bh_id_allocator.h` | `bh_id_allocator.c` | `test_bh_id_allocator.c` | capability slot/object ID path | partial |
-| Range tree/table | `bh_range_tree.h` | `bh_range_tree.c` | `test_bh_range_tree.c` | VM region lookup adapter | partial |
-| Ring buffer | `bh_ring.h` | `bh_ring.c` | `test_bh_ring.c` | core msgq | baseline |
-| Core MsgQ | `bh_core_msgq.h` | `bh_core_msgq.c` | none (uses ring tests) | future TLB/URPC | baseline |
+### E3-X-S6 — Memory-safe kernel abstraction layer
+Checked arithmetic, span/slice types, and ownership annotations for C.

--- a/quality/tests/core/ds/CMakeLists.txt
+++ b/quality/tests/core/ds/CMakeLists.txt
@@ -5,9 +5,13 @@ set(DS_TESTS
     test_bh_ring
     test_bh_seqlock
     test_bh_rcu_stub
+    test_bh_list
+    test_bh_bitmap
+    test_bh_handle_table
 )
 
 foreach(test_name IN LISTS DS_TESTS)
+    set(src "")
     if(test_name STREQUAL "test_bh_id_allocator")
         set(src bh_id_allocator.c)
     elseif(test_name STREQUAL "test_bh_range_tree")
@@ -18,12 +22,22 @@ foreach(test_name IN LISTS DS_TESTS)
         set(src bh_seqlock.c)
     elseif(test_name STREQUAL "test_bh_rcu_stub")
         set(src bh_rcu_stub.c)
+    elseif(test_name STREQUAL "test_bh_bitmap")
+        set(src bh_bitmap.c)
+    elseif(test_name STREQUAL "test_bh_handle_table")
+        set(src bh_handle_table.c)
     endif()
 
-    add_executable(${test_name} ${test_name}.c
-        ${CMAKE_SOURCE_DIR}/core/kernel/src/ds/${src}
-        ${CMAKE_SOURCE_DIR}/core/kernel/src/lib/base/status.c
-    )
+    if(src STREQUAL "")
+        add_executable(${test_name} ${test_name}.c
+            ${CMAKE_SOURCE_DIR}/core/kernel/src/lib/base/status.c
+        )
+    else()
+        add_executable(${test_name} ${test_name}.c
+            ${CMAKE_SOURCE_DIR}/core/kernel/src/ds/${src}
+            ${CMAKE_SOURCE_DIR}/core/kernel/src/lib/base/status.c
+        )
+    endif()
 
     target_include_directories(${test_name} PRIVATE
         ${CMAKE_SOURCE_DIR}/core/kernel/include

--- a/quality/tests/core/ds/test_bh_bitmap.c
+++ b/quality/tests/core/ds/test_bh_bitmap.c
@@ -1,0 +1,51 @@
+#include <bharat/kernel/ds/bh_bitmap.h>
+#include <assert.h>
+#include <stdio.h>
+#include <stdint.h>
+
+void test_bitmap_basic() {
+    uint8_t storage[2]; // 16 bits
+    bh_bitmap_t bitmap;
+    kstatus_t status = bh_bitmap_init(&bitmap, storage, 16);
+    assert(status == K_OK);
+
+    assert(!bh_bitmap_test(&bitmap, 0));
+    bh_bitmap_set(&bitmap, 0);
+    assert(bh_bitmap_test(&bitmap, 0));
+
+    bh_bitmap_set(&bitmap, 10);
+    assert(bh_bitmap_test(&bitmap, 10));
+    assert(!bh_bitmap_test(&bitmap, 11));
+
+    bh_bitmap_clear(&bitmap, 0);
+    assert(!bh_bitmap_test(&bitmap, 0));
+
+    size_t first_clear;
+    status = bh_bitmap_find_first_clear(&bitmap, &first_clear);
+    assert(status == K_OK);
+    assert(first_clear == 0);
+
+    size_t first_set;
+    status = bh_bitmap_find_first_set(&bitmap, &first_set);
+    assert(status == K_OK);
+    assert(first_set == 10);
+
+    bh_bitmap_set_range(&bitmap, 2, 4); // set 2, 3, 4, 5
+    assert(bh_bitmap_test(&bitmap, 2));
+    assert(bh_bitmap_test(&bitmap, 5));
+    assert(!bh_bitmap_test(&bitmap, 6));
+
+    bh_bitmap_clear_range(&bitmap, 10, 1);
+    assert(!bh_bitmap_test(&bitmap, 10));
+
+    // Test out of bounds
+    assert(bh_bitmap_set(&bitmap, 16) == K_ERR_INVALID_ARG);
+    assert(!bh_bitmap_test(&bitmap, 16));
+
+    printf("test_bitmap_basic passed\n");
+}
+
+int main() {
+    test_bitmap_basic();
+    return 0;
+}

--- a/quality/tests/core/ds/test_bh_handle_table.c
+++ b/quality/tests/core/ds/test_bh_handle_table.c
@@ -1,0 +1,50 @@
+#include <bharat/kernel/ds/bh_handle_table.h>
+#include <assert.h>
+#include <stdio.h>
+#include <stdint.h>
+
+void test_handle_table_basic() {
+    bh_handle_slot_t slots[8];
+    bh_handle_table_t table;
+    kstatus_t status = bh_handle_table_init(&table, slots, 8);
+    assert(status == K_OK);
+
+    int obj1 = 123;
+    bh_handle_t h1;
+    status = bh_handle_alloc(&table, &obj1, 1, 0xFULL, &h1);
+    assert(status == K_OK);
+    assert(bh_handle_validate(&table, h1));
+
+    void *lookup_obj = NULL;
+    uint64_t lookup_rights = 0;
+    status = bh_handle_lookup(&table, h1, 1, &lookup_obj, &lookup_rights);
+    assert(status == K_OK);
+    assert(*(int *)lookup_obj == 123);
+    assert(lookup_rights == 0xFULL);
+
+    // Type mismatch
+    status = bh_handle_lookup(&table, h1, 2, &lookup_obj, &lookup_rights);
+    assert(status == K_ERR_CAP_WRONG_TYPE);
+
+    // Revoke
+    status = bh_handle_revoke(&table, h1);
+    assert(status == K_OK);
+    assert(!bh_handle_validate(&table, h1));
+    assert(bh_handle_lookup(&table, h1, 1, &lookup_obj, NULL) == K_ERR_NOT_FOUND);
+
+    // Re-allocation should use same slot but different generation
+    bh_handle_t h2;
+    status = bh_handle_alloc(&table, &obj1, 1, 0xFULL, &h2);
+    assert(status == K_OK);
+    assert(bh_handle_index(h1) == bh_handle_index(h2));
+    assert(bh_handle_generation(h1) != bh_handle_generation(h2));
+    assert(!bh_handle_validate(&table, h1));
+    assert(bh_handle_validate(&table, h2));
+
+    printf("test_handle_table_basic passed\n");
+}
+
+int main() {
+    test_handle_table_basic();
+    return 0;
+}

--- a/quality/tests/core/ds/test_bh_list.c
+++ b/quality/tests/core/ds/test_bh_list.c
@@ -1,0 +1,52 @@
+#include <bharat/kernel/ds/bh_list.h>
+#include <assert.h>
+#include <stdio.h>
+
+typedef struct {
+    int value;
+    bh_list_node_t node;
+} test_item_t;
+
+void test_list_basic() {
+    BH_LIST_HEAD(head);
+    assert(bh_list_is_empty(&head));
+
+    test_item_t item1 = {.value = 1};
+    test_item_t item2 = {.value = 2};
+    test_item_t item3 = {.value = 3};
+
+    bh_list_push_back(&head, &item1.node);
+    assert(!bh_list_is_empty(&head));
+
+    bh_list_push_front(&head, &item2.node);
+    bh_list_push_back(&head, &item3.node);
+
+    // List should be: item2 (2), item1 (1), item3 (3)
+    bh_list_node_t *pos;
+    int expected[] = {2, 1, 3};
+    int i = 0;
+    bh_list_foreach(pos, &head) {
+        test_item_t *item = bh_list_entry(pos, test_item_t, node);
+        assert(item->value == expected[i++]);
+    }
+
+    bh_list_remove(&item1.node);
+    // List: item2 (2), item3 (3)
+    assert(bh_list_entry(head.next, test_item_t, node)->value == 2);
+    assert(bh_list_entry(head.prev, test_item_t, node)->value == 3);
+
+    bh_list_node_t *popped = bh_list_pop_front(&head);
+    assert(popped == &item2.node);
+    assert(bh_list_entry(head.next, test_item_t, node)->value == 3);
+
+    popped = bh_list_pop_back(&head);
+    assert(popped == &item3.node);
+    assert(bh_list_is_empty(&head));
+
+    printf("test_list_basic passed\n");
+}
+
+int main() {
+    test_list_basic();
+    return 0;
+}

--- a/quality/tests/core/ds/test_bh_ring.c
+++ b/quality/tests/core/ds/test_bh_ring.c
@@ -1,43 +1,55 @@
-#include <assert.h>
 #include <bharat/kernel/ds/bh_ring.h>
-#include <kernel/status.h>
+#include <assert.h>
+#include <stdio.h>
+#include <stdint.h>
 
 void test_ring_basic() {
+    uint32_t storage[4]; // capacity 4
     bh_ring_t ring;
-    uint32_t storage[4];
     bh_ring_init(&ring, storage, 4, sizeof(uint32_t));
 
     assert(bh_ring_is_empty(&ring));
+    assert(!bh_ring_is_full(&ring));
 
-    uint32_t val = 100;
-    assert(bh_ring_push(&ring, &val) == K_OK);
-    val = 200;
-    assert(bh_ring_push(&ring, &val) == K_OK);
-    val = 300;
-    assert(bh_ring_push(&ring, &val) == K_OK);
+    uint32_t val = 42;
+    kstatus_t status = bh_ring_push(&ring, &val);
+    assert(status == K_OK);
+    assert(!bh_ring_is_empty(&ring));
 
-    assert(bh_ring_is_full(&ring));
-    val = 400;
-    assert(bh_ring_push(&ring, &val) == K_ERR_IPC_QUEUE_FULL);
-
-    uint32_t out;
-    assert(bh_ring_pop(&ring, &out) == K_OK);
-    assert(out == 100);
-    assert(bh_ring_pop(&ring, &out) == K_OK);
-    assert(out == 200);
-
-    val = 500;
-    assert(bh_ring_push(&ring, &val) == K_OK);
-    assert(bh_ring_push(&ring, &val) == K_OK);
-    assert(bh_ring_is_full(&ring));
-
-    assert(bh_ring_pop(&ring, &out) == K_OK);
-    assert(out == 300);
-    assert(bh_ring_pop(&ring, &out) == K_OK);
-    assert(out == 500);
-    assert(bh_ring_pop(&ring, &out) == K_OK);
-    assert(out == 500);
+    uint32_t out_val = 0;
+    status = bh_ring_pop(&ring, &out_val);
+    assert(status == K_OK);
+    assert(out_val == 42);
     assert(bh_ring_is_empty(&ring));
+
+    // Fill the ring. Note: ring capacity is N-1 due to head/tail logic in some implementations.
+    // Let's check bh_ring.c logic again: ((ring->head + 1) % ring->capacity) == ring->tail
+    // So with capacity 4, it can hold 3 elements.
+    uint32_t i;
+    for (i = 1; i <= 3; i++) {
+        assert(bh_ring_push(&ring, &i) == K_OK);
+    }
+    assert(bh_ring_is_full(&ring));
+    assert(bh_ring_push(&ring, &i) == K_ERR_IPC_QUEUE_FULL);
+
+    // Pop and wraparound
+    assert(bh_ring_pop(&ring, &out_val) == K_OK);
+    assert(out_val == 1);
+    assert(!bh_ring_is_full(&ring));
+
+    uint32_t wrap_val = 100;
+    assert(bh_ring_push(&ring, &wrap_val) == K_OK);
+    assert(bh_ring_is_full(&ring));
+
+    assert(bh_ring_pop(&ring, &out_val) == K_OK);
+    assert(out_val == 2);
+    assert(bh_ring_pop(&ring, &out_val) == K_OK);
+    assert(out_val == 3);
+    assert(bh_ring_pop(&ring, &out_val) == K_OK);
+    assert(out_val == 100);
+    assert(bh_ring_is_empty(&ring));
+
+    printf("test_ring_basic passed\n");
 }
 
 int main() {


### PR DESCRIPTION
This PR establishes a clean algorithmic foundation for the Bharat-OS kernel. It includes:
1.  **Documentation Restructure**: `docs/architecture/kernel/kernel-algorithmic-foundations.md` now acts as a contract for algorithm placement and naming.
2.  **Canonical Primitives**: Implementation of three core data structures (`bh_list`, `bh_bitmap`, `bh_handle_table`) that follow the `bh_` internal naming convention and avoid heap allocation.
3.  **Host Testing**: Comprehensive unit tests for all new primitives, integrated into the host-side test build system.
4.  **Policy Alignment**: All implementations return `kstatus_t` and follow the mechanism-over-policy rule.


---
*PR created automatically by Jules for task [17982122171865358142](https://jules.google.com/task/17982122171865358142) started by @divyang4481*