### PR TITLE
Implement Heterogeneous Compute Substrate and Fallbacks (HET-DEMO-001)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,11 +85,16 @@ Access is capability-mediated. Every operation's authority explicitly identifies
 *(Note: Complete, system-wide capability enforcement across all async IPC paths is an ongoing target architecture under active hardening; our transitional image currently uses boot-time configurations as we close these gates.)*
 
 ### H — Heterogeneous Compute
-Bharat-OS treats CPUs, GPUs, NPUs, DSPs, high-speed NICs, and domain accelerators as first-class managed resources rather than isolated or opaque peripherals. The platform strictly enforces a clean architectural separation:
-* **Kernel:** Focuses strictly on deterministic execution mechanisms, queue registers, memory isolation, and IPC/uRPC primitives.
-* **Drivers:** Handle unprivileged low-level device and register control.
-* **Services:** Manage accelerator placement, scheduling policy, failover governance, power, and thermal decisions.
-* **Runtime:** Handles high-level analytical models, graph compilation, and unprivileged execution backends.
+Bharat-OS is designed to treat CPUs, GPUs, NPUs, DSPs, high-speed NICs, and domain accelerators as first-class managed compute resources rather than opaque peripherals.
+
+The architecture separates heterogeneous compute across four layers:
+
+* **Kernel:** Provides deterministic mechanisms for capability enforcement, queue/fence primitives, memory isolation, DMA/IOMMU integration, IPC/uRPC, and fault containment.
+* **Drivers:** Implement device-specific queue, register, interrupt, and data-movement mechanisms behind stable hardware contracts.
+* **Services:** Manage accelerator admission, placement, scheduling policy, health, failover, power, and thermal governance.
+* **Runtime:** Selects execution backends and handles higher-level workload and graph execution outside the kernel.
+
+**Current implementation status:** Bharat-OS already contains accelerator-specific capability types, neutral job/fence contracts, backend-dispatch infrastructure, accelerator-memory primitives, virtual accelerator scaffolding, and `accelmgr`/telemetry service contracts. End-to-end hardware accelerator execution and policy orchestration remain under active implementation and validation.
 
 ### A — Architecture Independent
 Stable, unified HAL and trap boundaries separate common operating mechanisms from ISA-specific and SoC-specific implementations.
@@ -196,6 +201,8 @@ We enforce strict, evidence-based governance to ensure that code, build graphs, 
 | Network Manager (netmgr) | 🟡 **PARTIAL** | `core/services/netmgr` | Production blocking receive |
 | Process Manager (process_mgr) | ⚪ **SCAFFOLD** | `core/services/process_manager` | Real ELF execution loading |
 | Virtual Memory Manager (vm_mgr) | ⚪ **SCAFFOLD** | `core/services/vm_manager` | On-demand page-pool orchestration |
+| Accelerator Capability & Dispatch Substrate | 🟡 **PARTIAL** | `core/kernel/include/capability.h, core/lib/runtime/backend_dispatch` | Production device queue realization, End-to-end accelerator service mediation |
+| Heterogeneous Compute Control Plane | ⚪ **SCAFFOLD** | `core/services/device/accelmgr, core/drivers/accel/virt_accel.c` | Real accelmgr event loop, Truthful hardware backend execution, Accelerator admission and telemetry integration |
 
 <!-- END MATURITY TABLE -->
 

--- a/core/drivers/accel/virt_accel.c
+++ b/core/drivers/accel/virt_accel.c
@@ -1,7 +1,22 @@
 #include <bharat/accel/accel.h>
 #include <kernel/status.h>
 
-// Pure mock device driver, strictly backend logic. No test logic here.
+// Real emulated device driver with test-support diagnostics.
+
+static uint64_t g_virt_accel_submit_count = 0;
+static bool g_virt_accel_fail_injection = false;
+
+uint64_t virt_accel_get_submit_count(void) {
+    return g_virt_accel_submit_count;
+}
+
+void virt_accel_reset_submit_count(void) {
+    g_virt_accel_submit_count = 0;
+}
+
+void virt_accel_set_fail_injection(bool enable) {
+    g_virt_accel_fail_injection = enable;
+}
 
 static int virt_accel_init(struct bharat_accel_device *dev) {
     (void)dev;
@@ -13,8 +28,38 @@ static void virt_accel_deinit(struct bharat_accel_device *dev) {
 }
 
 static int virt_accel_submit_job(struct bharat_accel_device *dev, void *job_descriptor) {
-    (void)dev;
-    (void)job_descriptor;
+    if (!dev) return K_ERR_INVALID_ARG;
+
+    // Increment submit count on each entry to prove that invocation reached the hardware layer
+    g_virt_accel_submit_count++;
+
+    if (g_virt_accel_fail_injection) {
+        return K_ERR_DEV_MMIO_FAULT; // Simulated hardware failure
+    }
+
+    if (!job_descriptor) {
+        return K_ERR_INVALID_ARG;
+    }
+
+    virt_accel_job_t *job = (virt_accel_job_t *)job_descriptor;
+
+    if (job->opcode != VIRT_ACCEL_OP_RELU_F32) {
+        return K_ERR_UNSUPPORTED;
+    }
+
+    if (!job->input || !job->output || job->input_elements == 0) {
+        return K_ERR_INVALID_ARG;
+    }
+
+    if (job->output_elements < job->input_elements) {
+        return K_ERR_OVERFLOW;
+    }
+
+    // Perform actual FP32 ReLU element-by-element
+    for (size_t i = 0; i < job->input_elements; i++) {
+        job->output[i] = job->input[i] > 0.0f ? job->input[i] : 0.0f;
+    }
+
     return K_OK;
 }
 

--- a/core/lib/runtime/accel/tensor_backend.h
+++ b/core/lib/runtime/accel/tensor_backend.h
@@ -26,11 +26,44 @@ struct backend_interface {
     int (*process_tensor)(tensor_op_t *op);
 };
 
-// Initialize the tensor dispatch layer
+typedef struct {
+    uint64_t backend_hw_selected;
+    uint64_t backend_sw_fallback;
+    uint64_t jobs_completed;
+    uint64_t jobs_failed;
+
+    uint64_t safe_mode_fallbacks;
+    uint64_t unavailable_fallbacks;
+} tensor_dispatch_stats_t;
+
+typedef struct {
+    const char *backend_name;
+    backend_type_t backend_type;
+    int execution_status;
+} tensor_dispatch_result_t;
+
+// Initialize the tensor dispatch layer and reset registry/stats
 int tensor_dispatch_init(void);
 
+// Generic API for consumers to select tensor backend
+const backend_provider_t *tensor_select_backend(
+    const bharat_hw_caps_t *caps,
+    const backend_dispatch_context_t *ctx);
+
 // Generic API for consumers to dispatch tensor ops
-int tensor_process(tensor_op_t *op, const backend_dispatch_context_t *ctx);
+int tensor_process(
+    tensor_op_t *op,
+    const bharat_hw_caps_t *caps,
+    const backend_dispatch_context_t *ctx);
+
+// Snapshot the dispatch stats
+void tensor_dispatch_get_stats(tensor_dispatch_stats_t *out);
+
+// Retrieve the last dispatch result
+void tensor_dispatch_get_last_result(tensor_dispatch_result_t *out);
+
+// Reset statistics specifically (useful for isolated tests)
+void tensor_dispatch_reset_stats(void);
 
 #ifdef __cplusplus
 }

--- a/core/lib/runtime/accel/tensor_dispatch.c
+++ b/core/lib/runtime/accel/tensor_dispatch.c
@@ -1,4 +1,12 @@
 #include "tensor_backend.h"
+#include <bharat/accel/accel.h>
+#include <string.h>
+
+// Extern prototype for accessing the emulated virtual NPU device driver
+extern bharat_accel_device_t* get_virt_accel_mock_device(void);
+
+static tensor_dispatch_stats_t g_stats = {0};
+static tensor_dispatch_result_t g_last_result = {NULL, (backend_type_t)0, 0};
 
 // Software fallback implementation
 static int sw_process_tensor(tensor_op_t *op) {
@@ -23,6 +31,8 @@ static int sw_init(void) {
 }
 
 static bool sw_is_available(const bharat_hw_caps_t *caps, const backend_dispatch_context_t *ctx) {
+    (void)caps;
+    (void)ctx;
     return true; // Software fallback is always available
 }
 
@@ -40,11 +50,33 @@ static const backend_provider_t sw_tensor_provider = {
     .get_interface = sw_get_interface
 };
 
-// Generic Hardware implementation (e.g., discrete NPU/GPU hooks)
+// Generic Hardware implementation (mapping to virtual NPU driver)
 static int hw_process_tensor(tensor_op_t *op) {
     if (!op || !op->input_tensor || !op->output_tensor) return -1;
-    // Just a hook for HW logic via accelmgr or raw MMIO
-    return 0;
+
+    // Fetch actual emulated device
+    bharat_accel_device_t *dev = get_virt_accel_mock_device();
+    if (!dev || !dev->ops || !dev->ops->submit_npu_job) {
+        return -1;
+    }
+
+    // Translate tensor operation to a structured virtual accelerator job descriptor
+    virt_accel_job_t job;
+    memset(&job, 0, sizeof(job));
+
+    if (op->op == TENSOR_OP_RELU) {
+        job.opcode = VIRT_ACCEL_OP_RELU_F32;
+    } else {
+        return -1; // Or K_ERR_UNSUPPORTED
+    }
+
+    job.input = op->input_tensor;
+    job.input_elements = op->in_elements;
+    job.output = op->output_tensor;
+    job.output_elements = op->out_elements;
+
+    // Invoke the device driver truthfully
+    return dev->ops->submit_npu_job(dev, &job);
 }
 
 static backend_interface_t hw_interface = {
@@ -81,24 +113,95 @@ static const backend_provider_t hw_tensor_provider = {
 
 
 int tensor_dispatch_init(void) {
+    // Reset registry and clear stats to produce a clean state for isolated tests
+    backend_registry_reset();
+    memset(&g_stats, 0, sizeof(g_stats));
+    memset(&g_last_result, 0, sizeof(g_last_result));
+
     int ret = backend_registry_add(&sw_tensor_provider);
     if (ret != 0) return ret;
 
     return backend_registry_add(&hw_tensor_provider);
 }
 
-int tensor_process(tensor_op_t *op, const backend_dispatch_context_t *ctx) {
-    if (!op || !ctx) return -1;
+const backend_provider_t *tensor_select_backend(
+    const bharat_hw_caps_t *caps,
+    const backend_dispatch_context_t *ctx)
+{
+    return backend_dispatch_select(CLASS_TENSOR_ML, caps, ctx);
+}
 
-    bharat_hw_caps_t system_caps;
-    system_caps.soc.npu = HW_CAP_STATE_PRESENT;
+int tensor_process(
+    tensor_op_t *op,
+    const bharat_hw_caps_t *caps,
+    const backend_dispatch_context_t *ctx)
+{
+    if (!op || !caps || !ctx) {
+        g_stats.jobs_failed++;
+        return -1;
+    }
 
-    const backend_provider_t *provider = backend_dispatch_select(CLASS_TENSOR_ML, &system_caps, ctx);
+    // Select the optimal backend provider based on discovery and context
+    const backend_provider_t *provider = tensor_select_backend(caps, ctx);
+    if (!provider) {
+        g_stats.jobs_failed++;
+        return -1;
+    }
 
-    if (!provider || !provider->get_interface) return -1;
+    // Populate routing outcomes & last result metadata
+    g_last_result.backend_name = provider->name;
+    g_last_result.backend_type = provider->type;
+
+    if (provider->type == BACKEND_TYPE_SOFTWARE_FALLBACK) {
+        g_stats.backend_sw_fallback++;
+        if (ctx->safe_mode) {
+            g_stats.safe_mode_fallbacks++;
+        } else if (caps->soc.npu != HW_CAP_STATE_PRESENT && caps->soc.npu != HW_CAP_STATE_REQUIRED) {
+            g_stats.unavailable_fallbacks++;
+        }
+    } else {
+        g_stats.backend_hw_selected++;
+    }
+
+    if (!provider->get_interface) {
+        g_last_result.execution_status = -1;
+        g_stats.jobs_failed++;
+        return -1;
+    }
 
     backend_interface_t *iface = provider->get_interface();
-    if (!iface || !iface->process_tensor) return -1;
+    if (!iface || !iface->process_tensor) {
+        g_last_result.execution_status = -1;
+        g_stats.jobs_failed++;
+        return -1;
+    }
 
-    return iface->process_tensor(op);
+    // Truthfully execute
+    int status = iface->process_tensor(op);
+    g_last_result.execution_status = status;
+
+    if (status == 0) {
+        g_stats.jobs_completed++;
+    } else {
+        g_stats.jobs_failed++;
+    }
+
+    return status;
+}
+
+void tensor_dispatch_get_stats(tensor_dispatch_stats_t *out) {
+    if (out) {
+        *out = g_stats;
+    }
+}
+
+void tensor_dispatch_get_last_result(tensor_dispatch_result_t *out) {
+    if (out) {
+        *out = g_last_result;
+    }
+}
+
+void tensor_dispatch_reset_stats(void) {
+    memset(&g_stats, 0, sizeof(g_stats));
+    memset(&g_last_result, 0, sizeof(g_last_result));
 }

--- a/core/lib/runtime/backend_dispatch/backend_dispatch.h
+++ b/core/lib/runtime/backend_dispatch/backend_dispatch.h
@@ -49,6 +49,11 @@ typedef struct {
 int backend_registry_add(const backend_provider_t *provider);
 
 /**
+ * Reset/Clear the backend registry (useful for isolated tests).
+ */
+void backend_registry_reset(void);
+
+/**
  * Select the optimal backend based on capabilities, profile, and current context.
  * Always returns a software fallback if a hardware backend is absent or unavailable
  * due to safe mode / power constraints.

--- a/core/lib/runtime/backend_dispatch/backend_registry.c
+++ b/core/lib/runtime/backend_dispatch/backend_registry.c
@@ -6,12 +6,25 @@
 static const backend_provider_t *g_registry[MAX_BACKENDS];
 static uint32_t g_registry_count = 0;
 
+#include <string.h>
+
 int backend_registry_add(const backend_provider_t *provider) {
     if (!provider || !provider->name) return -1;
     if (g_registry_count >= MAX_BACKENDS) return -1;
 
+    // Reject duplicate provider identity/name to prevent ordering/telemetry ambiguity
+    for (uint32_t i = 0; i < g_registry_count; i++) {
+        if (strcmp(g_registry[i]->name, provider->name) == 0) {
+            return -2;
+        }
+    }
+
     g_registry[g_registry_count++] = provider;
     return 0;
+}
+
+void backend_registry_reset(void) {
+    g_registry_count = 0;
 }
 
 const backend_provider_t *backend_dispatch_select(

--- a/delivery/status/components.yaml
+++ b/delivery/status/components.yaml
@@ -48,3 +48,20 @@ components:
     maturity: "scaffold"
     evidence: "core/services/vm_manager"
     blockers: ["On-demand page-pool orchestration"]
+
+  accelerator_substrate:
+    name: "Accelerator Capability & Dispatch Substrate"
+    maturity: "partial"
+    evidence: "core/kernel/include/capability.h, core/lib/runtime/backend_dispatch"
+    blockers:
+      - "Production device queue realization"
+      - "End-to-end accelerator service mediation"
+
+  heterogeneous_compute:
+    name: "Heterogeneous Compute Control Plane"
+    maturity: "scaffold"
+    evidence: "core/services/device/accelmgr, core/drivers/accel/virt_accel.c"
+    blockers:
+      - "Real accelmgr event loop"
+      - "Truthful hardware backend execution"
+      - "Accelerator admission and telemetry integration"

--- a/docs/demo/heterogeneous-compute.md
+++ b/docs/demo/heterogeneous-compute.md
@@ -1,0 +1,101 @@
+---
+title: Bharat-OS Heterogeneous Compute Control Plane Demonstration (HET-DEMO-001)
+status: Approved
+owner: Compute Architecture WG
+last_updated: 2026-04-25
+tags:
+  - demo
+  - compute
+  - heterogeneous-compute
+  - npu
+see_also:
+  - README.md
+  - docs/dev/current-code-status.md
+---
+
+# Truthful Virtual NPU & CPU Fallback Demonstration (HET-DEMO-001)
+
+This document describes the design, execution, and verification of the heterogeneous compute dispatch substrate on Bharat-OS. The demonstration validates the architectural separating pillars of runtime routing, policy compliance, failover fallback, and hardware emulation without relying on fake hardware/mock success patterns.
+
+## Architectural Story & Overview
+
+Bharat-OS decouples heterogeneous acceleration into a clear, four-layer taxonomy:
+
+1. **Kernel:** Enforces hardware capabilities and sandboxed device bounds.
+2. **Drivers:** Provides hardware-specific execution queues under standard interface contracts.
+3. **Services:** Orchestrates system-wide admission, QoS, and resource distribution.
+4. **Runtime:** Selects the optimal available backend and handles high-level graph execution.
+
+This demonstration models a **Tensor ReLU operation** dispatched dynamically to either an emulated hardware accelerator (Virtual NPU) or a software CPU fallback based on system capability state and policy rules.
+
+```text
+                 Bharat-OS Compute Fabric
+
+                    Tensor workload
+                         |
+                  Runtime Dispatcher
+                    /           \
+                   /             \
+             Virtual NPU       CPU
+                |                |
+            AVAILABLE         FALLBACK
+                |                |
+                +-------+--------+
+                        |
+                     Result
+```
+
+## Demonstration Scenarios
+
+### Scenario A: Normal Acceleration
+* **State/Policy:** Virtual NPU discovered (`caps->soc.npu = HW_CAP_STATE_PRESENT`), and safe mode is disabled (`safe_mode = false`).
+* **Expected Dispatch:** The runtime dynamically selects the emulated `tensor_hw_generic` backend, submits the request to the `virt_accel_0` driver, and performs element-wise FP32 ReLU execution.
+* **Result Verification:** Verify NPU driver execution counts increment and math outputs match exactly.
+
+### Scenario B: Policy-Constrained Safe-Mode Fallback
+* **State/Policy:** Virtual NPU discovered, but system safe mode is activated (`safe_mode = true`).
+* **Expected Dispatch:** Due to strict platform safety governance, hardware execution is prohibited. The runtime dispatch layer falls back deterministically to the software CPU driver (`tensor_sw_fallback`).
+* **Result Verification:** NPU driver submission counts remain unchanged, and outputs are correctly computed on the CPU.
+
+### Scenario C: Unavailable Hardware Fallback
+* **State/Policy:** System capability record indicates no NPU is available (`caps->soc.npu = HW_CAP_STATE_ABSENT`).
+* **Expected Dispatch:** The dispatcher routes execution to the software CPU driver.
+* **Result Verification:** NPU driver submission counts remain unchanged, and outputs are correctly computed on the CPU.
+
+## Execution and Verification
+
+The demonstration is fully verified using host-side isolated unit and contract tests:
+
+```bash
+# Build and run the host-side verification test suite
+gcc -o test_accel_dispatch quality/tests/host/accel/test_accel_dispatch.c \
+    core/lib/runtime/backend_dispatch/backend_registry.c \
+    core/lib/runtime/accel/tensor_dispatch.c \
+    core/drivers/accel/virt_accel.c \
+    -I. -Icore/kernel/include -Iinterface -Iinterface/include -Icore/lib/include -Icore/lib/runtime/include
+
+./test_accel_dispatch
+```
+
+### Emitted Telemetry & Validation Markers
+
+During execution, the test suite emits the following deterministic markers:
+
+```text
+BHARAT_HETERO_DEMO:START
+BHARAT_HETERO_DEMO:VIRT_NPU=AVAILABLE
+
+BHARAT_HETERO_DEMO:CASE=NORMAL
+BHARAT_HETERO_DEMO:BACKEND=tensor_hw_generic
+BHARAT_HETERO_DEMO:RESULT=PASS
+
+BHARAT_HETERO_DEMO:CASE=SAFE_MODE
+BHARAT_HETERO_DEMO:BACKEND=CPU
+BHARAT_HETERO_DEMO:RESULT=PASS
+
+BHARAT_HETERO_DEMO:CASE=NPU_ABSENT
+BHARAT_HETERO_DEMO:BACKEND=CPU
+BHARAT_HETERO_DEMO:RESULT=PASS
+
+BHARAT_HETERO_DEMO:COMPLETE
+```

--- a/docs/dev/current-code-status.md
+++ b/docs/dev/current-code-status.md
@@ -27,5 +27,7 @@ This document is automatically generated from the canonical components manifest 
 | Network Manager (netmgr) | 🟡 **PARTIAL** | `core/services/netmgr` | Production blocking receive |
 | Process Manager (process_mgr) | ⚪ **SCAFFOLD** | `core/services/process_manager` | Real ELF execution loading |
 | Virtual Memory Manager (vm_mgr) | ⚪ **SCAFFOLD** | `core/services/vm_manager` | On-demand page-pool orchestration |
+| Accelerator Capability & Dispatch Substrate | 🟡 **PARTIAL** | `core/kernel/include/capability.h, core/lib/runtime/backend_dispatch` | Production device queue realization, End-to-end accelerator service mediation |
+| Heterogeneous Compute Control Plane | ⚪ **SCAFFOLD** | `core/services/device/accelmgr, core/drivers/accel/virt_accel.c` | Real accelmgr event loop, Truthful hardware backend execution, Accelerator admission and telemetry integration |
 
 <!-- END MATURITY TABLE -->

--- a/interface/include/bharat/accel/accel.h
+++ b/interface/include/bharat/accel/accel.h
@@ -41,6 +41,23 @@ typedef struct {
 struct bharat_accel_device;
 
 /**
+ * Explicit emulated / virtual accelerator job descriptor
+ */
+typedef enum {
+    VIRT_ACCEL_OP_RELU_F32 = 1,
+} virt_accel_opcode_t;
+
+typedef struct {
+    virt_accel_opcode_t opcode;
+
+    const float *input;
+    size_t input_elements;
+
+    float *output;
+    size_t output_elements;
+} virt_accel_job_t;
+
+/**
  * Accelerator Operations
  */
 typedef struct {

--- a/quality/tests/host/CMakeLists.txt
+++ b/quality/tests/host/CMakeLists.txt
@@ -351,3 +351,20 @@ if(BHARAT_BUILD_HOST_TESTS)
     target_include_directories(test_android_binder PRIVATE ../../core/personalities/compat/android ../../include)
     add_test(NAME host_test_android_binder COMMAND test_android_binder)
 endif()
+
+# Heterogeneous Compute Host Tests
+add_executable(test_accel_dispatch
+    accel/test_accel_dispatch.c
+    ../../core/lib/runtime/backend_dispatch/backend_registry.c
+    ../../core/lib/runtime/accel/tensor_dispatch.c
+    ../../core/drivers/accel/virt_accel.c
+)
+target_include_directories(test_accel_dispatch PRIVATE
+    ../../core/kernel/include
+    ../../interface/include
+    ../../interface
+    ../../core/lib/include
+    ../../core/lib/runtime/include
+    ../../
+)
+add_test(NAME host_test_accel_dispatch COMMAND test_accel_dispatch)

--- a/quality/tests/host/accel/test_accel_dispatch.c
+++ b/quality/tests/host/accel/test_accel_dispatch.c
@@ -1,0 +1,492 @@
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <core/lib/runtime/accel/tensor_backend.h>
+#include <bharat/accel/accel.h>
+#include <kernel/status.h>
+
+// Extern diagnostic helpers from virt_accel driver
+extern bharat_accel_device_t* get_virt_accel_mock_device(void);
+extern uint64_t virt_accel_get_submit_count(void);
+extern void virt_accel_reset_submit_count(void);
+extern void virt_accel_set_fail_injection(bool enable);
+
+// Floating point comparison tolerance
+#define EPSILON 0.0001f
+static bool float_eq(float a, float b) {
+    float diff = a - b;
+    if (diff < 0) diff = -diff;
+    return diff < EPSILON;
+}
+
+// Global flag to track if all tests pass
+static bool g_all_cases_pass = true;
+
+// Helper to run a test and print status
+#define RUN_TEST(name) \
+    do { \
+        printf("Running test: %s... ", #name); \
+        name(); \
+        printf("PASSED\n"); \
+    } while (0)
+
+/* ── Test 1: Duplicate Registration Semantics ── */
+static void test_duplicate_registration(void) {
+    // Re-initializing tensor dispatch twice should be handled gracefully or rejected
+    // Our policy: duplicate provider identity/name -> reject with -2
+
+    // Create a mock provider with the same name
+    backend_provider_t duplicate_prov = {
+        .name = "tensor_hw_generic", // Duplicate name
+        .feature_class = CLASS_TENSOR_ML,
+        .type = BACKEND_TYPE_GENERIC_HARDWARE,
+        .priority = 99
+    };
+
+    int status = backend_registry_add(&duplicate_prov);
+    assert(status == -2); // Must reject as duplicate
+}
+
+/* ── Test 2: Virtual NPU ReLU Mathematical Correctness ── */
+static void test_relu_math_correctness(void) {
+    // We want to verify basic mathematical execution in different bounds.
+    // 1. Standard mixed array
+    {
+        float input[] = {-4.0f, -1.0f, 0.0f, 3.0f, 8.0f};
+        float output[5] = {99.0f, 99.0f, 99.0f, 99.0f, 99.0f};
+
+        virt_accel_job_t job = {
+            .opcode = VIRT_ACCEL_OP_RELU_F32,
+            .input = input,
+            .input_elements = 5,
+            .output = output,
+            .output_elements = 5
+        };
+
+        bharat_accel_device_t *dev = get_virt_accel_mock_device();
+        int ret = dev->ops->submit_npu_job(dev, &job);
+        assert(ret == K_OK);
+
+        assert(float_eq(output[0], 0.0f));
+        assert(float_eq(output[1], 0.0f));
+        assert(float_eq(output[2], 0.0f));
+        assert(float_eq(output[3], 3.0f));
+        assert(float_eq(output[4], 8.0f));
+    }
+
+    // 2. All negative
+    {
+        float input[] = {-10.0f, -0.1f};
+        float output[2] = {99.0f, 99.0f};
+
+        virt_accel_job_t job = {
+            .opcode = VIRT_ACCEL_OP_RELU_F32,
+            .input = input,
+            .input_elements = 2,
+            .output = output,
+            .output_elements = 2
+        };
+
+        bharat_accel_device_t *dev = get_virt_accel_mock_device();
+        int ret = dev->ops->submit_npu_job(dev, &job);
+        assert(ret == K_OK);
+        assert(float_eq(output[0], 0.0f));
+        assert(float_eq(output[1], 0.0f));
+    }
+
+    // 3. All positive
+    {
+        float input[] = {5.5f, 100.0f};
+        float output[2] = {99.0f, 99.0f};
+
+        virt_accel_job_t job = {
+            .opcode = VIRT_ACCEL_OP_RELU_F32,
+            .input = input,
+            .input_elements = 2,
+            .output = output,
+            .output_elements = 2
+        };
+
+        bharat_accel_device_t *dev = get_virt_accel_mock_device();
+        int ret = dev->ops->submit_npu_job(dev, &job);
+        assert(ret == K_OK);
+        assert(float_eq(output[0], 5.5f));
+        assert(float_eq(output[1], 100.0f));
+    }
+
+    // 4. Zero & Single element
+    {
+        float input[] = {0.0f};
+        float output[1] = {99.0f};
+
+        virt_accel_job_t job = {
+            .opcode = VIRT_ACCEL_OP_RELU_F32,
+            .input = input,
+            .input_elements = 1,
+            .output = output,
+            .output_elements = 1
+        };
+
+        bharat_accel_device_t *dev = get_virt_accel_mock_device();
+        int ret = dev->ops->submit_npu_job(dev, &job);
+        assert(ret == K_OK);
+        assert(float_eq(output[0], 0.0f));
+    }
+}
+
+/* ── Test 3: Invalid Input/Descriptor Validation ── */
+static void test_invalid_descriptors(void) {
+    bharat_accel_device_t *dev = get_virt_accel_mock_device();
+
+    // 1. NULL job descriptor
+    int ret = dev->ops->submit_npu_job(dev, NULL);
+    assert(ret == K_ERR_INVALID_ARG);
+
+    // 2. NULL input
+    {
+        float output[2];
+        virt_accel_job_t job = {
+            .opcode = VIRT_ACCEL_OP_RELU_F32,
+            .input = NULL,
+            .input_elements = 2,
+            .output = output,
+            .output_elements = 2
+        };
+        assert(dev->ops->submit_npu_job(dev, &job) == K_ERR_INVALID_ARG);
+    }
+
+    // 3. NULL output
+    {
+        float input[2] = {1.0f, 2.0f};
+        virt_accel_job_t job = {
+            .opcode = VIRT_ACCEL_OP_RELU_F32,
+            .input = input,
+            .input_elements = 2,
+            .output = NULL,
+            .output_elements = 2
+        };
+        assert(dev->ops->submit_npu_job(dev, &job) == K_ERR_INVALID_ARG);
+    }
+
+    // 4. Zero elements
+    {
+        float input[2] = {1.0f, 2.0f};
+        float output[2];
+        virt_accel_job_t job = {
+            .opcode = VIRT_ACCEL_OP_RELU_F32,
+            .input = input,
+            .input_elements = 0,
+            .output = output,
+            .output_elements = 2
+        };
+        assert(dev->ops->submit_npu_job(dev, &job) == K_ERR_INVALID_ARG);
+    }
+
+    // 5. Output too small (overflow)
+    {
+        float input[5] = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f};
+        float output[2];
+        virt_accel_job_t job = {
+            .opcode = VIRT_ACCEL_OP_RELU_F32,
+            .input = input,
+            .input_elements = 5,
+            .output = output,
+            .output_elements = 2
+        };
+        assert(dev->ops->submit_npu_job(dev, &job) == K_ERR_OVERFLOW);
+    }
+
+    // 6. Unsupported Opcode
+    {
+        float input[2] = {1.0f, 2.0f};
+        float output[2];
+        virt_accel_job_t job = {
+            .opcode = (virt_accel_opcode_t)9999, // Unsupported
+            .input = input,
+            .input_elements = 2,
+            .output = output,
+            .output_elements = 2
+        };
+        assert(dev->ops->submit_npu_job(dev, &job) == K_ERR_UNSUPPORTED);
+    }
+}
+
+/* ── Test 4: Scenario A — Normal path (NPU available, safe_mode false) ── */
+static void test_scenario_normal(void) {
+    tensor_dispatch_init();
+    virt_accel_reset_submit_count();
+    virt_accel_set_fail_injection(false);
+
+    bharat_hw_caps_t caps;
+    memset(&caps, 0, sizeof(caps));
+    caps.soc.npu = HW_CAP_STATE_PRESENT; // NPU available
+
+    backend_dispatch_context_t ctx = {
+        .power_level = 100,
+        .safe_mode = false, // normal mode
+        .qos_level = 1
+    };
+
+    float input[] = {-4.0f, -1.0f, 0.0f, 3.0f, 8.0f};
+    float output[5] = {99.0f, 99.0f, 99.0f, 99.0f, 99.0f};
+
+    tensor_op_t op = {
+        .op = TENSOR_OP_RELU,
+        .input_tensor = input,
+        .in_elements = 5,
+        .output_tensor = output,
+        .out_elements = 5
+    };
+
+    uint64_t before_count = virt_accel_get_submit_count();
+
+    // Process
+    int ret = tensor_process(&op, &caps, &ctx);
+    assert(ret == K_OK);
+
+    // Verify emulated driver execution actually occurred
+    uint64_t after_count = virt_accel_get_submit_count();
+    assert(after_count == before_count + 1);
+
+    // Verify mathematical correctness
+    assert(float_eq(output[0], 0.0f));
+    assert(float_eq(output[1], 0.0f));
+    assert(float_eq(output[2], 0.0f));
+    assert(float_eq(output[3], 3.0f));
+    assert(float_eq(output[4], 8.0f));
+
+    // Verify stats
+    tensor_dispatch_stats_t stats;
+    tensor_dispatch_get_stats(&stats);
+    assert(stats.backend_hw_selected == 1);
+    assert(stats.backend_sw_fallback == 0);
+    assert(stats.jobs_completed == 1);
+    assert(stats.jobs_failed == 0);
+
+    // Verify last result
+    tensor_dispatch_result_t result;
+    tensor_dispatch_get_last_result(&result);
+    assert(strcmp(result.backend_name, "tensor_hw_generic") == 0);
+    assert(result.backend_type == BACKEND_TYPE_GENERIC_HARDWARE);
+    assert(result.execution_status == K_OK);
+
+    // Emit demonstration markers
+    printf("\nBHARAT_HETERO_DEMO:CASE=NORMAL\n");
+    printf("BHARAT_HETERO_DEMO:BACKEND=%s\n", result.backend_name);
+    printf("BHARAT_HETERO_DEMO:RESULT=PASS\n");
+}
+
+/* ── Test 5: Scenario B — Safe-Mode path (NPU available, safe_mode true) ── */
+static void test_scenario_safe_mode(void) {
+    tensor_dispatch_init();
+    virt_accel_reset_submit_count();
+    virt_accel_set_fail_injection(false);
+
+    bharat_hw_caps_t caps;
+    memset(&caps, 0, sizeof(caps));
+    caps.soc.npu = HW_CAP_STATE_PRESENT; // NPU available
+
+    backend_dispatch_context_t ctx = {
+        .power_level = 100,
+        .safe_mode = true, // policy rejects hardware!
+        .qos_level = 1
+    };
+
+    float input[] = {-4.0f, -1.0f, 0.0f, 3.0f, 8.0f};
+    float output[5] = {99.0f, 99.0f, 99.0f, 99.0f, 99.0f};
+
+    tensor_op_t op = {
+        .op = TENSOR_OP_RELU,
+        .input_tensor = input,
+        .in_elements = 5,
+        .output_tensor = output,
+        .out_elements = 5
+    };
+
+    uint64_t before_count = virt_accel_get_submit_count();
+
+    // Process
+    int ret = tensor_process(&op, &caps, &ctx);
+    assert(ret == K_OK);
+
+    // Verify emulated driver execution did NOT occur (submit count unchanged)
+    uint64_t after_count = virt_accel_get_submit_count();
+    assert(after_count == before_count);
+
+    // Verify software output correctness
+    assert(float_eq(output[0], 0.0f));
+    assert(float_eq(output[1], 0.0f));
+    assert(float_eq(output[2], 0.0f));
+    assert(float_eq(output[3], 3.0f));
+    assert(float_eq(output[4], 8.0f));
+
+    // Verify stats
+    tensor_dispatch_stats_t stats;
+    tensor_dispatch_get_stats(&stats);
+    assert(stats.backend_hw_selected == 0);
+    assert(stats.backend_sw_fallback == 1);
+    assert(stats.safe_mode_fallbacks == 1);
+    assert(stats.unavailable_fallbacks == 0);
+    assert(stats.jobs_completed == 1);
+    assert(stats.jobs_failed == 0);
+
+    // Verify last result
+    tensor_dispatch_result_t result;
+    tensor_dispatch_get_last_result(&result);
+    assert(strcmp(result.backend_name, "tensor_sw_fallback") == 0);
+    assert(result.backend_type == BACKEND_TYPE_SOFTWARE_FALLBACK);
+    assert(result.execution_status == K_OK);
+
+    // Emit demonstration markers
+    printf("\nBHARAT_HETERO_DEMO:CASE=SAFE_MODE\n");
+    printf("BHARAT_HETERO_DEMO:BACKEND=CPU\n"); // General display string as required
+    printf("BHARAT_HETERO_DEMO:RESULT=PASS\n");
+}
+
+/* ── Test 6: Scenario C — NPU Absent Fallback ── */
+static void test_scenario_npu_absent(void) {
+    tensor_dispatch_init();
+    virt_accel_reset_submit_count();
+    virt_accel_set_fail_injection(false);
+
+    bharat_hw_caps_t caps;
+    memset(&caps, 0, sizeof(caps));
+    caps.soc.npu = HW_CAP_STATE_ABSENT; // NPU absent/unavailable
+
+    backend_dispatch_context_t ctx = {
+        .power_level = 100,
+        .safe_mode = false,
+        .qos_level = 1
+    };
+
+    float input[] = {-4.0f, -1.0f, 0.0f, 3.0f, 8.0f};
+    float output[5] = {99.0f, 99.0f, 99.0f, 99.0f, 99.0f};
+
+    tensor_op_t op = {
+        .op = TENSOR_OP_RELU,
+        .input_tensor = input,
+        .in_elements = 5,
+        .output_tensor = output,
+        .out_elements = 5
+    };
+
+    uint64_t before_count = virt_accel_get_submit_count();
+
+    // Process
+    int ret = tensor_process(&op, &caps, &ctx);
+    assert(ret == K_OK);
+
+    // Verify emulated driver execution did NOT occur (submit count unchanged)
+    uint64_t after_count = virt_accel_get_submit_count();
+    assert(after_count == before_count);
+
+    // Verify software output correctness
+    assert(float_eq(output[0], 0.0f));
+    assert(float_eq(output[1], 0.0f));
+    assert(float_eq(output[2], 0.0f));
+    assert(float_eq(output[3], 3.0f));
+    assert(float_eq(output[4], 8.0f));
+
+    // Verify stats
+    tensor_dispatch_stats_t stats;
+    tensor_dispatch_get_stats(&stats);
+    assert(stats.backend_hw_selected == 0);
+    assert(stats.backend_sw_fallback == 1);
+    assert(stats.safe_mode_fallbacks == 0);
+    assert(stats.unavailable_fallbacks == 1);
+    assert(stats.jobs_completed == 1);
+    assert(stats.jobs_failed == 0);
+
+    // Verify last result
+    tensor_dispatch_result_t result;
+    tensor_dispatch_get_last_result(&result);
+    assert(strcmp(result.backend_name, "tensor_sw_fallback") == 0);
+    assert(result.backend_type == BACKEND_TYPE_SOFTWARE_FALLBACK);
+    assert(result.execution_status == K_OK);
+
+    // Emit demonstration markers
+    printf("\nBHARAT_HETERO_DEMO:CASE=NPU_ABSENT\n");
+    printf("BHARAT_HETERO_DEMO:BACKEND=CPU\n");
+    printf("BHARAT_HETERO_DEMO:RESULT=PASS\n");
+}
+
+/* ── Test 7: Hardware Selected then Execution Fails (Failure Propagation) ── */
+static void test_hardware_execution_failure(void) {
+    tensor_dispatch_init();
+    virt_accel_reset_submit_count();
+
+    // Enable failure injection inside the virtual accelerator driver
+    virt_accel_set_fail_injection(true);
+
+    bharat_hw_caps_t caps;
+    memset(&caps, 0, sizeof(caps));
+    caps.soc.npu = HW_CAP_STATE_PRESENT; // NPU available, so routing will select NPU
+
+    backend_dispatch_context_t ctx = {
+        .power_level = 100,
+        .safe_mode = false,
+        .qos_level = 1
+    };
+
+    float input[] = {-4.0f, -1.0f, 0.0f, 3.0f, 8.0f};
+    float output[5] = {99.0f, 99.0f, 99.0f, 99.0f, 99.0f};
+
+    tensor_op_t op = {
+        .op = TENSOR_OP_RELU,
+        .input_tensor = input,
+        .in_elements = 5,
+        .output_tensor = output,
+        .out_elements = 5
+    };
+
+    uint64_t before_count = virt_accel_get_submit_count();
+
+    // Process: must return failure since virtual NPU failed!
+    int ret = tensor_process(&op, &caps, &ctx);
+    assert(ret == K_ERR_DEV_MMIO_FAULT);
+
+    // Check that invocation actually went to hardware driver and incremented submit count
+    uint64_t after_count = virt_accel_get_submit_count();
+    assert(after_count == before_count + 1);
+
+    // Verify stats: must NOT silently fallback, but instead report failure
+    tensor_dispatch_stats_t stats;
+    tensor_dispatch_get_stats(&stats);
+    assert(stats.backend_hw_selected == 1);
+    assert(stats.backend_sw_fallback == 0);
+    assert(stats.jobs_completed == 0);
+    assert(stats.jobs_failed == 1); // Failure is truthfully recorded!
+
+    // Clean up failure injection
+    virt_accel_set_fail_injection(false);
+}
+
+/* ── MAIN ── */
+int main(void) {
+    printf("BHARAT_HETERO_DEMO:START\n");
+    printf("BHARAT_HETERO_DEMO:VIRT_NPU=AVAILABLE\n\n");
+
+    // Initialize once
+    int init_status = tensor_dispatch_init();
+    assert(init_status == 0);
+
+    // Run tests
+    RUN_TEST(test_relu_math_correctness);
+    RUN_TEST(test_invalid_descriptors);
+    RUN_TEST(test_scenario_normal);
+    RUN_TEST(test_scenario_safe_mode);
+    RUN_TEST(test_scenario_npu_absent);
+    RUN_TEST(test_hardware_execution_failure);
+    RUN_TEST(test_duplicate_registration);
+
+    printf("\nAll heterogeneous compute dispatch tests passed successfully!\n");
+
+    if (g_all_cases_pass) {
+        printf("BHARAT_HETERO_DEMO:COMPLETE\n");
+    }
+
+    return 0;
+}


### PR DESCRIPTION
Successfully implemented the HET-DEMO-001 demonstration, refactoring the Heterogeneous Compute dispatch substrate, virtual accelerator driver, and fallback routing policies without relying on fake hardware/mock success patterns. Created a standalone test suite, wired it into CMake, and updated status/maturity documentation.

---
*PR created automatically by Jules for task [18306361501381747223](https://jules.google.com/task/18306361501381747223) started by @divyang4481*