### PR TITLE
Fail-closed packaging: require compiled init/rt-supervisor payload before emitting init_module.bin

### DIFF
--- a/docs/architecture/core/build-packaging-run-flash-debug-contract.md
+++ b/docs/architecture/core/build-packaging-run-flash-debug-contract.md
@@ -22,6 +22,7 @@ The build-to-run pipeline enforces rigid boundaries between systems:
 
 - **Build (`tools/build/build_executor.py`)**: Responsible only for invoking CMake and producing canonical artifacts (like `kernel.elf`). It has no knowledge of how to format binaries for specific emulators or flashers.
 - **Package (`tools/package/packager.py`)**: Derives target-specific artifacts (like `raw_bin` or `flash_image`) from canonical build outputs through registered transforms. It creates deterministic execution plans.
+  The package step is fail-closed for the first boot service module: it must find a compiled `core/services/init` payload for general-purpose targets or `core/services/rt-supervisor` for RT MPU-only targets before emitting `init_module.bin`; it exits non-zero instead of fabricating a mock module when that produced artifact is missing.
 - **Run (`tools/run/`)**: Consumes a resolved, packaged run manifest. It does not parse original YAML targets or read from the build directory. It expects fully formed paths to packaged run artifacts.
 - **Flash/Debug (`tools/flash/`, `tools/debug/`)**: Consumes resolved, packaged manifests to communicate with external hardware or debugger stubs.
 

--- a/quality/tests/tools/test_packager.py
+++ b/quality/tests/tools/test_packager.py
@@ -2,7 +2,17 @@ from pathlib import Path
 
 import pytest
 
-from tools.package.packager import FDT_MAGIC, _compact_qemu_dtb
+from tools.build.models import (
+    BootConfig,
+    BuildConfig,
+    BuildOutputs,
+    DtbConfig,
+    KernelConfig,
+    PackageConfig,
+    PackagePlan,
+    ResolvedTarget,
+)
+from tools.package.packager import FDT_MAGIC, _compact_qemu_dtb, _find_required_service_binary, execute_package
 
 
 def _dtb_bytes(total_size: int, padded_size: int) -> bytes:
@@ -40,3 +50,48 @@ def test_compact_qemu_dtb_rejects_invalid_blob(tmp_path: Path, contents: bytes) 
 
     with pytest.raises(RuntimeError, match="DTB"):
         _compact_qemu_dtb(dtb)
+
+
+def test_packager_rejects_missing_required_service_payload(tmp_path: Path) -> None:
+    with pytest.raises(RuntimeError, match="Required compiled payload 'services/init'.*synthetic boot module"):
+        _find_required_service_binary(tmp_path, "init")
+
+
+def test_packager_finds_required_service_payload(tmp_path: Path) -> None:
+    payload = tmp_path / "core" / "services" / "core" / "init" / "init"
+    payload.parent.mkdir(parents=True)
+    payload.write_bytes(b"compiled-init")
+
+    assert _find_required_service_binary(tmp_path, "init") == payload
+
+
+def _minimal_package_plan(tmp_path: Path) -> PackagePlan:
+    target = ResolvedTarget(
+        name="unit_target",
+        kind="qemu_target",
+        arch="x86_64",
+        board="qemu",
+        device_profile="desktop",
+        personality_profile="headless",
+        execution_profile="gp",
+        build=BuildConfig(cmake_preset="unit", cmake_defs={}),
+        kernel=KernelConfig(canonical_elf="kernel.elf"),
+        boot=BootConfig(protocol="multiboot2", artifact_format="elf", dtb=DtbConfig(mode="qemu_generated", required=False)),
+        package=PackageConfig(transforms=[]),
+    )
+    return PackagePlan(
+        target=target,
+        build_outputs=BuildOutputs(target=target, build_dir=tmp_path / "build"),
+        packaged_dir=tmp_path / "pkg",
+        manifest_dir=tmp_path / "manifests",
+    )
+
+
+def test_execute_package_fails_closed_without_required_service_payload(tmp_path: Path) -> None:
+    plan = _minimal_package_plan(tmp_path)
+    plan.build_outputs.build_dir.mkdir()
+
+    with pytest.raises(RuntimeError, match="Required compiled payload 'services/init'.*synthetic boot module"):
+        execute_package(plan, tmp_path)
+
+    assert not (plan.packaged_dir / "init_module.bin").exists()

--- a/tools/package/packager.py
+++ b/tools/package/packager.py
@@ -61,6 +61,30 @@ def make_package_plan(target: ResolvedTarget, build_outputs: BuildOutputs, repo_
     )
 
 
+def _candidate_service_binary_paths(build_dir: Path, binary_name: str) -> list[Path]:
+    return [
+        build_dir / "core" / "services" / "core" / binary_name / binary_name,
+        build_dir / "services" / "core" / binary_name / binary_name,
+        build_dir / "core" / "services" / binary_name / binary_name,
+        build_dir / "services" / binary_name / binary_name,
+    ]
+
+
+def _find_required_service_binary(build_dir: Path, binary_name: str) -> Path:
+    for path in _candidate_service_binary_paths(build_dir, binary_name):
+        if path.is_file():
+            return path
+        exe_path = path.with_suffix(".exe")
+        if exe_path.is_file():
+            return exe_path
+
+    candidates = ", ".join(str(path) for path in _candidate_service_binary_paths(build_dir, binary_name))
+    raise RuntimeError(
+        f"Required compiled payload 'services/{binary_name}' was not produced; "
+        f"refusing to package a synthetic boot module. Checked: {candidates}"
+    )
+
+
 def execute_package(plan: PackagePlan, repo_root: Path) -> PackageOutputs:
     print(f"\n[Package] Starting packaging for {plan.target.name}")
 
@@ -111,38 +135,18 @@ def execute_package(plan: PackagePlan, repo_root: Path) -> PackageOutputs:
     # -------------------------------------------------------------
     # Packaging of init_module (services/init or services/rt-supervisor)
     # -------------------------------------------------------------
-    import shutil
     import struct
 
     is_rt_mpu = (plan.target.execution_profile == "rt" and
                  plan.target.build.cmake_defs.get("BHARAT_PROFILE_MPU_ONLY") == "ON")
 
     binary_name = "rt-supervisor" if is_rt_mpu else "init"
-    possible_paths = [
-        plan.build_outputs.build_dir / "core" / "services" / "core" / binary_name / binary_name,
-        plan.build_outputs.build_dir / "services" / "core" / binary_name / binary_name,
-        plan.build_outputs.build_dir / "core" / "services" / binary_name / binary_name,
-        plan.build_outputs.build_dir / "services" / binary_name / binary_name,
-    ]
-
-    src_binary = None
-    for p in possible_paths:
-        if p.exists():
-            src_binary = p
-            break
-        p_exe = p.with_suffix(".exe")
-        if p_exe.exists():
-            src_binary = p_exe
-            break
+    src_binary = _find_required_service_binary(plan.build_outputs.build_dir, binary_name)
 
     init_module_path = plan.packaged_dir / "init_module.bin"
 
-    if src_binary and src_binary.exists():
-        payload_bytes = src_binary.read_bytes()
-        print(f"[Package] Found compiled payload for '{binary_name}' at {src_binary} ({len(payload_bytes)} bytes)")
-    else:
-        print(f"[Package] WARNING: Compiled payload '{binary_name}' not found. Generating simulated mock payload...")
-        payload_bytes = b"MOCK_PAYLOAD_" + binary_name.encode()
+    payload_bytes = src_binary.read_bytes()
+    print(f"[Package] Found compiled payload for 'services/{binary_name}' at {src_binary} ({len(payload_bytes)} bytes)")
 
     # Create the versioned Bharat boot-module container header:
     magic = 0xB4A2D1A5


### PR DESCRIPTION
### Motivation
- Prevent tooling from fabricating apparently valid boot evidence by removing the mock init payload fallback in the packager. 
- Deliver a minimal, tool-layer P0 fix that is confined to packaging/test tooling and does not change kernel ABI, scheduler, or boot protocols.

### Description
- Add service-payload discovery helpers to `tools/package/packager.py` and make packaging fail non-zero when a compiled `services/init` or `services/rt-supervisor` binary is not found instead of generating a synthetic payload. 
- Remove the synthetic/mock payload fallback and always package the produced binary into `init_module.bin` when present. 
- Add focused host tests `quality/tests/tools/test_packager.py` that verify missing-payload failure, successful discovery, and that `execute_package()` does not emit `init_module.bin` when the payload is absent. 
- Update documentation in `docs/architecture/core/build-packaging-run-flash-debug-contract.md` to record that the package step is fail-closed for the first boot service module.

### Testing
- `PYTHONPATH=. pytest -q quality/tests/tools/test_packager.py` — PASS (7 passed). 
- `python3 tools/lint/check_layer_references.py` — PASS (scan completed; reported 122 pre-existing layer-reference violations). 
- `python3 tools/lint/check_cmake_dependencies.py` — PASS (scan completed; reported 4 pre-existing dependency violations). 
- Per-target smoke builds: `./tools/build.sh all --target-yaml delivery/targets/qemu/<target>.yaml --smoke` — build and package phases completed for all five required targets (`x86_64_desktop_headless`, `arm64_desktop_headless`, `riscv64_desktop_headless`, `arm32_mmu_lite_headless`, `riscv32_mmu_lite_headless`), and the packager exercised the new fail-closed behavior (packaged `init_module.bin` when compiled payloads were present), but the runtime/smoke steps were BLOCKED by missing QEMU executables on the runner (examples: `qemu-system-x86_64`, `qemu-system-aarch64`, `qemu-system-riscv64`, `qemu-system-arm`, `qemu-system-riscv32`). 
- `python3 tools/run_qemu_matrix.py --help` — PASS; `python3 tools/run_qemu_matrix.py --headless --smoke` — BLOCKED/partial evidence: runner produced partial results but could not complete full-matrix smoke runs due to missing QEMU binaries and lack of `--all-arch` support on the runner.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7309d325008320ad63f7163938a4e3)