### PR TITLE
Use bundled OpenSBI for riscv32 QEMU targets

### DIFF
--- a/delivery/targets/qemu/riscv32_desktop_headless.yaml
+++ b/delivery/targets/qemu/riscv32_desktop_headless.yaml
@@ -51,9 +51,6 @@ run:
   serial:
     - stdio
   boot_artifact: kernel/kernel.elf
-  extra_args:
-    - "-bios"
-    - "/usr/lib/riscv32-linux-gnu/opensbi/generic/fw_dynamic.bin"
 
 debug:
   backend: gdb_remote

--- a/delivery/targets/qemu/riscv32_mmu_lite_headless.yaml
+++ b/delivery/targets/qemu/riscv32_mmu_lite_headless.yaml
@@ -48,9 +48,6 @@ run:
   machine: virt
   memory: 512M
   nographic: true
-  extra_args:
-    - "-bios"
-    - "/usr/lib/riscv32-linux-gnu/opensbi/generic/fw_dynamic.bin"
   serial:
     - stdio
   boot_artifact: kernel/kernel.elf


### PR DESCRIPTION
### Motivation
- Remove the hardcoded Linux OpenSBI BIOS path so QEMU uses its bundled/default OpenSBI firmware for riscv32 targets, making the run configuration portable (Windows/WSL) and aligning with the QEMU runner's `opensbi_payload` contract.

### Description
- Remove the explicit `extra_args: -bios /usr/lib/riscv32-linux-gnu/opensbi/generic/fw_dynamic.bin` entries from `delivery/targets/qemu/riscv32_mmu_lite_headless.yaml` and `delivery/targets/qemu/riscv32_desktop_headless.yaml` so the runner can rely on QEMU's bundled OpenSBI.

### Testing
- Ran `python3 tools/targets/validate.py` on both modified YAMLs (passed), ran `python3 tools/lint/check_layer_references.py` and `python3 tools/lint/check_cmake_dependencies.py` (tools executed successfully but reported existing pre-existing violations), and executed `./tools/build.sh all --target-yaml delivery/targets/qemu/riscv32_mmu_lite_headless.yaml --smoke` which built and packaged successfully while the QEMU smoke run was BLOCKED because `qemu-system-riscv32` is not available in this environment; other matrix build/run attempts were likewise blocked or partial due to missing QEMU binaries or DTB-generation helpers, and `python3 tools/run_qemu_matrix.py --headless --smoke` was used for a partial matrix run and observed the same blockers.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72fabdaf7c8320846eadf95f5f4869)