### PR TITLE
Resolve freestanding include paths and userspace policies in runtime object targets

### DIFF
--- a/core/lib/runtime/CMakeLists.txt
+++ b/core/lib/runtime/CMakeLists.txt
@@ -14,22 +14,29 @@ target_link_libraries(bharat_crt0 PUBLIC bharat_freestanding bharat_syscall)
 # Add the lib/runtime static library
 add_library(bharat_libruntime STATIC src/runtime.c src/freestanding_string.c host/runtime_host.c)
 
+# Common includes needed for userspace runtime and driver object layers
+set(BHARAT_RUNTIME_COMMON_INCLUDES
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+    ${CMAKE_SOURCE_DIR}/interface
+    ${CMAKE_SOURCE_DIR}/interface/include
+)
+
 # Add backend dispatch framework (Gated behind feature if needed, currently unconditionally available as an object/static)
 add_library(bharat_runtime_backend_dispatch OBJECT backend_dispatch/backend_registry.c)
-target_include_directories(bharat_runtime_backend_dispatch PRIVATE ${CMAKE_SOURCE_DIR}/interface)
-target_link_libraries(bharat_runtime_backend_dispatch PUBLIC bharat_freestanding)
+target_include_directories(bharat_runtime_backend_dispatch PRIVATE ${BHARAT_RUNTIME_COMMON_INCLUDES})
+target_link_libraries(bharat_runtime_backend_dispatch PUBLIC bharat_user_buildopts)
 bharat_configure_userspace_library(bharat_runtime_backend_dispatch)
 
 # Crypto Pilot
 add_library(bharat_runtime_crypto OBJECT crypto/crypto_dispatch.c)
-target_include_directories(bharat_runtime_crypto PRIVATE ${CMAKE_SOURCE_DIR}/interface)
-target_link_libraries(bharat_runtime_crypto PUBLIC bharat_freestanding bharat_runtime_backend_dispatch)
+target_include_directories(bharat_runtime_crypto PRIVATE ${BHARAT_RUNTIME_COMMON_INCLUDES})
+target_link_libraries(bharat_runtime_crypto PUBLIC bharat_user_buildopts bharat_runtime_backend_dispatch)
 bharat_configure_userspace_library(bharat_runtime_crypto)
 
 # Tensor Pilot
 add_library(bharat_runtime_tensor OBJECT accel/tensor_dispatch.c)
-target_include_directories(bharat_runtime_tensor PRIVATE ${CMAKE_SOURCE_DIR}/interface)
-target_link_libraries(bharat_runtime_tensor PUBLIC bharat_freestanding bharat_runtime_backend_dispatch)
+target_include_directories(bharat_runtime_tensor PRIVATE ${BHARAT_RUNTIME_COMMON_INCLUDES})
+target_link_libraries(bharat_runtime_tensor PUBLIC bharat_user_buildopts bharat_runtime_backend_dispatch)
 bharat_configure_userspace_library(bharat_runtime_tensor)
 
 # Set the public include directory


### PR DESCRIPTION
Successfully updated core/lib/runtime/CMakeLists.txt to consistently resolve local string.h and accel.h headers for the backend dispatch, crypto, and tensor dispatch object libraries. Verified that both the production x86_64_desktop_gui build and the arm64_desktop_headless cross-compilation targets compile and link successfully, and that the focused test_accel_dispatch host-unit test passes all verification scenarios.

---
*PR created automatically by Jules for task [18296168442704522725](https://jules.google.com/task/18296168442704522725) started by @divyang4481*