### PR TITLE
Harden ELF load-plan protections, machine enforcement, and loader rollback

### DIFF
--- a/core/kernel/src/process/user_image_loader.c
+++ b/core/kernel/src/process/user_image_loader.c
@@ -27,6 +27,71 @@
 #endif
 
 #define BH_USER_STACK_DEFAULT_SIZE (64U * 1024U)
+#define BH_LOADER_MAX_PAGES ((16U * 1024U * 1024U) / PAGE_SIZE)
+
+typedef struct {
+    uintptr_t va;
+    void *page;
+} loader_page_t;
+
+typedef struct {
+    address_space_t *aspace;
+    uintptr_t regions[18];
+    uint32_t region_count;
+    loader_page_t pages[BH_LOADER_MAX_PAGES];
+    uint32_t page_count;
+} loader_txn_t;
+
+static kstatus_t elf_plan_prot_to_vm(uint32_t plan_prot, uint32_t *out_vm_prot) {
+    const uint32_t known = BH_ELF_PROT_READ | BH_ELF_PROT_WRITE | BH_ELF_PROT_EXEC | BH_ELF_PROT_USER;
+    if (!out_vm_prot || (plan_prot & ~known) != 0U || (plan_prot & BH_ELF_PROT_USER) == 0U) {
+        return K_ERR_INVALID_ARG;
+    }
+    if ((plan_prot & BH_ELF_PROT_WRITE) != 0U && (plan_prot & BH_ELF_PROT_EXEC) != 0U) {
+        return K_ERR_DENIED;
+    }
+    uint32_t vm = 0;
+    if ((plan_prot & BH_ELF_PROT_READ) != 0U) vm |= VM_PROT_READ;
+    if ((plan_prot & BH_ELF_PROT_WRITE) != 0U) vm |= VM_PROT_WRITE;
+    if ((plan_prot & BH_ELF_PROT_EXEC) != 0U) vm |= VM_PROT_EXEC;
+    if ((plan_prot & BH_ELF_PROT_USER) != 0U) vm |= VM_PROT_USER;
+    *out_vm_prot = vm;
+    return K_OK;
+}
+
+static bh_elf_machine_t loader_expected_machine(bool *supported) {
+    *supported = true;
+#if defined(__x86_64__)
+    return BH_ELF_MACHINE_X86_64;
+#elif defined(__aarch64__)
+    return BH_ELF_MACHINE_AARCH64;
+#elif defined(__riscv) && (__riscv_xlen == 64)
+    return BH_ELF_MACHINE_RISCV64;
+#else
+    *supported = false;
+    return BH_ELF_MACHINE_X86_64;
+#endif
+}
+
+static void loader_txn_rollback(loader_txn_t *txn) {
+    bool cleanup_failed = false;
+    for (uint32_t i = txn->page_count; i > 0; --i) {
+        loader_page_t *page = &txn->pages[i - 1];
+        if (prot_domain_unmap_region(txn->aspace->prot_domain, page->va, PAGE_SIZE) != K_OK) {
+            cleanup_failed = true;
+        }
+        pmm_free_page(page->page);
+    }
+    for (uint32_t i = txn->region_count; i > 0; --i) {
+        if (aspace_region_detach(txn->aspace, txn->regions[i - 1]) != K_OK) {
+            cleanup_failed = true;
+        }
+    }
+    if (cleanup_failed) {
+        console_write_raw("[LOADER] rollback incomplete; poisoning address space\n", 52);
+        aspace_mark_poisoned(txn->aspace);
+    }
+}
 
 static void mem_copy(void *dst, const void *src, size_t size) {
     uint8_t *d = (uint8_t *)dst;
@@ -46,125 +111,125 @@ kstatus_t bh_user_image_load(
         return K_ERR_INVALID_ARG;
     }
 
-    bh_user_image_plan_v1_t plan;
-    int plan_res = bh_elf_generate_load_plan((const uint8_t *)image->bytes, image->size, aspace->user_base, aspace->user_limit, &plan);
-    if (plan_res != BH_ELF_PLAN_SUCCESS) {
-        console_write_raw("[LOADER] ELF generate load plan failed\n", 39);
-        return K_ERR_INVALID_ARG;
+    *out = (bh_user_image_result_t){0};
+
+    bool machine_supported = false;
+    bh_elf_machine_t expected_machine = loader_expected_machine(&machine_supported);
+    if (!machine_supported) {
+        return K_ERR_UNSUPPORTED;
     }
 
-    console_write_raw("[BOOTSTRAP] ELF validated via load plan\n", 40);
+    bh_user_image_plan_v1_t plan;
+    int plan_res = bh_elf_generate_load_plan_for_machine((const uint8_t *)image->bytes, image->size, aspace->user_base, aspace->user_limit, expected_machine, &plan);
+    if (plan_res != BH_ELF_PLAN_SUCCESS) {
+        console_write_raw("[LOADER] ELF generate load plan failed\n", 39);
+        return plan_res == BH_ELF_PLAN_ERR_UNSUPPORTED ? K_ERR_UNSUPPORTED : K_ERR_INVALID_ARG;
+    }
+
+    loader_txn_t txn = {.aspace = aspace};
+    kstatus_t status = K_OK;
 
     for (uint32_t i = 0; i < plan.segment_count; ++i) {
         bh_elf_load_segment_v1_t *seg = &plan.segments[i];
+        uint32_t prot = 0;
+        status = elf_plan_prot_to_vm(seg->prot, &prot);
+        if (status != K_OK) goto fail;
 
-        uint32_t prot = seg->prot;
         uint64_t start_addr = seg->virtual_address;
-        uint64_t aligned_start = start_addr & ~(PAGE_SIZE - 1);
+        uint64_t aligned_start = start_addr & ~(PAGE_SIZE - 1ULL);
         uint64_t end_addr = start_addr + seg->memory_size;
-        uint64_t aligned_end = (end_addr + PAGE_SIZE - 1) & ~(PAGE_SIZE - 1);
+        uint64_t aligned_end = (end_addr + PAGE_SIZE - 1ULL) & ~(PAGE_SIZE - 1ULL);
         uint64_t map_size = aligned_end - aligned_start;
 
         uint32_t map_flags = VM_MAP_FIXED;
-        if (prot & VM_PROT_EXEC) {
-            map_flags |= VM_MAP_EXEC_OK;
-        }
+        if ((prot & VM_PROT_EXEC) != 0U) map_flags |= VM_MAP_EXEC_OK;
 
         vm_region_t *region;
-        kstatus_t kst = aspace_region_reserve(aspace, aligned_start, map_size, prot, map_flags, VM_INHERIT_NONE, &region);
-        if (kst != K_OK) return kst;
+        status = aspace_region_reserve(aspace, aligned_start, map_size, prot, map_flags, VM_INHERIT_NONE, &region);
+        if (status != K_OK) goto fail;
+        txn.regions[txn.region_count++] = (uintptr_t)aligned_start;
 
-        // Allocate anonymous physical memory and map it (using naive individual page mapping for now)
         for (uint64_t off = 0; off < map_size; off += PAGE_SIZE) {
+            if (txn.page_count >= BH_LOADER_MAX_PAGES) { status = K_ERR_NO_RESOURCES; goto fail; }
             void *page_ptr = pmm_alloc_page_ex(MEM_NORMAL, PMM_ALLOC_ZERO);
-            if (!page_ptr) return K_ERR_NO_MEMORY;
-
-            prot_domain_map_region(aspace->prot_domain, aligned_start + off, (phys_addr_t)(uintptr_t)page_ptr, PAGE_SIZE, prot);
+            if (!page_ptr) { status = K_ERR_NO_MEMORY; goto fail; }
+            status = prot_domain_map_region(aspace->prot_domain, aligned_start + off, (phys_addr_t)(uintptr_t)page_ptr, PAGE_SIZE, prot);
+            if (status != K_OK) { pmm_free_page(page_ptr); goto fail; }
+            txn.pages[txn.page_count++] = (loader_page_t){.va = (uintptr_t)(aligned_start + off), .page = page_ptr};
         }
 
-        // Copy file data
         for (uint64_t off = 0; off < map_size; off += PAGE_SIZE) {
-             uintptr_t paddr = 0;
-             uint32_t out_prot = 0;
-             prot_domain_query_region(aspace->prot_domain, aligned_start + off, &paddr, &out_prot);
-             if (paddr) {
-                 void *kvirt = physmap_phys_to_virt(paddr);
-                 if (kvirt) {
-                     uint64_t page_va_start = aligned_start + off;
-                     uint64_t page_va_end = page_va_start + PAGE_SIZE;
-
-                     uint64_t copy_start = (start_addr > page_va_start) ? start_addr : page_va_start;
-                     uint64_t copy_end = (start_addr + seg->file_size < page_va_end) ? (start_addr + seg->file_size) : page_va_end;
-
-                     if (copy_start < copy_end) {
-                         size_t copy_len = copy_end - copy_start;
-                         size_t file_offset = copy_start - start_addr;
-                         mem_copy((uint8_t *)kvirt + (copy_start - page_va_start), (const uint8_t *)image->bytes + seg->file_offset + file_offset, copy_len);
-                     }
-                 }
-             }
+            uintptr_t paddr = 0;
+            uint32_t out_prot = 0;
+            status = prot_domain_query_region(aspace->prot_domain, aligned_start + off, &paddr, &out_prot);
+            if (status != K_OK || paddr == 0) { status = status != K_OK ? status : K_ERR_VM_UNMAPPED; goto fail; }
+            void *kvirt = physmap_phys_to_virt(paddr);
+            if (!kvirt) { status = K_ERR_VM_UNMAPPED; goto fail; }
+            uint64_t page_va_start = aligned_start + off;
+            uint64_t page_va_end = page_va_start + PAGE_SIZE;
+            uint64_t copy_start = (start_addr > page_va_start) ? start_addr : page_va_start;
+            uint64_t copy_end = (start_addr + seg->file_size < page_va_end) ? (start_addr + seg->file_size) : page_va_end;
+            if (copy_start < copy_end) {
+                size_t copy_len = copy_end - copy_start;
+                size_t file_offset = copy_start - start_addr;
+                mem_copy((uint8_t *)kvirt + (copy_start - page_va_start), (const uint8_t *)image->bytes + seg->file_offset + file_offset, copy_len);
+            }
         }
-
-        console_write_raw("[BOOTSTRAP] PT_LOAD mapped\n", 27);
     }
 
-    // 2. Allocate Stack
-    uintptr_t stack_top = (aspace->user_limit & ~(PAGE_SIZE - 1)); // e.g. 0x00007FFFFFFFF000
+    uintptr_t stack_top = (aspace->user_limit & ~(PAGE_SIZE - 1ULL));
     uintptr_t stack_base = stack_top - BH_USER_STACK_DEFAULT_SIZE;
     uintptr_t guard_base = stack_base - PAGE_SIZE;
-
     vm_region_t *stack_region;
-    kstatus_t kst = aspace_region_reserve(aspace, stack_base, BH_USER_STACK_DEFAULT_SIZE, VM_PROT_READ | VM_PROT_WRITE | VM_PROT_USER, VM_MAP_FIXED, VM_INHERIT_NONE, &stack_region);
-    if (kst != K_OK) return kst;
-
+    status = aspace_region_reserve(aspace, stack_base, BH_USER_STACK_DEFAULT_SIZE, VM_PROT_READ | VM_PROT_WRITE | VM_PROT_USER, VM_MAP_FIXED, VM_INHERIT_NONE, &stack_region);
+    if (status != K_OK) goto fail;
+    txn.regions[txn.region_count++] = stack_base;
     for (uint64_t off = 0; off < BH_USER_STACK_DEFAULT_SIZE; off += PAGE_SIZE) {
+        if (txn.page_count >= BH_LOADER_MAX_PAGES) { status = K_ERR_NO_RESOURCES; goto fail; }
         void *page_ptr = pmm_alloc_page_ex(MEM_NORMAL, PMM_ALLOC_ZERO);
-        if (!page_ptr) return K_ERR_NO_MEMORY;
-        prot_domain_map_region(aspace->prot_domain, stack_base + off, (phys_addr_t)(uintptr_t)page_ptr, PAGE_SIZE, VM_PROT_READ | VM_PROT_WRITE | VM_PROT_USER);
+        if (!page_ptr) { status = K_ERR_NO_MEMORY; goto fail; }
+        status = prot_domain_map_region(aspace->prot_domain, stack_base + off, (phys_addr_t)(uintptr_t)page_ptr, PAGE_SIZE, VM_PROT_READ | VM_PROT_WRITE | VM_PROT_USER);
+        if (status != K_OK) { pmm_free_page(page_ptr); goto fail; }
+        txn.pages[txn.page_count++] = (loader_page_t){.va = stack_base + off, .page = page_ptr};
     }
-    console_write_raw("[BOOTSTRAP] user stack created\n", 31);
 
-    // Guard page (unmapped) is implicitly created by skipping allocation at guard_base
-
-    // 3. Allocate and populate Startup Info page
     uintptr_t startup_va = guard_base - PAGE_SIZE;
-
     vm_region_t *startup_region;
-    kst = aspace_region_reserve(aspace, startup_va, PAGE_SIZE, VM_PROT_READ | VM_PROT_USER, VM_MAP_FIXED, VM_INHERIT_NONE, &startup_region);
-    if (kst != K_OK) return kst;
-
+    status = aspace_region_reserve(aspace, startup_va, PAGE_SIZE, VM_PROT_READ | VM_PROT_USER, VM_MAP_FIXED, VM_INHERIT_NONE, &startup_region);
+    if (status != K_OK) goto fail;
+    txn.regions[txn.region_count++] = startup_va;
     void *startup_phys = pmm_alloc_page_ex(MEM_NORMAL, PMM_ALLOC_ZERO);
-    if (!startup_phys) return K_ERR_NO_MEMORY;
-
+    if (!startup_phys) { status = K_ERR_NO_MEMORY; goto fail; }
     void *startup_kvirt = physmap_phys_to_virt((phys_addr_t)(uintptr_t)startup_phys);
+    if (!startup_kvirt) { pmm_free_page(startup_phys); status = K_ERR_VM_UNMAPPED; goto fail; }
     bharat_user_startup_t *startup = (bharat_user_startup_t *)startup_kvirt;
-
     startup->abi_version = 1;
     startup->struct_size = sizeof(bharat_user_startup_t);
     startup->argc = 0;
     startup->flags = 0;
     startup->argv = 0;
     startup->envp = 0;
-
-    // Hardcode some minimal multikernel info for now, as defined
     startup->bootstrap.abi_version = 1;
     startup->bootstrap.struct_size = sizeof(bharat_bootstrap_info_t);
-    startup->bootstrap.boot_session_id = 0x12345678; // A mock session ID
+    startup->bootstrap.boot_session_id = 0x12345678;
     startup->bootstrap.kernel_instance_id = 0;
     startup->bootstrap.home_core_id = hal_cpu_get_id();
     startup->bootstrap.available_kernel_mask = (1ULL << 0);
     startup->bootstrap.online_core_mask = (1ULL << hal_cpu_get_id());
-    // Caps will be populated later or seeded.
     startup->bootstrap.self_process_cap = 0;
     startup->bootstrap.bootstrap_cap = 0;
-
-    prot_domain_map_region(aspace->prot_domain, startup_va, (phys_addr_t)(uintptr_t)startup_phys, PAGE_SIZE, VM_PROT_READ | VM_PROT_USER);
-    console_write_raw("[BOOTSTRAP] bootstrap capabilities installed\n", 45);
+    status = prot_domain_map_region(aspace->prot_domain, startup_va, (phys_addr_t)(uintptr_t)startup_phys, PAGE_SIZE, VM_PROT_READ | VM_PROT_USER);
+    if (status != K_OK) { pmm_free_page(startup_phys); goto fail; }
+    txn.pages[txn.page_count++] = (loader_page_t){.va = startup_va, .page = startup_phys};
 
     out->entry_point = plan.entry_point;
     out->user_stack_top = stack_top;
     out->startup_va = startup_va;
     out->aspace = aspace;
-
     return K_OK;
+
+fail:
+    loader_txn_rollback(&txn);
+    *out = (bh_user_image_result_t){0};
+    return status;
 }

--- a/core/lib/elf/elf_load_plan.c
+++ b/core/lib/elf/elf_load_plan.c
@@ -17,6 +17,13 @@
 #define EM_AARCH64      183
 #define EM_RISCV        243
 
+static void plan_zero(void *ptr, size_t size) {
+    uint8_t *p = (uint8_t *)ptr;
+    for (size_t i = 0; i < size; ++i) {
+        p[i] = 0;
+    }
+}
+
 typedef struct {
     uint8_t   e_ident[EI_NIDENT];
     uint16_t  e_type;
@@ -34,7 +41,24 @@ typedef struct {
     uint16_t  e_shstrndx;
 } local_elf64_ehdr_t;
 
-int bh_elf_generate_load_plan(const uint8_t *bytes, size_t size, uint64_t user_base, uint64_t user_limit, bh_user_image_plan_v1_t *out_plan) {
+static bool machine_matches(uint16_t elf_machine, bh_elf_machine_t expected_machine) {
+    switch (expected_machine) {
+    case BH_ELF_MACHINE_X86_64:
+        return elf_machine == EM_X86_64;
+    case BH_ELF_MACHINE_AARCH64:
+        return elf_machine == EM_AARCH64;
+    case BH_ELF_MACHINE_RISCV64:
+        return elf_machine == EM_RISCV;
+    default:
+        return false;
+    }
+}
+
+int bh_elf_generate_load_plan_for_machine(const uint8_t *bytes, size_t size, uint64_t user_base, uint64_t user_limit, bh_elf_machine_t expected_machine, bh_user_image_plan_v1_t *out_plan) {
+    if (out_plan) {
+        plan_zero(out_plan, sizeof(*out_plan));
+    }
+
     if (!bytes || !out_plan) {
         return BH_ELF_PLAN_ERR_MALFORMED;
     }
@@ -54,8 +78,7 @@ int bh_elf_generate_load_plan(const uint8_t *bytes, size_t size, uint64_t user_b
         return BH_ELF_PLAN_ERR_MALFORMED;
     }
 
-    // Supported architectures: x86_64, ARM64, RISC-V
-    if (ehdr->e_machine != EM_X86_64 && ehdr->e_machine != EM_AARCH64 && ehdr->e_machine != EM_RISCV) {
+    if (!machine_matches(ehdr->e_machine, expected_machine)) {
         return BH_ELF_PLAN_ERR_UNSUPPORTED;
     }
 
@@ -117,7 +140,7 @@ int bh_elf_generate_load_plan(const uint8_t *bytes, size_t size, uint64_t user_b
         uint64_t v_start = seg->virtual_address;
         uint64_t v_end = v_start + seg->memory_size;
         if (v_end < v_start) {
-            return BH_ELF_PLAN_ERR_MALFORMED; // overflow
+            return BH_ELF_PLAN_ERR_BOUNDS;
         }
 
         if (v_start < user_base || v_end > user_limit) {
@@ -138,11 +161,14 @@ int bh_elf_generate_load_plan(const uint8_t *bytes, size_t size, uint64_t user_b
             }
         }
 
-        // Alignments
-        uint32_t prot = 4; // VM_PROT_USER
-        if (seg->flags & 4) prot |= 1; // VM_PROT_READ
-        if (seg->flags & 2) prot |= 2; // VM_PROT_WRITE
-        if (seg->flags & 1) prot |= 4; // VM_PROT_EXEC
+        if (seg->alignment > 1 && (seg->virtual_address % seg->alignment) != (seg->file_offset % seg->alignment)) {
+            return BH_ELF_PLAN_ERR_MALFORMED;
+        }
+
+        uint32_t prot = BH_ELF_PROT_USER;
+        if ((seg->flags & 4U) != 0U) prot |= BH_ELF_PROT_READ;
+        if ((seg->flags & 2U) != 0U) prot |= BH_ELF_PROT_WRITE;
+        if ((seg->flags & 1U) != 0U) prot |= BH_ELF_PROT_EXEC;
 
         out_plan->segments[i].virtual_address = seg->virtual_address;
         out_plan->segments[i].physical_address = seg->physical_address;
@@ -174,4 +200,8 @@ int bh_elf_generate_load_plan(const uint8_t *bytes, size_t size, uint64_t user_b
     }
 
     return BH_ELF_PLAN_SUCCESS;
+}
+
+int bh_elf_generate_load_plan(const uint8_t *bytes, size_t size, uint64_t user_base, uint64_t user_limit, bh_user_image_plan_v1_t *out_plan) {
+    return bh_elf_generate_load_plan_for_machine(bytes, size, user_base, user_limit, BH_ELF_MACHINE_X86_64, out_plan);
 }

--- a/interface/include/bharat/elf/elf_load_plan.h
+++ b/interface/include/bharat/elf/elf_load_plan.h
@@ -13,6 +13,17 @@
 #define BH_ELF_PLAN_ERR_UNSUPPORTED -6
 #define BH_ELF_PLAN_ERR_LIMIT -7
 
+#define BH_ELF_PROT_READ  (1U << 0)
+#define BH_ELF_PROT_WRITE (1U << 1)
+#define BH_ELF_PROT_EXEC  (1U << 2)
+#define BH_ELF_PROT_USER  (1U << 3)
+
+typedef enum {
+    BH_ELF_MACHINE_X86_64 = 0,
+    BH_ELF_MACHINE_AARCH64 = 1,
+    BH_ELF_MACHINE_RISCV64 = 2
+} bh_elf_machine_t;
+
 typedef struct {
     uint64_t virtual_address;
     uint64_t physical_address;
@@ -34,6 +45,7 @@ typedef struct {
     uint64_t startup_page_size;
 } bh_user_image_plan_v1_t;
 
+int bh_elf_generate_load_plan_for_machine(const uint8_t *bytes, size_t size, uint64_t user_base, uint64_t user_limit, bh_elf_machine_t expected_machine, bh_user_image_plan_v1_t *out_plan);
 int bh_elf_generate_load_plan(const uint8_t *bytes, size_t size, uint64_t user_base, uint64_t user_limit, bh_user_image_plan_v1_t *out_plan);
 
 #endif // BHARAT_ELF_LOAD_PLAN_H

--- a/quality/tests/host/process_vm/test_elf_load_plan.c
+++ b/quality/tests/host/process_vm/test_elf_load_plan.c
@@ -3,137 +3,72 @@
 #include <string.h>
 #include <bharat/elf/elf_load_plan.h>
 
-#define ELFCLASS64      2
-#define ELFDATA2LSB     1
-#define EV_CURRENT      1
-#define ET_EXEC         2
-#define ET_DYN          3
-#define EM_X86_64       62
+#define ELFCLASS64 2
+#define ELFCLASS32 1
+#define ELFDATA2LSB 1
+#define EV_CURRENT 1
+#define ET_EXEC 2
+#define ET_DYN 3
+#define EM_X86_64 62
+#define EM_AARCH64 183
+#define EM_RISCV 243
+#define PT_LOAD 1
+#define PF_X 1U
+#define PF_W 2U
+#define PF_R 4U
 
-typedef struct {
-    uint8_t   e_ident[16];
-    uint16_t  e_type;
-    uint16_t  e_machine;
-    uint32_t  e_version;
-    uint64_t  e_entry;
-    uint64_t  e_phoff;
-    uint64_t  e_shoff;
-    uint32_t  e_flags;
-    uint16_t  e_ehsize;
-    uint16_t  e_phentsize;
-    uint16_t  e_phnum;
-    uint16_t  e_shentsize;
-    uint16_t  e_shnum;
-    uint16_t  e_shstrndx;
-} mock_ehdr_t;
+typedef struct { uint8_t e_ident[16]; uint16_t e_type; uint16_t e_machine; uint32_t e_version; uint64_t e_entry; uint64_t e_phoff; uint64_t e_shoff; uint32_t e_flags; uint16_t e_ehsize; uint16_t e_phentsize; uint16_t e_phnum; uint16_t e_shentsize; uint16_t e_shnum; uint16_t e_shstrndx; } mock_ehdr_t;
+typedef struct { uint32_t p_type; uint32_t p_flags; uint64_t p_offset; uint64_t p_vaddr; uint64_t p_paddr; uint64_t p_filesz; uint64_t p_memsz; uint64_t p_align; } mock_phdr_t;
 
-typedef struct {
-    uint32_t  p_type;
-    uint32_t  p_flags;
-    uint64_t  p_offset;
-    uint64_t  p_vaddr;
-    uint64_t  p_paddr;
-    uint64_t  p_filesz;
-    uint64_t  p_memsz;
-    uint64_t  p_align;
-} mock_phdr_t;
-
-void setup_default_elf(uint8_t *buf, size_t buf_size, uint64_t entry, uint64_t vaddr, uint64_t filesz, uint64_t memsz, uint32_t flags) {
+static void setup_elf(uint8_t *buf, size_t buf_size, uint16_t machine, uint64_t entry, uint16_t phnum) {
     memset(buf, 0, buf_size);
-    mock_ehdr_t *ehdr = (mock_ehdr_t *)buf;
-    ehdr->e_ident[0] = 0x7f;
-    ehdr->e_ident[1] = 'E';
-    ehdr->e_ident[2] = 'L';
-    ehdr->e_ident[3] = 'F';
-    ehdr->e_ident[4] = ELFCLASS64;
-    ehdr->e_ident[5] = ELFDATA2LSB;
-    ehdr->e_ident[6] = EV_CURRENT;
-    ehdr->e_type = ET_EXEC;
-    ehdr->e_machine = EM_X86_64;
-    ehdr->e_version = EV_CURRENT;
-    ehdr->e_entry = entry;
-    ehdr->e_phoff = sizeof(mock_ehdr_t);
-    ehdr->e_ehsize = sizeof(mock_ehdr_t);
-    ehdr->e_phentsize = sizeof(mock_phdr_t);
-    ehdr->e_phnum = 1;
-
-    mock_phdr_t *phdr = (mock_phdr_t *)(buf + sizeof(mock_ehdr_t));
-    phdr->p_type = 1; // PT_LOAD
-    phdr->p_flags = flags;
-    phdr->p_offset = sizeof(mock_ehdr_t) + sizeof(mock_phdr_t);
-    phdr->p_vaddr = vaddr;
-    phdr->p_filesz = filesz;
-    phdr->p_memsz = memsz;
-    phdr->p_align = 1; // bypassed alignment modulo check
+    mock_ehdr_t *eh = (mock_ehdr_t *)buf;
+    eh->e_ident[0] = 0x7f; eh->e_ident[1] = 'E'; eh->e_ident[2] = 'L'; eh->e_ident[3] = 'F';
+    eh->e_ident[4] = ELFCLASS64; eh->e_ident[5] = ELFDATA2LSB; eh->e_ident[6] = EV_CURRENT;
+    eh->e_type = ET_EXEC; eh->e_machine = machine; eh->e_version = EV_CURRENT; eh->e_entry = entry;
+    eh->e_phoff = sizeof(mock_ehdr_t); eh->e_ehsize = sizeof(mock_ehdr_t); eh->e_phentsize = sizeof(mock_phdr_t); eh->e_phnum = phnum;
 }
 
-void test_load_plan_positive(void) {
-    uint8_t buf[1024];
-    setup_default_elf(buf, sizeof(buf), 0x1000, 0x1000, 128, 128, 5); // PF_X | PF_R (5)
-
-    bh_user_image_plan_v1_t plan;
-    int res = bh_elf_generate_load_plan(buf, sizeof(buf), 0x1000, 0x100000, &plan);
-    printf("Debug res: %d\n", res);
-    fflush(stdout);
-    assert(res == BH_ELF_PLAN_SUCCESS);
-    assert(plan.entry_point == 0x1000);
-    assert(plan.segment_count == 1);
-    assert(plan.segments[0].virtual_address == 0x1000);
-    assert(plan.segments[0].file_size == 128);
-    printf("test_load_plan_positive passed\n");
+static mock_phdr_t *phdr(uint8_t *buf, uint16_t idx) { return (mock_phdr_t *)(buf + sizeof(mock_ehdr_t) + idx * sizeof(mock_phdr_t)); }
+static void set_load(mock_phdr_t *ph, uint32_t flags, uint64_t off, uint64_t va, uint64_t filesz, uint64_t memsz, uint64_t align) {
+    ph->p_type = PT_LOAD; ph->p_flags = flags; ph->p_offset = off; ph->p_vaddr = va; ph->p_filesz = filesz; ph->p_memsz = memsz; ph->p_align = align;
+}
+static int gen(uint8_t *buf, size_t sz, bh_elf_machine_t m, bh_user_image_plan_v1_t *plan) {
+    return bh_elf_generate_load_plan_for_machine(buf, sz, 0x1000, 0x80000000ULL, m, plan);
 }
 
-void test_load_plan_wx_rejection(void) {
-    uint8_t buf[1024];
-    setup_default_elf(buf, sizeof(buf), 0x1000, 0x1000, 128, 128, 7); // PF_X | PF_W | PF_R (7) - W^X violation
-
-    bh_user_image_plan_v1_t plan;
-    int res = bh_elf_generate_load_plan(buf, sizeof(buf), 0x1000, 0x100000, &plan);
-    assert(res == BH_ELF_PLAN_ERR_WX);
-    printf("test_load_plan_wx_rejection passed\n");
+static void test_protections(void) {
+    uint8_t buf[4096]; bh_user_image_plan_v1_t plan;
+    setup_elf(buf, sizeof(buf), EM_X86_64, 0x1000, 1); set_load(phdr(buf,0), PF_R, 512, 0x1000, 16, 16, 1);
+    assert(gen(buf, sizeof(buf), BH_ELF_MACHINE_X86_64, &plan) == BH_ELF_PLAN_ERR_ENTRY);
+    setup_elf(buf, sizeof(buf), EM_X86_64, 0x1000, 2); set_load(phdr(buf,0), PF_R|PF_X, 512, 0x1000, 16, 16, 1); set_load(phdr(buf,1), PF_R|PF_W, 1024, 0x2000, 16, 16, 1);
+    assert(gen(buf, sizeof(buf), BH_ELF_MACHINE_X86_64, &plan) == BH_ELF_PLAN_SUCCESS);
+    assert(plan.segments[0].prot == (BH_ELF_PROT_USER|BH_ELF_PROT_READ|BH_ELF_PROT_EXEC));
+    assert((plan.segments[0].prot & BH_ELF_PROT_WRITE) == 0);
+    assert(plan.segments[1].prot == (BH_ELF_PROT_USER|BH_ELF_PROT_READ|BH_ELF_PROT_WRITE));
+    assert((plan.segments[1].prot & BH_ELF_PROT_EXEC) == 0);
+    setup_elf(buf, sizeof(buf), EM_X86_64, 0x1000, 1); set_load(phdr(buf,0), PF_R|PF_X|PF_W, 512, 0x1000, 16, 16, 1);
+    assert(gen(buf, sizeof(buf), BH_ELF_MACHINE_X86_64, &plan) == BH_ELF_PLAN_ERR_WX);
 }
 
-void test_load_plan_overlap(void) {
-    uint8_t buf[1024];
-    setup_default_elf(buf, sizeof(buf), 0x1000, 0x1000, 128, 128, 5);
-
-    // Add a second overlapping program header
-    mock_ehdr_t *ehdr = (mock_ehdr_t *)buf;
-    ehdr->e_phnum = 2;
-
-    mock_phdr_t *phdr2 = (mock_phdr_t *)(buf + sizeof(mock_ehdr_t) + sizeof(mock_phdr_t));
-    phdr2->p_type = 1; // PT_LOAD
-    phdr2->p_flags = 5;
-    phdr2->p_offset = sizeof(mock_ehdr_t) + 2 * sizeof(mock_phdr_t);
-    phdr2->p_vaddr = 0x1050; // Overlaps [0x1000, 0x1080)
-    phdr2->p_filesz = 128;
-    phdr2->p_memsz = 128;
-    phdr2->p_align = 1;
-
-    bh_user_image_plan_v1_t plan;
-    int res = bh_elf_generate_load_plan(buf, sizeof(buf), 0x1000, 0x100000, &plan);
-    assert(res == BH_ELF_PLAN_ERR_OVERLAP);
-    printf("test_load_plan_overlap passed\n");
+static void test_machine_matrix(void) {
+    uint8_t buf[2048]; bh_user_image_plan_v1_t plan;
+    const struct { uint16_t em; bh_elf_machine_t machine; } rows[] = {{EM_X86_64,BH_ELF_MACHINE_X86_64},{EM_AARCH64,BH_ELF_MACHINE_AARCH64},{EM_RISCV,BH_ELF_MACHINE_RISCV64}};
+    for (size_t i=0;i<3;i++) for (size_t j=0;j<3;j++) { setup_elf(buf,sizeof(buf),rows[i].em,0x1000,1); set_load(phdr(buf,0),PF_R|PF_X,512,0x1000,16,16,1); int r=gen(buf,sizeof(buf),rows[j].machine,&plan); assert((i==j && r==BH_ELF_PLAN_SUCCESS) || (i!=j && r==BH_ELF_PLAN_ERR_UNSUPPORTED)); }
+    setup_elf(buf,sizeof(buf),EM_X86_64,0x1000,1); ((mock_ehdr_t*)buf)->e_ident[4] = ELFCLASS32; set_load(phdr(buf,0),PF_R|PF_X,512,0x1000,16,16,1); assert(gen(buf,sizeof(buf),BH_ELF_MACHINE_X86_64,&plan) == BH_ELF_PLAN_ERR_MALFORMED);
 }
 
-void test_load_plan_out_of_bounds(void) {
-    uint8_t buf[1024];
-    setup_default_elf(buf, sizeof(buf), 0x1000, 0x1000, 128, 128, 5);
-
-    bh_user_image_plan_v1_t plan;
-    int res = bh_elf_generate_load_plan(buf, sizeof(buf), 0x500, 0x2000, &plan); // user_base is 0x500, entry is 0x1000 but segment goes up to 0x1000+128
-    assert(res == BH_ELF_PLAN_SUCCESS);
-
-    res = bh_elf_generate_load_plan(buf, sizeof(buf), 0x1500, 0x2000, &plan); // segment is 0x1000, outside user range
-    assert(res == BH_ELF_PLAN_ERR_BOUNDS);
-    printf("test_load_plan_out_of_bounds passed\n");
+static void test_bounds_and_malformed(void) {
+    uint8_t buf[4096]; bh_user_image_plan_v1_t plan;
+    setup_elf(buf,sizeof(buf),EM_X86_64,0x1000,1); set_load(phdr(buf,0),PF_R|PF_X,512,UINT64_MAX-8,16,16,1); assert(gen(buf,sizeof(buf),BH_ELF_MACHINE_X86_64,&plan)==BH_ELF_PLAN_ERR_BOUNDS);
+    setup_elf(buf,sizeof(buf),EM_X86_64,0x1000,1); set_load(phdr(buf,0),PF_R|PF_X,UINT64_MAX-8,0x1000,16,16,1); assert(gen(buf,sizeof(buf),BH_ELF_MACHINE_X86_64,&plan)!=BH_ELF_PLAN_SUCCESS);
+    setup_elf(buf,sizeof(buf),EM_X86_64,0x1000,1); set_load(phdr(buf,0),PF_R|PF_X,512,0x7ffffff0,32,32,1); assert(gen(buf,sizeof(buf),BH_ELF_MACHINE_X86_64,&plan)==BH_ELF_PLAN_ERR_BOUNDS);
+    setup_elf(buf,sizeof(buf),EM_X86_64,0x1000,0); assert(gen(buf,sizeof(buf),BH_ELF_MACHINE_X86_64,&plan)==BH_ELF_PLAN_ERR_MALFORMED);
+    setup_elf(buf,sizeof(buf),EM_X86_64,0x1000,17); for(int i=0;i<17;i++) set_load(phdr(buf,i),PF_R|PF_X,1024+i*16,0x1000+i*0x1000,8,8,1); assert(gen(buf,sizeof(buf),BH_ELF_MACHINE_X86_64,&plan)==BH_ELF_PLAN_ERR_LIMIT);
+    setup_elf(buf,sizeof(buf),EM_X86_64,0x3000,1); set_load(phdr(buf,0),PF_R|PF_X,512,0x1000,16,16,1); assert(gen(buf,sizeof(buf),BH_ELF_MACHINE_X86_64,&plan)==BH_ELF_PLAN_ERR_ENTRY);
+    setup_elf(buf,sizeof(buf),EM_X86_64,0x1000,2); set_load(phdr(buf,0),PF_R|PF_X,512,0x1000,16,128,1); set_load(phdr(buf,1),PF_R,1024,0x1070,16,16,1); assert(gen(buf,sizeof(buf),BH_ELF_MACHINE_X86_64,&plan)==BH_ELF_PLAN_ERR_OVERLAP);
+    setup_elf(buf,sizeof(buf),EM_X86_64,0x1000,1); set_load(phdr(buf,0),PF_R|PF_X,513,0x1000,16,16,4096); assert(gen(buf,sizeof(buf),BH_ELF_MACHINE_X86_64,&plan)==BH_ELF_PLAN_ERR_MALFORMED);
+    setup_elf(buf,sizeof(buf),EM_X86_64,0x1000,1); ((mock_ehdr_t*)buf)->e_phoff = sizeof(buf) - 8; set_load(phdr(buf,0),PF_R|PF_X,512,0x1000,16,16,1); assert(gen(buf,sizeof(buf),BH_ELF_MACHINE_X86_64,&plan)!=BH_ELF_PLAN_SUCCESS);
 }
 
-int main(void) {
-    test_load_plan_positive();
-    test_load_plan_wx_rejection();
-    test_load_plan_overlap();
-    test_load_plan_out_of_bounds();
-    printf("All ELF load plan tests passed!\n");
-    return 0;
-}
+int main(void) { test_protections(); test_machine_matrix(); test_bounds_and_malformed(); puts("All ELF load plan tests passed"); return 0; }


### PR DESCRIPTION
### Motivation

- Fix incorrect protection-bit construction and layering violation where the ELF library emitted kernel-private `VM_PROT_*` numeric values (user bit was wrong). 
- Make the user ELF load path fail-closed and atomic so partial loads cannot leak reserved regions, mapped pages, or allocated PMM pages. 
- Enforce that the kernel only accepts ELF images for the running architecture and explicitly reject unsupported 32-bit/PIE images. 

### Description

- Introduced ELF-plan protection flags and machine enum in `interface/include/bharat/elf/elf_load_plan.h` (`BH_ELF_PROT_*`, `bh_elf_machine_t`) and added `bh_elf_generate_load_plan_for_machine()` to zero the output plan before parsing. 
- Reworked `core/lib/elf/elf_load_plan.c` to emit only `BH_ELF_PROT_*` bits, validate alignments/bounds/overlap/W^X, require entry validation, and require an expected machine match rather than accepting any supported machine. 
- Added a kernel-local translator `elf_plan_prot_to_vm()` and an expected-machine selector in `core/kernel/src/process/user_image_loader.c`, translating plan protections to `VM_PROT_*` with explicit checks for unknown bits, missing user bit, and W+X. 
- Hardened `bh_user_image_load()` with a bounded loader transaction (`loader_txn_t`) that records reserved regions and mapped pages, checks every map/query/allocation result, performs reverse-order rollback on failure using `prot_domain_unmap_region`, `pmm_free_page`, and `aspace_region_detach`, and only publishes `out` after full success. 
- Added/updated host tests `quality/tests/host/process_vm/test_elf_load_plan.c` to cover protection bit construction, machine acceptance matrix, bounds/overflow cases, alignment/truncation, segment-count limit, overlap, and W^X rejection. 

### Testing

- Ran the newly extended host unit tests by compiling with sanitizers and executing the binary via: `cc -std=c11 -Wall -Wextra -Werror -fsanitize=address,undefined -Iinterface/include quality/tests/host/process_vm/test_elf_load_plan.c core/lib/elf/elf_load_plan.c core/lib/elf/elf_parser.c -o /tmp/test_elf_load_plan && /tmp/test_elf_load_plan`; result: PASS ("All ELF load plan tests passed").
- Attempted CMake-based host test build with `-DBHARAT_BUILD_HOST_TESTS=ON`; result: BLOCKED due to duplicate `test_servicemgr` target name in upstream host test CMake which prevented the configured host-test build from running. 
- Performed cross-target smoke builds with `./tools/build.sh all --target-yaml <target>` for x86_64/arm64/riscv64/arm32/riscv32; builds and packaging completed for those targets, but smoke QEMU runs were BLOCKED by missing QEMU runner binaries (`qemu-system-x86_64`, `qemu-system-aarch64`, `qemu-system-riscv64`, `qemu-system-arm`, `qemu-system-riscv32`) in the environment. 
- Ran repository linters and contract checks: `python3 tools/lint/check_layer_references.py` (reported existing layer-reference violations — FAIL/needs separate remediation), `python3 tools/lint/check_cmake_dependencies.py` (reported existing CMake dependency violations — FAIL), and `python3 tools/abi/syscall_abi.py --check` (reported unrelated dummy raw-syscall numbers present in other host tests — FAIL).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7303011e7083209fbe8e9ec94366ed)