### PR TITLE
mm: Canonical Memory Authority + MMU_FULL/MMU_LITE/MPU Closure

### DIFF
--- a/core/hal/mmu_lite/common/mmu_lite_backend.c
+++ b/core/hal/mmu_lite/common/mmu_lite_backend.c
@@ -1,9 +1,12 @@
 #include "mm/prot_domain.h"
 #include "slab.h"
+#include "kernel/status.h"
 #include <stddef.h>
 
 #define ERR_NOT_SUPPORTED -1
 #define MAX_LITE_REGIONS 64
+
+static prot_domain_ops_t mmu_lite_ops_common;
 
 // MMU Lite backend
 // Acts as a structured hardware boundary: eager mappings, constrained features, flat contiguous limits.
@@ -28,14 +31,14 @@ extern void lite_hw_pt_activate(void* pt);
 extern int lite_hw_map(void* pt, uintptr_t v, uintptr_t p, size_t s, uint32_t f);
 extern int lite_hw_unmap(void* pt, uintptr_t v, size_t s);
 
-static prot_domain_t* mmu_lite_create(void) {
+static int mmu_lite_create(prot_domain_t** out_domain) {
     prot_domain_t* domain = (prot_domain_t*)kmalloc(sizeof(prot_domain_t));
-    if (!domain) return NULL;
+    if (!domain) return K_ERR_NO_MEMORY;
 
     mmu_lite_backend_state_t* state = (mmu_lite_backend_state_t*)kmalloc(sizeof(mmu_lite_backend_state_t));
     if (!state) {
         kfree(domain);
-        return NULL;
+        return K_ERR_NO_MEMORY;
     }
 
     for (int i = 0; i < MAX_LITE_REGIONS; i++) {
@@ -45,8 +48,10 @@ static prot_domain_t* mmu_lite_create(void) {
     state->hardware_root_pt = NULL; // We'll stub this out for now
 
     domain->mode = PROT_MODE_MMU_LITE;
+    domain->ops = &mmu_lite_ops_common;
     domain->backend_state = state;
-    return domain;
+    *out_domain = domain;
+    return K_OK;
 }
 
 static void mmu_lite_destroy(prot_domain_t* domain) {
@@ -140,7 +145,7 @@ static int mmu_lite_query_region(prot_domain_t* domain, uintptr_t vaddr, uintptr
     return -1;
 }
 
-prot_domain_ops_t mmu_lite_ops_common = {
+static prot_domain_ops_t mmu_lite_ops_common = {
     .create = mmu_lite_create,
     .destroy = mmu_lite_destroy,
     .activate = mmu_lite_activate,

--- a/core/hal/prot/none/prot_none_backend.c
+++ b/core/hal/prot/none/prot_none_backend.c
@@ -1,16 +1,21 @@
 #include "mm/prot_domain.h"
 #include "slab.h"
+#include "kernel/status.h"
 #include <stddef.h>
 
 #define ERR_NOT_SUPPORTED -1
 
-static prot_domain_t* prot_none_create(void) {
+static prot_domain_ops_t prot_none_ops;
+
+static int prot_none_create(prot_domain_t** out_domain) {
     prot_domain_t* domain = (prot_domain_t*)kmalloc(sizeof(prot_domain_t));
-    if (!domain) return NULL;
+    if (!domain) return K_ERR_NO_MEMORY;
 
     domain->mode = PROT_MODE_NONE;
+    domain->ops = &prot_none_ops;
     domain->backend_state = NULL;
-    return domain;
+    *out_domain = domain;
+    return K_OK;
 }
 
 static void prot_none_destroy(prot_domain_t* domain) {
@@ -46,7 +51,7 @@ static int prot_none_query_region(prot_domain_t* domain, uintptr_t vaddr, uintpt
     return 0;
 }
 
-prot_domain_ops_t prot_none_ops = {
+static prot_domain_ops_t prot_none_ops = {
     .create = prot_none_create,
     .destroy = prot_none_destroy,
     .activate = prot_none_activate,

--- a/core/kernel/include/hal/hal_mpu.h
+++ b/core/kernel/include/hal/hal_mpu.h
@@ -25,4 +25,13 @@ int hal_mpu_disable_region(uint32_t region_id);
 void hal_mpu_activate_local(void);
 void hal_mpu_deactivate_local(void);
 
+typedef struct hal_mpu_ops {
+    int (*program_region)(uint32_t region_id, phys_addr_t base, size_t size, uint32_t flags);
+    int (*disable_region)(uint32_t region_id);
+    const hal_mpu_caps_t* (*get_caps)(void);
+} hal_mpu_ops_t;
+
+extern hal_mpu_ops_t *active_hal_mpu;
+void hal_mpu_register_ops(hal_mpu_ops_t *ops);
+
 #endif // BHARAT_HAL_MPU_H

--- a/core/kernel/include/mm/prot_domain.h
+++ b/core/kernel/include/mm/prot_domain.h
@@ -17,7 +17,7 @@ struct prot_domain;
 typedef struct prot_domain prot_domain_t;
 
 typedef struct prot_domain_ops {
-    prot_domain_t* (*create)(void);
+    int (*create)(prot_domain_t** out_domain);
     void (*destroy)(prot_domain_t* domain);
     void (*activate)(prot_domain_t* domain);
     int (*map_region)(prot_domain_t* domain, uintptr_t vaddr, uintptr_t paddr, size_t size, uint32_t flags);
@@ -36,7 +36,7 @@ struct prot_domain {
 void prot_domain_init(void);
 
 // Core API
-prot_domain_t* prot_domain_create(void);
+int prot_domain_create(prot_domain_t** out_domain);
 void prot_domain_destroy(prot_domain_t* domain);
 void prot_domain_activate(prot_domain_t* domain);
 int prot_domain_map_region(prot_domain_t* domain, uintptr_t vaddr, uintptr_t paddr, size_t size, uint32_t flags);

--- a/core/kernel/src/mm/prot_domain.c
+++ b/core/kernel/src/mm/prot_domain.c
@@ -1,6 +1,7 @@
 #include "mm/prot_domain.h"
 #include "../../include/mm/prot_domain.h"
 #include "../../include/hal/hal_pt.h"
+#include "../../include/hal/hal_mpu.h"
 #include "../../include/arch/arch_caps.h"
 #include "hal/hal_mm.h"
 #include "console/console_core.h"
@@ -12,26 +13,39 @@ static prot_mode_t active_mode = PROT_MODE_NONE;
 
 #include "slab.h"
 
+hal_mpu_ops_t *active_hal_mpu = NULL;
+void hal_mpu_register_ops(hal_mpu_ops_t *ops) {
+    active_hal_mpu = ops;
+}
+
+// Forward declarations of ops
+static prot_domain_ops_t mmu_full_backend_ops;
+static prot_domain_ops_t mmu_lite_backend_ops;
+static prot_domain_ops_t mpu_backend_ops;
+static prot_domain_ops_t prot_none_ops;
+
 // ---------------------------------------------------------------------------
 // 1. MMU_FULL Backend Realization
 // ---------------------------------------------------------------------------
-static prot_domain_t* mmu_full_create(void) {
+static int mmu_full_create(prot_domain_t** out_domain) {
     prot_domain_t* domain = (prot_domain_t*)kmalloc(sizeof(prot_domain_t));
-    if (!domain) return NULL;
+    if (!domain) return K_ERR_NO_MEMORY;
     domain->mode = PROT_MODE_MMU_FULL;
-    domain->ops = active_backend;
+    domain->ops = &mmu_full_backend_ops;
 
     if (active_hal_pt) {
         extern phys_addr_t vmm_get_kernel_root(void);
         domain->backend_state = (void*)(uintptr_t)hal_pt_create_address_space(vmm_get_kernel_root());
         if (!domain->backend_state) {
             kfree(domain);
-            return NULL;
+            return K_ERR_NO_MEMORY;
         }
     } else {
-        domain->backend_state = NULL;
+        kfree(domain);
+        return K_ERR_UNSUPPORTED;
     }
-    return domain;
+    *out_domain = domain;
+    return K_OK;
 }
 
 static void mmu_full_destroy(prot_domain_t* domain) {
@@ -51,21 +65,21 @@ static int mmu_full_map_region(prot_domain_t* domain, uintptr_t vaddr, uintptr_t
     if (active_hal_pt && domain && domain->backend_state) {
         return hal_pt_map_range((phys_addr_t)(uintptr_t)domain->backend_state, vaddr, paddr, size, flags);
     }
-    return -1;
+    return K_ERR_UNSUPPORTED;
 }
 
 static int mmu_full_unmap_region(prot_domain_t* domain, uintptr_t vaddr, size_t size) {
     if (active_hal_pt && domain && domain->backend_state) {
         return hal_pt_unmap_range((phys_addr_t)(uintptr_t)domain->backend_state, vaddr, size);
     }
-    return -1;
+    return K_ERR_UNSUPPORTED;
 }
 
 static int mmu_full_protect_region(prot_domain_t* domain, uintptr_t vaddr, size_t size, uint32_t flags) {
     if (active_hal_pt && domain && domain->backend_state) {
         return hal_pt_protect_range((phys_addr_t)(uintptr_t)domain->backend_state, vaddr, size, flags);
     }
-    return -1;
+    return K_ERR_UNSUPPORTED;
 }
 
 static int mmu_full_query_region(prot_domain_t* domain, uintptr_t vaddr, uintptr_t* paddr, uint32_t* flags) {
@@ -78,7 +92,7 @@ static int mmu_full_query_region(prot_domain_t* domain, uintptr_t vaddr, uintptr
         }
         return res;
     }
-    return -1;
+    return K_ERR_UNSUPPORTED;
 }
 
 static prot_domain_ops_t mmu_full_backend_ops = {
@@ -94,17 +108,31 @@ static prot_domain_ops_t mmu_full_backend_ops = {
 // ---------------------------------------------------------------------------
 // 2. MMU_LITE Backend Realization
 // ---------------------------------------------------------------------------
-static prot_domain_t* mmu_lite_create(void) {
+static int mmu_lite_create(prot_domain_t** out_domain) {
     prot_domain_t* domain = (prot_domain_t*)kmalloc(sizeof(prot_domain_t));
-    if (!domain) return NULL;
+    if (!domain) return K_ERR_NO_MEMORY;
     domain->mode = PROT_MODE_MMU_LITE;
-    domain->ops = active_backend;
-    domain->backend_state = NULL; // Constrained translation, often single globally configured root
-    return domain;
+    domain->ops = &mmu_lite_backend_ops;
+    domain->backend_state = NULL;
+
+    if (active_hal_pt) {
+        extern phys_addr_t vmm_get_kernel_root(void);
+        domain->backend_state = (void*)(uintptr_t)hal_pt_create_address_space(vmm_get_kernel_root());
+    } else {
+        kfree(domain);
+        return K_ERR_UNSUPPORTED;
+    }
+    *out_domain = domain;
+    return K_OK;
 }
 
 static void mmu_lite_destroy(prot_domain_t* domain) {
-    if (domain) kfree(domain);
+    if (domain) {
+        if (active_hal_pt && domain->backend_state) {
+            hal_pt_destroy_address_space((phys_addr_t)(uintptr_t)domain->backend_state);
+        }
+        kfree(domain);
+    }
 }
 
 static void mmu_lite_activate(prot_domain_t* domain) {
@@ -112,30 +140,48 @@ static void mmu_lite_activate(prot_domain_t* domain) {
 }
 
 static int mmu_lite_map_region(prot_domain_t* domain, uintptr_t vaddr, uintptr_t paddr, size_t size, uint32_t flags) {
-    (void)domain;
-    // MMU_LITE forbids runtime demand paging and only allows mapped ranges satisfying specific constraints
     if (size % 4096 != 0 || vaddr % 4096 != 0 || paddr % 4096 != 0) {
-        return K_ERR_INVALID_ARG; // Explicit validation error
+        return K_ERR_INVALID_ARG;
     }
-    // Only allow when mapping is pre-allocated or statically configured
-    if (flags & (1 << 4)) { // Assuming bit 4 represents lazy or demand faulting
-        return K_ERR_UNSUPPORTED; // Demand faulting/paging is forbidden
+    if (active_hal_pt && domain && domain->backend_state) {
+        return hal_pt_map_range((phys_addr_t)(uintptr_t)domain->backend_state, vaddr, paddr, size, flags);
     }
-    return 0; // Pre-realization success
+    return K_ERR_UNSUPPORTED;
 }
 
 static int mmu_lite_unmap_region(prot_domain_t* domain, uintptr_t vaddr, size_t size) {
-    (void)domain; (void)vaddr; (void)size;
-    return 0;
+    if (size % 4096 != 0 || vaddr % 4096 != 0) {
+        return K_ERR_INVALID_ARG;
+    }
+    if (active_hal_pt && domain && domain->backend_state) {
+        return hal_pt_unmap_range((phys_addr_t)(uintptr_t)domain->backend_state, vaddr, size);
+    }
+    return K_ERR_UNSUPPORTED;
 }
 
 static int mmu_lite_protect_region(prot_domain_t* domain, uintptr_t vaddr, size_t size, uint32_t flags) {
-    (void)domain; (void)vaddr; (void)size; (void)flags;
-    return 0;
+    if (size % 4096 != 0 || vaddr % 4096 != 0) {
+        return K_ERR_INVALID_ARG;
+    }
+    if (active_hal_pt && domain && domain->backend_state) {
+        return hal_pt_protect_range((phys_addr_t)(uintptr_t)domain->backend_state, vaddr, size, flags);
+    }
+    return K_ERR_UNSUPPORTED;
 }
 
 static int mmu_lite_query_region(prot_domain_t* domain, uintptr_t vaddr, uintptr_t* paddr, uint32_t* flags) {
-    (void)domain; (void)vaddr; (void)paddr; (void)flags;
+    if (vaddr % 4096 != 0) {
+        return K_ERR_INVALID_ARG;
+    }
+    if (active_hal_pt && domain && domain->backend_state) {
+        size_t mapped_size;
+        phys_addr_t pa;
+        int res = hal_pt_query_mapping((phys_addr_t)(uintptr_t)domain->backend_state, vaddr, &pa, &mapped_size, flags);
+        if (res == 0 && paddr) {
+            *paddr = (uintptr_t)pa;
+        }
+        return res;
+    }
     return K_ERR_UNSUPPORTED;
 }
 
@@ -152,58 +198,195 @@ static prot_domain_ops_t mmu_lite_backend_ops = {
 // ---------------------------------------------------------------------------
 // 3. MPU Backend Realization
 // ---------------------------------------------------------------------------
-static prot_domain_t* mpu_create(void) {
+#define MAX_MPU_DOMAINS_REGIONS 16
+
+typedef struct {
+    uintptr_t vaddr;
+    uintptr_t paddr;
+    size_t size;
+    uint32_t flags;
+    int region_id;
+    bool active;
+} mpu_domain_region_t;
+
+typedef struct {
+    mpu_domain_region_t regions[MAX_MPU_DOMAINS_REGIONS];
+    int count;
+} mpu_domain_state_t;
+
+static int mpu_create(prot_domain_t** out_domain) {
+    if (!active_hal_mpu || !active_hal_mpu->program_region) {
+        return K_ERR_UNSUPPORTED;
+    }
     prot_domain_t* domain = (prot_domain_t*)kmalloc(sizeof(prot_domain_t));
-    if (!domain) return NULL;
+    if (!domain) return K_ERR_NO_MEMORY;
+
+    mpu_domain_state_t* state = (mpu_domain_state_t*)kmalloc(sizeof(mpu_domain_state_t));
+    if (!state) {
+        kfree(domain);
+        return K_ERR_NO_MEMORY;
+    }
+    for (int i = 0; i < MAX_MPU_DOMAINS_REGIONS; i++) {
+        state->regions[i].active = false;
+    }
+    state->count = 0;
+
     domain->mode = PROT_MODE_MPU_ONLY;
-    domain->ops = active_backend;
-    domain->backend_state = NULL; // MPU does not allocate or require page-tables
-    return domain;
+    domain->ops = &mpu_backend_ops;
+    domain->backend_state = state;
+    *out_domain = domain;
+    return K_OK;
 }
 
 static void mpu_destroy(prot_domain_t* domain) {
-    if (domain) kfree(domain);
+    if (domain) {
+        if (domain->backend_state) {
+            mpu_domain_state_t* state = (mpu_domain_state_t*)domain->backend_state;
+            if (active_hal_mpu && active_hal_mpu->disable_region) {
+                for (int i = 0; i < MAX_MPU_DOMAINS_REGIONS; i++) {
+                    if (state->regions[i].active) {
+                        active_hal_mpu->disable_region(state->regions[i].region_id);
+                    }
+                }
+            }
+            kfree(state);
+        }
+        kfree(domain);
+    }
 }
 
 static void mpu_activate(prot_domain_t* domain) {
-    (void)domain;
+    if (!domain || !domain->backend_state) return;
+    if (active_hal_mpu && active_hal_mpu->program_region && active_hal_mpu->disable_region) {
+        mpu_domain_state_t* state = (mpu_domain_state_t*)domain->backend_state;
+        for (int i = 0; i < MAX_MPU_DOMAINS_REGIONS; i++) {
+            if (state->regions[i].active) {
+                active_hal_mpu->program_region(state->regions[i].region_id, state->regions[i].paddr, state->regions[i].size, state->regions[i].flags);
+            } else {
+                active_hal_mpu->disable_region(i);
+            }
+        }
+    }
 }
 
 static int mpu_map_region(prot_domain_t* domain, uintptr_t vaddr, uintptr_t paddr, size_t size, uint32_t flags) {
-    (void)domain; (void)flags;
-    // MPU is region-based, not paging-based.
-    // Validate alignment, power-of-two size or hardware alignment limits (typically 32 bytes to 4KB).
-    if (vaddr != paddr) {
-        // MPU platforms typically run with identity mappings or simple offset region translation
-        return K_ERR_UNSUPPORTED;
+    if (!domain || !domain->backend_state) return K_ERR_BAD_STATE;
+    if (!active_hal_mpu || !active_hal_mpu->program_region) return K_ERR_UNSUPPORTED;
+
+    mpu_domain_state_t* state = (mpu_domain_state_t*)domain->backend_state;
+
+    // Query capabilities for constraints
+    const hal_mpu_caps_t* caps = NULL;
+    if (active_hal_mpu->get_caps) {
+        caps = active_hal_mpu->get_caps();
     }
-    // Reject page-table allocation, TLB shootdown hooks, demand faulting or COW
-    if (flags & (1 << 4)) { // demand faulting / COW bit
-        return K_ERR_UNSUPPORTED;
-    }
-    if (size < 32 || (size & (size - 1)) != 0) {
-        // Common MPU hardware requirement: power-of-two size and size-aligned base
-        // Or at least 32-byte alignment.
-        if (vaddr % 32 != 0) {
+
+    if (caps) {
+        if (state->count >= (int)caps->max_regions) {
+            return K_ERR_NO_RESOURCES;
+        }
+        if (caps->requires_power_of_two_size) {
+            if (size == 0 || (size & (size - 1)) != 0) {
+                return K_ERR_INVALID_ARG;
+            }
+        }
+        if (size < caps->min_region_alignment || (vaddr % caps->min_region_alignment) != 0 || (paddr % caps->min_region_alignment) != 0) {
             return K_ERR_INVALID_ARG;
         }
     }
-    return 0; // Success under MPU model constraints
+
+    // Check overlaps in our tracked state
+    uintptr_t vend = vaddr + size;
+    for (int i = 0; i < MAX_MPU_DOMAINS_REGIONS; i++) {
+        if (state->regions[i].active) {
+            uintptr_t r_vstart = state->regions[i].vaddr;
+            uintptr_t r_vend = r_vstart + state->regions[i].size;
+            if (!(vend <= r_vstart || vaddr >= r_vend)) {
+                return K_ERR_VM_ALREADY_MAPPED;
+            }
+        }
+    }
+
+    // Find free slot
+    int slot = -1;
+    for (int i = 0; i < MAX_MPU_DOMAINS_REGIONS; i++) {
+        if (!state->regions[i].active) {
+            slot = i;
+            break;
+        }
+    }
+    if (slot == -1) return K_ERR_NO_RESOURCES;
+
+    // Call active MPU backend
+    int ret = active_hal_mpu->program_region(slot, paddr, size, flags);
+    if (ret != K_OK) return ret;
+
+    state->regions[slot].vaddr = vaddr;
+    state->regions[slot].paddr = paddr;
+    state->regions[slot].size = size;
+    state->regions[slot].flags = flags;
+    state->regions[slot].region_id = slot;
+    state->regions[slot].active = true;
+    state->count++;
+
+    return K_OK;
 }
 
 static int mpu_unmap_region(prot_domain_t* domain, uintptr_t vaddr, size_t size) {
-    (void)domain; (void)vaddr; (void)size;
-    return 0;
+    if (!domain || !domain->backend_state) return K_ERR_BAD_STATE;
+    if (!active_hal_mpu || !active_hal_mpu->disable_region) return K_ERR_UNSUPPORTED;
+
+    mpu_domain_state_t* state = (mpu_domain_state_t*)domain->backend_state;
+    for (int i = 0; i < MAX_MPU_DOMAINS_REGIONS; i++) {
+        if (state->regions[i].active && state->regions[i].vaddr == vaddr && state->regions[i].size == size) {
+            int ret = active_hal_mpu->disable_region(state->regions[i].region_id);
+            if (ret != K_OK) return ret;
+
+            state->regions[i].active = false;
+            state->count--;
+            return K_OK;
+        }
+    }
+    return K_ERR_NOT_FOUND;
 }
 
 static int mpu_protect_region(prot_domain_t* domain, uintptr_t vaddr, size_t size, uint32_t flags) {
-    (void)domain; (void)vaddr; (void)size; (void)flags;
-    return 0;
+    if (!domain || !domain->backend_state) return K_ERR_BAD_STATE;
+    if (!active_hal_mpu || !active_hal_mpu->program_region) return K_ERR_UNSUPPORTED;
+
+    mpu_domain_state_t* state = (mpu_domain_state_t*)domain->backend_state;
+    for (int i = 0; i < MAX_MPU_DOMAINS_REGIONS; i++) {
+        if (state->regions[i].active && state->regions[i].vaddr == vaddr && state->regions[i].size == size) {
+            int ret = active_hal_mpu->program_region(state->regions[i].region_id, state->regions[i].paddr, state->regions[i].size, flags);
+            if (ret != K_OK) return ret;
+
+            state->regions[i].flags = flags;
+            return K_OK;
+        }
+    }
+    return K_ERR_NOT_FOUND;
 }
 
 static int mpu_query_region(prot_domain_t* domain, uintptr_t vaddr, uintptr_t* paddr, uint32_t* flags) {
-    (void)domain; (void)vaddr; (void)paddr; (void)flags;
-    return K_ERR_UNSUPPORTED;
+    if (!domain || !domain->backend_state) return K_ERR_BAD_STATE;
+
+    mpu_domain_state_t* state = (mpu_domain_state_t*)domain->backend_state;
+    for (int i = 0; i < MAX_MPU_DOMAINS_REGIONS; i++) {
+        if (state->regions[i].active) {
+            uintptr_t r_vstart = state->regions[i].vaddr;
+            uintptr_t r_vend = r_vstart + state->regions[i].size;
+            if (vaddr >= r_vstart && vaddr < r_vend) {
+                if (paddr) {
+                    *paddr = state->regions[i].paddr + (vaddr - r_vstart);
+                }
+                if (flags) {
+                    *flags = state->regions[i].flags;
+                }
+                return K_OK;
+            }
+        }
+    }
+    return K_ERR_NOT_FOUND;
 }
 
 static prot_domain_ops_t mpu_backend_ops = {
@@ -252,39 +435,42 @@ prot_domain_ops_t* prot_domain_get_active_backend(void) {
     return active_backend;
 }
 
-prot_domain_t* prot_domain_create(void) {
-    if (!active_backend || !active_backend->create) return NULL;
-    return active_backend->create();
+int prot_domain_create(prot_domain_t** out_domain) {
+    if (!out_domain) return K_ERR_INVALID_ARG;
+    if (!active_backend || !active_backend->create) {
+        return K_ERR_UNSUPPORTED;
+    }
+    return active_backend->create(out_domain);
 }
 
 void prot_domain_destroy(prot_domain_t* domain) {
-    if (active_backend && active_backend->destroy) {
-        active_backend->destroy(domain);
+    if (domain && domain->ops && domain->ops->destroy) {
+        domain->ops->destroy(domain);
     }
 }
 
 void prot_domain_activate(prot_domain_t* domain) {
-    if (active_backend && active_backend->activate) {
-        active_backend->activate(domain);
+    if (domain && domain->ops && domain->ops->activate) {
+        domain->ops->activate(domain);
     }
 }
 
 int prot_domain_map_region(prot_domain_t* domain, uintptr_t vaddr, uintptr_t paddr, size_t size, uint32_t flags) {
-    if (!active_backend || !active_backend->map_region) return -1;
-    return active_backend->map_region(domain, vaddr, paddr, size, flags);
+    if (!domain || !domain->ops || !domain->ops->map_region) return K_ERR_UNSUPPORTED;
+    return domain->ops->map_region(domain, vaddr, paddr, size, flags);
 }
 
 int prot_domain_unmap_region(prot_domain_t* domain, uintptr_t vaddr, size_t size) {
-    if (!active_backend || !active_backend->unmap_region) return -1;
-    return active_backend->unmap_region(domain, vaddr, size);
+    if (!domain || !domain->ops || !domain->ops->unmap_region) return K_ERR_UNSUPPORTED;
+    return domain->ops->unmap_region(domain, vaddr, size);
 }
 
 int prot_domain_protect_region(prot_domain_t* domain, uintptr_t vaddr, size_t size, uint32_t flags) {
-    if (!active_backend || !active_backend->protect_region) return -1;
-    return active_backend->protect_region(domain, vaddr, size, flags);
+    if (!domain || !domain->ops || !domain->ops->protect_region) return K_ERR_UNSUPPORTED;
+    return domain->ops->protect_region(domain, vaddr, size, flags);
 }
 
 int prot_domain_query_region(prot_domain_t* domain, uintptr_t vaddr, uintptr_t* paddr, uint32_t* flags) {
-    if (!active_backend || !active_backend->query_region) return -1;
-    return active_backend->query_region(domain, vaddr, paddr, flags);
+    if (!domain || !domain->ops || !domain->ops->query_region) return K_ERR_UNSUPPORTED;
+    return domain->ops->query_region(domain, vaddr, paddr, flags);
 }

--- a/core/kernel/src/mm/vm/aspace/aspace.c
+++ b/core/kernel/src/mm/vm/aspace/aspace.c
@@ -103,7 +103,13 @@ int aspace_create(address_space_t **out_aspace, uint32_t flags) {
     mem_model_t current_model = mem_model_get_current();
 
     // Create protection domain backend first
-    as->prot_domain = prot_domain_create();
+    as->prot_domain = NULL;
+    kstatus_t pd_err = prot_domain_create(&as->prot_domain);
+    if (pd_err != K_OK && current_model != MEM_MODEL_NONE) {
+        kfree(as);
+        mm_stats.aspace_create_failures++;
+        return pd_err;
+    }
 
     // Setup page table / root_pt based on profile/model
     if (current_model == MEM_MODEL_MPU || profile == ASPACE_PROFILE_REGION_ONLY) {

--- a/core/kernel/src/tests/ktest_prot_domain.c
+++ b/core/kernel/src/tests/ktest_prot_domain.c
@@ -4,9 +4,40 @@
 #include "../../include/hal/hal.h"
 #include "../../include/hal/hal_pt.h"
 
+#include "../../include/hal/hal_mpu.h"
+
+static int mock_program_region(uint32_t region_id, phys_addr_t base, size_t size, uint32_t flags) {
+    (void)region_id; (void)base; (void)size; (void)flags;
+    return 0;
+}
+static int mock_disable_region(uint32_t region_id) {
+    (void)region_id;
+    return 0;
+}
+static const hal_mpu_caps_t mock_caps = {
+    .max_regions = 16,
+    .supports_subregions = false,
+    .requires_power_of_two_size = false,
+    .min_region_alignment = 32
+};
+static const hal_mpu_caps_t* mock_get_caps(void) {
+    return &mock_caps;
+}
+static hal_mpu_ops_t mock_mpu_ops = {
+    .program_region = mock_program_region,
+    .disable_region = mock_disable_region,
+    .get_caps = mock_get_caps
+};
+
 static bool test_prot_domain_create_destroy(void) {
-    prot_domain_t* domain = prot_domain_create();
-    KTEST_ASSERT(domain != NULL, "prot_domain_create should succeed");
+    hal_mpu_ops_t *old_ops = active_hal_mpu;
+    if (!active_hal_mpu) {
+        hal_mpu_register_ops(&mock_mpu_ops);
+    }
+
+    prot_domain_t* domain = NULL;
+    int pd_err = prot_domain_create(&domain);
+    KTEST_ASSERT(pd_err == K_OK && domain != NULL, "prot_domain_create should succeed");
 
     arch_caps_t caps = arch_get_caps();
     if (arch_caps_test(caps, ARCH_CAP_MMU_FULL)) {
@@ -20,6 +51,7 @@ static bool test_prot_domain_create_destroy(void) {
     }
 
     prot_domain_destroy(domain);
+    active_hal_mpu = old_ops;
     return true;
 }
 
@@ -29,8 +61,14 @@ static bool test_mpu_exhaustion(void) {
         return true; // Skip if not MPU
     }
 
-    prot_domain_t* domain = prot_domain_create();
-    KTEST_ASSERT(domain != NULL, "Domain create failed");
+    hal_mpu_ops_t *old_ops = active_hal_mpu;
+    if (!active_hal_mpu) {
+        hal_mpu_register_ops(&mock_mpu_ops);
+    }
+
+    prot_domain_t* domain = NULL;
+    int pd_err = prot_domain_create(&domain);
+    KTEST_ASSERT(pd_err == K_OK && domain != NULL, "Domain create failed");
 
     int i = 0;
     while(1) {
@@ -42,6 +80,7 @@ static bool test_mpu_exhaustion(void) {
         i++;
     }
     prot_domain_destroy(domain);
+    active_hal_mpu = old_ops;
     return true;
 }
 
@@ -51,8 +90,14 @@ static bool test_mpu_overlap(void) {
         return true; // Skip if not MPU
     }
 
-    prot_domain_t* domain = prot_domain_create();
-    KTEST_ASSERT(domain != NULL, "Domain create failed");
+    hal_mpu_ops_t *old_ops = active_hal_mpu;
+    if (!active_hal_mpu) {
+        hal_mpu_register_ops(&mock_mpu_ops);
+    }
+
+    prot_domain_t* domain = NULL;
+    int pd_err = prot_domain_create(&domain);
+    KTEST_ASSERT(pd_err == K_OK && domain != NULL, "Domain create failed");
 
     int ret = prot_domain_map_region(domain, 0x1000, 0x1000, 0x2000, 0);
     KTEST_ASSERT(ret == 0, "Map region 1 failed");
@@ -61,6 +106,7 @@ static bool test_mpu_overlap(void) {
     KTEST_ASSERT(ret < 0, "Map overlapping region 2 should fail");
 
     prot_domain_destroy(domain);
+    active_hal_mpu = old_ops;
     return true;
 }
 
@@ -70,8 +116,9 @@ static bool test_mmu_sparse_mapping(void) {
         return true; // Skip if not MMU
     }
 
-    prot_domain_t* domain = prot_domain_create();
-    KTEST_ASSERT(domain != NULL, "Domain create failed");
+    prot_domain_t* domain = NULL;
+    int pd_err = prot_domain_create(&domain);
+    KTEST_ASSERT(pd_err == K_OK && domain != NULL, "Domain create failed");
 
     // Test 1: Map low VA
     uintptr_t low_vaddr = 0x0000000040000000ULL; // 1 GiB
@@ -138,8 +185,9 @@ static bool test_prot_none_fail_fast(void) {
         return true; // Skip if supported
     }
 
-    prot_domain_t* domain = prot_domain_create();
-    KTEST_ASSERT(domain != NULL, "Domain create failed");
+    prot_domain_t* domain = NULL;
+    int pd_err = prot_domain_create(&domain);
+    KTEST_ASSERT(pd_err == K_OK && domain != NULL, "Domain create failed");
 
     int ret = prot_domain_map_region(domain, 0x10000000, 0x80000000, 4096, 0);
     KTEST_ASSERT(ret == -1, "Mapping on PROT_MODE_NONE should always fail explicitly with ERR_NOT_SUPPORTED");

--- a/quality/tests/benchmark_stubs.c
+++ b/quality/tests/benchmark_stubs.c
@@ -319,7 +319,7 @@ __attribute__((weak)) void hal_mm_backend_caps(hal_mm_backend_caps_t *out) {
     }
 }
 
-__attribute__((weak)) prot_domain_t* mock_prot_domain_create(void) { return (prot_domain_t*)0x1234; }
+__attribute__((weak)) int mock_prot_domain_create(prot_domain_t** out) { *out = (prot_domain_t*)0x1234; return 0; }
 __attribute__((weak)) prot_domain_ops_t mmu_full_ops_x86_64 = { .create = mock_prot_domain_create };
 __attribute__((weak)) prot_domain_ops_t mmu_lite_ops_common = { .create = mock_prot_domain_create };
 __attribute__((weak)) prot_domain_ops_t prot_none_ops = { .create = mock_prot_domain_create };

--- a/quality/tests/host/mm/test_memory_authority.c
+++ b/quality/tests/host/mm/test_memory_authority.c
@@ -12,7 +12,7 @@
 
 // Mock dependencies
 void hal_pt_init(void) {}
-struct prot_domain* prot_domain_create(void) { return NULL; }
+int prot_domain_create(struct prot_domain** out) { *out = NULL; return 0; }
 void prot_domain_destroy(struct prot_domain* pd) { (void)pd; }
 void mm_stats_inc_aspace_create_calls(void) {}
 phys_addr_t vmm_get_kernel_root(void) { return 0; }

--- a/quality/tests/host/mm/test_memory_profiles.c
+++ b/quality/tests/host/mm/test_memory_profiles.c
@@ -10,7 +10,7 @@
 
 // Mock dependencies
 void hal_pt_init(void) {}
-struct prot_domain* prot_domain_create(void) { return NULL; }
+int prot_domain_create(struct prot_domain** out) { *out = NULL; return 0; }
 void prot_domain_destroy(struct prot_domain* pd) { (void)pd; }
 void mm_stats_inc_aspace_create_calls(void) {}
 phys_addr_t vmm_get_kernel_root(void) { return 0; }

--- a/quality/tests/host/mm/test_prot_domain_truth.c
+++ b/quality/tests/host/mm/test_prot_domain_truth.c
@@ -1,0 +1,346 @@
+#include <mm/prot_domain.h>
+#include <hal/hal_pt.h>
+#include <hal/hal_mpu.h>
+#include <hal/hal_mm.h>
+#include <kernel/status.h>
+#include <mm/vm_mapping.h>
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+// Mock memory management
+void* kmalloc(size_t s) {
+    return malloc(s);
+}
+void kfree(void* p) {
+    free(p);
+}
+
+// Global active caps
+static hal_mm_backend_kind_t mock_backend_kind = HAL_MM_BACKEND_NONE;
+void hal_mm_backend_caps(hal_mm_backend_caps_t *out) {
+    memset(out, 0, sizeof(*out));
+    out->kind = mock_backend_kind;
+    out->max_regions = 16;
+}
+
+// Track PT calls
+static int pt_create_calls = 0;
+static int pt_destroy_calls = 0;
+static int pt_map_calls = 0;
+static int pt_unmap_calls = 0;
+static int pt_protect_calls = 0;
+static int pt_query_calls = 0;
+
+static int pt_inject_ret = 0;
+
+phys_addr_t vmm_get_kernel_root(void) {
+    return 0x5000;
+}
+
+static phys_addr_t mock_create_address_space(phys_addr_t kernel_root_table) {
+    pt_create_calls++;
+    return 0x9000;
+}
+static void mock_destroy_address_space(phys_addr_t root_pt) {
+    pt_destroy_calls++;
+}
+static int mock_map_range(phys_addr_t root_pt, virt_addr_t vaddr, phys_addr_t paddr, size_t size, uint32_t flags) {
+    pt_map_calls++;
+    return pt_inject_ret;
+}
+static int mock_unmap_range(phys_addr_t root_pt, virt_addr_t vaddr, size_t size) {
+    pt_unmap_calls++;
+    return pt_inject_ret;
+}
+static int mock_protect_range(phys_addr_t root_pt, virt_addr_t vaddr, size_t size, uint32_t new_flags) {
+    pt_protect_calls++;
+    return pt_inject_ret;
+}
+static int mock_query_mapping(phys_addr_t root_pt, virt_addr_t vaddr, phys_addr_t *paddr, size_t *mapped_size, uint32_t *flags) {
+    pt_query_calls++;
+    if (paddr) *paddr = 0x8000;
+    return pt_inject_ret;
+}
+
+phys_addr_t hal_pt_create_address_space(phys_addr_t kernel_root_table) {
+    if (active_hal_pt && active_hal_pt->create_address_space) {
+        return active_hal_pt->create_address_space(kernel_root_table);
+    }
+    return 0;
+}
+void hal_pt_destroy_address_space(phys_addr_t root_pt) {
+    if (active_hal_pt && active_hal_pt->destroy_address_space) {
+        active_hal_pt->destroy_address_space(root_pt);
+    }
+}
+int hal_pt_map_range(phys_addr_t root_pt, virt_addr_t vaddr, phys_addr_t paddr, size_t size, uint32_t flags) {
+    if (active_hal_pt && active_hal_pt->map_range) {
+        return active_hal_pt->map_range(root_pt, vaddr, paddr, size, flags);
+    }
+    return -1;
+}
+int hal_pt_unmap_range(phys_addr_t root_pt, virt_addr_t vaddr, size_t size) {
+    if (active_hal_pt && active_hal_pt->unmap_range) {
+        return active_hal_pt->unmap_range(root_pt, vaddr, size);
+    }
+    return -1;
+}
+int hal_pt_protect_range(phys_addr_t root_pt, virt_addr_t vaddr, size_t size, uint32_t new_flags) {
+    if (active_hal_pt && active_hal_pt->protect_range) {
+        return active_hal_pt->protect_range(root_pt, vaddr, size, new_flags);
+    }
+    return -1;
+}
+int hal_pt_query_mapping(phys_addr_t root_pt, virt_addr_t vaddr, phys_addr_t *paddr, size_t *mapped_size, uint32_t *flags) {
+    if (active_hal_pt && active_hal_pt->query_mapping) {
+        return active_hal_pt->query_mapping(root_pt, vaddr, paddr, mapped_size, flags);
+    }
+    return -1;
+}
+
+static hal_pt_ops_t mock_hal_pt_ops = {
+    .create_address_space = mock_create_address_space,
+    .destroy_address_space = mock_destroy_address_space,
+    .map_range = mock_map_range,
+    .unmap_range = mock_unmap_range,
+    .protect_range = mock_protect_range,
+    .query_mapping = mock_query_mapping,
+};
+
+hal_pt_ops_t *active_hal_pt = &mock_hal_pt_ops;
+
+void hal_pt_init(void) {}
+
+// Track MPU calls
+static int mpu_program_calls = 0;
+static int mpu_disable_calls = 0;
+static int mpu_caps_calls = 0;
+
+static int mpu_inject_ret = 0;
+
+static int mock_mpu_program_region(uint32_t region_id, phys_addr_t base, size_t size, uint32_t flags) {
+    mpu_program_calls++;
+    return mpu_inject_ret;
+}
+static int mock_mpu_disable_region(uint32_t region_id) {
+    mpu_disable_calls++;
+    return mpu_inject_ret;
+}
+static const hal_mpu_caps_t mock_mpu_caps = {
+    .max_regions = 16,
+    .supports_subregions = false,
+    .requires_power_of_two_size = false,
+    .min_region_alignment = 32
+};
+static const hal_mpu_caps_t* mock_mpu_get_caps(void) {
+    mpu_caps_calls++;
+    return &mock_mpu_caps;
+}
+
+static hal_mpu_ops_t mock_hal_mpu_ops = {
+    .program_region = mock_mpu_program_region,
+    .disable_region = mock_mpu_disable_region,
+    .get_caps = mock_mpu_get_caps,
+};
+
+// Reset trackers
+static void reset_counters(void) {
+    pt_create_calls = 0;
+    pt_destroy_calls = 0;
+    pt_map_calls = 0;
+    pt_unmap_calls = 0;
+    pt_protect_calls = 0;
+    pt_query_calls = 0;
+    pt_inject_ret = 0;
+
+    mpu_program_calls = 0;
+    mpu_disable_calls = 0;
+    mpu_caps_calls = 0;
+    mpu_inject_ret = 0;
+}
+
+void test_mmu_full_truth(void) {
+    printf("Running test_mmu_full_truth...\n");
+    reset_counters();
+    mock_backend_kind = HAL_MM_BACKEND_MMU_FULL;
+    prot_domain_init();
+
+    prot_domain_t* domain = NULL;
+    int ret = prot_domain_create(&domain);
+    assert(ret == K_OK);
+    assert(domain != NULL);
+    assert(domain->mode == PROT_MODE_MMU_FULL);
+    assert(pt_create_calls == 1);
+
+    // Test map
+    ret = prot_domain_map_region(domain, 0x1000, 0x2000, 4096, 0);
+    assert(ret == K_OK);
+    assert(pt_map_calls == 1);
+
+    // Test fail propagation
+    pt_inject_ret = K_ERR_DENIED;
+    ret = prot_domain_map_region(domain, 0x3000, 0x4000, 4096, 0);
+    assert(ret == K_ERR_DENIED);
+    assert(pt_map_calls == 2);
+
+    // Test unmap
+    pt_inject_ret = K_OK;
+    ret = prot_domain_unmap_region(domain, 0x1000, 4096);
+    assert(ret == K_OK);
+    assert(pt_unmap_calls == 1);
+
+    // Test protect
+    ret = prot_domain_protect_region(domain, 0x1000, 4096, 0);
+    assert(ret == K_OK);
+    assert(pt_protect_calls == 1);
+
+    // Test query
+    uintptr_t pa = 0;
+    ret = prot_domain_query_region(domain, 0x1000, &pa, NULL);
+    assert(ret == K_OK);
+    assert(pa == 0x8000);
+    assert(pt_query_calls == 1);
+
+    prot_domain_destroy(domain);
+    assert(pt_destroy_calls == 1);
+    printf("test_mmu_full_truth passed!\n");
+}
+
+void test_mmu_lite_truth(void) {
+    printf("Running test_mmu_lite_truth...\n");
+    reset_counters();
+    mock_backend_kind = HAL_MM_BACKEND_MMU_LITE;
+    prot_domain_init();
+
+    prot_domain_t* domain = NULL;
+    int ret = prot_domain_create(&domain);
+    assert(ret == K_OK);
+    assert(domain != NULL);
+    assert(domain->mode == PROT_MODE_MMU_LITE);
+
+    // Test map with VM_MAP_EXEC_OK
+    ret = prot_domain_map_region(domain, 0x1000, 0x2000, 4096, VM_MAP_EXEC_OK);
+    assert(ret == K_OK);
+    assert(pt_map_calls == 1); // Real backend was called
+
+    // Test alignment checks
+    ret = prot_domain_map_region(domain, 0x1001, 0x2000, 4096, 0);
+    assert(ret == K_ERR_INVALID_ARG);
+    assert(pt_map_calls == 1); // No backend call for bad arguments
+
+    // Unmap
+    ret = prot_domain_unmap_region(domain, 0x1000, 4096);
+    assert(ret == K_OK);
+    assert(pt_unmap_calls == 1);
+
+    // Protect
+    ret = prot_domain_protect_region(domain, 0x1000, 4096, 0);
+    assert(ret == K_OK);
+    assert(pt_protect_calls == 1);
+
+    // Invariant: no success without backend call
+    reset_counters();
+    active_hal_pt = NULL; // Unregister PT ops to simulate missing backend
+    ret = prot_domain_map_region(domain, 0x1000, 0x2000, 4096, 0);
+    assert(ret == K_ERR_UNSUPPORTED);
+    assert(pt_map_calls == 0);
+
+    active_hal_pt = &mock_hal_pt_ops;
+    prot_domain_destroy(domain);
+    printf("test_mmu_lite_truth passed!\n");
+}
+
+void test_mpu_truth(void) {
+    printf("Running test_mpu_truth...\n");
+    reset_counters();
+    mock_backend_kind = HAL_MM_BACKEND_MPU_ONLY;
+    hal_mpu_register_ops(&mock_hal_mpu_ops);
+    prot_domain_init();
+
+    prot_domain_t* domain = NULL;
+    int ret = prot_domain_create(&domain);
+    assert(ret == K_OK);
+    assert(domain != NULL);
+    assert(domain->mode == PROT_MODE_MPU_ONLY);
+
+    // Test map region
+    ret = prot_domain_map_region(domain, 0x1000, 0x1000, 4096, 0);
+    assert(ret == K_OK);
+    assert(mpu_program_calls == 1);
+    assert(pt_map_calls == 0); // No PT operations invoked for MPU
+
+    // Test overlap rejection
+    ret = prot_domain_map_region(domain, 0x1000, 0x1000, 4096, 0);
+    assert(ret == K_ERR_VM_ALREADY_MAPPED);
+    assert(mpu_program_calls == 1); // Not called since rejected early
+
+    // Test protect region
+    ret = prot_domain_protect_region(domain, 0x1000, 4096, 1);
+    assert(ret == K_OK);
+    assert(mpu_program_calls == 2);
+
+    // Test query region
+    uintptr_t pa = 0;
+    uint32_t flags = 0;
+    ret = prot_domain_query_region(domain, 0x1000, &pa, &flags);
+    assert(ret == K_OK);
+    assert(pa == 0x1000);
+    assert(flags == 1);
+
+    // Test unmap region
+    ret = prot_domain_unmap_region(domain, 0x1000, 4096);
+    assert(ret == K_OK);
+    assert(mpu_disable_calls == 1);
+
+    // Test fail-closed when active_hal_mpu is removed
+    active_hal_mpu = NULL;
+    ret = prot_domain_map_region(domain, 0x1000, 0x1000, 4096, 0);
+    assert(ret == K_ERR_UNSUPPORTED);
+    assert(mpu_program_calls == 2); // No new program call
+
+    active_hal_mpu = &mock_hal_mpu_ops;
+    prot_domain_destroy(domain);
+    printf("test_mpu_truth passed!\n");
+}
+
+void test_dispatch_invariance(void) {
+    printf("Running test_dispatch_invariance...\n");
+    reset_counters();
+
+    // 1. Create a MMU_FULL domain
+    mock_backend_kind = HAL_MM_BACKEND_MMU_FULL;
+    prot_domain_init();
+    prot_domain_t* dom_full = NULL;
+    int ret = prot_domain_create(&dom_full);
+    assert(ret == K_OK);
+
+    // 2. Change active backend to MMU_LITE
+    mock_backend_kind = HAL_MM_BACKEND_MMU_LITE;
+    prot_domain_init();
+    prot_domain_t* dom_lite = NULL;
+    ret = prot_domain_create(&dom_lite);
+    assert(ret == K_OK);
+
+    // 3. Verify they still route to their own specific backend_ops
+    assert(dom_full->ops->map_region != dom_lite->ops->map_region);
+
+    ret = prot_domain_map_region(dom_full, 0x1000, 0x2000, 4096, 0);
+    assert(ret == K_OK);
+    // dom_full should have routed via mmu_full ops
+    assert(dom_full->mode == PROT_MODE_MMU_FULL);
+
+    prot_domain_destroy(dom_full);
+    prot_domain_destroy(dom_lite);
+    printf("test_dispatch_invariance passed!\n");
+}
+
+int main(void) {
+    test_mmu_full_truth();
+    test_mmu_lite_truth();
+    test_mpu_truth();
+    test_dispatch_invariance();
+    printf("All backend-truth protection domain tests passed successfully!\n");
+    return 0;
+}

--- a/quality/tests/host/test_aspace_lifecycle.c
+++ b/quality/tests/host/test_aspace_lifecycle.c
@@ -9,7 +9,7 @@
 
 // Mock dependencies
 void hal_pt_init(void) {}
-struct prot_domain* prot_domain_create(void) { return NULL; }
+int prot_domain_create(struct prot_domain** out) { *out = NULL; return 0; }
 void prot_domain_destroy(struct prot_domain* pd) { (void)pd; }
 void mm_stats_inc_aspace_create_calls(void) {}
 phys_addr_t vmm_get_kernel_root(void) { return 0; }

--- a/quality/tests/test_vmm_fault.c
+++ b/quality/tests/test_vmm_fault.c
@@ -26,7 +26,7 @@ __attribute__((weak)) void kcache_free(int cache_id, void *obj) {
     free(obj);
 }
 
-__attribute__((weak)) prot_domain_t *prot_domain_create(void) { return (prot_domain_t *)malloc(256); }
+__attribute__((weak)) int prot_domain_create(prot_domain_t **out) { *out = (prot_domain_t *)malloc(256); return 0; }
 __attribute__((weak)) void prot_domain_init(void) {}
 __attribute__((weak)) phys_addr_t vmm_get_kernel_root(void) { return 0; }
 __attribute__((weak)) int mm_zero_phys_range(phys_addr_t start, size_t len) { (void)start; (void)len; return 0; }


### PR DESCRIPTION
Close the hardware-realization truth gaps in MMU_LITE and MPU backends. Make protection operations fail closed when a real programmed backend is unavailable, enforce object-oriented dispatch via domain->ops, and ensure fail-closed address-space creation. Completely remove wrong bit 4 COW/demand paging check. Added comprehensive host tests to ensure backend-truth and avoid regression.

---
*PR created automatically by Jules for task [10925832457261877912](https://jules.google.com/task/10925832457261877912) started by @divyang4481*