### PR TITLE
x86_64: Fix GDT / userspace entry, enable NX, and propagate user bit through page-table walk

### DIFF
--- a/core/arch/hal/x86/x86_64/hal_cpu.c
+++ b/core/arch/hal/x86/x86_64/hal_cpu.c
@@ -357,6 +357,23 @@ static inline void ioapic_write(uint8_t offset, uint32_t val) {
 }
 
 // --- GDT Definitions (TSS requires it) ---
+#define X86_GDT_KERNEL_CODE_INDEX 1
+#define X86_GDT_KERNEL_DATA_INDEX 2
+#define X86_GDT_USER_DATA_INDEX 3
+#define X86_GDT_USER_CODE_INDEX 4
+#define X86_GDT_TSS_INDEX 5
+
+#define X86_GDT_ACCESS_KERNEL_CODE 0x9AU
+#define X86_GDT_ACCESS_KERNEL_DATA 0x92U
+#define X86_GDT_ACCESS_USER_DATA 0xF2U
+#define X86_GDT_ACCESS_USER_CODE 0xFAU
+#define X86_GDT_ACCESS_TSS_AVAILABLE 0x89U
+
+#define X86_GDT_GRANULARITY_CODE64 0xAU
+#define X86_GDT_GRANULARITY_DATA 0xCU
+
+#define X86_GDT_TSS_SELECTOR (X86_GDT_TSS_INDEX << 3)
+
 static uint64_t g_gdt[8];
 static struct {
   uint16_t limit;
@@ -364,8 +381,7 @@ static struct {
 } __attribute__((packed)) g_gdtr;
 
 static void gdt_set_descriptor(int index, uint64_t base, uint32_t limit,
-                               uint8_t access, uint8_t gran)
-    __attribute__((unused));
+                               uint8_t access, uint8_t gran);
 static void gdt_set_descriptor(int index, uint64_t base, uint32_t limit,
                                uint8_t access, uint8_t gran) {
   if (index < 0 || index >= 8)
@@ -403,10 +419,15 @@ void hal_init(void) {
     core_id = 0; // Safeguard
 
   g_gdt[0] = 0;
-  g_gdt[1] = 0x00af9a000000ffff; // KCode (0x08)
-  g_gdt[2] = 0x00af92000000ffff; // KData (0x10)
-  g_gdt[3] = 0x00aff2000000ffff; // UData (0x18)
-  g_gdt[4] = 0x00affa000000ffff; // UCode (0x20)
+  gdt_set_descriptor(X86_GDT_KERNEL_CODE_INDEX, 0, 0xFFFFFU,
+                     X86_GDT_ACCESS_KERNEL_CODE,
+                     X86_GDT_GRANULARITY_CODE64);
+  gdt_set_descriptor(X86_GDT_KERNEL_DATA_INDEX, 0, 0xFFFFFU,
+                     X86_GDT_ACCESS_KERNEL_DATA, X86_GDT_GRANULARITY_DATA);
+  gdt_set_descriptor(X86_GDT_USER_DATA_INDEX, 0, 0xFFFFFU,
+                     X86_GDT_ACCESS_USER_DATA, X86_GDT_GRANULARITY_DATA);
+  gdt_set_descriptor(X86_GDT_USER_CODE_INDEX, 0, 0xFFFFFU,
+                     X86_GDT_ACCESS_USER_CODE, X86_GDT_GRANULARITY_CODE64);
 
   tss_entry_t *tss = &g_tss[core_id];
   tss->rsp0 = (uint64_t)g_per_core_stacks[core_id] + 16384;
@@ -414,7 +435,9 @@ void hal_init(void) {
   tss->iopb_offset = sizeof(tss_entry_t);
 
   uint64_t tss_base = (uint64_t)tss;
-  gdt_set_system_descriptor(5, tss_base, sizeof(tss_entry_t) - 1, 0x89);
+  gdt_set_system_descriptor(X86_GDT_TSS_INDEX, tss_base,
+                            sizeof(tss_entry_t) - 1,
+                            X86_GDT_ACCESS_TSS_AVAILABLE);
 
   g_gdtr.base = (uint64_t)&g_gdt[0];
   g_gdtr.limit = sizeof(g_gdt) - 1;
@@ -423,7 +446,7 @@ void hal_init(void) {
   __asm__ volatile("lgdt %0" : : "m"(g_gdtr));
 
   console_write_raw("H2\n", 3);
-  __asm__ volatile("ltr %w0" : : "r"(0x28));
+  __asm__ volatile("ltr %w0" : : "r"(X86_GDT_TSS_SELECTOR));
 
   console_write_raw("H3\n", 3);
 

--- a/core/arch/hal/x86/x86_64/hal_pt_x86_64.c
+++ b/core/arch/hal/x86/x86_64/hal_pt_x86_64.c
@@ -186,6 +186,9 @@ static int x86_pt_walk(phys_addr_t root_pt, virt_addr_t vaddr, bool create, uint
         pt_t* pdp_ptr = (pt_t*)x86_phys_to_virt(new_pdp);
         for(int i=0; i<512; i++) pdp_ptr->entries[i] = 0;
         pml4->entries[pml4_idx] = new_pdp | dir_flags;
+    } else if (create && (alloc_flags & HAL_PT_FLAG_USER)) {
+        /* User access requires U/S at every level, including shared roots. */
+        pml4->entries[pml4_idx] |= X86_PT_USER;
     }
 
     phys_addr_t pdp_pa = pml4->entries[pml4_idx] & X86_PAGE_MASK;
@@ -202,6 +205,9 @@ static int x86_pt_walk(phys_addr_t root_pt, virt_addr_t vaddr, bool create, uint
         pt_t* pd_ptr = (pt_t*)x86_phys_to_virt(new_pd);
         for(int i=0; i<512; i++) pd_ptr->entries[i] = 0;
         pdp->entries[pdp_idx] = new_pd | dir_flags;
+    } else if (create && (alloc_flags & HAL_PT_FLAG_USER) &&
+               !(pdp->entries[pdp_idx] & X86_PT_HUGE)) {
+        pdp->entries[pdp_idx] |= X86_PT_USER;
     } else if (pdp->entries[pdp_idx] & X86_PT_HUGE) {
         // 1GB huge page (not fully supported by map_4k, just report)
         out_result->present = true;
@@ -229,6 +235,9 @@ static int x86_pt_walk(phys_addr_t root_pt, virt_addr_t vaddr, bool create, uint
         pt_t* pt_ptr = (pt_t*)x86_phys_to_virt(new_pt);
         for(int i=0; i<512; i++) pt_ptr->entries[i] = 0;
         pd->entries[pd_idx] = new_pt | dir_flags;
+    } else if (create && (alloc_flags & HAL_PT_FLAG_USER) &&
+               !(pd->entries[pd_idx] & X86_PT_HUGE)) {
+        pd->entries[pd_idx] |= X86_PT_USER;
     } else if (pd->entries[pd_idx] & X86_PT_HUGE) {
         // 2MB huge page
         if (create && !(alloc_flags & HAL_PT_FLAG_LARGE_2M)) {

--- a/core/arch/x86/x86_64/boot/boot.S
+++ b/core/arch/x86/x86_64/boot/boot.S
@@ -18,6 +18,7 @@
 #define CR0_PG       (1 << 31)
 #define EFER_MSR     0xC0000080
 #define EFER_LME     (1 << 8)
+#define EFER_NXE     (1 << 11)
 #define PAGE_P       1
 #define PAGE_RW      2
 #define PAGE_PS      (1 << 7)   /* large (2 MiB) page */
@@ -171,10 +172,10 @@ _start:
     orl  $(CR4_PAE | (1 << 9) | (1 << 10)), %eax
     movl %eax,  %cr4
 
-    /* Set EFER.LME */
+    /* Enable long mode and NX before installing any NX-marked mappings. */
     movl $EFER_MSR, %ecx
     rdmsr
-    orl  $EFER_LME, %eax
+    orl  $(EFER_LME | EFER_NXE), %eax
     wrmsr
 
     /* Enable paging → activates long mode */

--- a/core/arch/x86/x86_64/kernel/cpu_local.c
+++ b/core/arch/x86/x86_64/kernel/cpu_local.c
@@ -10,6 +10,7 @@
 #define EFER_SCE         0x00000001
 
 extern void x86_64_syscall_entry(void);
+void x86_64_init_syscall(void);
 
 void arch_cpu_local_set(cpu_local_t *cl) {
     if (!cl) return;
@@ -22,6 +23,9 @@ void arch_cpu_local_set(cpu_local_t *cl) {
 
     __asm__ volatile("wrmsr" : : "a"(low), "d"(high), "c"(MSR_GS_BASE));
     __asm__ volatile("wrmsr" : : "a"(low), "d"(high), "c"(MSR_KERNEL_GS_BASE));
+
+    /* SYSCALL MSRs are core-local and must follow each core's GS setup. */
+    x86_64_init_syscall();
 }
 
 void x86_64_init_syscall(void) {

--- a/core/arch/x86/x86_64/user_entry.c
+++ b/core/arch/x86/x86_64/user_entry.c
@@ -5,6 +5,12 @@
 #include "sched/sched.h"
 #include "mm/physmap.h"
 
+#define X86_USER_DATA_SELECTOR 0x1B
+#define X86_USER_CODE_SELECTOR 0x23
+
+#define X86_STRINGIFY_INNER(value) #value
+#define X86_STRINGIFY(value) X86_STRINGIFY_INNER(value)
+
 kstatus_t arch_user_entry_prepare(
     arch_user_entry_t *out,
     address_space_t *aspace,
@@ -22,8 +28,14 @@ kstatus_t arch_user_entry_prepare(
         return K_ERR_INVALID_ARG;
     }
 
+    /* A directly entered SysV function observes RSP == 8 (mod 16), as if
+     * reached by CALL. Keep the synthetic return slot inside the mapped stack.
+     */
+    uintptr_t aligned_sp = user_sp & ~(uintptr_t)0xFU;
+    if (aligned_sp < sizeof(uintptr_t)) return K_ERR_INVALID_ARG;
+
     out->entry_pc = entry_pc;
-    out->user_sp = user_sp;
+    out->user_sp = aligned_sp - sizeof(uintptr_t);
     out->arg0 = arg0;
     out->aspace = aspace;
     // out->flags preserved
@@ -65,7 +77,9 @@ void arch_enter_user(const arch_user_entry_t *entry) {
     console_write_raw("  cr3_actual=", 13);
     print_hex(cr3_val);
     console_write_raw("\n  cr3_expected=", 16);
-    print_hex(0);
+    print_hex(entry->aspace && entry->aspace->prot_domain
+                  ? (uint64_t)(uintptr_t)entry->aspace->prot_domain->backend_state
+                  : 0);
     console_write_raw("\n  pid=", 7);
     print_hex(thread ? thread->process_id : 0);
     console_write_raw("\n  tid=", 7);
@@ -77,13 +91,13 @@ void arch_enter_user(const arch_user_entry_t *entry) {
     __asm__ volatile (
         "cli\n\t"
         "movq %0, %%rdi\n\t"
-        "movq $0x1B, %%rax\n\t"
-        "movq %%rax, %%ds\n\t"
-        "movq %%rax, %%es\n\t"
-        "pushq $0x1B\n\t"
+        "movw $" X86_STRINGIFY(X86_USER_DATA_SELECTOR) ", %%ax\n\t"
+        "movw %%ax, %%ds\n\t"
+        "movw %%ax, %%es\n\t"
+        "pushq $" X86_STRINGIFY(X86_USER_DATA_SELECTOR) "\n\t"
         "pushq %1\n\t"
         "pushq $0x202\n\t"
-        "pushq $0x23\n\t"
+        "pushq $" X86_STRINGIFY(X86_USER_CODE_SELECTOR) "\n\t"
         "pushq %2\n\t"
         "iretq\n\t"
         :

--- a/core/kernel/src/sched/sched.c
+++ b/core/kernel/src/sched/sched.c
@@ -961,6 +961,9 @@ void sched_switch_to(bh_thread_t *next, uint32_t core_id) {
   rq->context_switches++;
   g_cpu_locals[core_id].runqueue.context_switches++;
   g_cpu_locals[core_id].runqueue.current_thread = next;
+  /* Owner-core state: privilege-entry assembly consumes this stack top. */
+  g_cpu_locals[core_id].kernel_stack =
+      (uintptr_t)next->kernel_stack + 16384U;
 
   cpu_context_t *prev_ctx = current ? (cpu_context_t*)current->cpu_context : NULL;
   cpu_context_t *next_ctx = (cpu_context_t*)next->cpu_context;


### PR DESCRIPTION
### Motivation

- Userspace entry on x86_64 was faulting (#GP) during the final privilege transition because data-segment descriptors used invalid long-mode flags and the entry code used 64-bit segment loads and an unaligned synthetic user stack.  
- The boot path also enabled long mode without NX (EFER.NXE) and the MMU walker did not consistently set the U/S bit on non-leaf page-table entries, causing mismatched reachability vs leaf protections.  
- Make the smallest safe change set to ensure a deterministic, deny-by-default userspace transition that preserves existing architectures/ownership and avoids ABI changes.  

### Description

- Fix GDT construction: replace raw literal descriptors with named constants and helper invocations so kernel/user data segments use proper data-segment flags and the TSS selector is used consistently; move to descriptor helpers in `core/arch/hal/x86/x86_64/hal_cpu.c`.  
- Enable NX early in boot: set `EFER.NXE` along with `EFER.LME` before installing NX-marked mappings in `core/arch/x86/x86_64/boot/boot.S`.  
- Ensure per-level user bit propagation in x86 page-table walker so user mappings are reachable only when all intermediate entries are user-visible in `core/arch/hal/x86/x86_64/hal_pt_x86_64.c`.  
- Harden user-entry assembly and stack setup: use 16-bit `movw` for `DS`/`ES` loads, push named user selectors, and adjust the synthetic user `RSP` to satisfy SysV stack alignment in `core/arch/x86/x86_64/user_entry.c`.  
- Initialize SYSCALL MSRs after per-core GS-based CPU-local setup so each core programs its syscall MSRs only after its GS base is installed in `core/arch/x86/x86_64/kernel/cpu_local.c`.  
- Publish per-core kernel-stack-top into owner-core state before switches so the privilege entry assembly can rely on a known kernel stack top in `core/kernel/src/sched/sched.c`.  
- Files changed: `core/arch/hal/x86/x86_64/hal_cpu.c`, `core/arch/hal/x86/x86_64/hal_pt_x86_64.c`, `core/arch/hal/x86/x86_64/boot/boot.S`, `core/arch/x86/x86_64/kernel/cpu_local.c`, `core/arch/x86/x86_64/user_entry.c`, `core/kernel/src/sched/sched.c`.  
- No public ABI changes, no capability contract changes, and no generated artifacts were altered.  

### Testing

- Built and exercised the x86_64 headless smoke lane: `./tools/build.sh all --target-yaml delivery/targets/qemu/x86_64_desktop_headless.yaml --smoke` — PASS: build/package completed and QEMU run reached CPL3 and init; evidence shows `USER_ENTRY_X86` and `cr3_expected` matching the domain root, and the native syscall path is installed, but the run-time boot contract still timed out waiting for all mandatory userspace markers (observed as a timeout/partial success).  
- Repository checks: `python3 tools/lint/check_layer_references.py` and `python3 tools/lint/check_cmake_dependencies.py` and `python3 tools/abi/syscall_abi.py --check` were executed; these reported existing repository issues (layer-reference violations, some upward CMake dependencies, and test sources with dummy syscall numbers) that are pre-existing and unrelated to this focused x86 fix (FAIL for those checks).  
- Multi-target smoke matrix attempts: `python3 tools/run_qemu_matrix.py --headless --smoke` / per-target `./tools/build.sh all --target-yaml ... --smoke` were run for the five required targets; results: x86_64: partial PASS as above, arm64: built and ran but panicked in existing bootstrap path (FAIL), riscv64: built and ran but panicked in existing bootstrap path (FAIL), arm32 (mmu-lite): compile-time error in existing ARM code (FAIL), riscv32 (mmu-lite): packaging succeeded but QEMU missing OpenSBI firmware (BLOCKED).  
- QEMU presence and runner: `command -v qemu-system-x86_64` etc. — PASS (all five QEMU binaries present); `python3 tools/run_qemu_matrix.py --help` — PASS but the runner does not support the mandatory `--all-arch` gate (so the repository QEMU matrix all-arch gate is effectively BLOCKED in this environment).  

Notes and next steps (testing / validation): run the focused x86 headless smoke again in CI and collect the userspace/init markers to close the boot contract, and address the repository linter and cross-target failures (ARM compile error and RISC-V OpenSBI missing) before marking the full five-architecture gate PASS.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a741dcc0e148320b72edcad2ee74887)