### PR TITLE
test: remove dummy syscall sentinel from host fixtures

### DIFF
--- a/quality/tests/host/ipc/fabric/test_mk_replay.c
+++ b/quality/tests/host/ipc/fabric/test_mk_replay.c
@@ -3,6 +3,12 @@
 #include "ipc/mk_proto.h"
 #include "fake_hal.h"
 
+enum {
+    TEST_INITIAL_TIMESTAMP = 1000,
+    TEST_DUPLICATE_TIMESTAMP = 1010,
+    TEST_NEXT_SEQUENCE_TIMESTAMP = 1020,
+};
+
 int main(void) {
     printf("Running test_mk_replay...\n");
 
@@ -12,15 +18,18 @@ int main(void) {
     fake_hal_set_cpu_id(0);
 
     // 1. First time receiving sequence 100 from core 1/endpoint 10 should be OK
-    st = bh_mk_replay_check_and_add(1, 10, 1, 0, 0, 1, 1, 100, 1000);
+    st = bh_mk_replay_check_and_add(1, 10, 1, 0, 0, 1, 1, 100,
+                                    TEST_INITIAL_TIMESTAMP);
     assert(st == K_OK);
 
     // 2. Duplicate receive should be rejected with ALREADY_EXISTS
-    st = bh_mk_replay_check_and_add(1, 10, 1, 0, 0, 1, 1, 100, 1001);
+    st = bh_mk_replay_check_and_add(1, 10, 1, 0, 0, 1, 1, 100,
+                                    TEST_DUPLICATE_TIMESTAMP);
     assert(st == K_ERR_ALREADY_EXISTS);
 
     // 3. Different sequence should be OK
-    st = bh_mk_replay_check_and_add(1, 10, 1, 0, 0, 1, 1, 101, 1002);
+    st = bh_mk_replay_check_and_add(1, 10, 1, 0, 0, 1, 1, 101,
+                                    TEST_NEXT_SEQUENCE_TIMESTAMP);
     assert(st == K_OK);
 
     // 4. Fill replay cache to test circular overwrite

--- a/quality/tests/host/process_vm/test_pm_handle_lifecycle.c
+++ b/quality/tests/host/process_vm/test_pm_handle_lifecycle.c
@@ -3,6 +3,12 @@
 #include <string.h>
 #include <handle_table.h>
 
+enum {
+    TEST_PROCESS_OBJECT_TYPE = 1,
+    TEST_PROCESS_RIGHTS = 7,
+    TEST_REPLACEMENT_PROCESS_RIGHTS = 5,
+};
+
 void test_handle_table_lifecycle(void) {
     bh_user_handle_table_t table;
     bh_user_handle_slot_t slots[4];
@@ -12,11 +18,12 @@ void test_handle_table_lifecycle(void) {
     assert(table.count == 0);
     assert(table.capacity == 4);
 
-    int dummy_obj_1 = 42;
-    int dummy_obj_2 = 100;
+    int process_object = 42;
+    int replacement_process_object = 100;
 
     bh_handle_t handle1 = 0;
-    res = bh_user_handle_alloc(&table, &dummy_obj_1, 1001, 7, &handle1);
+    res = bh_user_handle_alloc(&table, &process_object, TEST_PROCESS_OBJECT_TYPE,
+                               TEST_PROCESS_RIGHTS, &handle1);
     assert(res == BH_HANDLE_TABLE_SUCCESS);
     assert(table.count == 1);
     assert(bh_user_handle_index(handle1) == 0);
@@ -24,10 +31,11 @@ void test_handle_table_lifecycle(void) {
 
     void *ret_obj = NULL;
     uint64_t ret_rights = 0;
-    res = bh_user_handle_lookup(&table, handle1, 1001, &ret_obj, &ret_rights);
+    res = bh_user_handle_lookup(&table, handle1, TEST_PROCESS_OBJECT_TYPE,
+                                &ret_obj, &ret_rights);
     assert(res == BH_HANDLE_TABLE_SUCCESS);
     assert(*(int *)ret_obj == 42);
-    assert(ret_rights == 7);
+    assert(ret_rights == TEST_PROCESS_RIGHTS);
 
     // Revoke
     res = bh_user_handle_revoke(&table, handle1);
@@ -35,22 +43,27 @@ void test_handle_table_lifecycle(void) {
     assert(table.count == 0);
 
     // Stale lookup should fail
-    res = bh_user_handle_lookup(&table, handle1, 1001, &ret_obj, NULL);
+    res = bh_user_handle_lookup(&table, handle1, TEST_PROCESS_OBJECT_TYPE,
+                                &ret_obj, NULL);
     assert(res == BH_HANDLE_TABLE_ERR_NOT_FOUND);
 
     // Allocate again on same slot - should increment generation to 2
     bh_handle_t handle2 = 0;
-    res = bh_user_handle_alloc(&table, &dummy_obj_2, 1001, 5, &handle2);
+    res = bh_user_handle_alloc(&table, &replacement_process_object,
+                               TEST_PROCESS_OBJECT_TYPE,
+                               TEST_REPLACEMENT_PROCESS_RIGHTS, &handle2);
     assert(res == BH_HANDLE_TABLE_SUCCESS);
     assert(bh_user_handle_index(handle2) == 0);
     assert(bh_user_handle_generation(handle2) == 2);
 
     // Lookup on stale handle1 should still fail
-    res = bh_user_handle_lookup(&table, handle1, 1001, &ret_obj, NULL);
+    res = bh_user_handle_lookup(&table, handle1, TEST_PROCESS_OBJECT_TYPE,
+                                &ret_obj, NULL);
     assert(res == BH_HANDLE_TABLE_ERR_NOT_FOUND);
 
     // Lookup on active handle2 should succeed
-    res = bh_user_handle_lookup(&table, handle2, 1001, &ret_obj, NULL);
+    res = bh_user_handle_lookup(&table, handle2, TEST_PROCESS_OBJECT_TYPE,
+                                &ret_obj, NULL);
     assert(res == BH_HANDLE_TABLE_SUCCESS);
     assert(*(int *)ret_obj == 100);
 


### PR DESCRIPTION
### Motivation

- The syscall ABI checker flagged a raw dummy value `1001` used in host-side tests; the change replaces those literals with named test constants to avoid spurious ABI warnings while preserving test semantics.

### Description

- Replaced the hard-coded object-type and rights usages of `1001` in `quality/tests/host/process_vm/test_pm_handle_lifecycle.c` with `TEST_PROCESS_OBJECT_TYPE`, `TEST_PROCESS_RIGHTS`, and `TEST_REPLACEMENT_PROCESS_RIGHTS` and renamed test fixtures for clarity.
- Replaced timestamp literals used as replay markers in `quality/tests/host/ipc/fabric/test_mk_replay.c` with `TEST_INITIAL_TIMESTAMP`, `TEST_DUPLICATE_TIMESTAMP`, and `TEST_NEXT_SEQUENCE_TIMESTAMP` while keeping sequence and replay assertions unchanged.
- Limited the edits to the two host-test sources and preserved all behavioral checks (stale-generation, handle reuse, duplicate-replay rejection, and circular-cache overwrite).

### Testing

- Ran `python3 tools/abi/syscall_abi.py --check` which passed with no dummy-syscall sentinel reported by the checker.
- Compiled and executed focused host binaries for both modified tests using direct `cc` commands and both test binaries passed when run locally.
- Ran `git diff --check` and a grep scan for `\b1001\b` against the two files to confirm the sentinel was removed, both checks passed.
- Ran repository linters `python3 tools/lint/check_layer_references.py` and `python3 tools/lint/check_cmake_dependencies.py` which completed but reported pre-existing, unrelated violations outside this change.
- Attempts to run full host-target builds and the mandatory five-target QEMU matrix were exercised but blocked by pre-existing repository issues (duplicate host test target and unrelated cross-build failures); these blockers are unrelated to the two-file change and remain unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7723bf074c8320b8f3fc16ee607df2)