### PR TITLE
Implement Architecture Maturity Gate

### DIFF
--- a/delivery/targets/arch_maturity.yaml
+++ b/delivery/targets/arch_maturity.yaml
@@ -1,0 +1,44 @@
+x86_64:
+  tier: full
+  boot: baseline
+  trap: baseline
+  syscall: baseline
+  mmu: baseline
+  smp: baseline
+  production_candidate: true
+
+arm64:
+  tier: full
+  boot: baseline
+  trap: baseline
+  syscall: baseline
+  mmu: baseline
+  smp: partial
+  production_candidate: true
+
+riscv64:
+  tier: full
+  boot: baseline
+  trap: baseline
+  syscall: partial
+  mmu: baseline
+  smp: partial
+  production_candidate: true
+
+arm32:
+  tier: edge32
+  boot: partial
+  trap: stub
+  syscall: unsupported
+  mmu: scaffold
+  smp: unsupported
+  production_candidate: false
+
+riscv32:
+  tier: edge32
+  boot: partial
+  trap: stub
+  syscall: unsupported
+  mmu: scaffold
+  smp: unsupported
+  production_candidate: false

--- a/docs/architecture/arm32-rv32-edge-tier-plan.md
+++ b/docs/architecture/arm32-rv32-edge-tier-plan.md
@@ -17,8 +17,8 @@ This document defines how Bharat-OS should add 32-bit architecture support witho
 
 Bharat-OS will support five CPU families in two runtime tiers:
 
-- **Tier 1 (Full Baseline):** `x86_64`, `arm64`, `riscv64`
-- **Tier 2 (EDGE32 Compact Ports):** `arm32`, `riscv32`
+- **Tier 1 (Full Baseline / `full`):** `x86_64`, `arm64`, `riscv64`
+- **Tier 2 (EDGE32 Compact Ports / `edge32`):** `arm32`, `riscv32`
 
 Tier 2 is first-class in product scope, but starts with a smaller mandatory feature envelope to avoid premature parity churn.
 

--- a/docs/dev/current-code-status.md
+++ b/docs/dev/current-code-status.md
@@ -176,7 +176,16 @@ Current limitations:
 3. **Runtime wiring gap**: multiple daemons initialize state but do not yet run complete production event loops.
 4. **Hardening gap**: observability, failure semantics, and profile-specific guarantees need deeper closure.
 
-## 5.1) Security production gate (explicit blocker)
+## 5.1) Architecture maturity gate
+
+To maintain transparency and prevent status inflation, architecture production claims are gated by `delivery/targets/arch_maturity.yaml`.
+
+- **Tier 1 (x86_64, arm64, riscv64)** are full production candidates only after required maturity checks (boot, trap, syscall, MMU, SMP) pass.
+- **Tier 2 (arm32, riscv32)** are EDGE32 targets and must not be marked as production candidates while core components (trap, syscall, MMU) remain as `stub`, `unsupported`, or `scaffold`.
+- **Production Candidate vs. Production Certified**: A "production candidate" status (e.g., for `riscv64`) indicates the architecture is eligible for deeper validation. It does not equate to production certification.
+- The gate is conservative and serves as a baseline check; it does not replace functional verification through QEMU or hardware tests.
+
+## 5.2) Security production gate (explicit blocker)
 
 To avoid status inflation, this repository treats capability enforcement maturity as a hard release gate:
 
@@ -185,7 +194,7 @@ To avoid status inflation, this repository treats capability enforcement maturit
 - Fail-closed behavior (like the current `netmgr` shim through `bharat_cap_validate()`) is required as an interim baseline, but does not by itself qualify as full production security.
 - Promotion to **Production** requires strict, code-backed capability checks across manager and dispatch paths, plus validation evidence.
 
-## 5.2) Core Kernel Ownership
+## 5.3) Core Kernel Ownership
 
 Status: **Partial / Phase K0 in progress**
 

--- a/tools/check_arch_maturity.py
+++ b/tools/check_arch_maturity.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""
+Architecture Maturity Gate Checker for Bharat-OS.
+
+Validates delivery/targets/arch_maturity.yaml to ensure that architectures
+marked as production candidates meet the minimum required maturity levels.
+"""
+
+import sys
+import argparse
+import os
+
+# Add common locations for PyYAML if not in path
+sys.path.append('/usr/lib/python3/dist-packages')
+
+# TODO: Cross-check delivery/targets/target_matrix.json once target metadata is stable.
+
+REQUIRED_ARCHES = ["x86_64", "arm64", "riscv64", "arm32", "riscv32"]
+REQUIRED_FIELDS = ["boot", "trap", "syscall", "mmu", "smp"]
+METADATA_FIELDS = ["tier", "notes", "production_candidate"]
+FORBIDDEN_FOR_PRODUCTION = ["stub", "unsupported", "scaffold"]
+
+def load_yaml(filepath):
+    try:
+        import yaml
+        with open(filepath, 'r') as f:
+            return yaml.safe_load(f)
+    except ImportError:
+        # Fallback for environments without PyYAML (very basic parser)
+        # This is a fallback to ensure the script works in minimal environments.
+        # It handles simple key-value YAML used in arch_maturity.yaml.
+        data = {}
+        current_arch = None
+        with open(filepath, 'r') as f:
+            for line in f:
+                stripped = line.strip()
+                if not stripped or stripped.startswith('#'):
+                    continue
+                if not line.startswith(' '):
+                    # Architecture name
+                    current_arch = stripped.split(':')[0].strip()
+                    data[current_arch] = {}
+                elif current_arch:
+                    # Field (indented)
+                    if ':' not in stripped:
+                        continue
+                    key, value = stripped.split(':', 1)
+                    key = key.strip()
+                    value = value.strip()
+                    if value.lower() == 'true':
+                        value = True
+                    elif value.lower() == 'false':
+                        value = False
+                    data[current_arch][key] = value
+        return data
+
+def main():
+    parser = argparse.ArgumentParser(description="Check architecture maturity levels.")
+    parser.add_argument("yaml_file", help="Path to arch_maturity.yaml")
+    args = parser.parse_args()
+
+    if not os.path.exists(args.yaml_file):
+        print(f"Error: {args.yaml_file} not found.")
+        return 1
+
+    data = load_yaml(args.yaml_file)
+    if not data:
+        print(f"Error: Failed to load or empty YAML: {args.yaml_file}")
+        return 1
+
+    errors = 0
+    warnings = 0
+
+    # 1. Check for required architectures
+    for arch in REQUIRED_ARCHES:
+        if arch not in data:
+            print(f"ERROR: Missing required architecture: {arch}")
+            errors += 1
+
+    for arch, fields in data.items():
+        if arch not in REQUIRED_ARCHES:
+            # We only strictly care about our defined architectures for now,
+            # but we can validate others if they are present.
+            pass
+
+        is_prod_candidate = fields.get("production_candidate", False)
+
+        # 2. Check for minimum required fields presence
+        for field in REQUIRED_FIELDS:
+            if field not in fields:
+                print(f"ERROR: {arch} is missing required field: {field}")
+                errors += 1
+
+        # 3. Generic maturity field check
+        for field, value in fields.items():
+            if field in METADATA_FIELDS:
+                continue
+
+            # 3a. Forbidden values check for production candidates
+            if is_prod_candidate and value in FORBIDDEN_FOR_PRODUCTION:
+                print(f"ERROR: {arch}.{field} is '{value}', but production_candidate=true.")
+                errors += 1
+
+            # 3b. Warning for 'partial' in production candidates
+            if is_prod_candidate and value == "partial":
+                print(f"WARNING: {arch}.{field} is partial; production_candidate=true means candidate only, not production-certified.")
+                warnings += 1
+
+    if errors > 0:
+        print(f"\nFAILED: {errors} error(s), {warnings} warning(s).")
+        return 1
+
+    print(f"\nPASSED: {warnings} warning(s).")
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
This change implements a truthful architecture maturity gate for Bharat-OS to prevent stubbed targets (especially arm32 and riscv32) from being incorrectly marked as production-ready. 

Key changes:
- Created delivery/targets/arch_maturity.yaml to track maturity levels (boot, trap, syscall, mmu, smp) for x86_64, arm64, riscv64, arm32, and riscv32.
- Added tools/check_arch_maturity.py, a standalone validation script that enforces maturity rules for production candidates.
- Updated docs/dev/current-code-status.md to explain the architecture maturity gate and distinguish between production candidates and production-certified targets.
- Updated docs/architecture/arm32-rv32-edge-tier-plan.md to map Tier 1/2 to full/edge32.

The checker script includes a fallback YAML parser to ensure it runs in minimal environments without PyYAML. It correctly fails if a production candidate has stub/unsupported/scaffold components and warns on partial components.

---
*PR created automatically by Jules for task [14766098017449695083](https://jules.google.com/task/14766098017449695083) started by @divyang4481*