### PR TITLE
Add Safety-Oriented Use Cases and Profile Consistency Tooling

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -328,6 +328,14 @@ python3 tools/run_qemu_matrix.py --headless --smoke
 python3 tools/run_qemu_matrix.py --gui --build-only
 ```
 
+### Documentation and Profile Consistency
+
+To ensure that all build profiles are properly documented in the README and architecture docs:
+
+```bash
+python3 tools/check_profiles.py
+```
+
 ---
 
 ## 11) Wrapper script summary (`build.ps1` and `build.sh`)

--- a/README.md
+++ b/README.md
@@ -57,12 +57,212 @@ We intentionally keep architecture documents forward-looking while maintaining c
 
 ## Device Profiles & Use-cases
 
-Bharat-OS targets multiple deployment classes. These profiles describe **how the current baseline maps to real devices today**, and what is planned next:
+Bharat-OS is intentionally profile-driven: the same small capability-oriented kernel can be composed with different services, drivers, stacks, and personalities depending on the device class. This avoids building a separate OS for every product category while still allowing deterministic, safety-aware, and resource-bounded deployments.
+
+> Current status: these profiles describe Bharat-OS architecture direction and implementation mapping. They are not yet production-certification claims. Safety, automotive, aerospace, and industrial deployments require additional validation, fault-containment, timing analysis, certification artifacts, and hardware-specific qualification.
 
 - **Mobile / Wearables (EDGE profile):** capability isolation, bounded footprint, and power-aware scheduling hooks are available now; production-grade power control policy is roadmap.
 - **Robotics / Drones (EDGE + RTOS-leaning):** deterministic IPC pathways and architecture portability are present; stronger real-time admission and fault-containment depth are roadmap.
 - **Network appliances / Edge gateways:** capability-mediated driver boundaries and multikernel messaging baseline are present; mature data-plane acceleration is roadmap.
 - **Data-center / clustered nodes:** NUMA/multicore scaffolding and URPC primitives are present; full distributed scheduling and high-scale service orchestration are roadmap.
+
+For automotive, industrial, aerospace, and cockpit profile mapping, see [Device Profiles and Use Cases](docs/architecture/device-profiles-and-use-cases.md).
+For safety-profile maturity and certification-readiness gaps, see [Safety-Oriented Profile Roadmap](docs/architecture/safety-oriented-profile-roadmap.md).
+
+### Safety-Oriented Profile Composition
+
+```mermaid
+graph TD
+    subgraph Apps["Apps / Domain Workloads"]
+        ADAS["ADAS / Perception"]
+        Cockpit["Digital Cockpit"]
+        Control["Industrial / Aerospace Control"]
+        Gateway["Gateway ECU"]
+    end
+
+    subgraph Services["User-space Services"]
+        SafetyMgr["Safety Manager"]
+        Telemetry["Telemetry & Diagnostics"]
+        DeviceMgr["Device Manager"]
+        NetMgr["Network / Gateway Manager"]
+        VehicleStack["Vehicle / Sensor / Actuator Stack"]
+        DisplayMgr["Display / Cockpit UI Manager"]
+        AIGov["AI / Accelerator Governor"]
+    end
+
+    subgraph Kernel["Bharat-OS Microkernel"]
+        Cap["Capabilities"]
+        IPC["IPC / URPC"]
+        Sched["Scheduler / Deadlines"]
+        MM["VMM / PMM"]
+        Fault["Fault Domains"]
+    end
+
+    subgraph HW["Hardware / HAL"]
+        CPU["CPU Cores"]
+        Sensors["Sensors / Buses"]
+        Accel["GPU / NPU / DSP"]
+        Display["Display"]
+        Network["Ethernet / CAN / Radio"]
+    end
+
+    ADAS --> VehicleStack
+    Cockpit --> DisplayMgr
+    Control --> SafetyMgr
+    Gateway --> NetMgr
+
+    VehicleStack --> IPC
+    DisplayMgr --> IPC
+    NetMgr --> IPC
+    SafetyMgr --> Fault
+    Telemetry --> IPC
+    AIGov --> Sched
+
+    IPC --> Cap
+    Sched --> CPU
+    MM --> CPU
+    Cap --> Sensors
+    Cap --> Accel
+    Cap --> Display
+    Cap --> Network
+```
+
+### ADAS / Autonomous Driving
+
+Bharat-OS is a good fit for future ADAS and autonomous-driving control platforms because the architecture separates safety-critical control paths from policy-heavy user-space services.
+
+Potential value:
+
+- **Mixed-criticality partitioning:** perception, planning, control, telemetry, diagnostics, and UI can run in isolated domains with explicit capabilities.
+- **Deterministic IPC/URPC:** low-latency message paths can connect camera/radar/lidar preprocessing, fusion, planning, and actuator-control services without making the kernel policy-heavy.
+- **Restartable user-space drivers:** sensor or accelerator drivers can fail and restart without forcing whole-system failure.
+- **AI/accelerator-aware scheduling roadmap:** AI inference workloads can be placed by a user-space governor while the kernel keeps bounded deterministic fallback behavior.
+- **Fault-domain design path:** perception failure, sensor timeout, control-path deadline miss, and driver crash can be classified into fault domains and routed to safe-state policy.
+
+Example mapping:
+
+| ADAS function | Bharat-OS mapping |
+| --- | --- |
+| Camera/radar/lidar input | User-space sensor drivers + capability-gated DMA/MMIO |
+| Perception pipeline | Accelerator/NPU/GPU service domain |
+| Sensor fusion | RT or latency-sensitive service domain |
+| Planning/control | RT profile with deadline-aware scheduling |
+| Vehicle communication | CAN/Ethernet gateway service |
+| Diagnostics | Telemetry + fault-domain service |
+| Safe fallback | Safety manager + watchdog + safe-state transition |
+
+### Gateway ECUs
+
+Bharat-OS can target gateway ECUs because its architecture naturally separates network-facing, vehicle-bus-facing, and diagnostic domains.
+
+Potential value:
+
+- **Capability-mediated networking:** each network interface, bus, or diagnostic endpoint can expose only the rights required by that service.
+- **Gateway service isolation:** routing, filtering, diagnostics, OTA, and telemetry can be separate services rather than one privileged monolith.
+- **Restartable communication stacks:** CAN, Ethernet, SOME/IP-like services, diagnostics, and update channels can restart independently.
+- **Policy outside kernel:** routing, firewall, diagnostic access, and update policy stay in services, keeping the kernel smaller.
+
+Example mapping:
+
+| Gateway ECU function | Bharat-OS mapping |
+| --- | --- |
+| CAN/CAN-FD bus access | Vehicle stack + bus driver capability |
+| Automotive Ethernet | Network stack + netmgr control plane |
+| Diagnostics | Isolated diagnostic service |
+| Firewall/routing | User-space gateway policy service |
+| OTA/update | Secure update service roadmap |
+| Fault reporting | Telemetry/diagnostic event service |
+
+### Industrial Control
+
+For industrial control, Bharat-OS should focus on deterministic timing, strong isolation, and resilient service recovery.
+
+Potential value:
+
+- **RT-leaning profile:** deterministic memory allocation, deadline metadata, and bounded IPC paths can support PLC-like and motion-control workloads.
+- **Sensor/actuator isolation:** actuator control can be capability-gated and separated from HMI, logging, and remote-management services.
+- **Fault containment:** a failed HMI, logging service, or network service should not directly corrupt control-loop execution.
+- **Small deployment footprint:** profile-based composition can disable unnecessary media, desktop, or cloud features.
+
+Example mapping:
+
+| Industrial function | Bharat-OS mapping |
+| --- | --- |
+| Control loop | RT service with deadline metadata |
+| Sensor sampling | Sensor manager + timestamped ring buffer |
+| Actuator command | Actuator queue + safe-stop path |
+| HMI panel | Framebuffer/lightweight UI profile |
+| Remote monitoring | Network + telemetry service |
+| Safety interlock | Watchdog + safety manager |
+
+### Aerospace Systems
+
+Aerospace use cases require extreme caution, but Bharat-OS has architectural ingredients that are useful for future research and prototyping.
+
+Potential value:
+
+- **Minimal trusted kernel base:** only scheduling, memory, traps, capabilities, IPC/uRPC, and fault handling should remain in kernel.
+- **Strict domain separation:** navigation, telemetry, payload, communications, and diagnostics can run as isolated services.
+- **Fault-domain model:** service failure can be isolated and escalated to safe-mode policy instead of uncontrolled system-wide failure.
+- **Cross-architecture portability:** x86_64, ARM64, and RISC-V targets allow experimentation across development boards, simulators, and future custom silicon.
+
+Example mapping:
+
+| Aerospace function | Bharat-OS mapping |
+| --- | --- |
+| Flight-critical loop | RT/safety profile service |
+| Telemetry | Isolated telemetry service |
+| Payload control | Separate capability-bounded service |
+| Communication bus | Network/radio stack service |
+| Health monitoring | Fault-domain + watchdog framework |
+| Safe mode | Safety manager policy service |
+
+### Digital Cockpit / Infotainment
+
+Digital cockpit is different from ADAS: it needs UI, media, Android/Linux compatibility paths, and strong separation from vehicle-control domains.
+
+Potential value:
+
+- **Domain split:** infotainment, cluster, navigation, voice assistant, media, and vehicle-status display can be separated.
+- **Display tiers:** headless, text console, framebuffer, lightweight embedded UI, and full compositor can be enabled by profile.
+- **Multi-personality direction:** Linux/Android personality work can support app/runtime compatibility without moving those compatibility layers into the kernel.
+- **Safety-aware UI isolation:** cluster-critical display paths can be separated from entertainment or third-party app domains.
+
+Example mapping:
+
+| Cockpit function | Bharat-OS mapping |
+| --- | --- |
+| Instrument cluster | Lightweight UI/framebuffer service |
+| Infotainment | Media stack + Android/Linux personality path |
+| Navigation | App/service domain |
+| Vehicle status | Read-only vehicle data capability |
+| Voice/AI assistant | User-space AI/accelerator service |
+| Secure warning overlay | Trusted UI/display broker roadmap |
+
+### Why Bharat-OS is interesting for these domains
+
+Bharat-OS is not trying to be a monolithic general-purpose OS. Its value is in a smaller capability-oriented kernel plus profile-selected services:
+
+- **Capability-based security:** access to memory, devices, IPC endpoints, and services is explicit and revocable.
+- **Microkernel layering:** policy-heavy behavior stays outside ring-0.
+- **Multikernel direction:** cross-core coordination uses explicit messaging rather than hidden global sharing.
+- **Profile-aware composition:** builds can select only the services needed for automotive, industrial, aerospace, cockpit, edge, or cloud profiles.
+- **Restartable services and drivers:** user-space services can be supervised, restarted, or isolated.
+- **Safety roadmap:** watchdogs, fault domains, deadline primitives, telemetry, and safe-state transitions can become common reusable foundations.
+
+### Near-term maturity gaps for safety-oriented profiles
+
+Before claiming production readiness for ADAS, gateway ECUs, industrial control, aerospace, or cockpit systems, Bharat-OS must close these gaps:
+
+- bounded scheduler and cross-core migration behavior
+- bounded TLB shootdown and memory invalidation protocol
+- strict capability enforcement at every IPC/service boundary
+- real service supervisor with restart/backoff/watchdog policy
+- fault-domain and safe-state transition framework
+- deadline/timer primitives with tests
+- device-class registry for sensors, actuators, display, network, storage, and accelerator devices
+- telemetry and diagnostic event service
+- clear separation between kernel mechanisms, services, stacks, and domain personalities
 
 ### High-Level Architecture
 
@@ -339,16 +539,6 @@ graph LR
     Detect -->|Edge| Edge
     Detect -->|Datacenter| Datacenter
 ```
-
-### Device Profiles & Use-cases
-
-Bharat-OS is intentionally profile-driven instead of forcing one heavyweight image on every board.
-
-- **Mobile & embedded:** revocable capabilities for sensor isolation, user-space driver recovery, and Bharat-RT static allocation for deterministic latency.
-- **Edge & IoT gateways:** small attack surface, real-time tuning, and hot-swappable network/USB drivers.
-- **Robotics & UAVs:** mixed-criticality partitioning, dedicated-core workflows, and low-latency URPC messaging between control/perception tasks.
-- **Network appliances:** isolated user-space drivers plus fast-path packet processing and restart without whole-system panic.
-- **Datacenter/cloud:** multikernel-friendly scaling on many-core/NUMA systems with demand paging and policy-driven AI scheduling.
 
 ### Subsystem Model
 

--- a/docs/architecture/device-profiles-and-use-cases.md
+++ b/docs/architecture/device-profiles-and-use-cases.md
@@ -11,9 +11,11 @@ see_also:
 ---
 # Device Profiles and Use-cases
 
+## Purpose
+
 This document maps Bharat-OS architectural features to practical deployment classes and distinguishes **implemented baseline** vs **roadmap**.
 
-## Profile model
+## Profile Composition Model
 
 Bharat-OS uses profile-oriented tuning to keep a shared kernel spine while changing policy and scale assumptions. The architecture specifically scales down through formal profiles rather than a messy half-port.
 
@@ -27,78 +29,204 @@ The three primary delivery tiers are:
 
 For a deep dive into achieving these small footprints, see the [Low-Footprint Design and Analysis](low-footprint-design.md) document.
 
-## Cross-profile architectural strengths (current baseline)
+## Existing / General Profiles
 
-1. **Capability-mediated authority**
-   - Object access is represented by explicit capabilities and rights checks.
-   - Delegation is constrained to subsets of existing rights.
-2. **Messaging-centric IPC**
-   - Endpoint IPC baseline for synchronous interactions.
-   - URPC ring primitives for bounded asynchronous pathways.
-3. **Driver boundary scaffolding**
-   - Device framework and MMIO registration patterns.
-   - Capability-gated mapping path for privileged accelerator MMIO windows.
-4. **Multicore/multikernel direction**
-   - Secondary-core boot hooks and per-core channel matrix baseline.
-   - NUMA descriptor baseline for placement-aware extensions.
-
-## Deployment mapping
-
-### 1) Mobile and wearables
-
+### Mobile / Wearables (MOBILE)
 **Current fit**
-
 - Capability isolation helps reduce blast radius for compromised components.
 - Scheduler telemetry hooks + AI suggestion path can support power-aware policy in user space.
 
 **Gaps / roadmap**
-
 - Production DVFS/thermal control integration and power-model calibration.
 - Hardening for sustained battery-constrained runtime behavior.
 
-### 2) Robotics and drones
-
+### Robotics / Drones (ROBOT, DRONE)
 **Current fit**
-
 - Message-passing architecture and bounded queues support deterministic control-plane behavior.
 - Architecture portability (x86_64/riscv64/arm64 build surfaces) supports mixed platform development.
 
 **Gaps / roadmap**
-
 - Stronger real-time scheduling guarantees and admission control.
 - More complete fault containment and recovery semantics for safety-critical subsystems via explicit fault domains and restart metadata.
 
-### 3) Network appliances and edge gateways
-
+### Network appliances / Edge gateways (EDGE, IOT)
 **Current fit**
-
 - Capability/driver boundary model supports service isolation.
 - Baseline multikernel messaging is compatible with control/data plane separation patterns.
 
 **Gaps / roadmap**
-
 - Mature high-throughput network stack/data plane acceleration.
 - Better asynchronous eventing and device-interrupt integration depth.
 - Standardized IPC/uRPC message classes (control, dataplane, telemetry) to cut code duplication.
 
-### 4) Data-center and clustered services
-
+### Laptop / Desktop (LAPTOP, DESKTOP)
 **Current fit**
+- Full VM support and SMP scalability allow for rich multitasking environments.
+- Capability-mediated driver access provides strong security for consumer devices.
 
+**Gaps / roadmap**
+- Advanced power management for mobile form factors.
+- Full desktop compositor and UI subsystem integration.
+
+### Medical Devices (MEDICAL)
+**Current fit**
+- Strict isolation and capability-based security are ideal for certified medical hardware.
+- Formal profile-driven composition ensures only necessary services are included, reducing the attack surface.
+
+**Gaps / roadmap**
+- Formal verification of core safety-critical paths.
+- Hardware-specific qualification for medical sensor interfaces.
+
+### Data-center / Clustered services
+**Current fit**
 - Multicore + NUMA scaffolding and URPC channels establish scale-out direction.
 - Policy/mechanism separation (including AI policy boundary) supports operational control planes.
 
 **Gaps / roadmap**
-
 - Full distributed scheduler behavior across nodes.
 - Production-grade memory management depth and service lifecycle orchestration.
 
-### 5) Research and education platforms
-
+### Research and Education Platforms
 **Current fit**
-
 - Clear separation of baseline vs deferred components supports experimentation.
 - ADR-driven governance provides traceability for design decisions.
+
+## Safety-Oriented and Vehicle Profiles
+
+Bharat-OS targets several safety-critical domains where architectural isolation and deterministic behavior are paramount.
+
+### ADAS / Autonomous Driving
+
+Bharat-OS is a good fit for future ADAS and autonomous-driving control platforms because the architecture separates safety-critical control paths from policy-heavy user-space services.
+
+**Potential value:**
+- **Mixed-criticality partitioning:** perception, planning, control, telemetry, diagnostics, and UI can run in isolated domains with explicit capabilities.
+- **Deterministic IPC/URPC:** low-latency message paths can connect camera/radar/lidar preprocessing, fusion, planning, and actuator-control services without making the kernel policy-heavy.
+- **Restartable user-space drivers:** sensor or accelerator drivers can fail and restart without forcing whole-system failure.
+
+**Example mapping:**
+
+| ADAS function | Bharat-OS mapping |
+| --- | --- |
+| Camera/radar/lidar input | User-space sensor drivers + capability-gated DMA/MMIO |
+| Perception pipeline | Accelerator/NPU/GPU service domain |
+| Sensor fusion | RT or latency-sensitive service domain |
+| Planning/control | RT profile with deadline-aware scheduling |
+| Vehicle communication | CAN/Ethernet gateway service |
+| Diagnostics | Telemetry + fault-domain service |
+| Safe fallback | Safety manager + watchdog + safe-state transition |
+
+### Gateway ECUs
+
+Bharat-OS can target gateway ECUs because its architecture naturally separates network-facing, vehicle-bus-facing, and diagnostic domains.
+
+**Potential value:**
+- **Capability-mediated networking:** each network interface, bus, or diagnostic endpoint can expose only the rights required by that service.
+- **Gateway service isolation:** routing, filtering, diagnostics, OTA, and telemetry can be separate services rather than one privileged monolith.
+- **Restartable communication stacks:** CAN, Ethernet, SOME/IP-like services, diagnostics, and update channels can restart independently.
+
+**Example mapping:**
+
+| Gateway ECU function | Bharat-OS mapping |
+| --- | --- |
+| CAN/CAN-FD bus access | Vehicle stack + bus driver capability |
+| Automotive Ethernet | Network stack + netmgr control plane |
+| Diagnostics | Isolated diagnostic service |
+| Firewall/routing | User-space gateway policy service |
+| OTA/update | Secure update service roadmap |
+| Fault reporting | Telemetry/diagnostic event service |
+
+### Industrial Control
+
+For industrial control, Bharat-OS should focus on deterministic timing, strong isolation, and resilient service recovery.
+
+**Potential value:**
+- **RT-leaning profile:** deterministic memory allocation, deadline metadata, and bounded IPC paths can support PLC-like and motion-control workloads.
+- **Sensor/actuator isolation:** actuator control can be capability-gated and separated from HMI, logging, and remote-management services.
+- **Fault containment:** a failed HMI, logging service, or network service should not directly corrupt control-loop execution.
+
+**Example mapping:**
+
+| Industrial function | Bharat-OS mapping |
+| --- | --- |
+| Control loop | RT service with deadline metadata |
+| Sensor sampling | Sensor manager + timestamped ring buffer |
+| Actuator command | Actuator queue + safe-stop path |
+| HMI panel | Framebuffer/lightweight UI profile |
+| Remote monitoring | Network + telemetry service |
+| Safety interlock | Watchdog + safety manager |
+
+### Aerospace Systems
+
+Aerospace use cases require extreme caution, but Bharat-OS has architectural ingredients that are useful for future research and prototyping.
+
+**Potential value:**
+- **Minimal trusted kernel base:** only scheduling, memory, traps, capabilities, IPC/uRPC, and fault handling should remain in kernel.
+- **Strict domain separation:** navigation, telemetry, payload, communications, and diagnostics can run as isolated services.
+- **Fault-domain model:** service failure can be isolated and escalated to safe-mode policy instead of uncontrolled system-wide failure.
+
+**Example mapping:**
+
+| Aerospace function | Bharat-OS mapping |
+| --- | --- |
+| Flight-critical loop | RT/safety profile service |
+| Telemetry | Isolated telemetry service |
+| Payload control | Separate capability-bounded service |
+| Communication bus | Network/radio stack service |
+| Health monitoring | Fault-domain + watchdog framework |
+| Safe mode | Safety manager policy service |
+
+### Digital Cockpit / Infotainment
+
+Digital cockpit is different from ADAS: it needs UI, media, Android/Linux compatibility paths, and strong separation from vehicle-control domains.
+
+**Potential value:**
+- **Domain split:** infotainment, cluster, navigation, voice assistant, media, and vehicle-status display can be separated.
+- **Display tiers:** headless, text console, framebuffer, lightweight embedded UI, and full compositor can be enabled by profile.
+- **Multi-personality direction:** Linux/Android personality work can support app/runtime compatibility without moving those compatibility layers into the kernel.
+
+**Example mapping:**
+
+| Cockpit function | Bharat-OS mapping |
+| --- | --- |
+| Instrument cluster | Lightweight UI/framebuffer service |
+| Infotainment | Media stack + Android/Linux personality path |
+| Navigation | App/service domain |
+| Vehicle status | Read-only vehicle data capability |
+| Voice/AI assistant | User-space AI/accelerator service |
+| Secure warning overlay | Trusted UI/display broker roadmap |
+
+## Cross-Domain Primitive Matrix
+
+| Primitive | ADAS | Gateway ECU | Industrial | Aerospace | Digital Cockpit |
+| --- | --- | --- | --- | --- | --- |
+| Capability isolation | required | required | required | required | required |
+| Fault domains | required | required | required | required | recommended |
+| Deadline/timer API | required | recommended | required | required | recommended |
+| Device class registry | required | required | required | required | required |
+| Telemetry/diagnostics | required | required | required | required | required |
+| Watchdog/safe-state | required | recommended | required | required | recommended |
+| Display stack | optional | optional | HMI only | optional | required |
+| Vehicle/sensor stack | required | required | actuator/sensor | mission bus | vehicle data read-only |
+
+## Current Maturity Gaps
+
+Before claiming production readiness for safety-oriented profiles, Bharat-OS must close these gaps:
+- Bounded scheduler and cross-core migration behavior.
+- Bounded TLB shootdown and memory invalidation protocol.
+- Strict capability enforcement at every IPC/service boundary.
+- Real service supervisor with restart/backoff/watchdog policy.
+- Fault-domain and safe-state transition framework.
+- Deadline/timer primitives with tests.
+- Device-class registry for sensors, actuators, display, network, storage, and accelerator devices.
+- Telemetry and diagnostic event service.
+
+## Next Implementation Roadmap
+
+1. **Implement fault-domain primitives** and service-facing fault event contract.
+2. **Develop device-class registry** for standardized sensor and actuator access.
+3. **Formalize watchdog and safe-state metadata** as a kernel/service contract.
+4. **Close capability enforcement gaps** in all core manager paths.
 
 ## References and alignment
 
@@ -106,21 +234,3 @@ For a deep dive into achieving these small footprints, see the [Low-Footprint De
 - Capability discipline aligns conceptually with seL4/L4-family authority modeling.
 
 These are architectural influences rather than claims of implementation equivalence.
-
-### 6) Automotive and EV distributed ECU systems
-
-**Current fit**
-
-- Capability-mediated isolation aligns with mixed-criticality domain boundaries.
-- Messaging-centric design aligns with ECU/domain decomposition and gateway routing.
-- Architecture portability supports central compute + peripheral ECU topologies.
-
-**Planned profile set**
-
-- `PROFILE_AUTOMOTIVE`
-
-**Gaps / roadmap**
-
-- Stronger hard RT guarantees and formal jitter/latency acceptance thresholds.
-- Production-ready TSN/SOME-IP integration and deterministic network timing.
-- End-to-end secure boot/update and rollback lifecycle across distributed ECUs.

--- a/docs/architecture/safety-oriented-profile-roadmap.md
+++ b/docs/architecture/safety-oriented-profile-roadmap.md
@@ -1,0 +1,76 @@
+---
+title: Safety-Oriented Profile Roadmap
+status: Proposed
+owner: Documentation Working Group
+last_updated: 2026-04-25
+tags:
+  - docs
+  - architecture
+  - roadmap
+  - safety
+see_also:
+  - README.md
+  - docs/architecture/device-profiles-and-use-cases.md
+---
+# Safety-Oriented Profile Roadmap
+
+This document outlines the architectural roadmap for Bharat-OS safety-oriented profiles, focusing on the separation of concerns across the kernel, services, stacks, and personalities.
+
+## Architectural Allocation
+
+To maintain a minimal and verifiable trusted computing base, Bharat-OS strictly allocates functionality across layers:
+
+### 1. What belongs in the Kernel
+- **Minimal mechanisms only:** Scheduling (including deadline primitives), memory mapping, syscall/trap handling, capability management, IPC/uRPC transport, and fault-domain tagging.
+- **Goal:** Keep the kernel policy-free and as small as possible.
+
+### 2. What belongs in Services
+- **System Policy:** Safety Manager, Fault Manager, Device Manager, and Service Supervisor.
+- **Resource Management:** Policy-heavy behavior such as restart/backoff logic, watchdog monitoring, and telemetry aggregation.
+
+### 3. What belongs in Stacks
+- **Subsystem Logic:** Composed network stacks (e.g., TSN, SOME/IP), storage subsystems, and vehicle/sensor stacks.
+- **Goal:** Provide reusable domain-specific logic that runs in user-space.
+
+### 4. What belongs in Personalities / Domain
+- **Application-Specific Mapping:** Domain profiles such as `AUTOMOTIVE`, `INDUSTRIAL`, or `AEROSPACE`.
+- **Goal:** Define the specific composition of services and stacks required for a particular use case.
+
+## Safety Maturity Levels (S-Levels)
+
+Bharat-OS uses a specific maturity lens for safety profiles, aligned with the existing repository taxonomy.
+
+| Safety-profile maturity | Description | Existing repo taxonomy alignment |
+| --- | --- | --- |
+| **S0 Scaffold** | Build profile exists; architecture defined but no runtime guarantees. | **Scaffold** |
+| **S1 Baseline** | Boots and runs with profile-specific service selection; basic isolation. | **Baseline** |
+| **S2 Bounded** | Key IPC, timer, and memory paths have bounded behavior tests and deterministic traces. | **Partial → Baseline+** (depending on tests) |
+| **S3 Fault-contained** | Services and drivers have explicit fault domains, restart policies, and safe-state transitions. | **Production-candidate prerequisite** |
+| **S4 Cert-prep** | Full traceability, timing evidence, safety case documentation, and hardware qualification artifacts. | **Beyond Production taxonomy; certification stage** |
+
+> **Note:** The current repository state is mostly **S0/S1** depending on the specific profile.
+
+## Maturity Gaps and Roadmap
+
+### Phase 1: Foundation (Current Focus)
+- Formalize `fault_domain_id` and tagging in kernel.
+- Implement fail-closed capability shims in all service entry points.
+- Define the `Safety Manager` contract and event structures.
+
+### Phase 2: Deterministic Primitives
+- Implement bounded execution paths for core IPC and memory operations.
+- Add deadline-aware scheduling metadata to thread primitives.
+- Introduce timing-trace validation in CI/CD.
+
+### Phase 3: Fault Containment & Recovery
+- Enable service-level restart with backoff and state recovery.
+- Implement the `Safe-State` transition manager.
+- Formalize driver isolation and recovery via IOMMU/capability mediation.
+
+### Phase 4: Certification Readiness
+- Generate automated traceability reports between requirements and tests.
+- Complete hardware-in-the-loop (HIL) validation for target boards.
+- Finalize safety case artifacts for selected profiles.
+
+## Important Caveat
+Bharat-OS is currently in an architecture-direction and prototyping phase. **S-levels do not equate to production safety certification.** Production deployments require additional validation, fault-containment analysis, and hardware-specific qualification.

--- a/quality/tests/tools/test_check_profiles.py
+++ b/quality/tests/tools/test_check_profiles.py
@@ -1,0 +1,135 @@
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+import importlib.util
+import sys
+
+class TestCheckProfiles(unittest.TestCase):
+    def setUp(self):
+        # Dynamically find the repo root relative to this test file
+        self.repo_root = Path(__file__).resolve().parents[3]
+        self.script_path = self.repo_root / "tools/check_profiles.py"
+
+    def _load_module(self):
+        spec = importlib.util.spec_from_file_location("check_profiles", str(self.script_path))
+        check_profiles = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(check_profiles)
+        return check_profiles
+
+    def test_checker_success(self):
+        """Test that the checker returns success when all profiles are documented."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+
+            # Create a mock build_config.json
+            build_config = {
+                "builds": {
+                    "test_build": {"profile": "TEST_PROFILE"}
+                }
+            }
+            config_file = tmpdir_path / "build_config.json"
+            with open(config_file, "w") as f:
+                json.dump(build_config, f)
+
+            # Create a mock README.md
+            readme_file = tmpdir_path / "README.md"
+            with open(readme_file, "w") as f:
+                f.write("# Bharat-OS\nThis project uses TEST_PROFILE.")
+
+            check_profiles = self._load_module()
+
+            # Mock the constants
+            check_profiles.BUILD_CONFIG = config_file
+            check_profiles.DOCS_DIRS = [readme_file]
+
+            # The main function returns 0 on success
+            # Redirect stdout to avoid cluttering test output
+            original_stdout = sys.stdout
+            sys.stdout = open(os.devnull, 'w')
+            try:
+                result = check_profiles.main()
+            finally:
+                sys.stdout.close()
+                sys.stdout = original_stdout
+
+            self.assertEqual(result, 0)
+
+    def test_checker_failure(self):
+        """Test that the checker returns failure when a profile is missing from docs."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+
+            # Create a mock build_config.json
+            build_config = {
+                "builds": {
+                    "test_build": {"profile": "MISSING_PROFILE"}
+                }
+            }
+            config_file = tmpdir_path / "build_config.json"
+            with open(config_file, "w") as f:
+                json.dump(build_config, f)
+
+            # Create a mock README.md without the profile
+            readme_file = tmpdir_path / "README.md"
+            with open(readme_file, "w") as f:
+                f.write("# Bharat-OS\nNo profiles here.")
+
+            check_profiles = self._load_module()
+
+            # Mock the constants
+            check_profiles.BUILD_CONFIG = config_file
+            check_profiles.DOCS_DIRS = [readme_file]
+
+            # The main function returns 1 on failure
+            original_stdout = sys.stdout
+            sys.stdout = open(os.devnull, 'w')
+            try:
+                result = check_profiles.main()
+            finally:
+                sys.stdout.close()
+                sys.stdout = original_stdout
+
+            self.assertEqual(result, 1)
+
+    def test_checker_alias_success(self):
+        """Test that the checker returns success when an alias is used in docs."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+
+            # Create a mock build_config.json
+            build_config = {
+                "builds": {
+                    "test_build": {"profile": "AUTOMOBILE"}
+                }
+            }
+            config_file = tmpdir_path / "build_config.json"
+            with open(config_file, "w") as f:
+                json.dump(build_config, f)
+
+            # Create a mock README.md using an alias
+            readme_file = tmpdir_path / "README.md"
+            with open(readme_file, "w") as f:
+                f.write("# Bharat-OS\nThis project supports AUTOMOTIVE use cases.")
+
+            check_profiles = self._load_module()
+
+            # Mock the constants
+            check_profiles.BUILD_CONFIG = config_file
+            check_profiles.DOCS_DIRS = [readme_file]
+
+            # AUTOMOTIVE is an alias for AUTOMOBILE
+            original_stdout = sys.stdout
+            sys.stdout = open(os.devnull, 'w')
+            try:
+                result = check_profiles.main()
+            finally:
+                sys.stdout.close()
+                sys.stdout = original_stdout
+
+            self.assertEqual(result, 0)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/check_profiles.py
+++ b/tools/check_profiles.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""
+Bharat-OS Profile Consistency Checker
+Scans build_config.json for active profiles and ensures they are documented in README/docs.
+"""
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+# Configuration
+REPO_ROOT = Path(__file__).parent.parent
+BUILD_CONFIG = REPO_ROOT / "build_config.json"
+DOCS_DIRS = [
+    REPO_ROOT / "README.md",
+    REPO_ROOT / "docs/architecture",
+]
+
+# Exact normalized matching aliases
+PROFILE_ALIASES = {
+    "AUTOMOBILE": {"AUTOMOBILE", "AUTOMOTIVE", "AUTOMOTIVE_PROFILE"},
+    "EV_AUTOMOBILE": {"EV_AUTOMOBILE", "EV_AUTOMOTIVE", "ELECTRIC_VEHICLE", "EV"},
+    "MOBILE": {"MOBILE"},
+    "IOT": {"IOT"},
+    "LAPTOP": {"LAPTOP"},
+    "MEDICAL": {"MEDICAL"},
+}
+
+def normalize_token(token):
+    """Normalize a token for comparison: uppercase, replace - and spaces with _."""
+    return token.upper().replace("-", "_").strip()
+
+def get_build_profiles(config_path):
+    """Extract unique profile names from build_config.json."""
+    if not config_path.exists():
+        print(f"Error: {config_path} not found.")
+        return set()
+
+    try:
+        with open(config_path, "r") as f:
+            data = json.load(f)
+    except json.JSONDecodeError as e:
+        print(f"Error parsing {config_path}: {e}")
+        return set()
+
+    profiles = set()
+    builds = data.get("builds", {})
+    for build_id, build_config in builds.items():
+        profile = build_config.get("profile")
+        if profile:
+            profiles.add(profile)
+
+    return profiles
+
+def get_documented_tokens(paths):
+    """Scan files and directories for uppercase tokens."""
+    tokens = set()
+
+    # Simple regex for uppercase tokens, allowing underscores
+    token_re = re.compile(r'\b[A-Z][A-Z0-9_]+\b')
+
+    for path in paths:
+        if path.is_file():
+            files = [path]
+        elif path.is_dir():
+            files = path.glob("*.md")
+        else:
+            continue
+
+        for file in files:
+            try:
+                with open(file, "r", encoding="utf-8") as f:
+                    content = f.read()
+                    found = token_re.findall(content)
+                    tokens.update(found)
+            except Exception as e:
+                print(f"Warning: Could not read {file}: {e}")
+
+    return tokens
+
+def main():
+    print("Bharat-OS Profile Inventory Checker")
+    print("-" * 40)
+
+    build_profiles = get_build_profiles(BUILD_CONFIG)
+    if not build_profiles:
+        print("No build profiles found in build_config.json.")
+        return 0
+
+    print("Known build profiles:")
+    for p in sorted(build_profiles):
+        print(f"- {p}")
+
+    doc_tokens = get_documented_tokens(DOCS_DIRS)
+
+    # Check for undocumented profiles
+    missing = []
+    for profile in build_profiles:
+        # Check for exact match
+        if profile in doc_tokens:
+            continue
+
+        # Check aliases
+        aliases = PROFILE_ALIASES.get(profile, set())
+        if any(alias in doc_tokens for alias in aliases):
+            continue
+
+        missing.append(profile)
+
+    print("\nDocumented profile tokens (subset):")
+    # Only print tokens that resemble profiles for brevity
+    relevant_tokens = sorted([t for t in doc_tokens if any(p in t or t in p for p in build_profiles) or t in ["RT", "SAFETY"]])
+    for t in relevant_tokens[:15]:
+        print(f"- {t}")
+    if len(relevant_tokens) > 15:
+        print(f"- ... ({len(relevant_tokens) - 15} more)")
+
+    if missing:
+        print("\nERR: The following build profiles are not mentioned in README or docs:")
+        for m in missing:
+            print(f"- {m}")
+        print("\nPlease update README.md or docs/architecture/ to include these profiles.")
+        return 1
+
+    print("\nOK: All build_config profiles are mentioned in README/docs.")
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
This PR focuses on aligning Bharat-OS documentation and build discipline with safety-critical domains such as Automotive (ADAS/ECU), Industrial, Aerospace, and Digital Cockpit.

Key changes:
1. **README Enrichment:** Merged and expanded the "Device Profiles & Use-cases" section with specific architectural mappings and a new "Safety-Oriented Profile Composition" Mermaid diagram.
2. **Detailed Architecture Docs:** Reorganized `docs/architecture/device-profiles-and-use-cases.md` to include comprehensive sections for the new domains and a cross-domain primitive matrix.
3. **Safety Roadmap:** Introduced `docs/architecture/safety-oriented-profile-roadmap.md` defining S0-S4 maturity levels and architectural allocation across the system layers.
4. **Drift-Warning Tooling:** Added `tools/check_profiles.py` to ensure build profiles in `build_config.json` remain documented, along with unit tests in `quality/tests/tools/test_check_profiles.py`.
5. **Developer Guidance:** Updated `BUILD.md` to include the profile checker in the developer workflow.

No kernel or service runtime code was modified in this PR. All wording remains conservative regarding safety certifications.

---
*PR created automatically by Jules for task [2713115316053181153](https://jules.google.com/task/2713115316053181153) started by @22f1000411*