### PR TITLE
netmgr: Production-harden static route table and deterministic LPM (NET-P2-001)

### DIFF
--- a/core/services/netmgr/CMakeLists.txt
+++ b/core/services/netmgr/CMakeLists.txt
@@ -65,6 +65,22 @@ else()
     )
     add_test(NAME test_netmgr_caps_host COMMAND test_netmgr_caps_host)
 
+    # Route Table Hardening Test (Host)
+    add_executable(test_route_table
+        tests/test_route_table.c
+        src/route_table.c
+        ../../lib/runtime/src/freestanding_string.c
+    )
+    target_include_directories(test_route_table PRIVATE
+        src
+        include
+        ../../include
+        ../../lib/net/include
+        ../../services/core/subsysmgr/include
+        ../../lib/runtime/include
+    )
+    add_test(NAME test_route_table COMMAND test_route_table)
+
     # Legacy/Integration Test (Optional, may need shim hardening)
     add_executable(test_netmgr_caps tests/test_netmgr_caps.c tests/test_netmgr_caps_stubs.c src/ipc_dispatch.c src/ipc_contract.c src/ipc_auth.c src/ipc_auth_core.c src/ipc_ops.c ../../kernel/src/ipc/contract_validate.c)
     target_include_directories(test_netmgr_caps PRIVATE src include ../../include ../../lib/cap/include ../../lib/net/include ../core/subsysmgr/include ../../lib/ipc/include ../../kernel/include ../../lib/runtime/include)

--- a/core/services/netmgr/include/route_table.h
+++ b/core/services/netmgr/include/route_table.h
@@ -15,6 +15,7 @@ typedef struct {
     uint8_t mask[16];
     uint8_t gateway[16];
     uint32_t metric;
+    uint8_t prefix_len;
     bool valid;
 } netmgr_route_t;
 

--- a/core/services/netmgr/src/route_table.c
+++ b/core/services/netmgr/src/route_table.c
@@ -5,34 +5,97 @@
 
 static netmgr_route_t g_routes[NETMGR_MAX_ROUTES];
 
-void netmgr_route_table_init(void) {
-    for (int i = 0; i < NETMGR_MAX_ROUTES; i++) {
-        g_routes[i].valid = false;
-        g_routes[i].if_id = NET_IF_ID_INVALID;
-        g_routes[i].af = NET_AF_UNSPEC;
-        g_routes[i].metric = 0;
-        memset(g_routes[i].dest, 0, 16);
-        memset(g_routes[i].mask, 0, 16);
-        memset(g_routes[i].gateway, 0, 16);
+static bool route_af_len(net_af_t af, size_t *len) {
+    switch (af) {
+        case NET_AF_INET:
+            *len = 4;
+            return true;
+        case NET_AF_INET6:
+            *len = 16;
+            return true;
+        default:
+            return false;
     }
 }
 
-static bool netmgr_route_equals(const uint8_t *a, const uint8_t *b, net_af_t af) {
-    int len = (af == NET_AF_INET) ? 4 : 16;
-    for(int i = 0; i < len; i++) {
-        if (a[i] != b[i]) return false;
+static bool route_mask_validate(const uint8_t *mask, size_t len, uint8_t *out_prefix_len) {
+    bool zero_seen = false;
+    uint32_t ones_count = 0;
+
+    for (size_t i = 0; i < len; i++) {
+        uint8_t byte = mask[i];
+        for (int bit = 7; bit >= 0; bit--) {
+            bool is_one = (byte >> bit) & 1;
+            if (is_one) {
+                if (zero_seen) {
+                    return false;
+                }
+                ones_count++;
+            } else {
+                zero_seen = true;
+            }
+        }
+    }
+
+    if (out_prefix_len) {
+        *out_prefix_len = (uint8_t)ones_count;
+    }
+    return true;
+}
+
+static void route_entry_reset(netmgr_route_t *entry) {
+    entry->valid = false;
+    entry->if_id = NET_IF_ID_INVALID;
+    entry->af = NET_AF_UNSPEC;
+    entry->metric = 0;
+    entry->prefix_len = 0;
+    memset(entry->dest, 0, sizeof(entry->dest));
+    memset(entry->mask, 0, sizeof(entry->mask));
+    memset(entry->gateway, 0, sizeof(entry->gateway));
+}
+
+void netmgr_route_table_init(void) {
+    for (int i = 0; i < NETMGR_MAX_ROUTES; i++) {
+        route_entry_reset(&g_routes[i]);
+    }
+}
+
+static bool netmgr_route_equals(const uint8_t *a, const uint8_t *b, size_t len) {
+    for (size_t i = 0; i < len; i++) {
+        if (a[i] != b[i]) {
+            return false;
+        }
     }
     return true;
 }
 
 netmgr_status_t netmgr_route_add(net_if_id_t if_id, net_af_t af, const uint8_t *dest, const uint8_t *mask, const uint8_t *gateway, uint32_t metric) {
-    if (if_id == NET_IF_ID_INVALID || af == NET_AF_UNSPEC || !dest || !mask) return NETMGR_STATUS_ERR_INVAL;
+    if (if_id == NET_IF_ID_INVALID || !dest || !mask) {
+        return NETMGR_STATUS_ERR_INVAL;
+    }
+
+    size_t len = 0;
+    if (!route_af_len(af, &len)) {
+        return NETMGR_STATUS_ERR_INVAL;
+    }
+
+    uint8_t prefix_len = 0;
+    if (!route_mask_validate(mask, len, &prefix_len)) {
+        return NETMGR_STATUS_ERR_INVAL;
+    }
+
+    // Canonicalize destination: dest & mask
+    uint8_t canonical_dest[16];
+    memset(canonical_dest, 0, sizeof(canonical_dest));
+    for (size_t i = 0; i < len; i++) {
+        canonical_dest[i] = dest[i] & mask[i];
+    }
 
     netmgr_route_t *existing = NULL;
     for (int i = 0; i < NETMGR_MAX_ROUTES; i++) {
         if (g_routes[i].valid && g_routes[i].af == af &&
-            netmgr_route_equals(g_routes[i].dest, dest, af) &&
-            netmgr_route_equals(g_routes[i].mask, mask, af)) {
+            netmgr_route_equals(g_routes[i].dest, canonical_dest, len) &&
+            netmgr_route_equals(g_routes[i].mask, mask, len)) {
             existing = &g_routes[i];
             break;
         }
@@ -41,11 +104,10 @@ netmgr_status_t netmgr_route_add(net_if_id_t if_id, net_af_t af, const uint8_t *
     if (existing) {
         existing->if_id = if_id;
         existing->metric = metric;
+        existing->prefix_len = prefix_len;
+        memset(existing->gateway, 0, sizeof(existing->gateway));
         if (gateway) {
-            int len = (af == NET_AF_INET) ? 4 : 16;
             memcpy(existing->gateway, gateway, len);
-        } else {
-            memset(existing->gateway, 0, 16);
         }
         return NETMGR_STATUS_OK;
     }
@@ -58,35 +120,55 @@ netmgr_status_t netmgr_route_add(net_if_id_t if_id, net_af_t af, const uint8_t *
         }
     }
 
-    if (free_slot == -1) return NETMGR_STATUS_ERR_NOSPACE;
+    if (free_slot == -1) {
+        return NETMGR_STATUS_ERR_NOSPACE;
+    }
 
     netmgr_route_t *entry = &g_routes[free_slot];
+    route_entry_reset(entry);
+
     entry->valid = true;
     entry->if_id = if_id;
     entry->af = af;
     entry->metric = metric;
+    entry->prefix_len = prefix_len;
 
-    int len = (af == NET_AF_INET) ? 4 : 16;
-    memcpy(entry->dest, dest, len);
+    memcpy(entry->dest, canonical_dest, len);
     memcpy(entry->mask, mask, len);
     if (gateway) {
         memcpy(entry->gateway, gateway, len);
-    } else {
-        memset(entry->gateway, 0, len);
     }
 
     return NETMGR_STATUS_OK;
 }
 
 netmgr_status_t netmgr_route_remove(net_af_t af, const uint8_t *dest, const uint8_t *mask) {
-    if (af == NET_AF_UNSPEC || !dest || !mask) return NETMGR_STATUS_ERR_INVAL;
+    if (!dest || !mask) {
+        return NETMGR_STATUS_ERR_INVAL;
+    }
+
+    size_t len = 0;
+    if (!route_af_len(af, &len)) {
+        return NETMGR_STATUS_ERR_INVAL;
+    }
+
+    if (!route_mask_validate(mask, len, NULL)) {
+        return NETMGR_STATUS_ERR_INVAL;
+    }
+
+    // Canonicalize supplied destination
+    uint8_t canonical_dest[16];
+    memset(canonical_dest, 0, sizeof(canonical_dest));
+    for (size_t i = 0; i < len; i++) {
+        canonical_dest[i] = dest[i] & mask[i];
+    }
 
     for (int i = 0; i < NETMGR_MAX_ROUTES; i++) {
         if (g_routes[i].valid && g_routes[i].af == af &&
-            netmgr_route_equals(g_routes[i].dest, dest, af) &&
-            netmgr_route_equals(g_routes[i].mask, mask, af)) {
-            g_routes[i].valid = false;
-            g_routes[i].if_id = NET_IF_ID_INVALID;
+            netmgr_route_equals(g_routes[i].dest, canonical_dest, len) &&
+            netmgr_route_equals(g_routes[i].mask, mask, len)) {
+
+            route_entry_reset(&g_routes[i]);
             return NETMGR_STATUS_OK;
         }
     }
@@ -95,36 +177,39 @@ netmgr_status_t netmgr_route_remove(net_af_t af, const uint8_t *dest, const uint
 }
 
 netmgr_route_t* netmgr_route_lookup(net_af_t af, const uint8_t *dest) {
-    if (af == NET_AF_UNSPEC || !dest) return NULL;
+    if (!dest) {
+        return NULL;
+    }
+
+    size_t len = 0;
+    if (!route_af_len(af, &len)) {
+        return NULL;
+    }
 
     netmgr_route_t *best_match = NULL;
-    uint8_t best_prefix_len = 0;
 
     for (int i = 0; i < NETMGR_MAX_ROUTES; i++) {
-        if (!g_routes[i].valid || g_routes[i].af != af) continue;
+        if (!g_routes[i].valid || g_routes[i].af != af) {
+            continue;
+        }
 
         bool match = true;
-        uint8_t current_prefix_len = 0;
-        int len = (af == NET_AF_INET) ? 4 : 16;
-        for (int j = 0; j < len; j++) {
-            if ((dest[j] & g_routes[i].mask[j]) != (g_routes[i].dest[j] & g_routes[i].mask[j])) {
+        for (size_t j = 0; j < len; j++) {
+            if ((dest[j] & g_routes[i].mask[j]) != g_routes[i].dest[j]) {
                 match = false;
                 break;
-            }
-            for (int bit = 7; bit >= 0; bit--) {
-                if ((g_routes[i].mask[j] >> bit) & 1) {
-                    current_prefix_len++;
-                } else {
-                    break;
-                }
             }
         }
 
         if (match) {
-            if (!best_match || current_prefix_len > best_prefix_len ||
-                (current_prefix_len == best_prefix_len && g_routes[i].metric < best_match->metric)) {
+            if (!best_match) {
                 best_match = &g_routes[i];
-                best_prefix_len = current_prefix_len;
+            } else if (g_routes[i].prefix_len > best_match->prefix_len) {
+                best_match = &g_routes[i];
+            } else if (g_routes[i].prefix_len == best_match->prefix_len) {
+                if (g_routes[i].metric < best_match->metric) {
+                    best_match = &g_routes[i];
+                }
             }
         }
     }

--- a/core/services/netmgr/tests/test_route_table.c
+++ b/core/services/netmgr/tests/test_route_table.c
@@ -1,0 +1,240 @@
+#include <stdio.h>
+#include <assert.h>
+#include <string.h>
+#include "route_table.h"
+
+static void test_ipv4_basics(void) {
+    printf("  Running test_ipv4_basics...\n");
+    netmgr_route_table_init();
+
+    net_if_id_t if_id = 1;
+    uint8_t ip_any[4] = {0, 0, 0, 0};
+    uint8_t mask_any[4] = {0, 0, 0, 0};
+
+    uint8_t ip_a[4] = {10, 0, 0, 0};
+    uint8_t mask_8[4] = {255, 0, 0, 0};
+
+    uint8_t ip_b[4] = {10, 20, 0, 0};
+    uint8_t mask_16[4] = {255, 255, 0, 0};
+
+    uint8_t ip_c[4] = {10, 20, 30, 0};
+    uint8_t mask_24[4] = {255, 255, 255, 0};
+
+    uint8_t ip_d[4] = {10, 20, 30, 40};
+    uint8_t mask_32[4] = {255, 255, 255, 255};
+
+    uint8_t gw[4] = {192, 168, 1, 1};
+
+    assert(netmgr_route_add(if_id, NET_AF_INET, ip_any, mask_any, gw, 100) == NETMGR_STATUS_OK);
+    assert(netmgr_route_add(if_id, NET_AF_INET, ip_a, mask_8, gw, 80) == NETMGR_STATUS_OK);
+    assert(netmgr_route_add(if_id, NET_AF_INET, ip_b, mask_16, gw, 60) == NETMGR_STATUS_OK);
+    assert(netmgr_route_add(if_id, NET_AF_INET, ip_c, mask_24, gw, 40) == NETMGR_STATUS_OK);
+    assert(netmgr_route_add(if_id, NET_AF_INET, ip_d, mask_32, gw, 20) == NETMGR_STATUS_OK);
+
+    uint8_t target1[4] = {8, 8, 8, 8};
+    netmgr_route_t *r = netmgr_route_lookup(NET_AF_INET, target1);
+    assert(r != NULL);
+    assert(r->prefix_len == 0);
+
+    uint8_t target2[4] = {10, 99, 1, 1};
+    r = netmgr_route_lookup(NET_AF_INET, target2);
+    assert(r != NULL);
+    assert(r->prefix_len == 8);
+
+    uint8_t target3[4] = {10, 20, 8, 8};
+    r = netmgr_route_lookup(NET_AF_INET, target3);
+    assert(r != NULL);
+    assert(r->prefix_len == 16);
+
+    uint8_t target4[4] = {10, 20, 30, 99};
+    r = netmgr_route_lookup(NET_AF_INET, target4);
+    assert(r != NULL);
+    assert(r->prefix_len == 24);
+
+    uint8_t target5[4] = {10, 20, 30, 40};
+    r = netmgr_route_lookup(NET_AF_INET, target5);
+    assert(r != NULL);
+    assert(r->prefix_len == 32);
+}
+
+static void test_canonicalization(void) {
+    printf("  Running test_canonicalization...\n");
+    netmgr_route_table_init();
+
+    net_if_id_t if_id = 2;
+    uint8_t ip_raw[4] = {10, 20, 30, 77};
+    uint8_t mask_24[4] = {255, 255, 255, 0};
+    uint8_t gw[4] = {10, 20, 30, 1};
+
+    assert(netmgr_route_add(if_id, NET_AF_INET, ip_raw, mask_24, gw, 10) == NETMGR_STATUS_OK);
+
+    uint8_t target[4] = {10, 20, 30, 99};
+    netmgr_route_t *r = netmgr_route_lookup(NET_AF_INET, target);
+    assert(r != NULL);
+    assert(r->dest[0] == 10 && r->dest[1] == 20 && r->dest[2] == 30 && r->dest[3] == 0);
+
+    assert(netmgr_route_add(if_id, NET_AF_INET, target, mask_24, NULL, 5) == NETMGR_STATUS_OK);
+
+    r = netmgr_route_lookup(NET_AF_INET, target);
+    assert(r != NULL);
+    assert(r->metric == 5);
+    for (int i = 0; i < 16; i++) {
+        assert(r->gateway[i] == 0);
+    }
+
+    uint8_t ip_other[4] = {10, 20, 30, 53};
+    assert(netmgr_route_remove(NET_AF_INET, ip_other, mask_24) == NETMGR_STATUS_OK);
+
+    assert(netmgr_route_lookup(NET_AF_INET, target) == NULL);
+}
+
+static void test_ipv6_basics(void) {
+    printf("  Running test_ipv6_basics...\n");
+    netmgr_route_table_init();
+
+    net_if_id_t if_id = 3;
+    uint8_t ip6_any[16] = {0};
+    uint8_t mask6_any[16] = {0};
+
+    uint8_t ip6_a[16] = {0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    uint8_t mask6_32[16] = {0xff, 0xff, 0xff, 0xff, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+
+    uint8_t ip6_b[16] = {0x20, 0x01, 0x0d, 0xb8, 0x12, 0x34, 0x56, 0x78, 0, 0, 0, 0, 0, 0, 0, 0};
+    uint8_t mask6_64[16] = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0, 0, 0, 0, 0, 0, 0, 0};
+
+    assert(netmgr_route_add(if_id, NET_AF_INET6, ip6_any, mask6_any, NULL, 50) == NETMGR_STATUS_OK);
+    assert(netmgr_route_add(if_id, NET_AF_INET6, ip6_a, mask6_32, NULL, 30) == NETMGR_STATUS_OK);
+    assert(netmgr_route_add(if_id, NET_AF_INET6, ip6_b, mask6_64, NULL, 10) == NETMGR_STATUS_OK);
+
+    uint8_t target_any[16] = {0x24, 0x00, 0x01, 0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    netmgr_route_t *r = netmgr_route_lookup(NET_AF_INET6, target_any);
+    assert(r != NULL);
+    assert(r->prefix_len == 0);
+
+    uint8_t target_32[16] = {0x20, 0x01, 0x0d, 0xb8, 0x99, 0x99, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    r = netmgr_route_lookup(NET_AF_INET6, target_32);
+    assert(r != NULL);
+    assert(r->prefix_len == 32);
+
+    uint8_t target_64[16] = {0x20, 0x01, 0x0d, 0xb8, 0x12, 0x34, 0x56, 0x78, 0xaa, 0xbb, 0, 0, 0, 0, 0, 0};
+    r = netmgr_route_lookup(NET_AF_INET6, target_64);
+    assert(r != NULL);
+    assert(r->prefix_len == 64);
+}
+
+static void test_invalid_masks(void) {
+    printf("  Running test_invalid_masks...\n");
+    netmgr_route_table_init();
+
+    net_if_id_t if_id = 4;
+    uint8_t dest[16] = {10, 0, 0, 0};
+
+    uint8_t invalid_m1[4] = {255, 0, 255, 0};
+    uint8_t invalid_m2[4] = {255, 255, 127, 255};
+    uint8_t invalid_m3[4] = {0, 255, 255, 0};
+
+    assert(netmgr_route_add(if_id, NET_AF_INET, dest, invalid_m1, NULL, 10) == NETMGR_STATUS_ERR_INVAL);
+    assert(netmgr_route_add(if_id, NET_AF_INET, dest, invalid_m2, NULL, 10) == NETMGR_STATUS_ERR_INVAL);
+    assert(netmgr_route_add(if_id, NET_AF_INET, dest, invalid_m3, NULL, 10) == NETMGR_STATUS_ERR_INVAL);
+
+    uint8_t invalid_m6_1[16] = {0xff, 0x00, 0xff, 0xff, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    uint8_t invalid_m6_2[16] = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x7f, 0xff, 0, 0, 0, 0, 0, 0, 0};
+
+    assert(netmgr_route_add(if_id, NET_AF_INET6, dest, invalid_m6_1, NULL, 10) == NETMGR_STATUS_ERR_INVAL);
+    assert(netmgr_route_add(if_id, NET_AF_INET6, dest, invalid_m6_2, NULL, 10) == NETMGR_STATUS_ERR_INVAL);
+}
+
+static void test_invalid_address_families(void) {
+    printf("  Running test_invalid_address_families...\n");
+    netmgr_route_table_init();
+
+    net_if_id_t if_id = 5;
+    uint8_t dest[16] = {10, 0, 0, 0};
+    uint8_t mask[16] = {255, 255, 255, 0};
+
+    assert(netmgr_route_add(if_id, NET_AF_UNSPEC, dest, mask, NULL, 10) == NETMGR_STATUS_ERR_INVAL);
+    assert(netmgr_route_add(if_id, NET_AF_PACKET, dest, mask, NULL, 10) == NETMGR_STATUS_ERR_INVAL);
+    assert(netmgr_route_add(if_id, (net_af_t)99, dest, mask, NULL, 10) == NETMGR_STATUS_ERR_INVAL);
+
+    assert(netmgr_route_lookup(NET_AF_UNSPEC, dest) == NULL);
+    assert(netmgr_route_lookup(NET_AF_PACKET, dest) == NULL);
+    assert(netmgr_route_lookup((net_af_t)99, dest) == NULL);
+
+    assert(netmgr_route_remove(NET_AF_UNSPEC, dest, mask) == NETMGR_STATUS_ERR_INVAL);
+    assert(netmgr_route_remove(NET_AF_PACKET, dest, mask) == NETMGR_STATUS_ERR_INVAL);
+    assert(netmgr_route_remove((net_af_t)99, dest, mask) == NETMGR_STATUS_ERR_INVAL);
+}
+
+static void test_capacity_limits(void) {
+    printf("  Running test_capacity_limits...\n");
+    netmgr_route_table_init();
+
+    net_if_id_t if_id = 6;
+    uint8_t mask[4] = {255, 255, 255, 255};
+
+    for (int i = 0; i < NETMGR_MAX_ROUTES; i++) {
+        uint8_t dest[4] = {10, 0, (uint8_t)(i >> 8), (uint8_t)i};
+        assert(netmgr_route_add(if_id, NET_AF_INET, dest, mask, NULL, 10) == NETMGR_STATUS_OK);
+    }
+
+    uint8_t dest_65[4] = {20, 0, 0, 1};
+    assert(netmgr_route_add(if_id, NET_AF_INET, dest_65, mask, NULL, 10) == NETMGR_STATUS_ERR_NOSPACE);
+
+    uint8_t dest_existing[4] = {10, 0, 0, 0};
+    assert(netmgr_route_add(if_id, NET_AF_INET, dest_existing, mask, NULL, 20) == NETMGR_STATUS_OK);
+
+    netmgr_route_t *r = netmgr_route_lookup(NET_AF_INET, dest_existing);
+    assert(r != NULL);
+    assert(r->metric == 20);
+}
+
+static void test_slot_reuse_hygiene(void) {
+    printf("  Running test_slot_reuse_hygiene...\n");
+    netmgr_route_table_init();
+
+    net_if_id_t if_id = 7;
+
+    uint8_t ip6_dest[16] = {0x20, 0x01, 0x0d, 0xb8, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc};
+    uint8_t ip6_mask[16] = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
+    uint8_t ip6_gw[16] = {0xfe, 0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1};
+
+    assert(netmgr_route_add(if_id, NET_AF_INET6, ip6_dest, ip6_mask, ip6_gw, 10) == NETMGR_STATUS_OK);
+
+    netmgr_route_t *r = netmgr_route_lookup(NET_AF_INET6, ip6_dest);
+    assert(r != NULL);
+    assert(r->af == NET_AF_INET6);
+
+    assert(netmgr_route_remove(NET_AF_INET6, ip6_dest, ip6_mask) == NETMGR_STATUS_OK);
+
+    uint8_t ip4_dest[4] = {192, 168, 1, 0};
+    uint8_t ip4_mask[4] = {255, 255, 255, 0};
+    uint8_t ip4_gw[4] = {192, 168, 1, 254};
+
+    assert(netmgr_route_add(if_id, NET_AF_INET, ip4_dest, ip4_mask, ip4_gw, 20) == NETMGR_STATUS_OK);
+
+    r = netmgr_route_lookup(NET_AF_INET, ip4_dest);
+    assert(r != NULL);
+    assert(r->af == NET_AF_INET);
+    assert(r->prefix_len == 24);
+
+    for (int i = 4; i < 16; i++) {
+        assert(r->dest[i] == 0);
+        assert(r->mask[i] == 0);
+        assert(r->gateway[i] == 0);
+    }
+}
+
+int main(void) {
+    printf("Starting NET-P2-001 Route Table Hardening tests...\n");
+
+    test_ipv4_basics();
+    test_canonicalization();
+    test_ipv6_basics();
+    test_invalid_masks();
+    test_invalid_address_families();
+    test_capacity_limits();
+    test_slot_reuse_hygiene();
+
+    printf("All NET-P2-001 tests passed successfully!\n");
+    return 0;
+}


### PR DESCRIPTION
Production-hardened the netmgr route table logic according to the specification. Enforced strict address-family checks, contiguous mask verification, destination prefix canonicalization, deterministic LPM lookups with clear tie-breakers, and slot-reuse buffer hygiene. Added a thorough host-test suite to fully cover positive and negative scenarios and verified that all tests are passing.

---
*PR created automatically by Jules for task [4859689130354153082](https://jules.google.com/task/4859689130354153082) started by @divyang4481*