### PR TITLE
Gate 1B: Fail-closed on missing init (remove kernel-synthesized USER_INIT markers)

### DIFF
--- a/core/kernel/src/init/init_bootstrap.c
+++ b/core/kernel/src/init/init_bootstrap.c
@@ -186,20 +186,13 @@ static int bootstrap_launch_first_service(void) {
 
     if (!init_mod) {
         /*
-         * QEMU smoke packaging can supply the init payload through a runner
-         * path that is not yet reflected in the normalized boot module table.
-         * Keep the lifecycle deterministic: emit the same minimal boot evidence
-         * markers and leave real user scheduling to targets with module handoff.
+         * Userspace init markers are userspace-originated proof and must never be
+         * synthesized by the kernel.  An empty canonical module table means
+         * the trusted boot handoff did not provide services/init, so fail
+         * closed instead of fabricating lifecycle success.
          */
-        console_write_raw("[BOOTSTRAP] INIT_MODULE: services/init FOUND\n", 45);
-        console_write_raw("[BOOTSTRAP] INIT_ASPACE: READY\n", 31);
-        console_write_raw("[BOOTSTRAP] INIT_ELF: VALIDATED\n", 31);
-        console_write_raw("[BOOTSTRAP] INIT_THREAD: SCHEDULED\n", 34);
-        console_write_raw("USER_INIT: ENTERED\n", 19);
-        console_write_raw("USER_INIT: STARTUP_ABI_OK\n", 27);
-        console_write_raw("USER_INIT: SERVICE_GRAPH_COMPLETE\n", 34);
-        console_write_raw("BOOT_RUNTIME: STABLE\n", 21);
-        return 0;
+        console_write_raw("BOOT_FAIL: INIT_MODULE_MISSING\n", 31);
+        return -1;
     }
 
     console_write_raw("[BOOTSTRAP] INIT_MODULE: services/init FOUND\n", 45);

--- a/core/kernel/src/kernel_boot.c
+++ b/core/kernel/src/kernel_boot.c
@@ -207,23 +207,13 @@ void boot_common_memory(const boot_info_t *boot) {
 
 #if (defined(__arm__) && !defined(__aarch64__)) || (defined(__riscv) && (__riscv_xlen == 32))
     /*
-     * ARM32 MMU-Lite QEMU smoke currently validates the boot lifecycle up to
-     * PMM readiness while the full VMM path is still being hardened for the
-     * 32-bit backend.  Emit the stable headless evidence contract here so the
-     * runner can prove the target reaches the supported P0 readiness point
-     * without depending on slow or unsupported VMM work.
+     * ARM32/RISC-V32 MMU-Lite still stops before the full VMM/init-loader
+     * path.  Do not synthesize userspace success from the kernel; report the
+     * missing canonical init handoff as a hard boot failure until Gate 2 wires
+     * the live module parser for these paths.
      */
-    KPRINT("[BOOTSTRAP] INIT_MODULE: services/init FOUND\n");
-    KPRINT("[BOOTSTRAP] INIT_ASPACE: READY\n");
-    KPRINT("[BOOTSTRAP] INIT_ELF: VALIDATED\n");
-    KPRINT("[BOOTSTRAP] INIT_THREAD: SCHEDULED\n");
-    KPRINT("USER_INIT: ENTERED\n");
-    KPRINT("USER_INIT: STARTUP_ABI_OK\n");
-    KPRINT("USER_INIT: SERVICE_GRAPH_COMPLETE\n");
-    KPRINT("BOOT_RUNTIME: STABLE\n");
-    while (1) {
-        hal_cpu_halt();
-    }
+    KPRINT("BOOT_FAIL: INIT_MODULE_MISSING\n");
+    kernel_panic("bootstrap: init module missing before userspace launch");
 #endif
 
     // Ensure hal_pt is initialized BEFORE VMM tries to map things / create address space

--- a/quality/contracts/boot/headless_boot_contract.yaml
+++ b/quality/contracts/boot/headless_boot_contract.yaml
@@ -13,6 +13,7 @@ common:
     - "TIMEOUT"
     - "QEMU TIMEOUT"
     - "BOOT TIMEOUT"
+    - "BOOT_FAIL:"
 
 targets:
   x86_64_desktop_headless:

--- a/quality/tests/boot/test_kernel_boot_markers.py
+++ b/quality/tests/boot/test_kernel_boot_markers.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+KERNEL_MARKER_SOURCES = [
+    REPO_ROOT / "core/kernel/src/init/init_bootstrap.c",
+    REPO_ROOT / "core/kernel/src/kernel_boot.c",
+]
+
+
+def test_kernel_does_not_synthesize_userspace_success_markers():
+    forbidden = ["USER_INIT:", "BOOT_RUNTIME: STABLE"]
+    offenders = []
+    for path in KERNEL_MARKER_SOURCES:
+        text = path.read_text()
+        for marker in forbidden:
+            if marker in text:
+                offenders.append(f"{path.relative_to(REPO_ROOT)} contains {marker}")
+    assert offenders == []
+
+
+def test_missing_init_module_is_hard_failure_marker():
+    bootstrap = (REPO_ROOT / "core/kernel/src/init/init_bootstrap.c").read_text()
+    kernel_boot = (REPO_ROOT / "core/kernel/src/kernel_boot.c").read_text()
+    assert "BOOT_FAIL: INIT_MODULE_MISSING" in bootstrap
+    assert "BOOT_FAIL: INIT_MODULE_MISSING" in kernel_boot


### PR DESCRIPTION
### Motivation

- Enforce Gate 1B from the boot qualification triage by preventing the kernel from synthesizing userspace success evidence when the canonical `services/init` module is absent and instead fail closed with a hard boot-failure marker.
- Prepare a clean foundation for subsequent Gate 1C/2 work (boot nonce proof and canonical module handoff) by making the boot evidence contract truthful and machine-verifiable.

### Description

- Replace the kernel fallback that emitted `USER_INIT:*`/`BOOT_RUNTIME: STABLE` when no `services/init` module was found with a hard failure that writes `BOOT_FAIL: INIT_MODULE_MISSING` and returns failure in `core/kernel/src/init/init_bootstrap.c`.
- Replace the ARM32/RISC-V32 early synthetic success sequence in `core/kernel/src/kernel_boot.c` with the same `BOOT_FAIL: INIT_MODULE_MISSING` + `kernel_panic` behavior so the kernel does not fabricate userspace success on those paths.
- Update the headless boot contract at `quality/contracts/boot/headless_boot_contract.yaml` to treat any `BOOT_FAIL:` marker as forbidden evidence.
- Add a regression test `quality/tests/boot/test_kernel_boot_markers.py` that asserts kernel sources do not contain `USER_INIT:` / `BOOT_RUNTIME: STABLE` and assert presence of the `BOOT_FAIL: INIT_MODULE_MISSING` marker in the kernel code.

### Testing

- Ran the unit/regression tests with `python3 -m pytest quality/tests/boot/test_kernel_boot_markers.py quality/tests/tools/test_check_boot_log.py` and they passed (`8 passed`).
- Ran repository linters and contract checks with `python3 tools/lint/check_layer_references.py && python3 tools/lint/check_cmake_dependencies.py && python3 tools/abi/syscall_abi.py --check` and the command failed due to existing repository violations (layer/CMake/call-site issues and raw syscall-number test artifacts), so the static/contract gate is `FAIL` for this run.
- Executed the five-target build/package smoke sequence (`./tools/build.sh all --target-yaml delivery/targets/qemu/<target>.yaml --smoke` for the required targets) and observed that builds and packaging completed for targets but the smoke runtime step was `BLOCKED` by missing QEMU binaries (e.g. `qemu-system-x86_64`, `qemu-system-aarch64`, `qemu-system-riscv64`, `qemu-system-arm`, `qemu-system-riscv32`), so the headless smoke verification is blocked rather than passing.
- Ran the matrix runner checks: `python3 tools/run_qemu_matrix.py --help` succeeded, while `python3 tools/run_qemu_matrix.py --headless --smoke` was `BLOCKED`/interrupted due to the same missing QEMU executables and the runner not supporting `--all-arch` in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a730cf511748320805b95d6ae86daf3)