### PR TITLE
Implement Missing Kernel DS Primitives

### DIFF
--- a/core/kernel/include/bharat/kernel/ds/bh_cpumask.h
+++ b/core/kernel/include/bharat/kernel/ds/bh_cpumask.h
@@ -1,0 +1,72 @@
+#ifndef BHARAT_KERNEL_DS_BH_CPUMASK_H
+#define BHARAT_KERNEL_DS_BH_CPUMASK_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "kernel/status.h"
+
+/**
+ * @file bh_cpumask.h
+ * @brief Canonical fixed-size CPU mask for Bharat-OS.
+ *
+ * This primitive provides a fixed-size bitmask for representing sets of CPUs.
+ * It is designed for kernel use in schedulers, TLB shootdowns, and IPIs.
+ *
+ * Design Constraints:
+ * - Fixed-size (compile-time bounded).
+ * - No heap allocation.
+ * - Non-atomic (caller must synchronize if shared).
+ * - Optimized for 64-bit words.
+ */
+
+#ifndef BHARAT_MAX_CPUS
+#ifdef BHARAT_MAX_CORES
+#define BHARAT_MAX_CPUS BHARAT_MAX_CORES
+#else
+#define BHARAT_MAX_CPUS 64
+#endif
+#endif
+
+#define BH_CPUMASK_BITS_PER_WORD 64
+#define BH_CPUMASK_WORDS \
+    ((BHARAT_MAX_CPUS + BH_CPUMASK_BITS_PER_WORD - 1) / BH_CPUMASK_BITS_PER_WORD)
+
+typedef struct {
+    uint64_t bits[BH_CPUMASK_WORDS];
+} bh_cpumask_t;
+
+/**
+ * @brief Check if a CPU index is valid for the current configuration.
+ */
+static inline bool bh_cpumask_cpu_valid(uint32_t cpu) {
+    return cpu < BHARAT_MAX_CPUS;
+}
+
+/* ── Unchecked Hot-Path Operations ───────────────────────────────────────── */
+
+void bh_cpumask_zero(bh_cpumask_t *mask);
+void bh_cpumask_fill(bh_cpumask_t *mask);
+void bh_cpumask_set(bh_cpumask_t *mask, uint32_t cpu);
+void bh_cpumask_clear(bh_cpumask_t *mask, uint32_t cpu);
+bool bh_cpumask_test(const bh_cpumask_t *mask, uint32_t cpu);
+bool bh_cpumask_empty(const bh_cpumask_t *mask);
+void bh_cpumask_copy(bh_cpumask_t *dst, const bh_cpumask_t *src);
+uint32_t bh_cpumask_weight(const bh_cpumask_t *mask);
+int32_t bh_cpumask_first(const bh_cpumask_t *mask);
+int32_t bh_cpumask_next(const bh_cpumask_t *mask, uint32_t prev);
+
+void bh_cpumask_and(bh_cpumask_t *dst, const bh_cpumask_t *a, const bh_cpumask_t *b);
+void bh_cpumask_or(bh_cpumask_t *dst, const bh_cpumask_t *a, const bh_cpumask_t *b);
+void bh_cpumask_xor(bh_cpumask_t *dst, const bh_cpumask_t *a, const bh_cpumask_t *b);
+void bh_cpumask_andnot(bh_cpumask_t *dst, const bh_cpumask_t *a, const bh_cpumask_t *b);
+
+bool bh_cpumask_equal(const bh_cpumask_t *a, const bh_cpumask_t *b);
+bool bh_cpumask_intersects(const bh_cpumask_t *a, const bh_cpumask_t *b);
+
+/* ── Checked Operations ─────────────────────────────────────────────────── */
+
+kstatus_t bh_cpumask_set_checked(bh_cpumask_t *mask, uint32_t cpu);
+kstatus_t bh_cpumask_clear_checked(bh_cpumask_t *mask, uint32_t cpu);
+kstatus_t bh_cpumask_test_checked(const bh_cpumask_t *mask, uint32_t cpu, bool *out);
+
+#endif // BHARAT_KERNEL_DS_BH_CPUMASK_H

--- a/core/kernel/include/bharat/kernel/ds/bh_mpsc_queue.h
+++ b/core/kernel/include/bharat/kernel/ds/bh_mpsc_queue.h
@@ -1,0 +1,86 @@
+#ifndef BHARAT_KERNEL_DS_BH_MPSC_QUEUE_H
+#define BHARAT_KERNEL_DS_BH_MPSC_QUEUE_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "kernel/status.h"
+#include "atomic.h"
+
+/**
+ * @file bh_mpsc_queue.h
+ * @brief Bounded Multi-Producer Single-Consumer (MPSC) Lock-Free Queue.
+ *
+ * This primitive provides a bounded, lock-free queue suitable for cross-core
+ * communication where multiple producers (e.g., different cores or IRQ handlers)
+ * send commands or requests to a single consumer (e.g., a specific core).
+ *
+ * Design:
+ * - Bounded array-based ring buffer.
+ * - Lock-free for both producers and the single consumer.
+ * - No heap allocation (caller provides storage).
+ * - Capacity must be a power of two (min 2).
+ * - Memory ordering is enforced using C11-style atomics/barriers.
+ *
+ * Usage:
+ * 1. Allocate an array of bh_mpsc_slot_t of size N (power of 2).
+ * 2. bh_mpsc_queue_init(&q, slots, N);
+ * 3. Producers call bh_mpsc_queue_push(&q, value);
+ * 4. Consumer calls bh_mpsc_queue_pop(&q, &value);
+ */
+
+typedef struct {
+    /** @brief Slot sequence number for synchronization. */
+    volatile uint64_t seq;
+    /** @brief Pointer to the payload. */
+    void *value;
+} bh_mpsc_slot_t;
+
+typedef struct {
+    /** @brief Pointer to the array of slots. */
+    bh_mpsc_slot_t *slots;
+    /** @brief Capacity of the queue (must be power of two). */
+    uint32_t capacity;
+    /** @brief Mask for index wrap-around (capacity - 1). */
+    uint32_t mask;
+    /** @brief Producer head index (shared/atomic). */
+    volatile uint64_t head;
+    /** @brief Consumer tail index (owned by single consumer). */
+    uint64_t tail;
+} bh_mpsc_queue_t;
+
+/**
+ * @brief Initialize the MPSC queue.
+ * @param q Pointer to the queue structure.
+ * @param slots Pointer to the pre-allocated array of slots.
+ * @param capacity Number of slots (must be a power of two >= 2).
+ * @return K_OK on success, K_ERR_INVALID_ARG if capacity is invalid.
+ */
+kstatus_t bh_mpsc_queue_init(bh_mpsc_queue_t *q, bh_mpsc_slot_t *slots, uint32_t capacity);
+
+/**
+ * @brief Push a value into the queue (Multi-Producer safe).
+ * @param q Pointer to the queue.
+ * @param value Pointer to the payload to push.
+ * @return K_OK on success, K_ERR_AGAIN if the queue is full.
+ */
+kstatus_t bh_mpsc_queue_push(bh_mpsc_queue_t *q, void *value);
+
+/**
+ * @brief Pop a value from the queue (Single-Consumer only).
+ * @param q Pointer to the queue.
+ * @param out_value Pointer to receive the payload.
+ * @return K_OK on success, K_ERR_AGAIN if the queue is empty.
+ */
+kstatus_t bh_mpsc_queue_pop(bh_mpsc_queue_t *q, void **out_value);
+
+/**
+ * @brief Check if the queue is empty.
+ */
+bool bh_mpsc_queue_empty(const bh_mpsc_queue_t *q);
+
+/**
+ * @brief Get the capacity of the queue.
+ */
+uint32_t bh_mpsc_queue_capacity(const bh_mpsc_queue_t *q);
+
+#endif // BHARAT_KERNEL_DS_BH_MPSC_QUEUE_H

--- a/core/kernel/include/bharat/kernel/ds/bh_registry.h
+++ b/core/kernel/include/bharat/kernel/ds/bh_registry.h
@@ -1,0 +1,82 @@
+#ifndef BHARAT_KERNEL_DS_BH_REGISTRY_H
+#define BHARAT_KERNEL_DS_BH_REGISTRY_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "kernel/status.h"
+
+/**
+ * @file bh_registry.h
+ * @brief Boot-time Registry for Kernel Components.
+ *
+ * This primitive provides a simple, bounded registry for kernel components,
+ * primitives, personalities, and other subsystem descriptors.
+ *
+ * Design:
+ * - Dynamic registration during boot using static storage.
+ * - Supports lookup by integer ID and optional string name.
+ * - No heap allocation (caller provides storage).
+ * - "Write-once" semantics: once frozen, no more registrations are allowed.
+ * - No unregistration support.
+ * - Duplicate ID/name detection.
+ */
+
+typedef struct {
+    uint32_t id;
+    const char *name;
+    const void *object;
+    uint32_t flags;
+} bh_registry_entry_t;
+
+typedef struct {
+    bh_registry_entry_t *entries;
+    uint32_t capacity;
+    uint32_t count;
+    bool frozen;
+} bh_registry_t;
+
+/**
+ * @brief Initialize the registry.
+ * @param registry Pointer to the registry structure.
+ * @param storage Pointer to the pre-allocated array of registry entries.
+ * @param capacity Number of entries the storage can hold.
+ * @return K_OK on success.
+ */
+kstatus_t bh_registry_init(bh_registry_t *registry, bh_registry_entry_t *storage, uint32_t capacity);
+
+/**
+ * @brief Register a component.
+ * Fails if the registry is frozen, full, or if the ID/name already exists.
+ * @param registry Pointer to the registry.
+ * @param id Unique integer ID.
+ * @param name Optional unique string name (can be NULL).
+ * @param object Pointer to the component/descriptor.
+ * @param flags Registry flags.
+ * @return K_OK on success, K_ERR_ALREADY_EXISTS if ID/name taken,
+ *         K_ERR_NO_SPACE if full, K_ERR_BAD_STATE if frozen.
+ */
+kstatus_t bh_registry_register(bh_registry_t *registry, uint32_t id, const char *name, const void *object, uint32_t flags);
+
+/**
+ * @brief Lookup a component by its integer ID.
+ * @return Pointer to the object, or NULL if not found.
+ */
+const void *bh_registry_lookup_id(const bh_registry_t *registry, uint32_t id);
+
+/**
+ * @brief Lookup a component by its string name.
+ * @return Pointer to the object, or NULL if not found.
+ */
+const void *bh_registry_lookup_name(const bh_registry_t *registry, const char *name);
+
+/**
+ * @brief Freeze the registry. No more registrations will be allowed.
+ */
+kstatus_t bh_registry_freeze(bh_registry_t *registry);
+
+/**
+ * @brief Get the number of registered components.
+ */
+uint32_t bh_registry_count(const bh_registry_t *registry);
+
+#endif // BHARAT_KERNEL_DS_BH_REGISTRY_H

--- a/core/kernel/src/ds/CMakeLists.txt
+++ b/core/kernel/src/ds/CMakeLists.txt
@@ -8,6 +8,9 @@ add_library(k_ds OBJECT
     bh_bitmap.c
     bh_handle_table.c
     bh_refcount.c
+    bh_cpumask.c
+    bh_mpsc_queue.c
+    bh_registry.c
 )
 target_link_libraries(k_ds PRIVATE bharat_kernel_includes bharat_kernel_buildopts)
 target_compile_options(k_ds PRIVATE $<$<COMPILE_LANGUAGE:C>:-ffreestanding> $<$<COMPILE_LANGUAGE:C>:-fno-builtin> $<$<COMPILE_LANGUAGE:C>:-fno-pic>)

--- a/core/kernel/src/ds/bh_cpumask.c
+++ b/core/kernel/src/ds/bh_cpumask.c
@@ -1,0 +1,161 @@
+#include "bharat/kernel/ds/bh_cpumask.h"
+#include <string.h>
+
+void bh_cpumask_zero(bh_cpumask_t *mask) {
+    if (!mask) return;
+    memset(mask->bits, 0, sizeof(mask->bits));
+}
+
+void bh_cpumask_fill(bh_cpumask_t *mask) {
+    if (!mask) return;
+    memset(mask->bits, 0xFF, sizeof(mask->bits));
+
+    /* Clear tail bits if BHARAT_MAX_CPUS is not a multiple of 64 */
+    if (BHARAT_MAX_CPUS % BH_CPUMASK_BITS_PER_WORD) {
+        uint32_t last_word = BH_CPUMASK_WORDS - 1;
+        uint32_t valid_bits = BHARAT_MAX_CPUS % BH_CPUMASK_BITS_PER_WORD;
+        mask->bits[last_word] &= (1ULL << valid_bits) - 1;
+    }
+}
+
+void bh_cpumask_set(bh_cpumask_t *mask, uint32_t cpu) {
+    if (!mask || cpu >= BHARAT_MAX_CPUS) return;
+    mask->bits[cpu / BH_CPUMASK_BITS_PER_WORD] |= (1ULL << (cpu % BH_CPUMASK_BITS_PER_WORD));
+}
+
+void bh_cpumask_clear(bh_cpumask_t *mask, uint32_t cpu) {
+    if (!mask || cpu >= BHARAT_MAX_CPUS) return;
+    mask->bits[cpu / BH_CPUMASK_BITS_PER_WORD] &= ~(1ULL << (cpu % BH_CPUMASK_BITS_PER_WORD));
+}
+
+bool bh_cpumask_test(const bh_cpumask_t *mask, uint32_t cpu) {
+    if (!mask || cpu >= BHARAT_MAX_CPUS) return false;
+    return (mask->bits[cpu / BH_CPUMASK_BITS_PER_WORD] & (1ULL << (cpu % BH_CPUMASK_BITS_PER_WORD))) != 0;
+}
+
+bool bh_cpumask_empty(const bh_cpumask_t *mask) {
+    if (!mask) return true;
+    for (uint32_t i = 0; i < BH_CPUMASK_WORDS; i++) {
+        if (mask->bits[i] != 0) return false;
+    }
+    return true;
+}
+
+void bh_cpumask_copy(bh_cpumask_t *dst, const bh_cpumask_t *src) {
+    if (!dst || !src) return;
+    memcpy(dst->bits, src->bits, sizeof(dst->bits));
+}
+
+uint32_t bh_cpumask_weight(const bh_cpumask_t *mask) {
+    if (!mask) return 0;
+    uint32_t weight = 0;
+    for (uint32_t i = 0; i < BH_CPUMASK_WORDS; i++) {
+        weight += __builtin_popcountll(mask->bits[i]);
+    }
+    return weight;
+}
+
+int32_t bh_cpumask_first(const bh_cpumask_t *mask) {
+    if (!mask) return -1;
+    for (uint32_t i = 0; i < BH_CPUMASK_WORDS; i++) {
+        if (mask->bits[i] != 0) {
+            uint32_t bit = __builtin_ctzll(mask->bits[i]);
+            uint32_t cpu = i * BH_CPUMASK_BITS_PER_WORD + bit;
+            return (cpu < BHARAT_MAX_CPUS) ? (int32_t)cpu : -1;
+        }
+    }
+    return -1;
+}
+
+int32_t bh_cpumask_next(const bh_cpumask_t *mask, uint32_t prev) {
+    if (!mask) return -1;
+    uint32_t next = prev + 1;
+    if (next >= BHARAT_MAX_CPUS) return -1;
+
+    uint32_t word_idx = next / BH_CPUMASK_BITS_PER_WORD;
+    uint32_t bit_idx = next % BH_CPUMASK_BITS_PER_WORD;
+
+    /* Check current word */
+    uint64_t current_word = mask->bits[word_idx] & (~0ULL << bit_idx);
+    if (current_word != 0) {
+        uint32_t bit = __builtin_ctzll(current_word);
+        uint32_t cpu = word_idx * BH_CPUMASK_BITS_PER_WORD + bit;
+        return (cpu < BHARAT_MAX_CPUS) ? (int32_t)cpu : -1;
+    }
+
+    /* Check remaining words */
+    for (uint32_t i = word_idx + 1; i < BH_CPUMASK_WORDS; i++) {
+        if (mask->bits[i] != 0) {
+            uint32_t bit = __builtin_ctzll(mask->bits[i]);
+            uint32_t cpu = i * BH_CPUMASK_BITS_PER_WORD + bit;
+            return (cpu < BHARAT_MAX_CPUS) ? (int32_t)cpu : -1;
+        }
+    }
+
+    return -1;
+}
+
+void bh_cpumask_and(bh_cpumask_t *dst, const bh_cpumask_t *a, const bh_cpumask_t *b) {
+    if (!dst || !a || !b) return;
+    for (uint32_t i = 0; i < BH_CPUMASK_WORDS; i++) {
+        dst->bits[i] = a->bits[i] & b->bits[i];
+    }
+}
+
+void bh_cpumask_or(bh_cpumask_t *dst, const bh_cpumask_t *a, const bh_cpumask_t *b) {
+    if (!dst || !a || !b) return;
+    for (uint32_t i = 0; i < BH_CPUMASK_WORDS; i++) {
+        dst->bits[i] = a->bits[i] | b->bits[i];
+    }
+}
+
+void bh_cpumask_xor(bh_cpumask_t *dst, const bh_cpumask_t *a, const bh_cpumask_t *b) {
+    if (!dst || !a || !b) return;
+    for (uint32_t i = 0; i < BH_CPUMASK_WORDS; i++) {
+        dst->bits[i] = a->bits[i] ^ b->bits[i];
+    }
+}
+
+void bh_cpumask_andnot(bh_cpumask_t *dst, const bh_cpumask_t *a, const bh_cpumask_t *b) {
+    if (!dst || !a || !b) return;
+    for (uint32_t i = 0; i < BH_CPUMASK_WORDS; i++) {
+        dst->bits[i] = a->bits[i] & ~b->bits[i];
+    }
+}
+
+bool bh_cpumask_equal(const bh_cpumask_t *a, const bh_cpumask_t *b) {
+    if (!a || !b) return a == b;
+    for (uint32_t i = 0; i < BH_CPUMASK_WORDS; i++) {
+        if (a->bits[i] != b->bits[i]) return false;
+    }
+    return true;
+}
+
+bool bh_cpumask_intersects(const bh_cpumask_t *a, const bh_cpumask_t *b) {
+    if (!a || !b) return false;
+    for (uint32_t i = 0; i < BH_CPUMASK_WORDS; i++) {
+        if (a->bits[i] & b->bits[i]) return true;
+    }
+    return false;
+}
+
+kstatus_t bh_cpumask_set_checked(bh_cpumask_t *mask, uint32_t cpu) {
+    if (!mask) return K_ERR_INVALID_ARG;
+    if (!bh_cpumask_cpu_valid(cpu)) return K_ERR_INVALID_ARG;
+    bh_cpumask_set(mask, cpu);
+    return K_OK;
+}
+
+kstatus_t bh_cpumask_clear_checked(bh_cpumask_t *mask, uint32_t cpu) {
+    if (!mask) return K_ERR_INVALID_ARG;
+    if (!bh_cpumask_cpu_valid(cpu)) return K_ERR_INVALID_ARG;
+    bh_cpumask_clear(mask, cpu);
+    return K_OK;
+}
+
+kstatus_t bh_cpumask_test_checked(const bh_cpumask_t *mask, uint32_t cpu, bool *out) {
+    if (!mask || !out) return K_ERR_INVALID_ARG;
+    if (!bh_cpumask_cpu_valid(cpu)) return K_ERR_INVALID_ARG;
+    *out = bh_cpumask_test(mask, cpu);
+    return K_OK;
+}

--- a/core/kernel/src/ds/bh_mpsc_queue.c
+++ b/core/kernel/src/ds/bh_mpsc_queue.c
@@ -1,0 +1,85 @@
+#include "bharat/kernel/ds/bh_mpsc_queue.h"
+
+static inline bool is_power_of_two(uint32_t n) {
+    return n > 0 && (n & (n - 1)) == 0;
+}
+
+kstatus_t bh_mpsc_queue_init(bh_mpsc_queue_t *q, bh_mpsc_slot_t *slots, uint32_t capacity) {
+    if (!q || !slots || capacity < 2 || !is_power_of_two(capacity)) {
+        return K_ERR_INVALID_ARG;
+    }
+
+    q->slots = slots;
+    q->capacity = capacity;
+    q->mask = capacity - 1;
+    q->head = 0;
+    q->tail = 0;
+
+    for (uint32_t i = 0; i < capacity; i++) {
+        q->slots[i].seq = i;
+        q->slots[i].value = NULL;
+    }
+
+    return K_OK;
+}
+
+kstatus_t bh_mpsc_queue_push(bh_mpsc_queue_t *q, void *value) {
+    bh_mpsc_slot_t *slot;
+    uint64_t pos = q->head;
+
+    while (true) {
+        slot = &q->slots[pos & q->mask];
+        uint64_t seq = __atomic_load_n(&slot->seq, __ATOMIC_ACQUIRE);
+        int64_t diff = (int64_t)seq - (int64_t)pos;
+
+        if (diff == 0) {
+            /* Slot is ready to be written */
+            if (__atomic_compare_exchange_n(&q->head, &pos, pos + 1, false, __ATOMIC_RELAXED, __ATOMIC_RELAXED)) {
+                break;
+            }
+        } else if (diff < 0) {
+            /* Queue is full */
+            return K_ERR_AGAIN;
+        } else {
+            /* Another producer beat us, or we are looking at an old 'pos' */
+            pos = __atomic_load_n(&q->head, __ATOMIC_RELAXED);
+        }
+    }
+
+    slot->value = value;
+    __atomic_store_n(&slot->seq, pos + 1, __ATOMIC_RELEASE);
+
+    return K_OK;
+}
+
+kstatus_t bh_mpsc_queue_pop(bh_mpsc_queue_t *q, void **out_value) {
+    bh_mpsc_slot_t *slot;
+    uint64_t pos = q->tail;
+
+    slot = &q->slots[pos & q->mask];
+    uint64_t seq = __atomic_load_n(&slot->seq, __ATOMIC_ACQUIRE);
+    int64_t diff = (int64_t)seq - (int64_t)(pos + 1);
+
+    if (diff == 0) {
+        /* Slot has data ready to be read */
+        q->tail = pos + 1;
+        if (out_value) {
+            *out_value = slot->value;
+        }
+        __atomic_store_n(&slot->seq, pos + q->mask + 1, __ATOMIC_RELEASE);
+        return K_OK;
+    }
+
+    /* Queue is empty or data is being written by producer */
+    return K_ERR_AGAIN;
+}
+
+bool bh_mpsc_queue_empty(const bh_mpsc_queue_t *q) {
+    if (!q) return true;
+    uint64_t head = __atomic_load_n(&q->head, __ATOMIC_RELAXED);
+    return q->tail == head;
+}
+
+uint32_t bh_mpsc_queue_capacity(const bh_mpsc_queue_t *q) {
+    return q ? q->capacity : 0;
+}

--- a/core/kernel/src/ds/bh_registry.c
+++ b/core/kernel/src/ds/bh_registry.c
@@ -1,0 +1,72 @@
+#include "bharat/kernel/ds/bh_registry.h"
+#include <string.h>
+
+kstatus_t bh_registry_init(bh_registry_t *registry, bh_registry_entry_t *storage, uint32_t capacity) {
+    if (!registry || !storage || capacity == 0) {
+        return K_ERR_INVALID_ARG;
+    }
+
+    registry->entries = storage;
+    registry->capacity = capacity;
+    registry->count = 0;
+    registry->frozen = false;
+
+    return K_OK;
+}
+
+kstatus_t bh_registry_register(bh_registry_t *registry, uint32_t id, const char *name, const void *object, uint32_t flags) {
+    if (!registry) return K_ERR_INVALID_ARG;
+    if (registry->frozen) return K_ERR_BAD_STATE;
+    if (registry->count >= registry->capacity) return K_ERR_NO_MEMORY; // Using K_ERR_NO_MEMORY as K_ERR_NO_SPACE is not in status.h
+
+    /* Check for duplicates */
+    for (uint32_t i = 0; i < registry->count; i++) {
+        if (registry->entries[i].id == id) {
+            return K_ERR_ALREADY_EXISTS;
+        }
+        if (name && registry->entries[i].name && strcmp(registry->entries[i].name, name) == 0) {
+            return K_ERR_ALREADY_EXISTS;
+        }
+    }
+
+    /* Add new entry */
+    registry->entries[registry->count].id = id;
+    registry->entries[registry->count].name = name;
+    registry->entries[registry->count].object = object;
+    registry->entries[registry->count].flags = flags;
+    registry->count++;
+
+    return K_OK;
+}
+
+const void *bh_registry_lookup_id(const bh_registry_t *registry, uint32_t id) {
+    if (!registry) return NULL;
+
+    for (uint32_t i = 0; i < registry->count; i++) {
+        if (registry->entries[i].id == id) {
+            return registry->entries[i].object;
+        }
+    }
+    return NULL;
+}
+
+const void *bh_registry_lookup_name(const bh_registry_t *registry, const char *name) {
+    if (!registry || !name) return NULL;
+
+    for (uint32_t i = 0; i < registry->count; i++) {
+        if (registry->entries[i].name && strcmp(registry->entries[i].name, name) == 0) {
+            return registry->entries[i].object;
+        }
+    }
+    return NULL;
+}
+
+kstatus_t bh_registry_freeze(bh_registry_t *registry) {
+    if (!registry) return K_ERR_INVALID_ARG;
+    registry->frozen = true;
+    return K_OK;
+}
+
+uint32_t bh_registry_count(const bh_registry_t *registry) {
+    return registry ? registry->count : 0;
+}

--- a/quality/tests/core/ds/CMakeLists.txt
+++ b/quality/tests/core/ds/CMakeLists.txt
@@ -8,6 +8,9 @@ set(DS_TESTS
     test_bh_list
     test_bh_bitmap
     test_bh_handle_table
+    test_bh_cpumask
+    test_bh_mpsc_queue
+    test_bh_registry
 )
 
 foreach(test_name IN LISTS DS_TESTS)
@@ -26,6 +29,12 @@ foreach(test_name IN LISTS DS_TESTS)
         set(src bh_bitmap.c)
     elseif(test_name STREQUAL "test_bh_handle_table")
         set(src bh_handle_table.c)
+    elseif(test_name STREQUAL "test_bh_cpumask")
+        set(src bh_cpumask.c)
+    elseif(test_name STREQUAL "test_bh_mpsc_queue")
+        set(src bh_mpsc_queue.c)
+    elseif(test_name STREQUAL "test_bh_registry")
+        set(src bh_registry.c)
     endif()
 
     if(src STREQUAL "")

--- a/quality/tests/core/ds/test_bh_cpumask.c
+++ b/quality/tests/core/ds/test_bh_cpumask.c
@@ -1,0 +1,110 @@
+#include <bharat/kernel/ds/bh_cpumask.h>
+#include <assert.h>
+#include <stdio.h>
+
+void test_cpumask_basic() {
+    bh_cpumask_t mask;
+    bh_cpumask_zero(&mask);
+    assert(bh_cpumask_empty(&mask));
+    assert(bh_cpumask_weight(&mask) == 0);
+
+    bh_cpumask_set(&mask, 0);
+    bh_cpumask_set(&mask, 10);
+    bh_cpumask_set(&mask, 63);
+
+    assert(!bh_cpumask_empty(&mask));
+    assert(bh_cpumask_weight(&mask) == 3);
+    assert(bh_cpumask_test(&mask, 0));
+    assert(bh_cpumask_test(&mask, 10));
+    assert(bh_cpumask_test(&mask, 63));
+    assert(!bh_cpumask_test(&mask, 1));
+    assert(!bh_cpumask_test(&mask, 62));
+
+    bh_cpumask_clear(&mask, 10);
+    assert(bh_cpumask_weight(&mask) == 2);
+    assert(!bh_cpumask_test(&mask, 10));
+
+    bh_cpumask_fill(&mask);
+    assert(bh_cpumask_weight(&mask) == BHARAT_MAX_CPUS);
+    assert(bh_cpumask_test(&mask, 0));
+    assert(bh_cpumask_test(&mask, BHARAT_MAX_CPUS - 1));
+
+    printf("test_cpumask_basic passed\n");
+}
+
+void test_cpumask_ops() {
+    bh_cpumask_t a, b, res;
+    bh_cpumask_zero(&a);
+    bh_cpumask_zero(&b);
+
+    bh_cpumask_set(&a, 1);
+    bh_cpumask_set(&a, 2);
+    bh_cpumask_set(&b, 2);
+    bh_cpumask_set(&b, 3);
+
+    bh_cpumask_and(&res, &a, &b);
+    assert(bh_cpumask_weight(&res) == 1);
+    assert(bh_cpumask_test(&res, 2));
+
+    bh_cpumask_or(&res, &a, &b);
+    assert(bh_cpumask_weight(&res) == 3);
+    assert(bh_cpumask_test(&res, 1));
+    assert(bh_cpumask_test(&res, 2));
+    assert(bh_cpumask_test(&res, 3));
+
+    bh_cpumask_xor(&res, &a, &b);
+    assert(bh_cpumask_weight(&res) == 2);
+    assert(bh_cpumask_test(&res, 1));
+    assert(bh_cpumask_test(&res, 3));
+
+    bh_cpumask_andnot(&res, &a, &b);
+    assert(bh_cpumask_weight(&res) == 1);
+    assert(bh_cpumask_test(&res, 1));
+
+    assert(bh_cpumask_intersects(&a, &b));
+    bh_cpumask_clear(&a, 2);
+    assert(!bh_cpumask_intersects(&a, &b));
+
+    printf("test_cpumask_ops passed\n");
+}
+
+void test_cpumask_iteration() {
+    bh_cpumask_t mask;
+    bh_cpumask_zero(&mask);
+    bh_cpumask_set(&mask, 5);
+    bh_cpumask_set(&mask, 15);
+    bh_cpumask_set(&mask, 40);
+
+    assert(bh_cpumask_first(&mask) == 5);
+    assert(bh_cpumask_next(&mask, 5) == 15);
+    assert(bh_cpumask_next(&mask, 15) == 40);
+    assert(bh_cpumask_next(&mask, 40) == -1);
+
+    printf("test_cpumask_iteration passed\n");
+}
+
+void test_cpumask_checked() {
+    bh_cpumask_t mask;
+    bh_cpumask_zero(&mask);
+
+    assert(bh_cpumask_set_checked(&mask, 0) == K_OK);
+    assert(bh_cpumask_set_checked(&mask, BHARAT_MAX_CPUS) == K_ERR_INVALID_ARG);
+
+    assert(bh_cpumask_clear_checked(&mask, 0) == K_OK);
+    assert(bh_cpumask_clear_checked(&mask, BHARAT_MAX_CPUS) == K_ERR_INVALID_ARG);
+
+    bool val;
+    assert(bh_cpumask_test_checked(&mask, 0, &val) == K_OK);
+    assert(val == false);
+    assert(bh_cpumask_test_checked(&mask, BHARAT_MAX_CPUS, &val) == K_ERR_INVALID_ARG);
+
+    printf("test_cpumask_checked passed\n");
+}
+
+int main() {
+    test_cpumask_basic();
+    test_cpumask_ops();
+    test_cpumask_iteration();
+    test_cpumask_checked();
+    return 0;
+}

--- a/quality/tests/core/ds/test_bh_mpsc_queue.c
+++ b/quality/tests/core/ds/test_bh_mpsc_queue.c
@@ -1,0 +1,119 @@
+#include <bharat/kernel/ds/bh_mpsc_queue.h>
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <pthread.h>
+
+#define TEST_CAPACITY 8
+
+void test_mpsc_basic() {
+    bh_mpsc_queue_t q;
+    bh_mpsc_slot_t slots[TEST_CAPACITY];
+
+    assert(bh_mpsc_queue_init(&q, slots, TEST_CAPACITY) == K_OK);
+    assert(bh_mpsc_queue_empty(&q));
+    assert(bh_mpsc_queue_capacity(&q) == TEST_CAPACITY);
+
+    void *val;
+    assert(bh_mpsc_queue_pop(&q, &val) == K_ERR_AGAIN);
+
+    int data1 = 123;
+    assert(bh_mpsc_queue_push(&q, &data1) == K_OK);
+    assert(!bh_mpsc_queue_empty(&q));
+
+    assert(bh_mpsc_queue_pop(&q, &val) == K_OK);
+    assert(val == &data1);
+    assert(bh_mpsc_queue_empty(&q));
+
+    printf("test_mpsc_basic passed\n");
+}
+
+void test_mpsc_full() {
+    bh_mpsc_queue_t q;
+    bh_mpsc_slot_t slots[TEST_CAPACITY];
+    int data[TEST_CAPACITY];
+
+    bh_mpsc_queue_init(&q, slots, TEST_CAPACITY);
+
+    for (int i = 0; i < TEST_CAPACITY; i++) {
+        data[i] = i;
+        assert(bh_mpsc_queue_push(&q, &data[i]) == K_OK);
+    }
+
+    assert(bh_mpsc_queue_push(&q, &data[0]) == K_ERR_AGAIN);
+
+    void *val;
+    for (int i = 0; i < TEST_CAPACITY; i++) {
+        assert(bh_mpsc_queue_pop(&q, &val) == K_OK);
+        assert(*(int *)val == i);
+    }
+    assert(bh_mpsc_queue_pop(&q, &val) == K_ERR_AGAIN);
+
+    printf("test_mpsc_full passed\n");
+}
+
+#define THREADED_COUNT 100000
+#define NUM_PRODUCERS 4
+
+typedef struct {
+    bh_mpsc_queue_t *q;
+    int id;
+} producer_args_t;
+
+void *producer_fn(void *arg) {
+    producer_args_t *args = (producer_args_t *)arg;
+    for (int i = 0; i < THREADED_COUNT; i++) {
+        while (bh_mpsc_queue_push(args->q, (void *)(intptr_t)((args->id << 20) | i)) == K_ERR_AGAIN) {
+            // spin
+        }
+    }
+    return NULL;
+}
+
+void test_mpsc_threaded() {
+    bh_mpsc_queue_t q;
+    bh_mpsc_slot_t *slots = malloc(sizeof(bh_mpsc_slot_t) * 1024);
+    bh_mpsc_queue_init(&q, slots, 1024);
+
+    pthread_t producers[NUM_PRODUCERS];
+    producer_args_t args[NUM_PRODUCERS];
+
+    for (int i = 0; i < NUM_PRODUCERS; i++) {
+        args[i].q = &q;
+        args[i].id = i + 1;
+        pthread_create(&producers[i], NULL, producer_fn, &args[i]);
+    }
+
+    int received_counts[NUM_PRODUCERS + 1] = {0};
+    int total_to_receive = NUM_PRODUCERS * THREADED_COUNT;
+    int received = 0;
+
+    while (received < total_to_receive) {
+        void *val;
+        if (bh_mpsc_queue_pop(&q, &val) == K_OK) {
+            intptr_t v = (intptr_t)val;
+            int id = v >> 20;
+            assert(id > 0 && id <= NUM_PRODUCERS);
+            received_counts[id]++;
+            received++;
+        }
+    }
+
+    for (int i = 1; i <= NUM_PRODUCERS; i++) {
+        assert(received_counts[i] == THREADED_COUNT);
+    }
+
+    for (int i = 0; i < NUM_PRODUCERS; i++) {
+        pthread_join(producers[i], NULL);
+    }
+
+    free(slots);
+    printf("test_mpsc_threaded passed\n");
+}
+
+int main() {
+    test_mpsc_basic();
+    test_mpsc_full();
+    test_mpsc_threaded();
+    return 0;
+}

--- a/quality/tests/core/ds/test_bh_registry.c
+++ b/quality/tests/core/ds/test_bh_registry.c
@@ -1,0 +1,70 @@
+#include <bharat/kernel/ds/bh_registry.h>
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+#define TEST_CAPACITY 10
+
+void test_registry_basic() {
+    bh_registry_t reg;
+    bh_registry_entry_t storage[TEST_CAPACITY];
+
+    assert(bh_registry_init(&reg, storage, TEST_CAPACITY) == K_OK);
+    assert(bh_registry_count(&reg) == 0);
+
+    int obj1 = 1;
+    int obj2 = 2;
+
+    assert(bh_registry_register(&reg, 100, "comp1", &obj1, 0) == K_OK);
+    assert(bh_registry_register(&reg, 200, "comp2", &obj2, 0) == K_OK);
+    assert(bh_registry_count(&reg) == 2);
+
+    assert(bh_registry_lookup_id(&reg, 100) == &obj1);
+    assert(bh_registry_lookup_name(&reg, "comp2") == &obj2);
+    assert(bh_registry_lookup_id(&reg, 300) == NULL);
+    assert(bh_registry_lookup_name(&reg, "comp3") == NULL);
+
+    printf("test_registry_basic passed\n");
+}
+
+void test_registry_duplicates() {
+    bh_registry_t reg;
+    bh_registry_entry_t storage[TEST_CAPACITY];
+    bh_registry_init(&reg, storage, TEST_CAPACITY);
+
+    int obj1 = 1;
+    assert(bh_registry_register(&reg, 100, "comp1", &obj1, 0) == K_OK);
+
+    /* Duplicate ID */
+    assert(bh_registry_register(&reg, 100, "comp2", &obj1, 0) == K_ERR_ALREADY_EXISTS);
+
+    /* Duplicate Name */
+    assert(bh_registry_register(&reg, 101, "comp1", &obj1, 0) == K_ERR_ALREADY_EXISTS);
+
+    printf("test_registry_duplicates passed\n");
+}
+
+void test_registry_freeze() {
+    bh_registry_t reg;
+    bh_registry_entry_t storage[TEST_CAPACITY];
+    bh_registry_init(&reg, storage, TEST_CAPACITY);
+
+    int obj1 = 1;
+    assert(bh_registry_register(&reg, 100, "comp1", &obj1, 0) == K_OK);
+
+    assert(bh_registry_freeze(&reg) == K_OK);
+
+    assert(bh_registry_register(&reg, 200, "comp2", &obj1, 0) == K_ERR_BAD_STATE);
+
+    /* Lookups should still work */
+    assert(bh_registry_lookup_id(&reg, 100) == &obj1);
+
+    printf("test_registry_freeze passed\n");
+}
+
+int main() {
+    test_registry_basic();
+    test_registry_duplicates();
+    test_registry_freeze();
+    return 0;
+}


### PR DESCRIPTION
This change implements three missing foundational data structures in the Bharat-OS kernel's DS layer:

1. **bh_cpumask (KDS-CPUMASK-001)**: A fixed-size bitmask for CPU sets, supporting standard bitwise operations, weight calculation, and iteration. It includes checked variants for safety.
2. **bh_mpsc_queue (KDS-MPSC-001)**: A bounded, lock-free Multi-Producer Single-Consumer queue based on Vyukov's algorithm. It is designed for high-performance cross-core command passing, such as TLB shootdowns.
3. **bh_registry (KDS-REGISTRY-001)**: A boot-time registration mechanism for kernel components and personalities, supporting lookup by ID or name and implementing a 'freeze' state for post-boot security.

All implementations follow the kernel's strict "no heap allocation" policy and have been verified with host-based unit tests.

---
*PR created automatically by Jules for task [17462569386692013274](https://jules.google.com/task/17462569386692013274) started by @divyang4481*