### PR TITLE
Fix QEMU PCI display and MMIO mappings on ARM64 and RISC-V64

### DIFF
--- a/core/hal/common/fdt_parser.c
+++ b/core/hal/common/fdt_parser.c
@@ -336,6 +336,8 @@ typedef struct {
     int is_pci;
     const void *reg_data;
     uint32_t reg_len;
+    const void *ranges_data;
+    uint32_t ranges_len;
     uint32_t ac;
     uint32_t sc;
     /* simple-framebuffer specific properties */
@@ -348,6 +350,9 @@ typedef struct {
 int fdt_parse_discovery(const void *fdt_ptr, system_discovery_t *discovery) {
   if (!fdt_is_valid(fdt_ptr) || !discovery) {
     return -1;
+  }
+  if (discovery->fdt_parsed) {
+    return 0;
   }
 
   const struct fdt_header *fdt = (const struct fdt_header *)fdt_ptr;
@@ -454,6 +459,47 @@ int fdt_parse_discovery(const void *fdt_ptr, system_discovery_t *discovery) {
         } else if (s->is_pci && discovery->pci_host_count < BHARAT_MAX_PCI_HOSTS) {
           discovery->pci_hosts[discovery->pci_host_count].ecam_base = base;
           discovery->pci_hosts[discovery->pci_host_count].ecam_size = size;
+          discovery->pci_hosts[discovery->pci_host_count].mmio32_base = 0;
+          discovery->pci_hosts[discovery->pci_host_count].mmio32_size = 0;
+          discovery->pci_hosts[discovery->pci_host_count].mmio64_base = 0;
+          discovery->pci_hosts[discovery->pci_host_count].mmio64_size = 0;
+
+          if (s->ranges_data && s->ranges_len > 0) {
+              const uint32_t *r_cell = (const uint32_t *)s->ranges_data;
+              uint32_t r_len_cells = s->ranges_len / 4;
+              uint32_t p_ac = stack[depth-1].ac;
+              uint32_t c_sc = s->sc;
+              if (c_sc == 0) c_sc = 2; // Default to 2
+              if (p_ac == 0) p_ac = 2; // Default to 2
+              uint32_t entry_cells = 3 + p_ac + c_sc;
+
+              for (uint32_t i = 0; i + entry_cells <= r_len_cells; i += entry_cells) {
+                  uint32_t flags_word = fdt32_to_cpu(r_cell[i]);
+                  uint32_t space_type = (flags_word >> 24) & 0x3;
+
+                  uint64_t parent_base = 0;
+                  if (p_ac == 2) {
+                      parent_base = ((uint64_t)fdt32_to_cpu(r_cell[i + 3]) << 32) | fdt32_to_cpu(r_cell[i + 4]);
+                  } else {
+                      parent_base = fdt32_to_cpu(r_cell[i + 3]);
+                  }
+
+                  uint64_t range_size = 0;
+                  if (c_sc == 2) {
+                      range_size = ((uint64_t)fdt32_to_cpu(r_cell[i + 3 + p_ac]) << 32) | fdt32_to_cpu(r_cell[i + 4 + p_ac]);
+                  } else {
+                      range_size = fdt32_to_cpu(r_cell[i + 3 + p_ac]);
+                  }
+
+                  if (space_type == 0x2) { // 32-bit MMIO
+                      discovery->pci_hosts[discovery->pci_host_count].mmio32_base = parent_base;
+                      discovery->pci_hosts[discovery->pci_host_count].mmio32_size = range_size;
+                  } else if (space_type == 0x3) { // 64-bit MMIO
+                      discovery->pci_hosts[discovery->pci_host_count].mmio64_base = parent_base;
+                      discovery->pci_hosts[discovery->pci_host_count].mmio64_size = range_size;
+                  }
+              }
+          }
           discovery->pci_host_count++;
         } else if (s->is_fb) {
           discovery->boot_video.phys_addr    = base;
@@ -504,6 +550,9 @@ int fdt_parse_discovery(const void *fdt_ptr, system_discovery_t *discovery) {
       if (str_eq(prop_name, "reg")) {
         stack[depth].reg_data = prop_data;
         stack[depth].reg_len = len;
+      } else if (str_eq(prop_name, "ranges")) {
+        stack[depth].ranges_data = prop_data;
+        stack[depth].ranges_len = len;
       } else if (str_eq(prop_name, "#address-cells")) {
         stack[depth].ac = fdt32_to_cpu(*(const uint32_t *)prop_data);
       } else if (str_eq(prop_name, "#size-cells")) {
@@ -546,5 +595,6 @@ int fdt_parse_discovery(const void *fdt_ptr, system_discovery_t *discovery) {
       break;
     }
   }
+  discovery->fdt_parsed = true;
   return 0;
 }

--- a/core/kernel/include/hal/hal_discovery.h
+++ b/core/kernel/include/hal/hal_discovery.h
@@ -100,6 +100,10 @@ typedef struct {
     uint16_t segment;   // PCI Segment Group Number
     uint8_t bus_start;
     uint8_t bus_end;
+    uint64_t mmio32_base;
+    uint64_t mmio32_size;
+    uint64_t mmio64_base;
+    uint64_t mmio64_size;
 } pci_host_desc_t;
 
 // --- IOMMUs ---
@@ -190,6 +194,7 @@ typedef struct {
     accel_discovery_t accel;
 
     boot_video_handoff_t boot_video;
+    bool fdt_parsed;
 } system_discovery_t;
 
 // TODO: Needs refactor: #include directive placed mid-file for dependency/order compatibility.

--- a/core/kernel/src/display/boot_video_map.c
+++ b/core/kernel/src/display/boot_video_map.c
@@ -5,6 +5,7 @@
 #include "hal/hal_mpa.h"
 #include "hal/hal_tlb.h"
 #include "bharat/display/boot_video.h"
+#include "bharat/display/display_caps.h"
 #include "mm/physmap.h"
 
 // Early boot video map logic.
@@ -38,17 +39,14 @@ int boot_video_map(const boot_info_t *boot) {
      */
     virt_addr_t fb_virt = 0;
 
+#if defined(__x86_64__)
     if (physmap_has_linear_map()) {
         void *virt_ptr = physmap_phys_to_virt(fb_phys);
         if (!virt_ptr) return -1;
         fb_virt = (virt_addr_t)(uintptr_t)virt_ptr;
     } else {
         /* No linear physmap — install an explicit mapping. */
-#if defined(__x86_64__)
         fb_virt = 0xFFFF800000000000ULL | (fb_phys & 0xFFFFFFFF);
-#else
-        fb_virt = 0xFFFF900000000000ULL | (fb_phys & 0xFFFFFFFF);
-#endif
         uint32_t flags = HAL_PT_FLAG_READ | HAL_PT_FLAG_WRITE | HAL_PT_FLAG_DEVICE;
         phys_addr_t current_root = active_mem_protect->cpu_ops.get_root();
         if (hal_pt_map_range(current_root, fb_virt, fb_phys, fb_size, flags) != 0) {
@@ -56,6 +54,37 @@ int boot_video_map(const boot_info_t *boot) {
         }
         hal_tlb_invalidate_all();
     }
+#else
+    // For other architectures (ARM64, RISC-V), try existing mapping truth check.
+    extern const uint64_t g_kernel_virt_offset;
+    fb_virt = g_kernel_virt_offset + fb_phys;
+
+    phys_addr_t current_root = active_mem_protect->cpu_ops.get_root();
+    if (current_root == 0) {
+        extern phys_addr_t vmm_get_kernel_root(void);
+        current_root = vmm_get_kernel_root();
+    }
+
+    phys_addr_t existing_pa = 0;
+    size_t mapped_size = 0;
+    uint32_t existing_flags = 0;
+    bool already_mapped = false;
+
+    if (current_root != 0 && hal_pt_query_mapping(current_root, fb_virt, &existing_pa, &mapped_size, &existing_flags) == 0) {
+        if (existing_pa == fb_phys) {
+            already_mapped = true;
+        }
+    }
+
+    if (!already_mapped) {
+        uint32_t flags = HAL_PT_FLAG_READ | HAL_PT_FLAG_WRITE | HAL_PT_FLAG_DEVICE;
+        if (current_root == 0) return -1;
+        if (hal_pt_map_range(current_root, fb_virt, fb_phys, fb_size, flags) != 0) {
+            return -1;
+        }
+        hal_tlb_invalidate_all();
+    }
+#endif
 
     // Pre-populate the GUI handoff with the correct mapped virtual address so
     // that boot_gui_run() finds it valid and skips the boot_video_collect()
@@ -83,5 +112,56 @@ int boot_video_map(const boot_info_t *boot) {
     }
 #endif
 
+    return 0;
+}
+
+int qemu_display_map_mmio(uint64_t phys, size_t size, uintptr_t *out_virt) {
+    if (phys == 0 || size == 0 || !out_virt) {
+        return -1;
+    }
+
+    // 1. Align range to page boundaries
+    uint64_t page_offset = phys & 0xFFFU;
+    uint64_t aligned_phys = phys & ~0xFFFU;
+    uint64_t aligned_size = (size + page_offset + 0xFFFU) & ~0xFFFU;
+
+    // 2. Derive a canonical kernel MMIO VA using g_kernel_virt_offset
+    extern const uint64_t g_kernel_virt_offset;
+    uint64_t aligned_virt = g_kernel_virt_offset + aligned_phys;
+
+    // 3. Obtain active kernel PT root
+    if (!active_mem_protect || !active_mem_protect->cpu_ops.get_root) {
+        return -1;
+    }
+    phys_addr_t current_root = active_mem_protect->cpu_ops.get_root();
+    if (current_root == 0) {
+        extern phys_addr_t vmm_get_kernel_root(void);
+        current_root = vmm_get_kernel_root();
+    }
+    if (current_root == 0) {
+        return -1;
+    }
+
+    // 4. Check whether mapping already exists
+    phys_addr_t existing_pa = 0;
+    size_t mapped_size = 0;
+    uint32_t existing_flags = 0;
+    bool already_mapped = false;
+
+    if (hal_pt_query_mapping(current_root, aligned_virt, &existing_pa, &mapped_size, &existing_flags) == 0) {
+        if (existing_pa == aligned_phys) {
+            already_mapped = true;
+        }
+    }
+
+    if (!already_mapped) {
+        uint32_t flags = HAL_PT_FLAG_READ | HAL_PT_FLAG_WRITE | HAL_PT_FLAG_DEVICE;
+        if (hal_pt_map_range(current_root, aligned_virt, aligned_phys, aligned_size, flags) != 0) {
+            return -1;
+        }
+        hal_tlb_invalidate_all();
+    }
+
+    *out_virt = (uintptr_t)(aligned_virt + page_offset);
     return 0;
 }

--- a/core/platform/boards/qemu-virt-arm64/machine_display.c
+++ b/core/platform/boards/qemu-virt-arm64/machine_display.c
@@ -77,123 +77,189 @@ static void log_hex32(uint32_t val) {
     hal_serial_write(buf);
 }
 
+static void log_hex64(uint64_t val) {
+    hal_serial_write("0x");
+    const char *hex = "0123456789abcdef";
+    char buf[17];
+    for (int i = 15; i >= 0; i--) {
+        buf[i] = hex[val & 0xF];
+        val >>= 4;
+    }
+    buf[16] = '\0';
+    hal_serial_write(buf);
+}
+
 static void virt_scan_pci_ecam_for_vga(system_discovery_t *discovery) {
     if (!discovery || discovery->boot_video.valid) return;
     
-    uintptr_t ecam_bases[5];
-    size_t count = 0;
-    
-    if (discovery->pci_host_count > 0 && discovery->pci_hosts[0].ecam_base != 0) {
-        ecam_bases[count++] = (uintptr_t)discovery->pci_hosts[0].ecam_base;
+    if (discovery->pci_host_count == 0 || discovery->pci_hosts[0].ecam_base == 0) {
+        hal_serial_write("BHARAT_DISPLAY:FAIL=NO_PCI_HOST\n");
+        return;
     }
-    ecam_bases[count++] = 0x40100000ULL;
-    ecam_bases[count++] = 0x30000000ULL;
-    ecam_bases[count++] = 0x3F000000ULL;
-    ecam_bases[count++] = 0x20000000ULL;
-    
-    hal_serial_write("[PCI Scan] Starting PCIe ECAM probe...\n");
 
-    for (size_t b = 0; b < count; b++) {
-        uintptr_t phys_ecam = ecam_bases[b];
-        if (phys_ecam == 0) continue;
-        
-        uintptr_t virt_ecam = 0;
-        if (physmap_has_linear_map()) {
-            void *v = physmap_phys_to_virt(phys_ecam);
-            if (v) virt_ecam = (uintptr_t)v;
-        }
-        if (virt_ecam == 0) virt_ecam = phys_ecam;
-        
-        for (int bus = 0; bus < 4; bus++) {
-            for (int dev = 0; dev < 32; dev++) {
-                volatile uint32_t *ecam_dev = (volatile uint32_t *)(virt_ecam + ((uintptr_t)bus << 20) + ((uintptr_t)dev << 15));
-                uint32_t vendor_device = ecam_dev[0];
-                
-                if (vendor_device != 0xFFFFFFFF && vendor_device != 0x00000000) {
-                    hal_serial_write("  [PCI Dev Found] ECAM Base: ");
-                    log_hex32((uint32_t)phys_ecam);
-                    hal_serial_write(" Bus: "); log_hex32(bus);
-                    hal_serial_write(" Dev: "); log_hex32(dev);
-                    hal_serial_write(" ID: "); log_hex32(vendor_device);
+    uint64_t phys_ecam = discovery->pci_hosts[0].ecam_base;
+    uint64_t ecam_size = discovery->pci_hosts[0].ecam_size;
+    if (ecam_size == 0) ecam_size = 0x1000000;
+
+    hal_serial_write("BHARAT_DISPLAY:PCI_ECAM=");
+    log_hex64(phys_ecam);
+    hal_serial_write("\n");
+
+    uintptr_t virt_ecam = 0;
+    if (qemu_display_map_mmio(phys_ecam, ecam_size, &virt_ecam) != 0) {
+        hal_serial_write("BHARAT_DISPLAY:FAIL=ECAM_MAP\n");
+        return;
+    }
+    hal_serial_write("BHARAT_DISPLAY:ECAM_MAP=PASS\n");
+
+    uint64_t mmio_base = discovery->pci_hosts[0].mmio32_base;
+    uint64_t mmio_size = discovery->pci_hosts[0].mmio32_size;
+    if (mmio_base == 0 || mmio_size == 0) {
+        // Fallback for ARM64 QEMU virt PCIe MMIO range
+        mmio_base = 0x10000000ULL;
+        mmio_size = 0x2EFF0000ULL;
+    }
+
+    hal_serial_write("BHARAT_DISPLAY:PCI_MMIO_BASE=");
+    log_hex64(mmio_base);
+    hal_serial_write("\n");
+    hal_serial_write("BHARAT_DISPLAY:PCI_MMIO_SIZE=");
+    log_hex64(mmio_size);
+    hal_serial_write("\n");
+
+    bool vga_found = false;
+
+    for (int bus = 0; bus < 4 && !vga_found; bus++) {
+        for (int dev = 0; dev < 32 && !vga_found; dev++) {
+            volatile uint32_t *ecam_dev = (volatile uint32_t *)(virt_ecam + ((uintptr_t)bus << 20) + ((uintptr_t)dev << 15));
+            uint32_t vendor_device = ecam_dev[0];
+
+            if (vendor_device != 0xFFFFFFFF && vendor_device != 0x00000000) {
+                uint16_t vendor_id = vendor_device & 0xFFFF;
+                uint16_t device_id = (vendor_device >> 16) & 0xFFFF;
+
+                if (vendor_id == 0x1234 || (vendor_id == 0x1b36 && (device_id == 0x0100 || device_id == 0x000d))) {
+                    hal_serial_write("BHARAT_DISPLAY:VGA_FOUND\n");
+                    vga_found = true;
+
+                    // Read current BARs
+                    uint32_t orig_bar0 = ecam_dev[4];
+                    uint32_t orig_bar2 = ecam_dev[6];
+
+                    // Probe sizes
+                    ecam_dev[4] = 0xFFFFFFFF;
+                    uint32_t mask0 = ecam_dev[4];
+                    ecam_dev[4] = orig_bar0;
+
+                    ecam_dev[6] = 0xFFFFFFFF;
+                    uint32_t mask2 = ecam_dev[6];
+                    ecam_dev[6] = orig_bar2;
+
+                    uint32_t size0 = ~(mask0 & 0xFFFFFFF0) + 1;
+                    uint32_t size2 = ~(mask2 & 0xFFFFFFF0) + 1;
+
+                    if (size0 == 0 || size0 > 0x10000000) size0 = 0x1000000; // default 16MB
+                    if (size2 == 0 || size2 > 0x10000000) size2 = 0x1000;    // default 4KB
+
+                    uint32_t bar0 = orig_bar0;
+                    uint32_t bar2 = orig_bar2;
+
+                    // Assign BAR0 if unprogrammed
+                    if ((bar0 & 0xFFFFFFF0) == 0) {
+                        bar0 = (uint32_t)mmio_base;
+                        ecam_dev[4] = bar0;
+                    }
+                    // Assign BAR2 if unprogrammed
+                    if ((bar2 & 0xFFFFFFF0) == 0) {
+                        uint32_t aligned_bar2 = (bar0 + size0 + size2 - 1) & ~(size2 - 1);
+                        bar2 = aligned_bar2;
+                        ecam_dev[6] = bar2;
+                    }
+
+                    // Enable Memory Space (bit 1) + Bus Master (bit 2)
+                    ecam_dev[1] |= 0x06;
+
+                    uint64_t fb_phys = bar0 & 0xFFFFFFF0;
+                    uint64_t mmio_phys = bar2 & 0xFFFFFFF0;
+
+                    hal_serial_write("BHARAT_DISPLAY:BAR0=");
+                    log_hex64(fb_phys);
+                    hal_serial_write("\n");
+                    hal_serial_write("BHARAT_DISPLAY:BAR2=");
+                    log_hex64(mmio_phys);
                     hal_serial_write("\n");
 
-                    uint16_t vendor_id = vendor_device & 0xFFFF;
-                    uint16_t device_id = (vendor_device >> 16) & 0xFFFF;
-
-                    // Match Bochs VGA (0x1234:0x1111 or 0x1234:0x1110), QEMU stdvga (0x1234:0x0001), or RedHat VGA (0x1b36:0x0100 / 0x1b36:0x000d)
-                    if (vendor_id == 0x1234 || (vendor_id == 0x1b36 && (device_id == 0x0100 || device_id == 0x000d))) {
-                        hal_serial_write("  [VGA Match] Recognized Bochs/QEMU display device!\n");
-                        uint32_t bar0 = ecam_dev[4]; // BAR0 (offset 0x10)
-                        uint32_t bar2 = ecam_dev[6]; // BAR2 (offset 0x18)
-
-                        // Assign BARs in QEMU virt PCIe 32-bit MMIO space (0x40000000+)
-                        if ((bar0 & 0xFFFFFFF0) == 0) {
-                            bar0 = 0x40000000 + ((uint32_t)dev * 0x1000000);
-                            ecam_dev[4] = bar0;
-                        }
-                        if ((bar2 & 0xFFFFFFF0) == 0) {
-                            bar2 = bar0 + 0x800000; // 8MB offset for MMIO control regs
-                            ecam_dev[6] = bar2;
-                        }
-                        
-                        // Enable Memory Space (bit 1) + Bus Master (bit 2) in Command Register
-                        ecam_dev[1] |= 0x06;
-                        
-                        uint32_t fb_phys = bar0 & 0xFFFFFFF0;
-                        uint32_t mmio_phys = bar2 & 0xFFFFFFF0;
-                        
-                        uintptr_t virt_mmio = 0;
-                        if (physmap_has_linear_map()) {
-                            void *v = physmap_phys_to_virt(mmio_phys);
-                            if (v) virt_mmio = (uintptr_t)v;
-                        }
-                        if (virt_mmio == 0) virt_mmio = mmio_phys;
-
-                        /* Ensure MMIO region is mapped in page tables if MMU is active */
-                        if (active_mem_protect && active_mem_protect->cpu_ops.get_root) {
-                            phys_addr_t root = active_mem_protect->cpu_ops.get_root();
-                            if (root != 0) {
-                                uint32_t map_flags = HAL_PT_FLAG_READ | HAL_PT_FLAG_WRITE | HAL_PT_FLAG_DEVICE;
-                                hal_pt_map_range(root, virt_mmio, mmio_phys, 0x100000, map_flags);
-                                hal_tlb_invalidate_all();
-                            }
-                        }
-                        
-                        /* Program Bochs VBE MMIO registers */
-                        if (virt_mmio != 0) {
-                            volatile uint16_t *vbe = (volatile uint16_t *)virt_mmio;
-                            vbe[4] = 0x00; // VBE_DISPI_INDEX_ENABLE = 0
-                            vbe[1] = 1024; // VBE_DISPI_INDEX_XRES = 1024
-                            vbe[2] = 768;  // VBE_DISPI_INDEX_YRES = 768
-                            vbe[3] = 32;   // VBE_DISPI_INDEX_BPP = 32
-                            vbe[4] = 0x41; // VBE_DISPI_ENABLED | VBE_DISPI_LFB_ENABLED
-                        }
-                        
-                        discovery->boot_video.phys_addr    = fb_phys;
-                        discovery->boot_video.virt_addr    = fb_phys;
-                        discovery->boot_video.width        = 1024;
-                        discovery->boot_video.height       = 768;
-                        discovery->boot_video.stride_bytes = 1024 * 4;
-                        discovery->boot_video.size         = 1024 * 768 * 4;
-                        discovery->boot_video.format       = PIXEL_FORMAT_ARGB8888;
-                        discovery->boot_video.valid        = true;
-
-                        /* Synchronize g_boot_info console for kernel_boot.c UI activation */
-                        extern const boot_info_t *g_boot_info;
-                        if (g_boot_info) {
-                            boot_info_t *b = (boot_info_t *)g_boot_info;
-                            b->console.type = BOOT_CONSOLE_FRAMEBUFFER;
-                            b->console.fb_phys_base = fb_phys;
-                            b->console.fb_width = 1024;
-                            b->console.fb_height = 768;
-                            b->console.fb_pitch = 1024 * 4;
-                            b->console.fb_bpp = 32;
-                        }
+                    // Validate BAR allocations are within discovered PCI MMIO boundaries and don't overlap with RAM
+                    if (fb_phys < mmio_base || fb_phys + size0 > mmio_base + mmio_size ||
+                        mmio_phys < mmio_base || mmio_phys + size2 > mmio_base + mmio_size) {
+                        hal_serial_write("BHARAT_DISPLAY:FAIL=BAR_ALLOC_OUT_OF_BOUNDS\n");
                         return;
                     }
+
+                    // On ARM64, RAM starts at 0x40000000. Ensure no overlap with RAM range!
+                    if ((fb_phys >= 0x40000000 && fb_phys < 0x40000000 + 0x40000000) ||
+                        (mmio_phys >= 0x40000000 && mmio_phys < 0x40000000 + 0x40000000)) {
+                        hal_serial_write("BHARAT_DISPLAY:FAIL=BAR_ALLOC_RAM_OVERLAP\n");
+                        return;
+                    }
+
+                    // Map control BAR
+                    uintptr_t virt_mmio = 0;
+                    if (qemu_display_map_mmio(mmio_phys, size2, &virt_mmio) != 0) {
+                        hal_serial_write("BHARAT_DISPLAY:FAIL=CTRL_MAP\n");
+                        return;
+                    }
+                    hal_serial_write("BHARAT_DISPLAY:CTRL_MAP=PASS\n");
+
+                    // Program Bochs VBE registers
+                    if (virt_mmio != 0) {
+                        volatile uint16_t *vbe = (volatile uint16_t *)virt_mmio;
+                        vbe[4] = 0x00; // VBE_DISPI_INDEX_ENABLE = 0
+                        vbe[1] = 1024; // VBE_DISPI_INDEX_XRES = 1024
+                        vbe[2] = 768;  // VBE_DISPI_INDEX_YRES = 768
+                        vbe[3] = 32;   // VBE_DISPI_INDEX_BPP = 32
+                        vbe[4] = 0x41; // VBE_DISPI_ENABLED | VBE_DISPI_LFB_ENABLED
+                    }
+
+                    // Map Framebuffer BAR
+                    uintptr_t virt_fb = 0;
+                    if (qemu_display_map_mmio(fb_phys, size0, &virt_fb) != 0) {
+                        hal_serial_write("BHARAT_DISPLAY:FAIL=FB_MAP\n");
+                        return;
+                    }
+                    hal_serial_write("BHARAT_DISPLAY:FB_MAP=PASS\n");
+
+                    discovery->boot_video.phys_addr    = fb_phys;
+                    discovery->boot_video.virt_addr    = virt_fb;
+                    discovery->boot_video.width        = 1024;
+                    discovery->boot_video.height       = 768;
+                    discovery->boot_video.stride_bytes = 1024 * 4;
+                    discovery->boot_video.size         = 1024 * 768 * 4;
+                    discovery->boot_video.format       = PIXEL_FORMAT_ARGB8888;
+                    discovery->boot_video.valid        = true;
+
+                    /* Synchronize g_boot_info console for kernel_boot.c UI activation */
+                    extern const boot_info_t *g_boot_info;
+                    if (g_boot_info) {
+                        boot_info_t *b = (boot_info_t *)g_boot_info;
+                        b->console.type = BOOT_CONSOLE_FRAMEBUFFER;
+                        b->console.fb_phys_base = fb_phys;
+                        b->console.fb_width = 1024;
+                        b->console.fb_height = 768;
+                        b->console.fb_pitch = 1024 * 4;
+                        b->console.fb_bpp = 32;
+                    }
+
+                    hal_serial_write("BHARAT_DISPLAY:MODE=1024x768x32\n");
+                    hal_serial_write("BHARAT_DISPLAY:READY\n");
+                    return;
                 }
             }
         }
+    }
+
+    if (!vga_found) {
+        hal_serial_write("BHARAT_DISPLAY:FAIL=VGA_NOT_FOUND\n");
     }
 }
 

--- a/core/platform/boards/qemu-virt-riscv64/machine_display.c
+++ b/core/platform/boards/qemu-virt-riscv64/machine_display.c
@@ -32,123 +32,189 @@ static void log_hex32(uint32_t val) {
     hal_serial_write(buf);
 }
 
+static void log_hex64(uint64_t val) {
+    hal_serial_write("0x");
+    const char *hex = "0123456789abcdef";
+    char buf[17];
+    for (int i = 15; i >= 0; i--) {
+        buf[i] = hex[val & 0xF];
+        val >>= 4;
+    }
+    buf[16] = '\0';
+    hal_serial_write(buf);
+}
+
 static void virt_scan_pci_ecam_for_vga(system_discovery_t *discovery) {
     if (!discovery || discovery->boot_video.valid) return;
     
-    uintptr_t ecam_bases[5];
-    size_t count = 0;
-    
-    if (discovery->pci_host_count > 0 && discovery->pci_hosts[0].ecam_base != 0) {
-        ecam_bases[count++] = (uintptr_t)discovery->pci_hosts[0].ecam_base;
+    if (discovery->pci_host_count == 0 || discovery->pci_hosts[0].ecam_base == 0) {
+        hal_serial_write("BHARAT_DISPLAY:FAIL=NO_PCI_HOST\n");
+        return;
     }
-    ecam_bases[count++] = 0x30000000ULL;
-    ecam_bases[count++] = 0x40100000ULL;
-    ecam_bases[count++] = 0x3F000000ULL;
-    ecam_bases[count++] = 0x20000000ULL;
-    
-    hal_serial_write("[PCI Scan] Starting PCIe ECAM probe...\n");
 
-    for (size_t b = 0; b < count; b++) {
-        uintptr_t phys_ecam = ecam_bases[b];
-        if (phys_ecam == 0) continue;
-        
-        uintptr_t virt_ecam = 0;
-        if (physmap_has_linear_map()) {
-            void *v = physmap_phys_to_virt(phys_ecam);
-            if (v) virt_ecam = (uintptr_t)v;
-        }
-        if (virt_ecam == 0) virt_ecam = phys_ecam;
-        
-        for (int bus = 0; bus < 4; bus++) {
-            for (int dev = 0; dev < 32; dev++) {
-                volatile uint32_t *ecam_dev = (volatile uint32_t *)(virt_ecam + ((uintptr_t)bus << 20) + ((uintptr_t)dev << 15));
-                uint32_t vendor_device = ecam_dev[0];
-                
-                if (vendor_device != 0xFFFFFFFF && vendor_device != 0x00000000) {
-                    hal_serial_write("  [PCI Dev Found] ECAM Base: ");
-                    log_hex32((uint32_t)phys_ecam);
-                    hal_serial_write(" Bus: "); log_hex32(bus);
-                    hal_serial_write(" Dev: "); log_hex32(dev);
-                    hal_serial_write(" ID: "); log_hex32(vendor_device);
+    uint64_t phys_ecam = discovery->pci_hosts[0].ecam_base;
+    uint64_t ecam_size = discovery->pci_hosts[0].ecam_size;
+    if (ecam_size == 0) ecam_size = 0x1000000;
+
+    hal_serial_write("BHARAT_DISPLAY:PCI_ECAM=");
+    log_hex64(phys_ecam);
+    hal_serial_write("\n");
+
+    uintptr_t virt_ecam = 0;
+    if (qemu_display_map_mmio(phys_ecam, ecam_size, &virt_ecam) != 0) {
+        hal_serial_write("BHARAT_DISPLAY:FAIL=ECAM_MAP\n");
+        return;
+    }
+    hal_serial_write("BHARAT_DISPLAY:ECAM_MAP=PASS\n");
+
+    uint64_t mmio_base = discovery->pci_hosts[0].mmio32_base;
+    uint64_t mmio_size = discovery->pci_hosts[0].mmio32_size;
+    if (mmio_base == 0 || mmio_size == 0) {
+        // Fallback for RISC-V 64 QEMU virt PCIe MMIO range
+        mmio_base = 0x40000000ULL;
+        mmio_size = 0x20000000ULL;
+    }
+
+    hal_serial_write("BHARAT_DISPLAY:PCI_MMIO_BASE=");
+    log_hex64(mmio_base);
+    hal_serial_write("\n");
+    hal_serial_write("BHARAT_DISPLAY:PCI_MMIO_SIZE=");
+    log_hex64(mmio_size);
+    hal_serial_write("\n");
+
+    bool vga_found = false;
+
+    for (int bus = 0; bus < 4 && !vga_found; bus++) {
+        for (int dev = 0; dev < 32 && !vga_found; dev++) {
+            volatile uint32_t *ecam_dev = (volatile uint32_t *)(virt_ecam + ((uintptr_t)bus << 20) + ((uintptr_t)dev << 15));
+            uint32_t vendor_device = ecam_dev[0];
+
+            if (vendor_device != 0xFFFFFFFF && vendor_device != 0x00000000) {
+                uint16_t vendor_id = vendor_device & 0xFFFF;
+                uint16_t device_id = (vendor_device >> 16) & 0xFFFF;
+
+                if (vendor_id == 0x1234 || (vendor_id == 0x1b36 && (device_id == 0x0100 || device_id == 0x000d))) {
+                    hal_serial_write("BHARAT_DISPLAY:VGA_FOUND\n");
+                    vga_found = true;
+
+                    // Read current BARs
+                    uint32_t orig_bar0 = ecam_dev[4];
+                    uint32_t orig_bar2 = ecam_dev[6];
+
+                    // Probe sizes
+                    ecam_dev[4] = 0xFFFFFFFF;
+                    uint32_t mask0 = ecam_dev[4];
+                    ecam_dev[4] = orig_bar0;
+
+                    ecam_dev[6] = 0xFFFFFFFF;
+                    uint32_t mask2 = ecam_dev[6];
+                    ecam_dev[6] = orig_bar2;
+
+                    uint32_t size0 = ~(mask0 & 0xFFFFFFF0) + 1;
+                    uint32_t size2 = ~(mask2 & 0xFFFFFFF0) + 1;
+
+                    if (size0 == 0 || size0 > 0x10000000) size0 = 0x1000000; // default 16MB
+                    if (size2 == 0 || size2 > 0x10000000) size2 = 0x1000;    // default 4KB
+
+                    uint32_t bar0 = orig_bar0;
+                    uint32_t bar2 = orig_bar2;
+
+                    // Assign BAR0 if unprogrammed
+                    if ((bar0 & 0xFFFFFFF0) == 0) {
+                        bar0 = (uint32_t)mmio_base;
+                        ecam_dev[4] = bar0;
+                    }
+                    // Assign BAR2 if unprogrammed
+                    if ((bar2 & 0xFFFFFFF0) == 0) {
+                        uint32_t aligned_bar2 = (bar0 + size0 + size2 - 1) & ~(size2 - 1);
+                        bar2 = aligned_bar2;
+                        ecam_dev[6] = bar2;
+                    }
+
+                    // Enable Memory Space (bit 1) + Bus Master (bit 2)
+                    ecam_dev[1] |= 0x06;
+
+                    uint64_t fb_phys = bar0 & 0xFFFFFFF0;
+                    uint64_t mmio_phys = bar2 & 0xFFFFFFF0;
+
+                    hal_serial_write("BHARAT_DISPLAY:BAR0=");
+                    log_hex64(fb_phys);
+                    hal_serial_write("\n");
+                    hal_serial_write("BHARAT_DISPLAY:BAR2=");
+                    log_hex64(mmio_phys);
                     hal_serial_write("\n");
 
-                    uint16_t vendor_id = vendor_device & 0xFFFF;
-                    uint16_t device_id = (vendor_device >> 16) & 0xFFFF;
-
-                    // Match Bochs VGA (0x1234:0x1111 or 0x1234:0x1110), QEMU stdvga (0x1234:0x0001), or RedHat VGA (0x1b36:0x0100 / 0x1b36:0x000d)
-                    if (vendor_id == 0x1234 || (vendor_id == 0x1b36 && (device_id == 0x0100 || device_id == 0x000d))) {
-                        hal_serial_write("  [VGA Match] Recognized Bochs/QEMU display device!\n");
-                        uint32_t bar0 = ecam_dev[4]; // BAR0 (offset 0x10)
-                        uint32_t bar2 = ecam_dev[6]; // BAR2 (offset 0x18)
-
-                        // Assign BARs in QEMU virt PCIe 32-bit MMIO space (0x40000000+)
-                        if ((bar0 & 0xFFFFFFF0) == 0) {
-                            bar0 = 0x40000000 + ((uint32_t)dev * 0x1000000);
-                            ecam_dev[4] = bar0;
-                        }
-                        if ((bar2 & 0xFFFFFFF0) == 0) {
-                            bar2 = bar0 + 0x800000; // 8MB offset for MMIO control regs
-                            ecam_dev[6] = bar2;
-                        }
-                        
-                        // Enable Memory Space (bit 1) + Bus Master (bit 2) in Command Register
-                        ecam_dev[1] |= 0x06;
-                        
-                        uint32_t fb_phys = bar0 & 0xFFFFFFF0;
-                        uint32_t mmio_phys = bar2 & 0xFFFFFFF0;
-                        
-                        uintptr_t virt_mmio = 0;
-                        if (physmap_has_linear_map()) {
-                            void *v = physmap_phys_to_virt(mmio_phys);
-                            if (v) virt_mmio = (uintptr_t)v;
-                        }
-                        if (virt_mmio == 0) virt_mmio = mmio_phys;
-
-                        /* Ensure MMIO region is mapped in page tables if MMU is active */
-                        if (active_mem_protect && active_mem_protect->cpu_ops.get_root) {
-                            phys_addr_t root = active_mem_protect->cpu_ops.get_root();
-                            if (root != 0) {
-                                uint32_t map_flags = HAL_PT_FLAG_READ | HAL_PT_FLAG_WRITE | HAL_PT_FLAG_DEVICE;
-                                hal_pt_map_range(root, virt_mmio, mmio_phys, 0x100000, map_flags);
-                                hal_tlb_invalidate_all();
-                            }
-                        }
-                        
-                        /* Program Bochs VBE MMIO registers */
-                        if (virt_mmio != 0) {
-                            volatile uint16_t *vbe = (volatile uint16_t *)virt_mmio;
-                            vbe[4] = 0x00; // VBE_DISPI_INDEX_ENABLE = 0
-                            vbe[1] = 1024; // VBE_DISPI_INDEX_XRES = 1024
-                            vbe[2] = 768;  // VBE_DISPI_INDEX_YRES = 768
-                            vbe[3] = 32;   // VBE_DISPI_INDEX_BPP = 32
-                            vbe[4] = 0x41; // VBE_DISPI_ENABLED | VBE_DISPI_LFB_ENABLED
-                        }
-                        
-                        discovery->boot_video.phys_addr    = fb_phys;
-                        discovery->boot_video.virt_addr    = fb_phys;
-                        discovery->boot_video.width        = 1024;
-                        discovery->boot_video.height       = 768;
-                        discovery->boot_video.stride_bytes = 1024 * 4;
-                        discovery->boot_video.size         = 1024 * 768 * 4;
-                        discovery->boot_video.format       = PIXEL_FORMAT_ARGB8888;
-                        discovery->boot_video.valid        = true;
-
-                        /* Synchronize g_boot_info console for kernel_boot.c UI activation */
-                        extern const boot_info_t *g_boot_info;
-                        if (g_boot_info) {
-                            boot_info_t *b = (boot_info_t *)g_boot_info;
-                            b->console.type = BOOT_CONSOLE_FRAMEBUFFER;
-                            b->console.fb_phys_base = fb_phys;
-                            b->console.fb_width = 1024;
-                            b->console.fb_height = 768;
-                            b->console.fb_pitch = 1024 * 4;
-                            b->console.fb_bpp = 32;
-                        }
+                    // Validate BAR allocations are within discovered PCI MMIO boundaries and don't overlap with RAM
+                    if (fb_phys < mmio_base || fb_phys + size0 > mmio_base + mmio_size ||
+                        mmio_phys < mmio_base || mmio_phys + size2 > mmio_base + mmio_size) {
+                        hal_serial_write("BHARAT_DISPLAY:FAIL=BAR_ALLOC_OUT_OF_BOUNDS\n");
                         return;
                     }
+
+                    // On RISC-V 64, RAM starts at 0x80000000. Ensure no overlap with RAM range!
+                    if ((fb_phys >= 0x80000000 && fb_phys < 0x80000000 + 0x40000000) ||
+                        (mmio_phys >= 0x80000000 && mmio_phys < 0x80000000 + 0x40000000)) {
+                        hal_serial_write("BHARAT_DISPLAY:FAIL=BAR_ALLOC_RAM_OVERLAP\n");
+                        return;
+                    }
+
+                    // Map control BAR
+                    uintptr_t virt_mmio = 0;
+                    if (qemu_display_map_mmio(mmio_phys, size2, &virt_mmio) != 0) {
+                        hal_serial_write("BHARAT_DISPLAY:FAIL=CTRL_MAP\n");
+                        return;
+                    }
+                    hal_serial_write("BHARAT_DISPLAY:CTRL_MAP=PASS\n");
+
+                    // Program Bochs VBE registers
+                    if (virt_mmio != 0) {
+                        volatile uint16_t *vbe = (volatile uint16_t *)virt_mmio;
+                        vbe[4] = 0x00; // VBE_DISPI_INDEX_ENABLE = 0
+                        vbe[1] = 1024; // VBE_DISPI_INDEX_XRES = 1024
+                        vbe[2] = 768;  // VBE_DISPI_INDEX_YRES = 768
+                        vbe[3] = 32;   // VBE_DISPI_INDEX_BPP = 32
+                        vbe[4] = 0x41; // VBE_DISPI_ENABLED | VBE_DISPI_LFB_ENABLED
+                    }
+
+                    // Map Framebuffer BAR
+                    uintptr_t virt_fb = 0;
+                    if (qemu_display_map_mmio(fb_phys, size0, &virt_fb) != 0) {
+                        hal_serial_write("BHARAT_DISPLAY:FAIL=FB_MAP\n");
+                        return;
+                    }
+                    hal_serial_write("BHARAT_DISPLAY:FB_MAP=PASS\n");
+
+                    discovery->boot_video.phys_addr    = fb_phys;
+                    discovery->boot_video.virt_addr    = virt_fb;
+                    discovery->boot_video.width        = 1024;
+                    discovery->boot_video.height       = 768;
+                    discovery->boot_video.stride_bytes = 1024 * 4;
+                    discovery->boot_video.size         = 1024 * 768 * 4;
+                    discovery->boot_video.format       = PIXEL_FORMAT_ARGB8888;
+                    discovery->boot_video.valid        = true;
+
+                    /* Synchronize g_boot_info console for kernel_boot.c UI activation */
+                    extern const boot_info_t *g_boot_info;
+                    if (g_boot_info) {
+                        boot_info_t *b = (boot_info_t *)g_boot_info;
+                        b->console.type = BOOT_CONSOLE_FRAMEBUFFER;
+                        b->console.fb_phys_base = fb_phys;
+                        b->console.fb_width = 1024;
+                        b->console.fb_height = 768;
+                        b->console.fb_pitch = 1024 * 4;
+                        b->console.fb_bpp = 32;
+                    }
+
+                    hal_serial_write("BHARAT_DISPLAY:MODE=1024x768x32\n");
+                    hal_serial_write("BHARAT_DISPLAY:READY\n");
+                    return;
                 }
             }
         }
+    }
+
+    if (!vga_found) {
+        hal_serial_write("BHARAT_DISPLAY:FAIL=VGA_NOT_FOUND\n");
     }
 }
 

--- a/interface/include/bharat/display/display_caps.h
+++ b/interface/include/bharat/display/display_caps.h
@@ -48,4 +48,7 @@ typedef struct display_probe_result {
 int machine_get_display_caps(machine_display_caps_t *out);
 int machine_probe_boot_video(display_probe_result_t *out, boot_video_handoff_t *video);
 
+// QEMU Display MMIO mapping helper
+int qemu_display_map_mmio(uint64_t phys, size_t size, uintptr_t *out_virt);
+
 #endif // BHARAT_DISPLAY_CAPS_H

--- a/quality/tests/host/test_fdt_parser.c
+++ b/quality/tests/host/test_fdt_parser.c
@@ -161,6 +161,84 @@ int main() {
         return 1;
     }
 
+    // Case 7: FDT Idempotence
+    INIT_FDT();
+    *p++ = cpu_to_fdt32(FDT_BEGIN_NODE);
+    strcpy((char *)p, "node1"); // 6 bytes -> 8 aligned
+    p += 2;
+    *p++ = cpu_to_fdt32(FDT_END_NODE);
+    *p++ = cpu_to_fdt32(FDT_END);
+    fdt->size_dt_struct = cpu_to_fdt32((uint8_t*)p - (buffer + sizeof(struct fdt_header)));
+
+    res = fdt_parse_discovery(buffer, &disco);
+    if (res != 0) {
+        printf("Test 7 (Idempotence part 1) Failed\n");
+        return 1;
+    }
+    // Now parse again. It should be idempotent (return 0 and not duplicate/alter counts)
+    res = fdt_parse_discovery(buffer, &disco);
+    if (res != 0) {
+        printf("Test 7 (Idempotence part 2) Failed\n");
+        return 1;
+    }
+
+    // Case 8: PCI Ranges Property Extraction
+    INIT_FDT();
+    strcpy(str_table, "compatible");
+    strcpy(str_table + 11, "reg");
+    strcpy(str_table + 15, "ranges");
+    fdt->size_dt_strings = cpu_to_fdt32(128);
+
+    *p++ = cpu_to_fdt32(FDT_BEGIN_NODE);
+    strcpy((char *)p, "pcie@0");
+    p += 2;
+
+    // compatible = "pci-host-ecam-generic"
+    *p++ = cpu_to_fdt32(FDT_PROP);
+    char pci_comp[] = "pci-host-ecam-generic";
+    *p++ = cpu_to_fdt32(sizeof(pci_comp));
+    *p++ = cpu_to_fdt32(0); // "compatible" offset
+    uint32_t comp_pad_len = (sizeof(pci_comp) + 3) & ~3U;
+    memset((char*)p, 0, comp_pad_len);
+    memcpy((char*)p, pci_comp, sizeof(pci_comp));
+    p += comp_pad_len / 4;
+
+    // reg (ECAM)
+    *p++ = cpu_to_fdt32(FDT_PROP);
+    *p++ = cpu_to_fdt32(16); // 16 bytes
+    *p++ = cpu_to_fdt32(11); // "reg" offset
+    *p++ = cpu_to_fdt32(0); // ecam base
+    *p++ = cpu_to_fdt32(0x30000000);
+    *p++ = cpu_to_fdt32(0); // ecam size
+    *p++ = cpu_to_fdt32(0x10000000);
+
+    // ranges
+    *p++ = cpu_to_fdt32(FDT_PROP);
+    *p++ = cpu_to_fdt32(28); // 1 entry of 7 cells = 28 bytes
+    *p++ = cpu_to_fdt32(15); // "ranges" offset
+    // 1 entry: space_type=0x2 (32-bit MMIO), parent_base=0x40000000, size=0x20000000
+    *p++ = cpu_to_fdt32(0x02000000); // flags
+    *p++ = cpu_to_fdt32(0); // child base
+    *p++ = cpu_to_fdt32(0x40000000);
+    *p++ = cpu_to_fdt32(0); // parent base
+    *p++ = cpu_to_fdt32(0x40000000);
+    *p++ = cpu_to_fdt32(0); // size
+    *p++ = cpu_to_fdt32(0x20000000);
+
+    *p++ = cpu_to_fdt32(FDT_END_NODE);
+    *p++ = cpu_to_fdt32(FDT_END);
+    fdt->size_dt_struct = cpu_to_fdt32((uint8_t*)p - (buffer + sizeof(struct fdt_header)));
+
+    res = fdt_parse_discovery(buffer, &disco);
+    if (res != 0 || disco.pci_host_count == 0) {
+        printf("Test 8 Failed: PCIe ranges parsing. res=%d count=%d\n", res, disco.pci_host_count);
+        return 1;
+    }
+    if (disco.pci_hosts[0].mmio32_base != 0x40000000 || disco.pci_hosts[0].mmio32_size != 0x20000000) {
+        printf("Test 8 Failed: base=0x%lx size=0x%lx\n", disco.pci_hosts[0].mmio32_base, disco.pci_hosts[0].mmio32_size);
+        return 1;
+    }
+
     printf("All advanced boundary tests passed!\n");
     return 0;
 }


### PR DESCRIPTION
Resolved the early display initialization failures on ARM64 and RISC-V64 architectures under QEMU by ensuring proper PCI ECAM/BAR configuration, memory mapping, and FDT idempotency.

Key Changes:
1. Extended pci_host_desc_t and FDT parser to dynamically extract PCIe ranges (32-bit and 64-bit MMIO).
2. Added parse-once fdt_parsed idempotence to system_discovery_t.
3. Created qemu_display_map_mmio helper to safely map device registers and framebuffers using active translation root and g_kernel_virt_offset.
4. Corrected ARM64 BAR base allocator to use PCIe MMIO bounds instead of guest RAM.
5. Resolved boot_video_map mapping truth logic to correctly map framebuffers on ARM64 and RISC-V64.
6. Maintained x86_64 working path.
7. Added detailed BHARAT_DISPLAY serial diagnostics.
8. Extended host unit tests for PCIe ranges and FDT idempotence.

---
*PR created automatically by Jules for task [820436535926018342](https://jules.google.com/task/820436535926018342) started by @divyang4481*