### PR TITLE
fix: translate PCI display BARs on ARM64 virt

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -231,7 +231,9 @@ Runtime command includes serial-first bring-up (`-nographic -monitor none -seria
 ./tools/build.sh all --target-yaml delivery/targets/qemu/x86_64_desktop_headless.yaml --smoke
 ./tools/build.sh all --target-yaml delivery/targets/qemu/x86_64_desktop_gui.yaml --interactive
 ./tools/build.sh all --target-yaml delivery/targets/qemu/arm64_desktop_headless.yaml --smoke
+./tools/build.sh all --target-yaml delivery/targets/qemu/arm64_desktop_gui.yaml --interactive
 ./tools/build.sh all --target-yaml delivery/targets/qemu/riscv64_desktop_headless.yaml --smoke
+./tools/build.sh run --target-yaml delivery/targets/qemu/riscv64_desktop_gui.yaml --interactive
 ./tools/build.sh all --target-yaml delivery/targets/qemu/arm32_mmu_lite_headless.yaml --smoke
 ./tools/build.sh all --target-yaml delivery/targets/qemu/riscv32_mmu_lite_headless.yaml --smoke
 ```

--- a/core/hal/common/fdt_parser.c
+++ b/core/hal/common/fdt_parser.c
@@ -459,8 +459,10 @@ int fdt_parse_discovery(const void *fdt_ptr, system_discovery_t *discovery) {
         } else if (s->is_pci && discovery->pci_host_count < BHARAT_MAX_PCI_HOSTS) {
           discovery->pci_hosts[discovery->pci_host_count].ecam_base = base;
           discovery->pci_hosts[discovery->pci_host_count].ecam_size = size;
+          discovery->pci_hosts[discovery->pci_host_count].mmio32_pci_base = 0;
           discovery->pci_hosts[discovery->pci_host_count].mmio32_base = 0;
           discovery->pci_hosts[discovery->pci_host_count].mmio32_size = 0;
+          discovery->pci_hosts[discovery->pci_host_count].mmio64_pci_base = 0;
           discovery->pci_hosts[discovery->pci_host_count].mmio64_base = 0;
           discovery->pci_hosts[discovery->pci_host_count].mmio64_size = 0;
 
@@ -477,6 +479,13 @@ int fdt_parse_discovery(const void *fdt_ptr, system_discovery_t *discovery) {
                   uint32_t flags_word = fdt32_to_cpu(r_cell[i]);
                   uint32_t space_type = (flags_word >> 24) & 0x3;
 
+                  /* PCI ranges always use three child address cells.  The
+                   * first contains flags and the remaining two are the PCI
+                   * bus address.  Keep it separate from the parent CPU
+                   * address: on ARM virt these address spaces are offset. */
+                  uint64_t pci_base = ((uint64_t)fdt32_to_cpu(r_cell[i + 1]) << 32) |
+                                      fdt32_to_cpu(r_cell[i + 2]);
+
                   uint64_t parent_base = 0;
                   if (p_ac == 2) {
                       parent_base = ((uint64_t)fdt32_to_cpu(r_cell[i + 3]) << 32) | fdt32_to_cpu(r_cell[i + 4]);
@@ -492,9 +501,11 @@ int fdt_parse_discovery(const void *fdt_ptr, system_discovery_t *discovery) {
                   }
 
                   if (space_type == 0x2) { // 32-bit MMIO
+                      discovery->pci_hosts[discovery->pci_host_count].mmio32_pci_base = pci_base;
                       discovery->pci_hosts[discovery->pci_host_count].mmio32_base = parent_base;
                       discovery->pci_hosts[discovery->pci_host_count].mmio32_size = range_size;
                   } else if (space_type == 0x3) { // 64-bit MMIO
+                      discovery->pci_hosts[discovery->pci_host_count].mmio64_pci_base = pci_base;
                       discovery->pci_hosts[discovery->pci_host_count].mmio64_base = parent_base;
                       discovery->pci_hosts[discovery->pci_host_count].mmio64_size = range_size;
                   }

--- a/core/kernel/include/hal/hal_discovery.h
+++ b/core/kernel/include/hal/hal_discovery.h
@@ -100,8 +100,10 @@ typedef struct {
     uint16_t segment;   // PCI Segment Group Number
     uint8_t bus_start;
     uint8_t bus_end;
+    uint64_t mmio32_pci_base; // Child (PCI bus) address from the FDT ranges entry
     uint64_t mmio32_base;
     uint64_t mmio32_size;
+    uint64_t mmio64_pci_base; // Child (PCI bus) address from the FDT ranges entry
     uint64_t mmio64_base;
     uint64_t mmio64_size;
 } pci_host_desc_t;

--- a/core/platform/boards/qemu-virt-arm64/machine_display.c
+++ b/core/platform/boards/qemu-virt-arm64/machine_display.c
@@ -116,12 +116,14 @@ static void virt_scan_pci_ecam_for_vga(system_discovery_t *discovery) {
     }
     hal_serial_write("BHARAT_DISPLAY:ECAM_MAP=PASS\n");
 
+    uint64_t pci_mmio_base = discovery->pci_hosts[0].mmio32_pci_base;
     uint64_t mmio_base = discovery->pci_hosts[0].mmio32_base;
     uint64_t mmio_size = discovery->pci_hosts[0].mmio32_size;
     if (mmio_base == 0 || mmio_size == 0) {
         // Fallback for ARM64 QEMU virt PCIe MMIO range
         mmio_base = 0x10000000ULL;
         mmio_size = 0x2EFF0000ULL;
+        pci_mmio_base = 0;
     }
 
     hal_serial_write("BHARAT_DISPLAY:PCI_MMIO_BASE=");
@@ -167,10 +169,16 @@ static void virt_scan_pci_ecam_for_vga(system_discovery_t *discovery) {
 
                     uint32_t bar0 = orig_bar0;
                     uint32_t bar2 = orig_bar2;
+                    uint64_t pci_alloc_base = pci_mmio_base;
+
+                    /* A zero BAR means disabled, even when the PCI range
+                     * itself starts at bus address zero.  Leave the first
+                     * framebuffer-sized slot unused in that case. */
+                    if (pci_alloc_base == 0) pci_alloc_base = size0;
 
                     // Assign BAR0 if unprogrammed
                     if ((bar0 & 0xFFFFFFF0) == 0) {
-                        bar0 = (uint32_t)mmio_base;
+                        bar0 = (uint32_t)pci_alloc_base;
                         ecam_dev[4] = bar0;
                     }
                     // Assign BAR2 if unprogrammed
@@ -183,8 +191,14 @@ static void virt_scan_pci_ecam_for_vga(system_discovery_t *discovery) {
                     // Enable Memory Space (bit 1) + Bus Master (bit 2)
                     ecam_dev[1] |= 0x06;
 
-                    uint64_t fb_phys = bar0 & 0xFFFFFFF0;
-                    uint64_t mmio_phys = bar2 & 0xFFFFFFF0;
+                    uint64_t fb_bus = bar0 & 0xFFFFFFF0;
+                    uint64_t mmio_bus = bar2 & 0xFFFFFFF0;
+                    if (fb_bus < pci_mmio_base || mmio_bus < pci_mmio_base) {
+                        hal_serial_write("BHARAT_DISPLAY:FAIL=BAR_BELOW_PCI_RANGE\n");
+                        return;
+                    }
+                    uint64_t fb_phys = mmio_base + (fb_bus - pci_mmio_base);
+                    uint64_t mmio_phys = mmio_base + (mmio_bus - pci_mmio_base);
 
                     hal_serial_write("BHARAT_DISPLAY:BAR0=");
                     log_hex64(fb_phys);

--- a/core/platform/boards/qemu-virt-riscv64/machine_display.c
+++ b/core/platform/boards/qemu-virt-riscv64/machine_display.c
@@ -67,12 +67,14 @@ static void virt_scan_pci_ecam_for_vga(system_discovery_t *discovery) {
     }
     hal_serial_write("BHARAT_DISPLAY:ECAM_MAP=PASS\n");
 
+    uint64_t pci_mmio_base = discovery->pci_hosts[0].mmio32_pci_base;
     uint64_t mmio_base = discovery->pci_hosts[0].mmio32_base;
     uint64_t mmio_size = discovery->pci_hosts[0].mmio32_size;
     if (mmio_base == 0 || mmio_size == 0) {
         // Fallback for RISC-V 64 QEMU virt PCIe MMIO range
         mmio_base = 0x40000000ULL;
         mmio_size = 0x20000000ULL;
+        pci_mmio_base = 0x40000000ULL;
     }
 
     hal_serial_write("BHARAT_DISPLAY:PCI_MMIO_BASE=");
@@ -118,10 +120,12 @@ static void virt_scan_pci_ecam_for_vga(system_discovery_t *discovery) {
 
                     uint32_t bar0 = orig_bar0;
                     uint32_t bar2 = orig_bar2;
+                    uint64_t pci_alloc_base = pci_mmio_base;
+                    if (pci_alloc_base == 0) pci_alloc_base = size0;
 
                     // Assign BAR0 if unprogrammed
                     if ((bar0 & 0xFFFFFFF0) == 0) {
-                        bar0 = (uint32_t)mmio_base;
+                        bar0 = (uint32_t)pci_alloc_base;
                         ecam_dev[4] = bar0;
                     }
                     // Assign BAR2 if unprogrammed
@@ -134,8 +138,14 @@ static void virt_scan_pci_ecam_for_vga(system_discovery_t *discovery) {
                     // Enable Memory Space (bit 1) + Bus Master (bit 2)
                     ecam_dev[1] |= 0x06;
 
-                    uint64_t fb_phys = bar0 & 0xFFFFFFF0;
-                    uint64_t mmio_phys = bar2 & 0xFFFFFFF0;
+                    uint64_t fb_bus = bar0 & 0xFFFFFFF0;
+                    uint64_t mmio_bus = bar2 & 0xFFFFFFF0;
+                    if (fb_bus < pci_mmio_base || mmio_bus < pci_mmio_base) {
+                        hal_serial_write("BHARAT_DISPLAY:FAIL=BAR_BELOW_PCI_RANGE\n");
+                        return;
+                    }
+                    uint64_t fb_phys = mmio_base + (fb_bus - pci_mmio_base);
+                    uint64_t mmio_phys = mmio_base + (mmio_bus - pci_mmio_base);
 
                     hal_serial_write("BHARAT_DISPLAY:BAR0=");
                     log_hex64(fb_phys);


### PR DESCRIPTION
### Motivation

- QEMU `virt` exposes PCI bus addresses in FDT `ranges` that must be translated to CPU physical MMIO before mapping, and the ARM64 path was treating CPU-side MMIO as PCI BAR addresses which prevented the boot GUI from displaying.
- Ensure the kernel can detect and map the Bochs/QEMU framebuffer on ARM64 (and keep RISC-V behaviour explicit) by preserving PCI child/bus address info and translating BARs correctly.

### Description

- Add `mmio32_pci_base` and `mmio64_pci_base` to `pci_host_desc_t` in `core/kernel/include/hal/hal_discovery.h` to preserve the PCI (child/bus) base from FDT `ranges`.
- Parse and record the PCI bus base for MMIO ranges in `core/hal/common/fdt_parser.c` so PCI child addresses are available alongside parent CPU addresses.
- Update `core/platform/boards/qemu-virt-arm64/machine_display.c` to:
  - use the recorded PCI bus base when programming BAR0/BAR2 (avoid assigning BAR 0 when the PCI bus window starts at zero),
  - translate BAR bus addresses into CPU physical addresses via `mmio_base + (bar_bus - pci_mmio_base)` before mapping,
  - validate BAR allocations against the discovered PCI MMIO window and check for RAM overlap, and
  - keep diagnostic `BHARAT_DISPLAY` logging for failure modes.
- Apply the same PCI-to-CPU translation and allocation logic to the RISC-V `qemu-virt` display path in `core/platform/boards/qemu-virt-riscv64/machine_display.c` for parity and robustness.

### Testing

- Ran `python3 tools/check_profiles.py`, which completed successfully.
- Ran `git diff --check` with no whitespace/patch errors detected.
- Built ARM64 artifacts with `ninja -C build/arm64-edge -j2`, which completed/returned with expected build output for the modified targets.
- Attempted `./tools/build.sh all --target riscv64_desktop_headless`; the RISC-V build was started and progressed but the runner detached before a definitive completion status could be observed (build progress observed in logs).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a68d779a5b88320b660dbd4ac55973e)