### PR TITLE
Fix ARM64 QEMU GUI boot after first serial marker

### DIFF
--- a/core/arch/arm/arm64/boot/entry.c
+++ b/core/arch/arm/arm64/boot/entry.c
@@ -11,12 +11,12 @@
 
 // Early boot entry for ARM64
 void kernel_main(uintptr_t fdt_ptr) {
+    /* boot.S has already enabled the PL011.  Keep this path allocation-free
+     * and use the raw UART until kernel_main_common() discovers and registers
+     * the normal console backend.  Binding the profile-based UART here used
+     * indirect driver calls before the early console was initialized and
+     * could trap immediately after this marker on QEMU's ARM virt machine. */
     hal_serial_write("BOOT: kernel_main reached\n");
-
-    if (fdt_ptr == 0) fdt_ptr = 0x40000000;
-
-    extern void hal_serial_init(void);
-    hal_serial_init();
 
     if (fdt_ptr == 0) fdt_ptr = 0x40000000;
 

--- a/delivery/targets/qemu/arm64_desktop_gui.yaml
+++ b/delivery/targets/qemu/arm64_desktop_gui.yaml
@@ -34,7 +34,7 @@ package:
 
 run:
   backend: qemu
-  machine: virt
+  machine: "virt,gic-version=3"
   cpu: cortex-a72
   memory: 1024M
   nographic: false
@@ -42,8 +42,6 @@ run:
     - stdio
   boot_artifact: kernel/kernel.elf
   extra_args:
-    - "-machine"
-    - "virt,gic-version=3"
     - "-device"
     - "bochs-display"
     - "-device"


### PR DESCRIPTION
### Motivation

- ARM64 GUI boots were not producing host-visible boot logs and the QEMU GUI did not appear while RISC-V and x86_64 targets worked, indicating an ARM-specific early-boot problem.  
- Investigation showed an early `hal_serial_init()` / profile-based UART bind occurred before the common console discovery and a duplicate `-machine` argument caused the runner/packager to disagree on the QEMU machine string.

### Description

- Keep the ARM64 early C entry on the raw PL011 path by removing the early `hal_serial_init()` call and adding a comment explaining deferral until the common console is ready in `core/arch/arm/arm64/boot/entry.c`.  
- Configure the ARM64 GUI target’s canonical QEMU machine string by setting `run.machine: "virt,gic-version=3"` in `delivery/targets/qemu/arm64_desktop_gui.yaml`.  
- Remove the duplicate `-machine` entries from `run.extra_args` so the packager/runner and manifest agree on the machine configuration and avoid duplicate-flag warnings.

### Testing

- Ran `python3 -m pytest -q` and all tests passed (`12 passed`).  
- Ran `python3 tools/build.py all --target-yaml delivery/targets/qemu/arm64_desktop_gui.yaml`, which completed the kernel build and produced `kernel/kernel.elf` but packaging stopped when attempting to invoke `qemu-system-aarch64` because that binary is not present in the environment.  
- Ran `git diff --check` to validate there were no whitespace/patch issues and it reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a68cc9ac2788320aecb02637c117cfc)