### PR TITLE
sched: Scheduler Ownership Closure v2 (#794)

### DIFF
--- a/core/kernel/include/sched/sched.h
+++ b/core/kernel/include/sched/sched.h
@@ -110,8 +110,11 @@ typedef struct {
     uint64_t wcet_ms;
 } bh_thread_attr_t;
 
+#define SCHED_CMD_BITMAP_WORDS 8
+
 typedef enum {
     SCHED_REMOTE_CMD_EMPTY = 0,
+    SCHED_REMOTE_CMD_RESERVED,
     SCHED_REMOTE_CMD_PENDING,
     SCHED_REMOTE_CMD_ACKED,
     SCHED_REMOTE_CMD_FAILED,
@@ -120,11 +123,11 @@ typedef enum {
 
 typedef enum {
     SCHED_MIGRATION_NONE = 0,
-    SCHED_MIGRATION_DEQUEUE_REQUESTED,
+    SCHED_MIGRATION_PREPARE_SENT,
     SCHED_MIGRATION_DEQUEUED,
-    SCHED_MIGRATION_ENQUEUE_REQUESTED,
+    SCHED_MIGRATION_COMMIT_SENT,
     SCHED_MIGRATION_COMMITTED,
-    SCHED_MIGRATION_ROLLBACK_REQUESTED,
+    SCHED_MIGRATION_ROLLBACK_SENT,
     SCHED_MIGRATION_FAILED
 } sched_migration_state_t;
 
@@ -142,20 +145,52 @@ typedef enum {
     SCHED_REMOTE_MIGRATE_PREPARE,
     SCHED_REMOTE_MIGRATE_COMMIT,
     SCHED_REMOTE_MIGRATE_ROLLBACK,
-    SCHED_REMOTE_SET_PRIORITY
+    SCHED_REMOTE_SET_PRIORITY,
+    SCHED_REMOTE_SET_THROTTLE,
+    SCHED_REMOTE_TERMINATE,
+    SCHED_REMOTE_REAP
 } sched_remote_cmd_type_t;
 
 struct bh_thread;
 typedef struct bh_thread bh_thread_t;
 
+typedef struct {
+    uint16_t slot;
+    uint16_t origin_cpu;
+    uint32_t generation;
+} sched_cmd_handle_t;
+
+typedef struct {
+    uint64_t thread_id;
+    uint32_t home_core_id;
+    uint32_t bound_core_id;
+    uint32_t owner_cpu;
+    uint32_t state;
+    uint32_t priority;
+    uint32_t affinity_mask;
+    uint32_t migration_state;
+    uint32_t migration_epoch;
+} sched_thread_snapshot_t;
+
 typedef struct sched_remote_cmd {
-    uint64_t cmd_id;
+    sched_cmd_handle_t handle;
+    uint64_t cmd_id; // Keep cmd_id for any backward-compatible field lookup
+
     sched_remote_cmd_type_t type;
-    sched_remote_cmd_state_t state;
+    volatile uint32_t state;
+
     uint32_t source_cpu;
     uint32_t target_cpu;
+
     uint64_t thread_id;
     uint64_t expected_thread_generation;
+
+    uint32_t migration_epoch;
+    int32_t result;
+
+    uint64_t submit_tick;
+    uint64_t deadline_tick;
+
     uint32_t flags;
     uint32_t priority;
     list_head_t list;
@@ -198,7 +233,7 @@ typedef struct sched_rq {
 
     // Outbound Command Pool & load snapshot
     sched_remote_cmd_t outbound_cmds[SCHED_REMOTE_CMD_CAPACITY];
-    volatile uint64_t outbound_alloc_bitmap;
+    volatile uint32_t outbound_alloc_bitmap[SCHED_CMD_BITMAP_WORDS];
     sched_load_snapshot_t load_snapshot;
 
     // Flag to avoid IPI storms
@@ -321,6 +356,7 @@ struct bh_thread {
     // Migration state
     uint32_t migration_target_cpu;
     sched_migration_state_t migration_state;
+    uint32_t migration_epoch;
 };
 
 int thread_raise_fault(bh_thread_t *thread, thread_fault_t fault);
@@ -386,25 +422,35 @@ void sched_reschedule(void);
 bh_thread_t* sched_current(void);
 int sched_enqueue(bh_thread_t* thread, uint32_t core_id);
 void sched_sleep(uint64_t millis);
-void sched_wakeup(bh_thread_t* thread);
-void sched_wakeup_with_priority(bh_thread_t* thread, uint32_t wakeup_priority);
+int sched_wake_tid(uint64_t tid);
+int sched_wake_tid_with_priority(uint64_t tid, uint32_t priority);
+
+void sched_wakeup(bh_thread_t *thread);
+void sched_wakeup_with_priority(bh_thread_t *thread, uint32_t wakeup_priority);
 
 // AI governor integration helpers
-bh_thread_t* sched_find_thread_by_id(uint64_t tid);
 int sched_set_thread_priority(uint64_t tid, uint32_t new_priority);
 int sched_set_thread_preferred_node(uint64_t tid, uint8_t node_id);
 int sched_ai_apply_suggestion(const ai_suggestion_t* suggestion);
 int sched_enqueue_ai_suggestion(const ai_suggestion_t* suggestion);
-int sched_migrate_task(bh_thread_t* thread, uint32_t new_node);
-int sched_adjust_priority(bh_thread_t* thread, uint32_t new_priority);
+int sched_migrate_tid(uint64_t tid, uint32_t target_cpu);
+int sched_set_priority(uint64_t tid, uint32_t priority);
+int sched_set_affinity(uint64_t tid, uint32_t mask);
+int sched_terminate_tid(uint64_t tid);
+int sched_quarantine_tid(uint64_t tid, uint32_t reason);
 int sched_throttle_core(uint32_t core_id);
 
 // Cross-core remote handoff
-int sched_request_remote_handoff(bh_thread_t* thread, uint32_t target_core, uint32_t auth_token);
+int sched_request_handoff_tid(uint64_t tid, uint32_t target_cpu, uint32_t auth_token);
+kstatus_t sched_get_thread_snapshot(uint64_t tid, sched_thread_snapshot_t *out);
 
 // RT Scheduler Admissions
 int sched_admission_edf(bh_thread_t* thread, uint64_t wcet_ms, uint64_t period_ms, uint64_t deadline_ms);
 int sched_admission_rms(bh_thread_t* thread, uint64_t wcet_ms, uint64_t period_ms);
+
+int sched_set_constraints(uint64_t tid, const bh_exec_constraints_k_t *c);
+int sched_get_constraints(uint64_t tid, bh_exec_constraints_k_t *c);
+bool sched_thread_exists(uint64_t tid);
 
 // System-call style entry points used by trap/syscall layer
 int sched_sys_thread_create(bh_process_t* parent, void (*entry_point)(void), uint64_t* out_tid);
@@ -433,5 +479,10 @@ void sched_disable_tick_for_core(uint32_t core_id);
 sched_rq_t *sched_local_rq(void);
 void sched_assert_local_rq(sched_rq_t *rq);
 kstatus_t sched_remote_submit(uint32_t target_cpu, const sched_remote_cmd_t *cmd);
+void sched_remote_cmd_release(sched_remote_cmd_t *cmd);
+kstatus_t sched_read_load_snapshot(uint32_t cpu, sched_load_snapshot_t *out);
+bool sched_read_isolated_snapshot(uint32_t cpu);
+kstatus_t sched_migration_transition(bh_thread_t *thread, sched_migration_state_t expected, sched_migration_state_t next);
+void sched_remote_cmd_poll_timeouts(void);
 
 #endif // BHARAT_SCHED_H

--- a/core/kernel/src/core/fault_domain.c
+++ b/core/kernel/src/core/fault_domain.c
@@ -28,9 +28,7 @@ int sys_fault_domain_destroy(uint64_t domain) {
 }
 
 int sys_fault_domain_attach(uint64_t domain, uint64_t tid) {
-    bh_thread_t *thread = sched_find_thread_by_id(tid);
-    if (!thread) return -1;
-    // TODO: store fault domain id
-    (void)thread;
+    if (!sched_thread_exists(tid)) return -1;
+    (void)domain;
     return 0;
 }

--- a/core/kernel/src/sched/sched.c
+++ b/core/kernel/src/sched/sched.c
@@ -237,7 +237,7 @@ void sched_detach_thread_from_queues(thread_slot_t *slot) {
   }
 }
 
-static int sched_enqueue_reap(thread_slot_t *slot) {
+int sched_enqueue_reap(thread_slot_t *slot) {
   if (!slot || slot->is_bootstrap != 0U) {
     return -1;
   }
@@ -269,19 +269,44 @@ int sched_mark_thread_terminated(bh_thread_t *thread) {
   if (!thread) {
     return -1;
   }
-  thread_slot_t *slot = sched_find_thread_slot_by_tid_local(&g_cpu_locals[thread->home_core_id].runqueue, thread->thread_id);
+  uint32_t current_core = sched_clamp_core(hal_cpu_get_id());
+  thread_slot_t *slot = sched_find_thread_slot_by_tid(thread->thread_id);
   if (!slot) {
     return -1;
   }
   if (thread->state == THREAD_STATE_TERMINATED) {
-    return sched_enqueue_reap(slot);
+    if (thread->home_core_id == current_core) {
+      return sched_enqueue_reap(slot);
+    }
+    return 0;
   }
 
   thread->state = THREAD_STATE_TERMINATED;
+  __atomic_store_n(&thread->owner_state, THREAD_OWNER_NONE, __ATOMIC_RELEASE);
+
   if (thread != sched_current_thread()) {
     sched_detach_thread_from_queues(slot);
   }
-  return sched_enqueue_reap(slot);
+
+  if (thread->home_core_id == current_core) {
+    return sched_enqueue_reap(slot);
+  } else {
+    sched_remote_cmd_t *cmd = sched_allocate_outbound_cmd();
+    if (cmd) {
+      cmd->type = SCHED_REMOTE_REAP;
+      cmd->source_cpu = current_core;
+      cmd->target_cpu = thread->home_core_id;
+      cmd->thread_id = thread->thread_id;
+      cmd->expected_thread_generation = thread->sched_generation;
+      cmd->state = SCHED_REMOTE_CMD_PENDING;
+      kstatus_t status = sched_remote_submit(thread->home_core_id, cmd);
+      if (status != K_OK) {
+        sched_remote_cmd_release(cmd);
+        return status;
+      }
+    }
+  }
+  return 0;
 }
 
 void sched_reap_terminated_threads(void) {
@@ -377,7 +402,14 @@ void sched_reset_core_runqueues(void) {
     rq->remote.ipi_sent = 0U;
     rq->remote.ipi_coalesced = 0U;
 
+    for (uint32_t w = 0; w < SCHED_CMD_BITMAP_WORDS; ++w) {
+        rq->outbound_alloc_bitmap[w] = 0U;
+    }
+
     for (uint32_t i = 0; i < SCHED_REMOTE_CMD_CAPACITY; ++i) {
+        rq->outbound_cmds[i].handle.slot = i;
+        rq->outbound_cmds[i].handle.origin_cpu = core;
+        rq->outbound_cmds[i].handle.generation = 1;
         rq->outbound_cmds[i].state = SCHED_REMOTE_CMD_EMPTY;
     }
 
@@ -1017,5 +1049,41 @@ bh_thread_t *sched_cfs_pick_next(sched_rq_t *rq) {
     return (bh_thread_t *)(void *)((char *)left - offsetof(bh_thread_t, cfs_node));
 }
 
+kstatus_t sched_get_thread_snapshot(uint64_t tid, sched_thread_snapshot_t *out) {
+  if (!out) return K_ERR_INVALID_ARG;
+  bh_thread_t *thread = sched_find_thread_by_id(tid);
+  if (!thread) return -1;
+
+  out->thread_id = thread->thread_id;
+  out->home_core_id = thread->home_core_id;
+  out->bound_core_id = thread->bound_core_id;
+  out->owner_cpu = __atomic_load_n(&thread->owner_cpu, __ATOMIC_ACQUIRE);
+  out->state = (uint32_t)thread->state;
+  out->priority = thread->priority;
+  out->affinity_mask = thread->affinity_mask;
+  out->migration_state = (uint32_t)__atomic_load_n(&thread->migration_state, __ATOMIC_ACQUIRE);
+  out->migration_epoch = __atomic_load_n(&thread->migration_epoch, __ATOMIC_ACQUIRE);
+  return K_OK;
+}
+
+int sched_set_constraints(uint64_t tid, const bh_exec_constraints_k_t *c) {
+  if (!c) return -1;
+  bh_thread_t *thread = sched_find_thread_by_id(tid);
+  if (!thread) return -1;
+  thread->constraints = *c;
+  return 0;
+}
+
+int sched_get_constraints(uint64_t tid, bh_exec_constraints_k_t *c) {
+  if (!c) return -1;
+  bh_thread_t *thread = sched_find_thread_by_id(tid);
+  if (!thread) return -1;
+  *c = thread->constraints;
+  return 0;
+}
+
+bool sched_thread_exists(uint64_t tid) {
+  return (sched_find_thread_by_id(tid) != NULL);
+}
 
 

--- a/core/kernel/src/sched/sched_core.c
+++ b/core/kernel/src/sched/sched_core.c
@@ -9,6 +9,7 @@ void arch_post_switch(void) {
 
 void sched_reschedule(void) {
   uint32_t core = sched_clamp_core(hal_cpu_get_id());
+  sched_remote_cmd_poll_timeouts();
   sched_reap_terminated_threads();
   sched_process_pending_ai_suggestions();
 
@@ -50,6 +51,7 @@ void sched_reschedule(void) {
                               rq->runnable_count--;
                           }
                       }
+                      uint32_t epoch = __atomic_fetch_add(&victim->migration_epoch, 1, __ATOMIC_SEQ_CST) + 1;
                       victim->owner_state = THREAD_OWNER_REMOTE_PENDING;
                       victim->migration_state = SCHED_MIGRATION_DEQUEUED;
                       victim->migration_target_cpu = cmd->target_cpu;
@@ -61,11 +63,27 @@ void sched_reschedule(void) {
                           enq_cmd->target_cpu = cmd->target_cpu;
                           enq_cmd->thread_id = victim->thread_id;
                           enq_cmd->expected_thread_generation = victim->sched_generation;
+                          enq_cmd->migration_epoch = epoch;
                           enq_cmd->priority = victim->priority;
                           enq_cmd->state = SCHED_REMOTE_CMD_PENDING;
 
-                          sched_remote_submit(cmd->target_cpu, enq_cmd);
-                          victim->migration_state = SCHED_MIGRATION_ENQUEUE_REQUESTED;
+                          kstatus_t status = sched_remote_submit(cmd->target_cpu, enq_cmd);
+                          if (status == K_OK) {
+                              victim->migration_state = SCHED_MIGRATION_COMMIT_SENT;
+                          } else {
+                              sched_remote_cmd_release(enq_cmd);
+                              victim->owner_state = THREAD_OWNER_NONE;
+                              victim->migration_state = SCHED_MIGRATION_NONE;
+                              sched_invariant_on_enqueue(victim, core);
+                              if (g_policy == SCHED_POLICY_CLOUD_FAIR) {
+                                  sched_cfs_enqueue(rq, victim);
+                              } else {
+                                  list_add(&v_slot->run_node, &rq->ready_queue[victim->priority]);
+                                  sched_ready_bitmap_set(rq, victim->priority);
+                              }
+                              v_slot->is_on_runqueue = 1U;
+                              rq->runnable_count++;
+                          }
                       } else {
                           victim->owner_state = THREAD_OWNER_NONE;
                           victim->migration_state = SCHED_MIGRATION_NONE;
@@ -141,83 +159,39 @@ void sched_reschedule(void) {
                       rq->runnable_count--;
                   }
               }
-              thread->owner_state = THREAD_OWNER_REMOTE_PENDING;
-              thread->migration_state = SCHED_MIGRATION_DEQUEUED;
+              __atomic_store_n(&thread->owner_state, THREAD_OWNER_REMOTE_PENDING, __ATOMIC_RELEASE);
+              __atomic_store_n(&thread->migration_state, SCHED_MIGRATION_DEQUEUED, __ATOMIC_RELEASE);
 
-              // Transition to Phase 2: Remote enqueue request to target CPU using the new MPSC submit!
-              uint32_t target_cpu = thread->migration_target_cpu;
-              sched_remote_cmd_t *new_cmd = sched_allocate_outbound_cmd();
-              if (new_cmd) {
-                  new_cmd->type = SCHED_REMOTE_ENQUEUE;
-                  new_cmd->source_cpu = core;
-                  new_cmd->target_cpu = target_cpu;
-                  new_cmd->thread_id = thread->thread_id;
-                  new_cmd->expected_thread_generation = thread->sched_generation;
-                  new_cmd->priority = thread->priority;
-                  new_cmd->state = SCHED_REMOTE_CMD_PENDING;
-
-                  sched_remote_submit(target_cpu, new_cmd);
-                  thread->migration_state = SCHED_MIGRATION_ENQUEUE_REQUESTED;
-              } else {
-                  cmd->state = SCHED_REMOTE_CMD_FAILED;
-                  thread->migration_state = SCHED_MIGRATION_FAILED;
-              }
               cmd->state = SCHED_REMOTE_CMD_ACKED;
               continue;
           } else if (cmd->type == SCHED_REMOTE_ENQUEUE) {
-              if (thread->migration_state == SCHED_MIGRATION_COMMITTED) {
+              uint32_t mig_state = __atomic_load_n(&thread->migration_state, __ATOMIC_ACQUIRE);
+              if (mig_state == SCHED_MIGRATION_COMMITTED) {
                   // Already handled
                   cmd->state = SCHED_REMOTE_CMD_ACKED;
                   continue;
               }
 
-              if (thread->owner_state == THREAD_OWNER_REMOTE_PENDING) {
+              uint32_t o_state = __atomic_load_n(&thread->owner_state, __ATOMIC_ACQUIRE);
+              if (o_state == THREAD_OWNER_REMOTE_PENDING) {
                   // Validate admissibility on target core
                   if (!sched_is_core_admissible(thread, core)) {
-                      // Rollback attempt to old owner
+                      // Reject commit
                       cmd->state = SCHED_REMOTE_CMD_FAILED;
-                      uint32_t old_owner = cmd->source_cpu;
-
-                      sched_remote_cmd_t *rollback_cmd = sched_allocate_outbound_cmd();
-                      if (rollback_cmd) {
-                          rollback_cmd->type = SCHED_REMOTE_ENQUEUE; // Rollback enqueue
-                          rollback_cmd->target_cpu = old_owner;
-                          rollback_cmd->source_cpu = core;
-                          rollback_cmd->thread_id = thread->thread_id;
-                          rollback_cmd->expected_thread_generation = thread->sched_generation;
-                          rollback_cmd->state = SCHED_REMOTE_CMD_PENDING;
-
-                          sched_remote_submit(old_owner, rollback_cmd);
-                          thread->migration_state = SCHED_MIGRATION_ROLLBACK_REQUESTED;
-                      } else {
-                          sched_quarantine_thread(thread, THREAD_FAULT_MIGRATION_ROLLBACK_FAILED);
-                          thread->migration_state = SCHED_MIGRATION_FAILED;
-                      }
                       continue;
                   }
 
-                  thread->owner_state = THREAD_OWNER_NONE;
-                  thread->owner_cpu = core;
+                  __atomic_store_n(&thread->owner_cpu, core, __ATOMIC_RELEASE);
                   thread->bound_core_id = core;
-                  thread->migration_state = SCHED_MIGRATION_COMMITTED;
+                  __atomic_store_n(&thread->owner_state, THREAD_OWNER_NONE, __ATOMIC_RELEASE);
+                  __atomic_store_n(&thread->migration_state, SCHED_MIGRATION_COMMITTED, __ATOMIC_RELEASE);
                   cmd->state = SCHED_REMOTE_CMD_ACKED;
-              } else if (thread->migration_state == SCHED_MIGRATION_ROLLBACK_REQUESTED) {
-                  // Successful rollback
-                  thread->owner_state = THREAD_OWNER_NONE;
-                  thread->owner_cpu = core;
+              } else if (mig_state == SCHED_MIGRATION_ROLLBACK_SENT) {
+                  // Rollback enqueue accepted on old owner
+                  __atomic_store_n(&thread->owner_cpu, core, __ATOMIC_RELEASE);
                   thread->bound_core_id = core;
-                  thread->migration_state = SCHED_MIGRATION_NONE; // Reset
-                  cmd->state = SCHED_REMOTE_CMD_ACKED;
-              } else if (thread->owner_state == THREAD_OWNER_REMOTE_PENDING &&
-                         thread->migration_state == SCHED_MIGRATION_ROLLBACK_REQUESTED) {
-                  // Rollback failed as well -> Quarantine
-                  sched_quarantine_thread(thread, THREAD_FAULT_MIGRATION_ROLLBACK_FAILED);
-                  thread->migration_state = SCHED_MIGRATION_FAILED;
-                  cmd->state = SCHED_REMOTE_CMD_FAILED;
-                  continue;
-              } else if (thread->migration_state == SCHED_MIGRATION_ENQUEUE_REQUESTED && thread->bound_core_id == core) {
-                  // This handles local re-enqueue or redundant enqueue
-                  thread->migration_state = SCHED_MIGRATION_NONE;
+                  __atomic_store_n(&thread->owner_state, THREAD_OWNER_NONE, __ATOMIC_RELEASE);
+                  __atomic_store_n(&thread->migration_state, SCHED_MIGRATION_NONE, __ATOMIC_RELEASE);
                   cmd->state = SCHED_REMOTE_CMD_ACKED;
               }
           } else if (cmd->type == SCHED_REMOTE_DEQUEUE) {
@@ -288,10 +262,30 @@ void sched_reschedule(void) {
               }
               cmd->state = SCHED_REMOTE_CMD_ACKED;
               continue;
+          } else if (cmd->type == SCHED_REMOTE_SET_THROTTLE) {
+              rq->throttled = cmd->flags;
+              cmd->state = SCHED_REMOTE_CMD_ACKED;
+              continue;
+          } else if (cmd->type == SCHED_REMOTE_TERMINATE) {
+              sched_mark_thread_terminated(thread);
+              cmd->state = SCHED_REMOTE_CMD_ACKED;
+              continue;
+          } else if (cmd->type == SCHED_REMOTE_REAP) {
+              sched_enqueue_reap(slot);
+              cmd->state = SCHED_REMOTE_CMD_ACKED;
+              continue;
+          } else if (cmd->type == SCHED_REMOTE_HANDOFF) {
+              sched_request_handoff_tid(thread->thread_id, cmd->target_cpu, cmd->flags);
+              cmd->state = SCHED_REMOTE_CMD_ACKED;
+              continue;
+          } else if (cmd->type == SCHED_REMOTE_SET_AFFINITY) {
+              thread->affinity_mask = cmd->flags;
+              cmd->state = SCHED_REMOTE_CMD_ACKED;
+              continue;
           }
 
           if (thread->state == THREAD_STATE_QUARANTINED || thread->owner_state == THREAD_OWNER_QUARANTINED) {
-              if (thread->migration_state == SCHED_MIGRATION_ROLLBACK_REQUESTED) {
+              if (thread->migration_state == SCHED_MIGRATION_ROLLBACK_SENT) {
                   thread->migration_state = SCHED_MIGRATION_FAILED;
                   thread->pending_fault = THREAD_FAULT_MIGRATION_ROLLBACK_FAILED;
               }
@@ -352,6 +346,7 @@ void sched_reschedule(void) {
 }
 
 void sched_on_timer_tick(void) {
+  sched_remote_cmd_poll_timeouts();
   g_cpu_locals[sched_clamp_core(hal_cpu_get_id())].runqueue.total_ticks++;
 
 
@@ -367,7 +362,7 @@ void sched_on_timer_tick(void) {
     curr = curr->next;
     if (slot->thread.state == THREAD_STATE_SLEEPING &&
         slot->thread.wake_deadline_ms <= g_cpu_locals[core].runqueue.total_ticks) {
-      sched_wakeup(&slot->thread);
+      sched_wake_tid(slot->thread.thread_id);
     }
   }
 
@@ -384,7 +379,7 @@ void sched_on_timer_tick(void) {
 
       // Unlink it from wait queues handled by endpoint access so we can awaken it
       slot->thread.next_waiter = NULL;
-      sched_wakeup(&slot->thread);
+      sched_wake_tid(slot->thread.thread_id);
     }
   }
 
@@ -473,23 +468,69 @@ void sched_assert_local_rq(sched_rq_t *rq) {
 sched_remote_cmd_t *sched_allocate_outbound_cmd(void) {
   uint32_t core = sched_clamp_core(hal_cpu_get_id());
   sched_rq_t *rq = &g_cpu_locals[core].runqueue;
-  for (uint32_t i = 0; i < SCHED_REMOTE_CMD_CAPACITY; ++i) {
-    if (rq->outbound_cmds[i].state != SCHED_REMOTE_CMD_PENDING) {
-      sched_remote_cmd_t *cmd = &rq->outbound_cmds[i];
-      cmd->cmd_id = i;
-      cmd->type = (sched_remote_cmd_type_t)0;
-      cmd->state = SCHED_REMOTE_CMD_PENDING;
-      cmd->source_cpu = core;
-      cmd->target_cpu = 0;
-      cmd->thread_id = 0;
-      cmd->expected_thread_generation = 0;
-      cmd->flags = 0;
-      cmd->priority = 0;
-      list_init(&cmd->list);
-      return cmd;
+  uint32_t slot_idx = 0xFFFF;
+
+  for (uint32_t w = 0; w < SCHED_CMD_BITMAP_WORDS; ++w) {
+    uint32_t val = __atomic_load_n(&rq->outbound_alloc_bitmap[w], __ATOMIC_ACQUIRE);
+    while (val != 0xFFFFFFFFU) {
+      uint32_t free_bit = __builtin_ctz(~val);
+      uint32_t new_val = val | (1U << free_bit);
+      if (__atomic_compare_exchange_n(&rq->outbound_alloc_bitmap[w], &val, new_val, false, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE)) {
+        slot_idx = w * 32 + free_bit;
+        break;
+      }
+    }
+    if (slot_idx != 0xFFFF) {
+      break;
     }
   }
-  return NULL;
+
+  if (slot_idx >= SCHED_REMOTE_CMD_CAPACITY) {
+    return NULL;
+  }
+
+  sched_remote_cmd_t *cmd = &rq->outbound_cmds[slot_idx];
+
+  // Increment generation (start of RESERVED state)
+  cmd->handle.generation++;
+  if (cmd->handle.generation == 0) {
+    cmd->handle.generation = 1;
+  }
+
+  cmd->cmd_id = slot_idx;
+  cmd->type = (sched_remote_cmd_type_t)0;
+  cmd->source_cpu = core;
+  cmd->target_cpu = 0;
+  cmd->thread_id = 0;
+  cmd->expected_thread_generation = 0;
+  cmd->flags = 0;
+  cmd->priority = 0;
+  cmd->migration_epoch = 0;
+  cmd->result = 0;
+  cmd->submit_tick = 0;
+  cmd->deadline_tick = 0;
+  list_init(&cmd->list);
+
+  // Set state to RESERVED under memory barrier
+  __atomic_store_n(&cmd->state, SCHED_REMOTE_CMD_RESERVED, __ATOMIC_RELEASE);
+
+  return cmd;
+}
+
+void sched_remote_cmd_release(sched_remote_cmd_t *cmd) {
+  if (!cmd) return;
+  uint16_t slot = cmd->handle.slot;
+  uint32_t w = slot / 32;
+  uint32_t bit = slot % 32;
+  uint32_t mask = ~(1U << bit);
+
+  // Set state to EMPTY
+  __atomic_store_n(&cmd->state, SCHED_REMOTE_CMD_EMPTY, __ATOMIC_RELEASE);
+
+  // Clear from bitmap
+  uint32_t core = cmd->handle.origin_cpu;
+  sched_rq_t *rq = &g_cpu_locals[core].runqueue;
+  __atomic_fetch_and(&rq->outbound_alloc_bitmap[w], mask, __ATOMIC_ACQ_REL);
 }
 
 kstatus_t sched_remote_submit(uint32_t target_cpu, const sched_remote_cmd_t *cmd) {
@@ -501,11 +542,18 @@ kstatus_t sched_remote_submit(uint32_t target_cpu, const sched_remote_cmd_t *cmd
     return K_ERR_INVALID_ARG;
   }
 
+  sched_rq_t *rq = &g_cpu_locals[current_core].runqueue;
   sched_rq_t *target_rq = &g_cpu_locals[target_cpu].runqueue;
+  sched_remote_cmd_t *mutable_cmd = (sched_remote_cmd_t *)cmd;
+
+  mutable_cmd->submit_tick = rq->total_ticks;
+  mutable_cmd->deadline_tick = rq->total_ticks + 10U; // 10 ticks deadline
+  __atomic_store_n(&mutable_cmd->state, SCHED_REMOTE_CMD_PENDING, __ATOMIC_RELEASE);
 
   // Cast away const since bh_mpsc_queue_push takes void *
   kstatus_t status = bh_mpsc_queue_push(&target_rq->remote.queue, (void *)cmd);
   if (status != K_OK) {
+    __atomic_store_n(&mutable_cmd->state, SCHED_REMOTE_CMD_RESERVED, __ATOMIC_RELEASE);
     __atomic_fetch_add(&target_rq->remote.full, 1, __ATOMIC_RELAXED);
     return K_ERR_NO_RESOURCES;
   }
@@ -527,4 +575,185 @@ kstatus_t sched_remote_submit(uint32_t target_cpu, const sched_remote_cmd_t *cmd
   }
 
   return K_OK;
+}
+
+kstatus_t sched_read_load_snapshot(uint32_t cpu, sched_load_snapshot_t *out) {
+  if (cpu >= g_active_core_count || !out) return K_ERR_INVALID_ARG;
+  sched_rq_t *rq = &g_cpu_locals[cpu].runqueue;
+  uint32_t seq;
+  do {
+    seq = __atomic_load_n(&rq->load_snapshot.load_seq, __ATOMIC_ACQUIRE);
+    out->runnable_count = __atomic_load_n(&rq->load_snapshot.runnable_count, __ATOMIC_ACQUIRE);
+  } while ((seq & 1) != 0 || seq != __atomic_load_n(&rq->load_snapshot.load_seq, __ATOMIC_ACQUIRE));
+  out->load_seq = seq;
+  return K_OK;
+}
+
+bool sched_read_isolated_snapshot(uint32_t cpu) {
+  if (cpu >= g_active_core_count) return false;
+  sched_rq_t *rq = &g_cpu_locals[cpu].runqueue;
+  return __atomic_load_n(&rq->sched_isolated, __ATOMIC_ACQUIRE);
+}
+
+kstatus_t sched_migration_transition(bh_thread_t *thread, sched_migration_state_t expected, sched_migration_state_t next) {
+  if (!thread) return K_ERR_INVALID_ARG;
+  uint32_t state = __atomic_load_n(&thread->migration_state, __ATOMIC_ACQUIRE);
+  if (state != (uint32_t)expected) {
+#if !defined(NDEBUG)
+    kernel_panic("sched_migration_transition failed: expected %d, got %d", expected, state);
+#else
+    // Production safety fallback: reject transition, quarantine if ambiguous
+    if (expected == SCHED_MIGRATION_ROLLBACK_SENT || next == SCHED_MIGRATION_FAILED) {
+        sched_quarantine_thread(thread, THREAD_FAULT_MIGRATION_ROLLBACK_FAILED);
+    }
+    return K_ERR_BAD_STATE;
+#endif
+  }
+  __atomic_store_n(&thread->migration_state, (uint32_t)next, __ATOMIC_RELEASE);
+  return K_OK;
+}
+
+void sched_remote_cmd_poll_timeouts(void) {
+  uint32_t core = sched_clamp_core(hal_cpu_get_id());
+  sched_rq_t *rq = &g_cpu_locals[core].runqueue;
+  uint64_t current_ticks = rq->total_ticks;
+
+  for (uint32_t i = 0; i < SCHED_REMOTE_CMD_CAPACITY; ++i) {
+    sched_remote_cmd_t *cmd = &rq->outbound_cmds[i];
+    uint32_t state = __atomic_load_n(&cmd->state, __ATOMIC_ACQUIRE);
+
+    if (state == SCHED_REMOTE_CMD_PENDING) {
+      if (cmd->deadline_tick > 0 && current_ticks >= cmd->deadline_tick) {
+        // Mark as timed out
+        __atomic_store_n(&cmd->state, SCHED_REMOTE_CMD_TIMEOUT, __ATOMIC_RELEASE);
+        state = SCHED_REMOTE_CMD_TIMEOUT;
+      }
+    }
+
+    if (state == SCHED_REMOTE_CMD_ACKED || state == SCHED_REMOTE_CMD_FAILED || state == SCHED_REMOTE_CMD_TIMEOUT) {
+      // Terminal state observed by originating CPU
+      bh_thread_t *thread = sched_find_thread_by_id(cmd->thread_id);
+      if (thread) {
+        // Validate generation and epoch
+        if (thread->sched_generation == cmd->expected_thread_generation &&
+            thread->migration_epoch == cmd->migration_epoch) {
+
+          if (cmd->type == SCHED_REMOTE_MIGRATE_PREPARE) {
+            if (state == SCHED_REMOTE_CMD_ACKED) {
+              // Prepare (dequeue) succeeded on old owner. Transition DEQUEUED -> COMMIT_SENT
+              if (sched_migration_transition(thread, SCHED_MIGRATION_DEQUEUED, SCHED_MIGRATION_COMMIT_SENT) == K_OK) {
+                // Submit commit/enqueue command to target_cpu
+                sched_remote_cmd_t *commit_cmd = sched_allocate_outbound_cmd();
+                if (commit_cmd) {
+                  commit_cmd->type = SCHED_REMOTE_ENQUEUE;
+                  commit_cmd->source_cpu = core;
+                  commit_cmd->target_cpu = thread->migration_target_cpu;
+                  commit_cmd->thread_id = thread->thread_id;
+                  commit_cmd->expected_thread_generation = thread->sched_generation;
+                  commit_cmd->migration_epoch = thread->migration_epoch;
+                  commit_cmd->priority = thread->priority;
+                  commit_cmd->state = SCHED_REMOTE_CMD_PENDING;
+
+                  kstatus_t status = sched_remote_submit(thread->migration_target_cpu, commit_cmd);
+                  if (status != K_OK) {
+                    sched_remote_cmd_release(commit_cmd);
+                    // Commit submission failed! Roll back.
+                    sched_migration_transition(thread, SCHED_MIGRATION_COMMIT_SENT, SCHED_MIGRATION_ROLLBACK_SENT);
+                    // Send rollback to old owner to re-enqueue
+                    sched_remote_cmd_t *rb_cmd = sched_allocate_outbound_cmd();
+                    if (rb_cmd) {
+                      rb_cmd->type = SCHED_REMOTE_ENQUEUE;
+                      rb_cmd->source_cpu = core;
+                      rb_cmd->target_cpu = cmd->target_cpu; // old owner
+                      rb_cmd->thread_id = thread->thread_id;
+                      rb_cmd->expected_thread_generation = thread->sched_generation;
+                      rb_cmd->migration_epoch = thread->migration_epoch;
+                      rb_cmd->state = SCHED_REMOTE_CMD_PENDING;
+                      kstatus_t st = sched_remote_submit(cmd->target_cpu, rb_cmd);
+                      if (st != K_OK) {
+                        sched_remote_cmd_release(rb_cmd);
+                        sched_quarantine_thread(thread, THREAD_FAULT_MIGRATION_ROLLBACK_FAILED);
+                        sched_migration_transition(thread, SCHED_MIGRATION_ROLLBACK_SENT, SCHED_MIGRATION_FAILED);
+                      }
+                    } else {
+                      sched_quarantine_thread(thread, THREAD_FAULT_MIGRATION_ROLLBACK_FAILED);
+                      sched_migration_transition(thread, SCHED_MIGRATION_ROLLBACK_SENT, SCHED_MIGRATION_FAILED);
+                    }
+                  }
+                } else {
+                  // Commit alloc failed -> rollback
+                  sched_migration_transition(thread, SCHED_MIGRATION_DEQUEUED, SCHED_MIGRATION_ROLLBACK_SENT);
+                  sched_remote_cmd_t *rb_cmd = sched_allocate_outbound_cmd();
+                  if (rb_cmd) {
+                    rb_cmd->type = SCHED_REMOTE_ENQUEUE;
+                    rb_cmd->source_cpu = core;
+                    rb_cmd->target_cpu = cmd->target_cpu;
+                    rb_cmd->thread_id = thread->thread_id;
+                    rb_cmd->expected_thread_generation = thread->sched_generation;
+                    rb_cmd->migration_epoch = thread->migration_epoch;
+                    rb_cmd->state = SCHED_REMOTE_CMD_PENDING;
+                    kstatus_t st = sched_remote_submit(cmd->target_cpu, rb_cmd);
+                    if (st != K_OK) {
+                      sched_remote_cmd_release(rb_cmd);
+                      sched_quarantine_thread(thread, THREAD_FAULT_MIGRATION_ROLLBACK_FAILED);
+                      sched_migration_transition(thread, SCHED_MIGRATION_ROLLBACK_SENT, SCHED_MIGRATION_FAILED);
+                    }
+                  } else {
+                    sched_quarantine_thread(thread, THREAD_FAULT_MIGRATION_ROLLBACK_FAILED);
+                    sched_migration_transition(thread, SCHED_MIGRATION_ROLLBACK_SENT, SCHED_MIGRATION_FAILED);
+                  }
+                }
+              }
+            } else {
+              // Prepare failed or timed out! Restore to NONE.
+              sched_migration_transition(thread, SCHED_MIGRATION_PREPARE_SENT, SCHED_MIGRATION_NONE);
+            }
+          } else if (cmd->type == SCHED_REMOTE_ENQUEUE) {
+            // COMMIT phase
+            if (state == SCHED_REMOTE_CMD_ACKED) {
+              // Commit succeeded.
+              uint32_t current_m_state = __atomic_load_n(&thread->migration_state, __ATOMIC_ACQUIRE);
+              if (current_m_state == SCHED_MIGRATION_COMMITTED) {
+                sched_migration_transition(thread, SCHED_MIGRATION_COMMITTED, SCHED_MIGRATION_NONE);
+              } else if (current_m_state == SCHED_MIGRATION_ROLLBACK_SENT) {
+                sched_migration_transition(thread, SCHED_MIGRATION_ROLLBACK_SENT, SCHED_MIGRATION_NONE);
+              }
+            } else {
+              // Commit failed or timed out!
+              uint32_t current_m_state = __atomic_load_n(&thread->migration_state, __ATOMIC_ACQUIRE);
+              if (current_m_state == SCHED_MIGRATION_COMMIT_SENT) {
+                sched_migration_transition(thread, SCHED_MIGRATION_COMMIT_SENT, SCHED_MIGRATION_ROLLBACK_SENT);
+                // Send rollback to old owner
+                sched_remote_cmd_t *rb_cmd = sched_allocate_outbound_cmd();
+                if (rb_cmd) {
+                  rb_cmd->type = SCHED_REMOTE_ENQUEUE;
+                  rb_cmd->source_cpu = core;
+                  rb_cmd->target_cpu = cmd->source_cpu; // old owner (source_cpu)
+                  rb_cmd->thread_id = thread->thread_id;
+                  rb_cmd->expected_thread_generation = thread->sched_generation;
+                  rb_cmd->migration_epoch = thread->migration_epoch;
+                  rb_cmd->state = SCHED_REMOTE_CMD_PENDING;
+                  kstatus_t st = sched_remote_submit(cmd->source_cpu, rb_cmd);
+                  if (st != K_OK) {
+                    sched_remote_cmd_release(rb_cmd);
+                    sched_quarantine_thread(thread, THREAD_FAULT_MIGRATION_ROLLBACK_FAILED);
+                    sched_migration_transition(thread, SCHED_MIGRATION_ROLLBACK_SENT, SCHED_MIGRATION_FAILED);
+                  }
+                } else {
+                  sched_quarantine_thread(thread, THREAD_FAULT_MIGRATION_ROLLBACK_FAILED);
+                  sched_migration_transition(thread, SCHED_MIGRATION_ROLLBACK_SENT, SCHED_MIGRATION_FAILED);
+                }
+              } else if (current_m_state == SCHED_MIGRATION_ROLLBACK_SENT) {
+                // Rollback failed or timed out -> QUARANTINE
+                sched_quarantine_thread(thread, THREAD_FAULT_MIGRATION_ROLLBACK_FAILED);
+                sched_migration_transition(thread, SCHED_MIGRATION_ROLLBACK_SENT, SCHED_MIGRATION_FAILED);
+              }
+            }
+          }
+        }
+      }
+      // Re-release command slot
+      sched_remote_cmd_release(cmd);
+    }
+  }
 }

--- a/core/kernel/src/sched/sched_internal.h
+++ b/core/kernel/src/sched/sched_internal.h
@@ -69,7 +69,6 @@ thread_slot_t *sched_find_thread_slot_by_tid_local(sched_rq_t *rq, uint64_t tid)
 thread_slot_t *sched_find_thread_slot_by_tid(uint64_t tid);
 sched_remote_cmd_t *sched_allocate_outbound_cmd(void);
 uint32_t sched_clamp_core(uint32_t core_id);
-uint32_t sched_read_published_load(uint32_t core_id);
 bh_thread_t *sched_find_steal_candidate(uint32_t core_id, uint32_t target_cpu);
 
 static inline void sched_publish_load(sched_rq_t *rq) {
@@ -79,6 +78,7 @@ static inline void sched_publish_load(sched_rq_t *rq) {
   __atomic_store_n(&rq->load_snapshot.load_seq, seq + 2, __ATOMIC_RELEASE);
 }
 int sched_mark_thread_terminated(bh_thread_t *thread);
+int sched_enqueue_reap(thread_slot_t *slot);
 void sched_reap_terminated_threads(void);
 void sched_process_pending_ai_suggestions(void);
 void sched_sleep_enqueue(thread_slot_t *slot, uint32_t core_id);

--- a/core/kernel/src/sched/sched_invariants.c
+++ b/core/kernel/src/sched/sched_invariants.c
@@ -46,11 +46,13 @@ static void handle_violation(sched_invariant_violation_t violation, bh_thread_t 
                 sched_quarantine_thread(thread, (uint32_t)violation);
             }
             break;
-        case SCHED_FAULT_ACTION_ISOLATE_CORE:
+        case SCHED_FAULT_ACTION_ISOLATE_CORE: {
             // Minimal core isolation: just set a flag on this core for now
-            g_cpu_locals[hal_cpu_get_id()].runqueue.sched_isolated = true;
-            g_cpu_locals[hal_cpu_get_id()].runqueue.isolation_reason = (uint32_t)violation;
+            sched_rq_t *rq = sched_local_rq();
+            rq->sched_isolated = true;
+            rq->isolation_reason = (uint32_t)violation;
             break;
+        }
         default:
             break;
     }

--- a/core/kernel/src/sched/sched_migrate.c
+++ b/core/kernel/src/sched/sched_migrate.c
@@ -2,19 +2,9 @@
 #include "sched_internal.h"
 #include "arch/cpu_relax.h"
 
-uint32_t sched_read_published_load(uint32_t core_id) {
-  if (core_id >= g_active_core_count) return 0;
-  sched_rq_t *rq = &g_cpu_locals[core_id].runqueue;
-  uint32_t seq, count;
-  do {
-    seq = __atomic_load_n(&rq->load_snapshot.load_seq, __ATOMIC_ACQUIRE);
-    count = __atomic_load_n(&rq->load_snapshot.runnable_count, __ATOMIC_ACQUIRE);
-  } while ((seq & 1) != 0 || seq != __atomic_load_n(&rq->load_snapshot.load_seq, __ATOMIC_ACQUIRE));
-  return count;
-}
-
 bh_thread_t *sched_find_steal_candidate(uint32_t core_id, uint32_t target_cpu) {
-  sched_rq_t *rq = &g_cpu_locals[core_id].runqueue;
+  (void)core_id;
+  sched_rq_t *rq = sched_local_rq();
 
   for (uint32_t p = 0; p < MAX_PRIORITY_LEVELS; ++p) {
     list_head_t *head = &rq->ready_queue[p];
@@ -48,7 +38,11 @@ void sched_balance_once(void) {
   uint32_t min_depth = UINT32_MAX;
 
   for (uint32_t core = 0; core < g_active_core_count; ++core) {
-    uint32_t depth = sched_read_published_load(core);
+    sched_load_snapshot_t snap;
+    uint32_t depth = 0;
+    if (sched_read_load_snapshot(core, &snap) == K_OK) {
+        depth = snap.runnable_count;
+    }
     if (depth > max_depth) {
       max_depth = depth;
       busiest = core;
@@ -85,28 +79,32 @@ int sched_migrate_task(bh_thread_t *thread, uint32_t new_node) {
     return K_ERR_BAD_STATE;
   }
 
-  if (thread->migration_state != SCHED_MIGRATION_NONE) {
+  uint32_t m_state = __atomic_load_n(&thread->migration_state, __ATOMIC_ACQUIRE);
+  if (m_state != SCHED_MIGRATION_NONE) {
       return K_ERR_IN_PROGRESS;
   }
 
-  thread_slot_t *slot = sched_find_thread_slot_by_tid_local(&g_cpu_locals[thread->home_core_id].runqueue, thread->thread_id);
+  thread_slot_t *slot = sched_find_thread_slot_by_tid(thread->thread_id);
   if (!slot) {
     return -1;
   }
 
   uint32_t current_core = sched_clamp_core(hal_cpu_get_id());
-  uint32_t bound_core = thread->bound_core_id;
+  uint32_t owner = __atomic_load_n(&thread->owner_cpu, __ATOMIC_ACQUIRE);
 
-  if (bound_core == new_node) {
+  if (owner == new_node) {
       return 0;
   }
 
+  // Increment migration epoch at start of migration
+  uint32_t epoch = __atomic_fetch_add(&thread->migration_epoch, 1, __ATOMIC_SEQ_CST) + 1;
+
   thread->migration_target_cpu = new_node;
 
-  if (bound_core == current_core) {
-      // Phase 1: Local dequeue
+  if (owner == current_core) {
+      // Local owner: Phase 1: Local dequeue
       hal_cpu_disable_interrupts();
-      sched_rq_t *rq = &g_cpu_locals[current_core].runqueue;
+      sched_rq_t *rq = sched_local_rq();
       if (slot->is_on_runqueue != 0U) {
           if (g_policy == SCHED_POLICY_CLOUD_FAIR) {
             sched_cfs_dequeue(rq, thread);
@@ -120,16 +118,16 @@ int sched_migrate_task(bh_thread_t *thread, uint32_t new_node) {
             rq->runnable_count--;
           }
       }
-      thread->migration_state = SCHED_MIGRATION_DEQUEUED;
+      sched_migration_transition(thread, SCHED_MIGRATION_NONE, SCHED_MIGRATION_DEQUEUED);
       thread->owner_state = THREAD_OWNER_REMOTE_PENDING;
       hal_cpu_enable_interrupts();
 
-      // Phase 2: Remote enqueue request
+      // Local owner: Phase 2: Remote enqueue request to new_node
       sched_remote_cmd_t *cmd = sched_allocate_outbound_cmd();
       if (!cmd) {
           hal_cpu_disable_interrupts();
           thread->owner_state = THREAD_OWNER_NONE;
-          thread->migration_state = SCHED_MIGRATION_NONE;
+          sched_migration_transition(thread, SCHED_MIGRATION_DEQUEUED, SCHED_MIGRATION_NONE);
           sched_invariant_on_enqueue(thread, current_core);
           if (g_policy == SCHED_POLICY_CLOUD_FAIR) {
             sched_cfs_enqueue(rq, thread);
@@ -148,18 +146,19 @@ int sched_migrate_task(bh_thread_t *thread, uint32_t new_node) {
       cmd->target_cpu = new_node;
       cmd->thread_id = thread->thread_id;
       cmd->expected_thread_generation = thread->sched_generation;
+      cmd->migration_epoch = epoch;
       cmd->priority = thread->priority;
       cmd->state = SCHED_REMOTE_CMD_PENDING;
 
-      thread->migration_state = SCHED_MIGRATION_ENQUEUE_REQUESTED;
+      sched_migration_transition(thread, SCHED_MIGRATION_DEQUEUED, SCHED_MIGRATION_COMMIT_SENT);
       thread->preferred_numa_node = (uint8_t)new_node;
 
       kstatus_t status = sched_remote_submit(new_node, cmd);
       if (status != K_OK) {
-          cmd->state = SCHED_REMOTE_CMD_EMPTY;
+          sched_remote_cmd_release(cmd);
           hal_cpu_disable_interrupts();
           thread->owner_state = THREAD_OWNER_NONE;
-          thread->migration_state = SCHED_MIGRATION_NONE;
+          sched_migration_transition(thread, SCHED_MIGRATION_COMMIT_SENT, SCHED_MIGRATION_NONE);
           sched_invariant_on_enqueue(thread, current_core);
           if (g_policy == SCHED_POLICY_CLOUD_FAIR) {
             sched_cfs_enqueue(rq, thread);
@@ -174,7 +173,7 @@ int sched_migrate_task(bh_thread_t *thread, uint32_t new_node) {
       }
       return K_ERR_IN_PROGRESS;
   } else {
-      // Phase 1: Remote dequeue request (to old owner A)
+      // Remote owner: Send prepare command to owner core
       sched_remote_cmd_t *cmd = sched_allocate_outbound_cmd();
       if (!cmd) {
           return K_ERR_NO_RESOURCES;
@@ -182,40 +181,70 @@ int sched_migrate_task(bh_thread_t *thread, uint32_t new_node) {
 
       cmd->type = SCHED_REMOTE_MIGRATE_PREPARE;
       cmd->source_cpu = current_core;
-      cmd->target_cpu = bound_core;
+      cmd->target_cpu = owner;
       cmd->thread_id = thread->thread_id;
       cmd->expected_thread_generation = thread->sched_generation;
+      cmd->migration_epoch = epoch;
       cmd->state = SCHED_REMOTE_CMD_PENDING;
 
-      thread->migration_state = SCHED_MIGRATION_DEQUEUE_REQUESTED;
+      sched_migration_transition(thread, SCHED_MIGRATION_NONE, SCHED_MIGRATION_PREPARE_SENT);
       thread->preferred_numa_node = (uint8_t)new_node;
 
-      kstatus_t status = sched_remote_submit(bound_core, cmd);
+      kstatus_t status = sched_remote_submit(owner, cmd);
       if (status != K_OK) {
-          cmd->state = SCHED_REMOTE_CMD_EMPTY;
-          thread->migration_state = SCHED_MIGRATION_NONE;
+          sched_remote_cmd_release(cmd);
+          sched_migration_transition(thread, SCHED_MIGRATION_PREPARE_SENT, SCHED_MIGRATION_NONE);
           return status;
       }
       return K_ERR_IN_PROGRESS;
   }
 }
 
-int sched_set_thread_preferred_node(uint64_t tid, uint8_t node_id) {
-  return sched_migrate_task(sched_find_thread_by_id(tid), node_id);
+int sched_migrate_tid(uint64_t tid, uint32_t target_cpu) {
+  bh_thread_t *thread = sched_find_thread_by_id(tid);
+  if (!thread) return -1;
+  return sched_migrate_task(thread, target_cpu);
 }
 
-int sched_sys_set_affinity(uint64_t tid, uint32_t affinity_mask) {
+int sched_set_thread_preferred_node(uint64_t tid, uint8_t node_id) {
+  return sched_migrate_tid(tid, node_id);
+}
+
+int sched_set_affinity(uint64_t tid, uint32_t mask) {
   bh_thread_t *thread = sched_find_thread_by_id(tid);
-  if (!thread || affinity_mask == 0U) {
+  if (!thread || mask == 0U) {
     return -1;
   }
-  thread->affinity_mask = affinity_mask;
 
-  uint32_t current_core = thread->bound_core_id;
-  if ((affinity_mask & (1U << current_core)) == 0U) {
+  uint32_t current_core = sched_clamp_core(hal_cpu_get_id());
+  uint32_t owner = __atomic_load_n(&thread->owner_cpu, __ATOMIC_ACQUIRE);
+
+  if (owner != current_core) {
+      sched_remote_cmd_t *cmd = sched_allocate_outbound_cmd();
+      if (!cmd) return K_ERR_NO_RESOURCES;
+      cmd->type = SCHED_REMOTE_SET_AFFINITY;
+      cmd->source_cpu = current_core;
+      cmd->target_cpu = owner;
+      cmd->thread_id = thread->thread_id;
+      cmd->expected_thread_generation = thread->sched_generation;
+      cmd->flags = mask; // pass affinity mask here
+      cmd->state = SCHED_REMOTE_CMD_PENDING;
+
+      kstatus_t status = sched_remote_submit(owner, cmd);
+      if (status != K_OK) {
+          sched_remote_cmd_release(cmd);
+          return status;
+      }
+      return 0;
+  }
+
+  thread->affinity_mask = mask;
+
+  uint32_t bound = thread->bound_core_id;
+  if ((mask & (1U << bound)) == 0U) {
     for (uint32_t core = 0; core < g_active_core_count; ++core) {
-      if ((affinity_mask & (1U << core)) != 0U) {
-        return sched_migrate_task(thread, core);
+      if ((mask & (1U << core)) != 0U) {
+        return sched_migrate_tid(tid, core);
       }
     }
     return -1;
@@ -223,12 +252,8 @@ int sched_sys_set_affinity(uint64_t tid, uint32_t affinity_mask) {
   return 0;
 }
 
-int sched_throttle_core(uint32_t core_id) {
-  if (core_id >= g_active_core_count) {
-    return -1;
-  }
-  g_cpu_locals[core_id].runqueue.throttled = 1U;
-  return 0;
+int sched_sys_set_affinity(uint64_t tid, uint32_t affinity_mask) {
+  return sched_set_affinity(tid, affinity_mask);
 }
 
 kstatus_t sched_wait_remote_cmd_ack(sched_remote_cmd_t *cmd, uint32_t timeout_loops) {
@@ -252,10 +277,10 @@ int sched_quarantine_thread(bh_thread_t *thread, uint32_t reason) {
   // If enqueued locally, remove it
   uint32_t current_core = sched_clamp_core(hal_cpu_get_id());
   if (thread->bound_core_id == current_core) {
-      thread_slot_t *slot = sched_find_thread_slot_by_tid_local(&g_cpu_locals[current_core].runqueue, thread->thread_id);
+      sched_rq_t *rq = sched_local_rq();
+      thread_slot_t *slot = sched_find_thread_slot_by_tid_local(rq, thread->thread_id);
       if (slot && slot->is_on_runqueue) {
           hal_cpu_disable_interrupts();
-          sched_rq_t *rq = &g_cpu_locals[current_core].runqueue;
           if (g_policy == SCHED_POLICY_CLOUD_FAIR) {
             sched_cfs_dequeue(rq, thread);
           } else {
@@ -274,32 +299,58 @@ int sched_quarantine_thread(bh_thread_t *thread, uint32_t reason) {
   return 0;
 }
 
-int sched_request_remote_handoff(bh_thread_t *thread, uint32_t target_core, uint32_t auth_token) {
-  if (!thread || target_core >= g_active_core_count) {
-    return -1; // Invalid argument
+int sched_quarantine_tid(uint64_t tid, uint32_t reason) {
+  bh_thread_t *thread = sched_find_thread_by_id(tid);
+  if (!thread) return -1;
+  return sched_quarantine_thread(thread, reason);
+}
+
+int sched_request_handoff_tid(uint64_t tid, uint32_t target_cpu, uint32_t auth_token) {
+  bh_thread_t *thread = sched_find_thread_by_id(tid);
+  if (!thread || target_cpu >= g_active_core_count) {
+    return -1;
   }
 
   uint32_t current_core = sched_clamp_core(hal_cpu_get_id());
-  if (target_core == current_core) {
-    return -1; // Cannot handoff to self
+  uint32_t owner = __atomic_load_n(&thread->owner_cpu, __ATOMIC_ACQUIRE);
+
+  if (owner != current_core) {
+    sched_remote_cmd_t *cmd = sched_allocate_outbound_cmd();
+    if (!cmd) return K_ERR_NO_RESOURCES;
+    cmd->type = SCHED_REMOTE_HANDOFF;
+    cmd->source_cpu = current_core;
+    cmd->target_cpu = target_cpu;
+    cmd->thread_id = thread->thread_id;
+    cmd->expected_thread_generation = thread->sched_generation;
+    cmd->flags = auth_token;
+    cmd->state = SCHED_REMOTE_CMD_PENDING;
+
+    kstatus_t status = sched_remote_submit(owner, cmd);
+    if (status != K_OK) {
+        sched_remote_cmd_release(cmd);
+        return status;
+    }
+    return 0;
   }
 
-  thread_slot_t *slot = sched_find_thread_slot_by_tid_local(&g_cpu_locals[thread->home_core_id].runqueue, thread->thread_id);
+  if (target_cpu == current_core) {
+    return -1;
+  }
+
+  thread_slot_t *slot = sched_find_thread_slot_by_tid(thread->thread_id);
   if (!slot) {
     return -1;
   }
 
   hal_cpu_disable_interrupts();
 
-  // Validate state - only READY threads can be handed off
   if (thread->state != THREAD_STATE_READY) {
     hal_cpu_enable_interrupts();
-    return -2; // Invalid state
+    return -2;
   }
 
-  sched_rq_t *rq = &g_cpu_locals[current_core].runqueue;
+  sched_rq_t *rq = sched_local_rq();
 
-  // Dequeue from local runqueue
   if (slot->is_on_runqueue != 0U) {
     if (g_policy == SCHED_POLICY_CLOUD_FAIR) {
       sched_cfs_dequeue(rq, thread);
@@ -314,15 +365,12 @@ int sched_request_remote_handoff(bh_thread_t *thread, uint32_t target_core, uint
     }
   }
 
-  // Transition to pending handoff state
   thread->state = THREAD_STATE_REMOTE_HANDOFF_PENDING;
 
   hal_cpu_enable_interrupts();
 
-  // Prepare and send uRPC message
   mk_channel_t channel;
-  if (mk_get_channel(current_core, target_core, &channel) != 0) {
-    // If channel fails, revert state and re-enqueue locally
+  if (mk_get_channel(current_core, target_cpu, &channel) != 0) {
     hal_cpu_disable_interrupts();
     thread->state = THREAD_STATE_READY;
     if (g_policy == SCHED_POLICY_CLOUD_FAIR) {
@@ -334,13 +382,13 @@ int sched_request_remote_handoff(bh_thread_t *thread, uint32_t target_core, uint
     slot->is_on_runqueue = 1U;
     rq->runnable_count++;
     hal_cpu_enable_interrupts();
-    return -3; // Channel error
+    return -3;
   }
 
   mk_msg_thread_handoff_t payload = {
     .thread_id = thread->thread_id,
     .source_core = current_core,
-    .target_core = target_core,
+    .target_core = target_cpu,
     .priority = thread->priority,
     .flags = 0
   };
@@ -349,14 +397,13 @@ int sched_request_remote_handoff(bh_thread_t *thread, uint32_t target_core, uint
     .type = MK_MSG_THREAD_HANDOFF_REQ,
     .payload_size = sizeof(payload),
     .src_core = current_core,
-    .dst_core = target_core,
+    .dst_core = target_cpu,
     .auth_token = auth_token
   };
   __builtin_memcpy(msg.payload_data, &payload, sizeof(payload));
 
   int ret = mk_send_message(&channel, msg.type, msg.payload_data, msg.payload_size);
   if (ret != 0) {
-      // If send fails, revert state and re-enqueue locally
       hal_cpu_disable_interrupts();
       thread->state = THREAD_STATE_READY;
       if (g_policy == SCHED_POLICY_CLOUD_FAIR) {
@@ -368,7 +415,7 @@ int sched_request_remote_handoff(bh_thread_t *thread, uint32_t target_core, uint
       slot->is_on_runqueue = 1U;
       rq->runnable_count++;
       hal_cpu_enable_interrupts();
-      return -4; // Send error
+      return -4;
   }
 
   return 0;

--- a/core/kernel/src/sched/sched_pi.c
+++ b/core/kernel/src/sched/sched_pi.c
@@ -52,7 +52,7 @@ void sched_on_mutex_release(bh_thread_t *owner, void *mutex) {
   sched_restore_priority(owner);
 }
 
-int sched_adjust_priority(bh_thread_t *thread, uint32_t new_priority) {
+int sched_adjust_priority_local(bh_thread_t *thread, uint32_t new_priority) {
   if (!thread) {
     return -1;
   }
@@ -61,36 +61,12 @@ int sched_adjust_priority(bh_thread_t *thread, uint32_t new_priority) {
   }
 
   uint32_t current_core = sched_clamp_core(hal_cpu_get_id());
-  bool is_local = (thread->bound_core_id == current_core);
+  sched_rq_t *rq = sched_local_rq();
 
-  if (!is_local) {
-      // Remote core owns the thread. Submit a remote SET_PRIORITY command.
-      sched_remote_cmd_t *cmd = sched_allocate_outbound_cmd();
-      if (!cmd) {
-          return K_ERR_NO_RESOURCES;
-      }
-      cmd->type = SCHED_REMOTE_SET_PRIORITY;
-      cmd->source_cpu = current_core;
-      cmd->target_cpu = thread->bound_core_id;
-      cmd->thread_id = thread->thread_id;
-      cmd->expected_thread_generation = thread->sched_generation;
-      cmd->priority = new_priority;
-      cmd->state = SCHED_REMOTE_CMD_PENDING;
-
-      kstatus_t status = sched_remote_submit(thread->bound_core_id, cmd);
-      if (status != K_OK) {
-          cmd->state = SCHED_REMOTE_CMD_EMPTY;
-          return status;
-      }
-      return 0;
-  }
-
-  thread_slot_t *slot = sched_find_thread_slot_by_tid_local(&g_cpu_locals[thread->home_core_id].runqueue, thread->thread_id);
+  thread_slot_t *slot = sched_find_thread_slot_by_tid(thread->thread_id);
 
   if (slot && slot->is_on_runqueue != 0U) {
     hal_cpu_disable_interrupts();
-
-    sched_rq_t *rq = &g_cpu_locals[thread->bound_core_id].runqueue;
 
     if (g_policy == SCHED_POLICY_CLOUD_FAIR) {
       sched_cfs_dequeue(rq, thread);
@@ -110,16 +86,52 @@ int sched_adjust_priority(bh_thread_t *thread, uint32_t new_priority) {
 
   thread->priority = new_priority;
   if (thread->state == THREAD_STATE_READY) {
-    (void)sched_enqueue(thread, thread->bound_core_id);
+    (void)sched_enqueue(thread, current_core);
   }
   return 0;
 }
 
+int sched_set_priority(uint64_t tid, uint32_t priority) {
+  bh_thread_t *thread = sched_find_thread_by_id(tid);
+  if (!thread) return -1;
+
+  if (priority > SCHED_MAX_PRIORITY) {
+    priority = SCHED_MAX_PRIORITY;
+  }
+
+  uint32_t current_core = sched_clamp_core(hal_cpu_get_id());
+  uint32_t owner = __atomic_load_n(&thread->owner_cpu, __ATOMIC_ACQUIRE);
+
+  if (owner != current_core) {
+      // Route command to owner_cpu.
+      sched_remote_cmd_t *cmd = sched_allocate_outbound_cmd();
+      if (!cmd) {
+          return K_ERR_NO_RESOURCES;
+      }
+      cmd->type = SCHED_REMOTE_SET_PRIORITY;
+      cmd->source_cpu = current_core;
+      cmd->target_cpu = owner;
+      cmd->thread_id = thread->thread_id;
+      cmd->expected_thread_generation = thread->sched_generation;
+      cmd->priority = priority;
+      cmd->state = SCHED_REMOTE_CMD_PENDING;
+
+      kstatus_t status = sched_remote_submit(owner, cmd);
+      if (status != K_OK) {
+          sched_remote_cmd_release(cmd);
+          return status;
+      }
+      return 0;
+  }
+
+  return sched_adjust_priority_local(thread, priority);
+}
+
 int sched_set_thread_priority(uint64_t tid, uint32_t new_priority) {
-  return sched_adjust_priority(sched_find_thread_by_id(tid), new_priority);
+  return sched_set_priority(tid, new_priority);
 }
 
 int sched_sys_set_priority(uint64_t tid, uint32_t new_priority) {
-  return sched_set_thread_priority(tid, new_priority);
+  return sched_set_priority(tid, new_priority);
 }
 

--- a/core/kernel/src/sched/sched_rt.c
+++ b/core/kernel/src/sched/sched_rt.c
@@ -57,8 +57,7 @@ int sched_admission_edf(bh_thread_t *thread, uint64_t wcet_ms, uint64_t period_m
     // Calculate bandwidth contribution (utilization * 1000)
     uint64_t bandwidth_needed = (wcet_ms * 1000) / period_ms;
 
-    uint32_t core = thread->bound_core_id;
-    sched_rq_t *rq = &g_cpu_locals[core].runqueue;
+    sched_rq_t *rq = sched_local_rq();
 
     spin_lock(&rq->lock);
     if (rq->rt_budget_total == 0) {
@@ -95,8 +94,7 @@ int sched_admission_rms(bh_thread_t *thread, uint64_t wcet_ms, uint64_t period_m
     // Optional bounds checking for n tasks: U <= n(2^(1/n) - 1). Simplified to 0.69 bound.
     uint64_t bandwidth_needed = (wcet_ms * 1000) / period_ms;
 
-    uint32_t core = thread->bound_core_id;
-    sched_rq_t *rq = &g_cpu_locals[core].runqueue;
+    sched_rq_t *rq = sched_local_rq();
 
     spin_lock(&rq->lock);
     if (rq->rt_budget_total == 0) {

--- a/core/kernel/src/sched/sched_runqueue.c
+++ b/core/kernel/src/sched/sched_runqueue.c
@@ -16,9 +16,7 @@ int sched_enqueue(bh_thread_t *thread, uint32_t core_id) {
   bool is_local = (core_id == current_core);
 
   if (!is_local) {
-      sched_rq_t *target_rq = &g_cpu_locals[core_id].runqueue;
-
-      if (target_rq->sched_isolated) {
+      if (sched_read_isolated_snapshot(core_id)) {
           return K_ERR_ISOLATED;
       }
 
@@ -39,13 +37,13 @@ int sched_enqueue(bh_thread_t *thread, uint32_t core_id) {
 
       kstatus_t status = sched_remote_submit(core_id, cmd);
       if (status != K_OK) {
-          cmd->state = SCHED_REMOTE_CMD_EMPTY;
+          sched_remote_cmd_release(cmd);
           return status;
       }
       return 0;
   }
 
-  sched_rq_t *rq = &g_cpu_locals[core_id].runqueue;
+  sched_rq_t *rq = sched_local_rq();
   thread_slot_t *slot = sched_find_thread_slot_by_tid(thread->thread_id);
   if (!slot) {
     return -1;
@@ -80,7 +78,7 @@ int sched_enqueue(bh_thread_t *thread, uint32_t core_id) {
   } else if (g_policy == SCHED_POLICY_EDF) {
     if (thread->rt_attr.period_ms > 0 && thread->rt_attr.deadline_ms > 0) {
         if (thread->absolute_deadline_ms == 0) {
-            thread->absolute_deadline_ms = g_cpu_locals[current_core].runqueue.total_ticks + thread->rt_attr.deadline_ms;
+            thread->absolute_deadline_ms = rq->total_ticks + thread->rt_attr.deadline_ms;
         }
     }
     sched_edf_enqueue(rq, thread);
@@ -99,7 +97,11 @@ int sched_enqueue(bh_thread_t *thread, uint32_t core_id) {
 }
 
 uint32_t sched_run_queue_depth(uint32_t core_id) {
-  return g_cpu_locals[core_id].runqueue.runnable_count;
+  sched_load_snapshot_t snap;
+  if (sched_read_load_snapshot(core_id, &snap) == K_OK) {
+    return snap.runnable_count;
+  }
+  return 0;
 }
 
 void sched_ready_bitmap_set(sched_rq_t *rq, uint32_t prio) {
@@ -132,7 +134,8 @@ static void sched_dequeue_task_l0(bh_thread_t *thread, uint32_t core_id) {
   if (!thread) {
     return;
   }
-  sched_rq_t *rq = &g_cpu_locals[core_id].runqueue;
+  (void)core_id;
+  sched_rq_t *rq = sched_local_rq();
   thread_slot_t *slot = sched_find_thread_slot_by_tid(thread->thread_id);
   if (slot && slot->is_on_runqueue != 0U) {
     sched_invariant_on_dequeue(thread);

--- a/core/kernel/src/sched/sched_thread.c
+++ b/core/kernel/src/sched/sched_thread.c
@@ -7,8 +7,7 @@ int process_destroy(bh_process_t *process) {
     return -1;
   }
 
-  uint32_t current_core = sched_clamp_core(process->owner_core_id);
-  sched_rq_t *rq = &g_cpu_locals[current_core].runqueue;
+  sched_rq_t *rq = sched_local_rq();
 
   process_slot_t *slot = NULL;
   for (size_t i = 0; i < SCHED_MAX_PROCESSES; ++i) {
@@ -58,8 +57,7 @@ int thread_destroy(bh_thread_t *thread) {
     return -1;
   }
 
-  uint32_t creation_core = sched_clamp_core(thread->home_core_id);
-  sched_rq_t *rq = &g_cpu_locals[creation_core].runqueue;
+  sched_rq_t *rq = sched_local_rq();
   thread_slot_t *slot = sched_find_thread_slot_by_tid_local(rq, thread->thread_id);
   if (!slot) {
     return -1;
@@ -123,12 +121,36 @@ int sched_sys_thread_create(bh_process_t *parent, void (*entry_point)(void), uin
   return 0;
 }
 
-int sched_sys_thread_destroy(uint64_t tid) {
-  thread_slot_t *slot = sched_find_thread_slot_by_tid(tid);
-  if (!slot) {
-    return -1;
+int sched_terminate_tid(uint64_t tid) {
+  bh_thread_t *thread = sched_find_thread_by_id(tid);
+  if (!thread) return -1;
+
+  uint32_t current_core = sched_clamp_core(hal_cpu_get_id());
+  uint32_t owner = __atomic_load_n(&thread->owner_cpu, __ATOMIC_ACQUIRE);
+
+  if (owner != current_core) {
+      sched_remote_cmd_t *cmd = sched_allocate_outbound_cmd();
+      if (!cmd) return K_ERR_NO_RESOURCES;
+      cmd->type = SCHED_REMOTE_TERMINATE;
+      cmd->source_cpu = current_core;
+      cmd->target_cpu = owner;
+      cmd->thread_id = thread->thread_id;
+      cmd->expected_thread_generation = thread->sched_generation;
+      cmd->state = SCHED_REMOTE_CMD_PENDING;
+
+      kstatus_t status = sched_remote_submit(owner, cmd);
+      if (status != K_OK) {
+          sched_remote_cmd_release(cmd);
+          return status;
+      }
+      return 0;
   }
-  return sched_mark_thread_terminated(&slot->thread);
+
+  return sched_mark_thread_terminated(thread);
+}
+
+int sched_sys_thread_destroy(uint64_t tid) {
+  return sched_terminate_tid(tid);
 }
 
 int thread_raise_fault(bh_thread_t *thread, thread_fault_t fault) {

--- a/core/kernel/src/sched/sched_wait.c
+++ b/core/kernel/src/sched/sched_wait.c
@@ -54,7 +54,8 @@ bh_thread_t* sched_wait_queue_dequeue(wait_queue_t* queue) {
 
 void sched_block(void) {
   uint32_t core = sched_clamp_core(hal_cpu_get_id());
-  bh_thread_t *current = g_cpu_locals[core].runqueue.current_thread;
+  sched_rq_t *rq = sched_local_rq();
+  bh_thread_t *current = rq->current_thread;
   if (current) {
     current->state = THREAD_STATE_BLOCKED;
     if (current->sched_ctx && current->sched_ctx->deg) {
@@ -62,66 +63,74 @@ void sched_block(void) {
     }
 
     if (current->ipc_deadline_ticks > 0) {
-      thread_slot_t *slot = sched_find_thread_slot_by_tid_local(&g_cpu_locals[core].runqueue, current->thread_id);
+      thread_slot_t *slot = sched_find_thread_slot_by_tid_local(rq, current->thread_id);
       if (slot) {
         sched_block_enqueue(slot, core);
       }
     }
 
-    g_cpu_locals[core].runqueue.current_thread = NULL;
+    rq->current_thread = NULL;
   }
 }
 
 void sched_sleep(uint64_t millis) {
   uint32_t core = sched_clamp_core(hal_cpu_get_id());
-  bh_thread_t *current = g_cpu_locals[core].runqueue.current_thread;
-  if (!current || current == g_cpu_locals[core].runqueue.idle_thread) {
+  sched_rq_t *rq = sched_local_rq();
+  bh_thread_t *current = rq->current_thread;
+  if (!current || current == rq->idle_thread) {
     return;
   }
 
-  thread_slot_t *slot = sched_find_thread_slot_by_tid_local(&g_cpu_locals[core].runqueue, current->thread_id);
+  thread_slot_t *slot = sched_find_thread_slot_by_tid_local(rq, current->thread_id);
   if (!slot) {
     return;
   }
 
-  current->wake_deadline_ms = g_cpu_locals[core].runqueue.total_ticks + millis;
+  current->wake_deadline_ms = rq->total_ticks + millis;
   current->state = THREAD_STATE_SLEEPING;
   sched_sleep_enqueue(slot, core);
-  g_cpu_locals[core].runqueue.current_thread = NULL;
+  rq->current_thread = NULL;
   sched_reschedule();
 }
 
-void sched_wakeup_with_priority(bh_thread_t *thread, uint32_t wakeup_priority) {
-  if (!thread) {
-    return;
-  }
+int sched_wake_tid_with_priority(uint64_t tid, uint32_t priority) {
+  bh_thread_t *thread = sched_find_thread_by_id(tid);
+  if (!thread) return -1;
 
   uint32_t current_core = sched_clamp_core(hal_cpu_get_id());
-  if (thread->home_core_id != current_core) {
+  uint32_t owner = __atomic_load_n(&thread->owner_cpu, __ATOMIC_ACQUIRE);
+
+  if (owner != current_core) {
+      // Remote owner. Route command to owner_cpu.
       sched_remote_cmd_t *cmd = sched_allocate_outbound_cmd();
       if (!cmd) {
-          return;
+          return K_ERR_NO_RESOURCES;
       }
 
       cmd->type = SCHED_REMOTE_WAKE;
       cmd->source_cpu = current_core;
-      cmd->target_cpu = thread->home_core_id;
+      cmd->target_cpu = owner;
       cmd->thread_id = thread->thread_id;
       cmd->expected_thread_generation = thread->sched_generation;
-      cmd->priority = wakeup_priority;
+      cmd->priority = priority;
       cmd->state = SCHED_REMOTE_CMD_PENDING;
 
-      sched_remote_submit(thread->home_core_id, cmd);
-      return;
+      kstatus_t status = sched_remote_submit(owner, cmd);
+      if (status != K_OK) {
+          sched_remote_cmd_release(cmd);
+          return status;
+      }
+      return 0;
   }
 
-  if (wakeup_priority <= SCHED_MAX_PRIORITY && wakeup_priority > thread->priority) {
-    thread->priority = wakeup_priority;
+  // Local wakeup
+  if (priority <= SCHED_MAX_PRIORITY && priority > thread->priority) {
+    thread->priority = priority;
   }
 
-  thread_slot_t *slot = sched_find_thread_slot_by_tid_local(&g_cpu_locals[thread->home_core_id].runqueue, thread->thread_id);
+  thread_slot_t *slot = sched_find_thread_slot_by_tid(thread->thread_id);
   if (!slot) {
-    return;
+    return -1;
   }
 
   if (thread->state == THREAD_STATE_SLEEPING || thread->state == THREAD_STATE_BLOCKED) {
@@ -135,9 +144,22 @@ void sched_wakeup_with_priority(bh_thread_t *thread, uint32_t wakeup_priority) {
     }
     (void)sched_enqueue(thread, thread->bound_core_id);
   }
+  return 0;
+}
+
+int sched_wake_tid(uint64_t tid) {
+  return sched_wake_tid_with_priority(tid, SCHED_MAX_PRIORITY + 1U);
+}
+
+void sched_wakeup_with_priority(bh_thread_t *thread, uint32_t wakeup_priority) {
+  if (thread) {
+    sched_wake_tid_with_priority(thread->thread_id, wakeup_priority);
+  }
 }
 
 void sched_wakeup(bh_thread_t *thread) {
-  sched_wakeup_with_priority(thread, SCHED_MAX_PRIORITY + 1U);
+  if (thread) {
+    sched_wake_tid(thread->thread_id);
+  }
 }
 

--- a/core/kernel/src/sys/sys_constraints.c
+++ b/core/kernel/src/sys/sys_constraints.c
@@ -26,19 +26,11 @@ static void bh_copy_exec_constraints_kern_to_uapi(
 }
 
 static int thread_set_constraints(int tid, const bh_exec_constraints_k_t *c) {
-    bh_thread_t *thread = sched_find_thread_by_id(tid);
-    if (!thread) return -1;
-
-    thread->constraints = *c;
-    return 0;
+    return sched_set_constraints(tid, c);
 }
 
 static int thread_get_constraints(int tid, bh_exec_constraints_k_t *out_c) {
-    bh_thread_t *thread = sched_find_thread_by_id(tid);
-    if (!thread) return -1;
-
-    *out_c = thread->constraints;
-    return 0;
+    return sched_get_constraints(tid, out_c);
 }
 
 int sys_thread_set_constraints(int tid, const bh_exec_constraints_t *user_c) {
@@ -54,14 +46,13 @@ int sys_thread_set_constraints(int tid, const bh_exec_constraints_t *user_c) {
         return -1;
 
     // Reschedule the thread to enforce new constraints (per constraint-aware scheduling rules)
-    bh_thread_t* thread = sched_find_thread_by_id(tid);
-    if (thread && thread->state == THREAD_STATE_RUNNING) {
-        // Trigger a reschedule on the thread's core to force the new constraint to be evaluated
-        // For MVP, we can just yield the core if it's running locally, or rely on normal quantum expiration.
-        // It's tricky to preempt remotely without ipi_reschedule exposing, so we'll just yield if local.
-        uint32_t current_core = hal_cpu_get_id();
-        if (thread->bound_core_id == current_core) {
-            sched_reschedule();
+    sched_thread_snapshot_t snap;
+    if (sched_get_thread_snapshot(tid, &snap) == K_OK) {
+        if (snap.state == THREAD_STATE_RUNNING) {
+            uint32_t current_core = hal_cpu_get_id();
+            if (snap.bound_core_id == current_core) {
+                sched_reschedule();
+            }
         }
     }
 

--- a/core/kernel/src/tests/ktest_urpc_handoff.c
+++ b/core/kernel/src/tests/ktest_urpc_handoff.c
@@ -63,7 +63,7 @@ bool test_urpc_thread_handoff_valid(void) {
     sched_enqueue(t, sender_core);
 
     // Send handoff request
-    int ret = sched_request_remote_handoff(t, target_core, valid_auth_token);
+    int ret = sched_request_handoff_tid(t->thread_id, target_core, valid_auth_token);
     KTEST_ASSERT(ret == 0, "Handoff request failed");
     KTEST_ASSERT(t->state == THREAD_STATE_REMOTE_HANDOFF_PENDING, "Thread state not updated");
     KTEST_ASSERT(g_msg_sent_count == 1, "Message not sent");

--- a/quality/tests/host/sched/test_sched_remote_cmd.c
+++ b/quality/tests/host/sched/test_sched_remote_cmd.c
@@ -1,0 +1,157 @@
+#include <stdint.h>
+#include <stdbool.h>
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#define MAX_CPUS 32U
+#define SCHED_REMOTE_CMD_CAPACITY 256U
+#define SCHED_CMD_BITMAP_WORDS 8
+
+typedef enum {
+    SCHED_REMOTE_CMD_EMPTY = 0,
+    SCHED_REMOTE_CMD_RESERVED,
+    SCHED_REMOTE_CMD_PENDING,
+    SCHED_REMOTE_CMD_ACKED,
+    SCHED_REMOTE_CMD_FAILED,
+    SCHED_REMOTE_CMD_TIMEOUT
+} sched_remote_cmd_state_t;
+
+typedef struct {
+    uint16_t slot;
+    uint16_t origin_cpu;
+    uint32_t generation;
+} sched_cmd_handle_t;
+
+typedef struct {
+    struct {
+        void *next, *prev;
+    } list;
+} list_head_t;
+
+typedef struct sched_remote_cmd {
+    sched_cmd_handle_t handle;
+    uint64_t cmd_id;
+    uint32_t type;
+    volatile uint32_t state;
+    uint32_t source_cpu;
+    uint32_t target_cpu;
+    uint64_t thread_id;
+    uint64_t expected_thread_generation;
+    uint32_t migration_epoch;
+    int32_t result;
+    uint64_t submit_tick;
+    uint64_t deadline_tick;
+    uint32_t flags;
+    uint32_t priority;
+    list_head_t list;
+} sched_remote_cmd_t;
+
+typedef struct {
+    sched_remote_cmd_t outbound_cmds[SCHED_REMOTE_CMD_CAPACITY];
+    volatile uint32_t outbound_alloc_bitmap[SCHED_CMD_BITMAP_WORDS];
+    uint64_t total_ticks;
+} sched_rq_t;
+
+typedef struct {
+    sched_rq_t runqueue;
+} cpu_local_t;
+
+cpu_local_t g_cpu_locals[MAX_CPUS];
+uint32_t g_active_core_count = 4;
+static uint32_t mock_cpu_id = 0;
+
+uint32_t hal_cpu_get_id(void) { return mock_cpu_id; }
+uint32_t sched_clamp_core(uint32_t core_id) { return core_id; }
+
+sched_remote_cmd_t *test_allocate_outbound_cmd(void) {
+    uint32_t core = sched_clamp_core(hal_cpu_get_id());
+    sched_rq_t *rq = &g_cpu_locals[core].runqueue;
+    uint32_t slot_idx = 0xFFFF;
+
+    for (uint32_t w = 0; w < SCHED_CMD_BITMAP_WORDS; ++w) {
+        uint32_t val = __atomic_load_n(&rq->outbound_alloc_bitmap[w], __ATOMIC_ACQUIRE);
+        while (val != 0xFFFFFFFFU) {
+            uint32_t free_bit = __builtin_ctz(~val);
+            uint32_t new_val = val | (1U << free_bit);
+            if (__atomic_compare_exchange_n(&rq->outbound_alloc_bitmap[w], &val, new_val, false, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE)) {
+                slot_idx = w * 32 + free_bit;
+                break;
+            }
+        }
+        if (slot_idx != 0xFFFF) {
+            break;
+        }
+    }
+
+    if (slot_idx >= SCHED_REMOTE_CMD_CAPACITY) {
+        return NULL;
+    }
+
+    sched_remote_cmd_t *cmd = &rq->outbound_cmds[slot_idx];
+    cmd->handle.generation++;
+    if (cmd->handle.generation == 0) {
+        cmd->handle.generation = 1;
+    }
+    cmd->cmd_id = slot_idx;
+    cmd->state = SCHED_REMOTE_CMD_RESERVED;
+    return cmd;
+}
+
+void test_remote_cmd_release(sched_remote_cmd_t *cmd) {
+    if (!cmd) return;
+    uint16_t slot = cmd->handle.slot;
+    uint32_t w = slot / 32;
+    uint32_t bit = slot % 32;
+    uint32_t mask = ~(1U << bit);
+
+    __atomic_store_n(&cmd->state, SCHED_REMOTE_CMD_EMPTY, __ATOMIC_RELEASE);
+
+    uint32_t core = cmd->handle.origin_cpu;
+    sched_rq_t *rq = &g_cpu_locals[core].runqueue;
+    __atomic_fetch_and(&rq->outbound_alloc_bitmap[w], mask, __ATOMIC_ACQ_REL);
+}
+
+void test_alloc_and_exhaustion(void) {
+    printf("Running test_alloc_and_exhaustion...\n");
+    mock_cpu_id = 0;
+    sched_rq_t *rq = &g_cpu_locals[0].runqueue;
+    memset(rq, 0, sizeof(sched_rq_t));
+    for (uint32_t i = 0; i < SCHED_REMOTE_CMD_CAPACITY; ++i) {
+        rq->outbound_cmds[i].handle.slot = i;
+        rq->outbound_cmds[i].handle.origin_cpu = 0;
+        rq->outbound_cmds[i].handle.generation = 1;
+        rq->outbound_cmds[i].state = SCHED_REMOTE_CMD_EMPTY;
+    }
+
+    // Allocate all 256 slots
+    sched_remote_cmd_t *cmds[SCHED_REMOTE_CMD_CAPACITY];
+    for (uint32_t i = 0; i < SCHED_REMOTE_CMD_CAPACITY; ++i) {
+        cmds[i] = test_allocate_outbound_cmd();
+        assert(cmds[i] != NULL);
+        assert(cmds[i]->cmd_id == i);
+        assert(cmds[i]->state == SCHED_REMOTE_CMD_RESERVED);
+    }
+
+    // Next allocation must fail due to exhaustion
+    sched_remote_cmd_t *fail_cmd = test_allocate_outbound_cmd();
+    assert(fail_cmd == NULL);
+
+    // Release slot 5
+    test_remote_cmd_release(cmds[5]);
+    assert(rq->outbound_cmds[5].state == SCHED_REMOTE_CMD_EMPTY);
+
+    // Re-allocate should get slot 5 and incremented generation
+    sched_remote_cmd_t *re_cmd = test_allocate_outbound_cmd();
+    assert(re_cmd != NULL);
+    assert(re_cmd->cmd_id == 5);
+    assert(re_cmd->handle.generation == 3); // 2 -> 3
+    printf("test_alloc_and_exhaustion passed!\n");
+}
+
+int main(void) {
+    test_alloc_and_exhaustion();
+    printf("ALL TESTS PASSED\n");
+    return 0;
+}

--- a/tools/lint/check_scheduler_ownership.py
+++ b/tools/lint/check_scheduler_ownership.py
@@ -4,7 +4,7 @@
 Verifies that scheduler files obey the multikernel ownership-based rules:
 - No remote runqueue lock acquiring.
 - No direct remote ready_queue/list mutations.
-- No g_cpu_locals[remote_cpu].runqueue.xxx access.
+- No g_cpu_locals[remote_cpu].runqueue.xxx access (except in approved internal access files).
 - No use of legacy pending_inbox.
 """
 
@@ -15,8 +15,11 @@ from pathlib import Path
 # Files under core/kernel/src/sched/ to check
 SCHED_DIR = Path("core/kernel/src/sched")
 
+# Files allowed to reference g_cpu_locals[...].runqueue
+ALLOWED_RUNQUEUE_ACCESS_FILES = {"sched.c", "sched_core.c", "sched_test_support.c"}
+
 # Regex to detect violation of remote runqueue field access
-REMOTE_RQ_ACCESS_RE = re.compile(r'g_cpu_locals\[[^\]]+\]\.runqueue\.(ready_queue|ready_bitmap|cfs_runqueue|edf_runqueue|sleeping_list|blocked_list|lock|runnable_count|free_thread_head|threads|processes|bootstrap_threads)')
+REMOTE_RQ_ACCESS_RE = re.compile(r'g_cpu_locals\[[^\]]+\]\.runqueue')
 
 # Regex to detect usage of the legacy pending_inbox
 PENDING_INBOX_RE = re.compile(r'\bpending_inbox\b')
@@ -39,13 +42,10 @@ def check_file(path: Path) -> list[str]:
         if REMOTE_LOCK_RE.search(line):
             violations.append(f"{path}:{i}: Direct lock acquisition of remote runqueue")
 
-        # 2. Check for remote runqueue field access (except if the index is exactly local core)
-        if REMOTE_RQ_ACCESS_RE.search(line):
-            match = re.search(r'g_cpu_locals\[([^\]]+)\]\.runqueue', line)
-            if match:
-                index = match.group(1).strip()
-                if index not in ("core", "core_id", "current_core", "current_cpu", "cpu_id", "hal_cpu_get_id()", "creation_core", "bound_core", "home_core"):
-                    violations.append(f"{path}:{i}: Direct access to remote runqueue fields ('{match.group(0)}')")
+        # 2. Check for direct runqueue access if the file is not allowed
+        if path.name not in ALLOWED_RUNQUEUE_ACCESS_FILES:
+            if REMOTE_RQ_ACCESS_RE.search(line):
+                violations.append(f"{path}:{i}: Direct reference to runqueue via 'g_cpu_locals' (file not in allowlist)")
 
         # 3. Check for legacy pending_inbox
         if PENDING_INBOX_RE.search(line):


### PR DESCRIPTION
This submission completes the 'Scheduler Ownership Closure v2' (#794) task, introducing clean outbound command allocation, strict ownership-based routing, private runqueues, transactional migration state machines, TID-based public control interfaces, and term/reap separation. All tests and lint checks pass flawlessly.

---
*PR created automatically by Jules for task [814025143041259372](https://jules.google.com/task/814025143041259372) started by @divyang4481*