### PR TITLE
boot: fail-closed on unresolved runtime profiles

### DIFF
--- a/core/kernel/src/init/init_bootstrap.c
+++ b/core/kernel/src/init/init_bootstrap.c
@@ -5,6 +5,7 @@
 #include "process/user_image_loader.h"
 #include "arch/context_switch.h"
 #include "hal/hal.h"
+#include "hal/hal_timer.h"
 #include "mm/physmap.h"
 #include "mm/prot_domain.h"
 #include "mm/vm_mapping.h"
@@ -128,17 +129,25 @@ static int bh_rt_supervisor_start(const boot_module_t *mod) {
         return -1;
     }
 
-    // 2. Create MPU Domain
-    prot_domain_t *domain = NULL;
-    if (prot_domain_create(&domain) != K_OK || !domain) {
-        // Fallback if MPU backend is not registered (e.g. mock/stub)
-        console_write_raw("[BOOTSTRAP] WARNING: MPU backend not registered. Simulated map.\n", 64);
-        domain = (prot_domain_t *)pmm_alloc_page_ex(MEM_NORMAL, PMM_ALLOC_ZERO); // Dummy page as mock domain
+    /*
+     * The process address space is the sole memory authority for every
+     * protection model.  For MPU it owns a REGION_ONLY protection domain;
+     * never fabricate a domain or replace the address-space pointer.
+     */
+    bh_process_t *proc = process_create("rt-supervisor");
+    if (!proc || !proc->addr_space || !proc->addr_space->prot_domain) {
+        init_boot_fail("RT_ASPACE_READY", K_ERR_UNSUPPORTED);
+        return -1;
     }
+    address_space_t *aspace = proc->addr_space;
+    prot_domain_t *domain = aspace->prot_domain;
 
     // 3. Plan & Install regions
     uintptr_t entry_point = 0;
-    bh_rt_region_plan_create_and_install(domain, mod, &entry_point);
+    if (bh_rt_region_plan_create_and_install(domain, mod, &entry_point) != 0) {
+        init_boot_fail("RT_REGIONS", K_ERR_VM_UNMAPPED);
+        return -1;
+    }
 
     // 4. Activate MPU domain
     prot_domain_activate(domain);
@@ -149,11 +158,6 @@ static int bh_rt_supervisor_start(const boot_module_t *mod) {
     console_write_raw("[BOOTSTRAP] RT_SCHEDULER: ACTIVE\n", 33);
 
     // 6. Spawn Thread
-    bh_process_t *proc = process_create("rt-supervisor");
-    if (!proc) return -1;
-    proc->addr_space = (address_space_t *)domain; // Cast for MPU mapping
-
-    // Setup detached unprivileged thread pointing to RT-supervisor entry point
     bh_thread_t *thread = thread_create_detached(proc, (void (*)(void))entry_point);
     if (!thread) return -1;
 
@@ -175,7 +179,11 @@ static int bh_rt_supervisor_start(const boot_module_t *mod) {
         startup->execution_profile = g_boot_info->execution_profile;
         startup->memory_model = (uint32_t)g_boot_info->memory_model;
         startup->cpu_id = (uint32_t)hal_cpu_get_id();
-        startup->timer_frequency = 1000000; // Simulated 1MHz
+        startup->timer_frequency = hal_timer_read_freq();
+        if (startup->timer_frequency == 0U) {
+            init_boot_fail("RT_TIMER_FREQUENCY", K_ERR_UNSUPPORTED);
+            return -1;
+        }
     }
 
     set_thread_arg0(thread, startup_phys);

--- a/core/kernel/src/kernel_boot.c
+++ b/core/kernel/src/kernel_boot.c
@@ -26,6 +26,7 @@
 #include "security/credentials.h"
 #include "security/isolation.h"
 #include "profile/subsystem_profile.h"
+#include "profile/execution_mode.h"
 #include "trap.h"
 #include "boot/boot_args.h"
 #include "boot/boot_info.h"
@@ -205,17 +206,6 @@ void boot_common_memory(const boot_info_t *boot) {
     KPRINT("BOOT: pmm initialized\n");
     KPRINT("[BOOT] BOOT_MEMORY: MODULES_RESERVED\n");
 
-#if (defined(__arm__) && !defined(__aarch64__)) || (defined(__riscv) && (__riscv_xlen == 32))
-    /*
-     * ARM32/RISC-V32 MMU-Lite still stops before the full VMM/init-loader
-     * path.  Do not synthesize userspace success from the kernel; report the
-     * missing canonical init handoff as a hard boot failure until Gate 2 wires
-     * the live module parser for these paths.
-     */
-    KPRINT("BOOT_FAIL: INIT_MODULE_MISSING\n");
-    kernel_panic("bootstrap: init module missing before userspace launch");
-#endif
-
     // Ensure hal_pt is initialized BEFORE VMM tries to map things / create address space
     hal_pt_init();
     hal_tlb_init();
@@ -282,6 +272,12 @@ void boot_common_platform_services(const boot_info_t *boot) {
 
     extern void bharat_algorithm_backends_init(void);
     bharat_algorithm_backends_init();
+
+    KPRINT("  [PROFILE] Resolving execution mode and CPU partitions\n");
+    if (bharat_execution_mode_init() != K_OK) {
+      kernel_panic("execution mode/CPU partition initialization failed");
+    }
+    bharat_execution_mode_print_summary();
 
     KPRINT("  [SCHED] Initializing global scheduler\n");
     if (sched_global_init(boot_policy->smp_target_cores) != 0 ||
@@ -563,7 +559,8 @@ void boot_common_runtime(const boot_info_t *boot) {
     KPRINT("  [BOOT] Runtime mode: ");
     KPRINT(bharat_boot_mode_name(mode));
     KPRINT("\n");
-    KPRINT("  [BOOT] Kernel loading successful - boot complete\n");
+    KPRINT("  [BOOT] KERNEL_RUNTIME_READY\n");
+    KPRINT("  [BOOT] USERSPACE_LAUNCH_BEGIN\n");
 
     switch (mode) {
         case BHARAT_BOOT_MODE_AUTOMOTIVE:

--- a/core/kernel/src/mm/mem_model.c
+++ b/core/kernel/src/mm/mem_model.c
@@ -11,7 +11,8 @@ mem_model_t mem_model_get_current(void) {
 #elif defined(BHARAT_PROFILE_MMU_FULL)
     return MEM_MODEL_MMU_FULL;
 #else
-    return MEM_MODEL_MMU_FULL;
+    /* An omitted model is a configuration error, never an MMU grant. */
+    return MEM_MODEL_NONE;
 #endif
 }
 
@@ -32,7 +33,8 @@ kstatus_t mem_runtime_caps_from_hal(const struct hal_mem_caps *hal_caps, mem_run
     out_caps->supports_region_protection = (hal_caps->model >= HAL_MEMORY_MODEL_MPU);
     out_caps->supports_shared_memory = (hal_caps->model >= HAL_MEMORY_MODEL_MMU_LITE);
 
-    out_caps->supports_dma_map = true; // Baseline assumption for M0
+    /* DMA translation is optional platform truth, not implied by CPU VM. */
+    out_caps->supports_dma_map = hal_caps->supports_iommu;
     out_caps->supports_iommu = hal_caps->supports_iommu;
     out_caps->supports_numa = false; // Not yet reported by HAL
     out_caps->supports_hugepage = hal_caps->supports_hugepages;
@@ -85,10 +87,10 @@ uint64_t mem_model_get_caps(void) {
         case MEM_MODEL_MMU_FULL:
             return MEM_CAP_VIRT_ADDRSPACE | MEM_CAP_PAGE_MAP | MEM_CAP_PAGE_PROTECT |
                    MEM_CAP_DEMAND_FAULT | MEM_CAP_SHARED_ASPACE | MEM_CAP_TLB_INVALIDATE |
-                   MEM_CAP_DMA_MAP | MEM_CAP_IOMMU | MEM_CAP_PER_CORE_PMM_CACHE;
+                   MEM_CAP_PER_CORE_PMM_CACHE;
         case MEM_MODEL_MMU_LITE:
             return MEM_CAP_VIRT_ADDRSPACE | MEM_CAP_PAGE_MAP | MEM_CAP_PAGE_PROTECT |
-                   MEM_CAP_TLB_INVALIDATE | MEM_CAP_DMA_MAP;
+                   MEM_CAP_TLB_INVALIDATE;
         case MEM_MODEL_MPU:
             return MEM_CAP_REGION_PROTECT;
         default:
@@ -113,7 +115,7 @@ kstatus_t mem_model_validate_hal_caps(mem_model_t model, const hal_memory_caps_t
             if (!hal_caps->supports_mpu_only && !hal_caps->supports_mmu_full) return K_ERR_UNSUPPORTED;
             break;
         default:
-            break;
+            return K_ERR_UNSUPPORTED;
     }
 
     return K_OK;

--- a/core/kernel/src/sched/cpu_partition.c
+++ b/core/kernel/src/sched/cpu_partition.c
@@ -151,8 +151,9 @@ bool cpu_partition_allows_class(uint32_t cpu_id, bharat_sched_class_mask_t class
 
 bool cpu_partition_allows_any_class(uint32_t cpu_id, bharat_sched_class_mask_t class_mask) {
     const bharat_cpu_partition_desc_t *desc = cpu_partition_get(cpu_id);
-    if (!desc || desc->allowed_sched_classes == 0) {
-        return true;
+    if (!desc || desc->allowed_sched_classes == BHARAT_SCHED_CLASS_NONE ||
+        class_mask == BHARAT_SCHED_CLASS_NONE) {
+        return false;
     }
     return (desc->allowed_sched_classes & class_mask) != 0;
 }

--- a/docs/adr/ADR-019-fail-closed-boot-profile-publication.md
+++ b/docs/adr/ADR-019-fail-closed-boot-profile-publication.md
@@ -1,0 +1,58 @@
+# ADR-019: Fail-closed boot profile publication
+
+## Status
+
+Accepted
+
+## Context
+
+Boot previously treated an omitted memory-model selection as `MMU_FULL`,
+advertised DMA/IOMMU capabilities as properties of that selection, allowed a
+missing CPU-partition descriptor to admit any scheduling class, and published
+the scheduler before resolving execution-mode partitions.  The 32-bit common
+boot path also stopped on an ISA conditional rather than allowing the selected
+memory backend and user-entry backend to report their actual support status.
+
+The MPU bootstrap additionally fabricated a protection-domain pointer on
+backend failure and stored it in the process address-space field.  That bypassed
+the canonical process memory authority and could publish an invalid object.
+
+## Decision
+
+1. An omitted memory model resolves to `MEM_MODEL_NONE` and validation rejects
+   it.  Model capabilities describe only guarantees intrinsic to the model;
+   optional DMA/IOMMU capabilities remain HAL-discovered runtime truth.
+2. The BSP resolves and validates execution mode and CPU partitions before
+   scheduler global publication.  Partition lookup failure, a zero class mask,
+   and an empty admission request deny admission.
+3. Common boot contains no ARM32/RISC-V32 early panic.  Unsupported memory or
+   user-entry behavior must be returned by the responsible backend.
+4. `bh_process_t::addr_space` remains the sole process memory authority for
+   MMU, MMU-Lite, and MPU.  The RT bootstrap consumes the protection domain
+   owned by that address space and fails closed if it is unavailable.
+5. Kernel readiness and userspace launch are diagnostic milestones, not boot
+   completion.  `BOOT_COMPLETE` remains reserved for userspace-originated
+   stable-runtime evidence under the boot evidence contract.
+
+## Ownership and synchronization
+
+The BSP is the single writer of execution configuration during boot.  After
+successful initialization, readers receive a const descriptor and scheduler
+publication consumes that immutable topology.  Each process owns exactly one
+address space, whose backend protection domain is created and destroyed by the
+address-space lifecycle.  This decision adds no remote mutation or wire
+protocol.
+
+## Failure behavior
+
+Missing configuration, missing protection backends, invalid partitions, and
+zero timer frequency are rejected before scheduler or RT-userspace
+publication.  No fallback object is allocated and no capability is inferred.
+
+## Consequences
+
+Targets must explicitly select a memory model and provide truthful HAL
+capabilities.  Bring-up configurations that previously relied on optimistic
+defaults now stop at the responsible validation boundary.  Full five-target
+boot claims still require executable matrix evidence; removal of an ISA panic
+alone is not evidence that a target reaches userspace.

--- a/docs/architecture/core/execution-mode-and-cpu-partitioning.md
+++ b/docs/architecture/core/execution-mode-and-cpu-partitioning.md
@@ -69,3 +69,12 @@ This framework scaffolds the mechanism for CPU partitioning. Future work will in
 - Implementing the Service Supervisor and runtime policy managers.
 - Advanced capabilities-based runtime thread reassignment.
 - EDF (Earliest Deadline First) scheduler class integration.
+
+## Boot publication and admission invariant
+
+The BSP resolves the execution mode and validates the complete CPU-partition
+descriptor before `sched_global_init()` or `sched_system_enable()` publishes
+the scheduler.  The published descriptor is read-only after initialization.
+Missing partition descriptors, spare partitions with `NONE` classes, and empty
+class requests deny admission; bootstrap code must use an explicit bootstrap
+path rather than relying on a fail-open production admission API.

--- a/docs/architecture/memory/mem-model-hal-contract.md
+++ b/docs/architecture/memory/mem-model-hal-contract.md
@@ -25,3 +25,8 @@ Standardizes how the kernel validates hardware memory capabilities against the s
 
 ## Boot Validation
 The kernel calls `mem_model_validate_hal_caps` early in the boot sequence. If the hardware does not support the required features of the selected memory model (e.g., MMU_FULL on an MPU system), the kernel fails closed with a panic.
+
+An omitted selection is `MEM_MODEL_NONE` and is rejected. `MMU_FULL` describes
+CPU virtual-memory semantics only; it does not imply DMA mapping or an IOMMU.
+Those optional capabilities are published exclusively by HAL discovery and
+validated separately against the selected profile contract.

--- a/quality/tests/boot/test_kernel_boot_markers.py
+++ b/quality/tests/boot/test_kernel_boot_markers.py
@@ -18,8 +18,15 @@ def test_kernel_does_not_synthesize_userspace_success_markers():
     assert offenders == []
 
 
-def test_missing_init_module_is_hard_failure_marker():
+def test_missing_init_module_is_reported_by_loader_not_isa_gate():
     bootstrap = (REPO_ROOT / "core/kernel/src/init/init_bootstrap.c").read_text()
     kernel_boot = (REPO_ROOT / "core/kernel/src/kernel_boot.c").read_text()
     assert "BOOT_FAIL: INIT_MODULE_MISSING" in bootstrap
-    assert "BOOT_FAIL: INIT_MODULE_MISSING" in kernel_boot
+    assert "BOOT_FAIL: INIT_MODULE_MISSING" not in kernel_boot
+
+
+def test_kernel_readiness_is_not_boot_completion():
+    kernel_boot = (REPO_ROOT / "core/kernel/src/kernel_boot.c").read_text()
+    assert "KERNEL_RUNTIME_READY" in kernel_boot
+    assert "USERSPACE_LAUNCH_BEGIN" in kernel_boot
+    assert "Kernel loading successful - boot complete" not in kernel_boot

--- a/quality/tests/host/sched/test_cpu_partition.c
+++ b/quality/tests/host/sched/test_cpu_partition.c
@@ -136,6 +136,12 @@ void test_class_allowance(void) {
 
     // Alias
     assert(cpu_partition_allows_class(0, BHARAT_SCHED_CLASS_SYSTEM | BHARAT_SCHED_CLASS_FIFO_RT) == true);
+
+    /* Missing, spare, and empty requests are all denied after configuration. */
+    assert(cpu_partition_allows_any_class(1, BHARAT_SCHED_CLASS_SYSTEM) == false);
+    g_test_config.cpu_partitions[0].allowed_sched_classes = BHARAT_SCHED_CLASS_NONE;
+    assert(cpu_partition_allows_any_class(0, BHARAT_SCHED_CLASS_SYSTEM) == false);
+    assert(cpu_partition_allows_any_class(0, BHARAT_SCHED_CLASS_NONE) == false);
 }
 
 int main(void) {

--- a/quality/tests/host/test_mem_model_hal_validation.c
+++ b/quality/tests/host/test_mem_model_hal_validation.c
@@ -35,6 +35,9 @@ void test_mem_model_validation(void) {
     // Case 5: MPU requested, HAL lacks it
     caps.supports_mpu_only = false;
     assert(mem_model_validate_hal_caps(MEM_MODEL_MPU, &caps) == K_ERR_UNSUPPORTED);
+
+    // Case 6: an unselected model must never inherit optimistic MMU behavior
+    assert(mem_model_validate_hal_caps(MEM_MODEL_NONE, &caps) == K_ERR_UNSUPPORTED);
 }
 
 int main(void) {


### PR DESCRIPTION
### Motivation

- Remove fragile ISA-gated early kernel panics and let the memory/user-entry backends report unsupported targets instead of collapsing them into a synthetic "init missing" failure. 
- Prevent optimistic hardware/memory assumptions (implicit `MMU_FULL` and assumed DMA/IOMMU) from granting capabilities or fabricating objects during boot. 
- Ensure execution-mode/CPU-partition configuration is resolved before the scheduler is published and that MPU/RT bootstrap uses the canonical process address-space authority. 

### Description

- Change `mem_model_get_current()` to return `MEM_MODEL_NONE` when no model is selected and make `mem_model_validate_hal_caps()` fail closed for `MEM_MODEL_NONE`. 
- Normalize runtime capability derivation so DMA mapping is taken from HAL truth (`hal_caps->supports_iommu`) and remove implicit DMA/IOMMU bits from `mem_model_get_caps()`. 
- Remove the early ARM32/RISC-V32 panic in `boot_common_memory` and call `bharat_execution_mode_init()` (and print an execution-mode summary) before `sched_global_init()`/`sched_system_enable()`, and replace the single `BOOT COMPLETE` line with `KERNEL_RUNTIME_READY` and `USERSPACE_LAUNCH_BEGIN`. 
- Replace the RT/MPU dummy fallback in `bh_rt_supervisor_start()` by consuming the `proc->addr_space->prot_domain`, reject missing backends, and use `hal_timer_read_freq()` (failing if zero) instead of a simulated 1 MHz; remove the unsafe `proc->addr_space = (address_space_t *)domain` cast. 
- Make `cpu_partition_allows_any_class()` fail-closed for missing partitions, spare/`NONE` partitions, or empty class requests. 
- Add/update tests and documentation: update `quality/tests/boot/test_kernel_boot_markers.py`, expand host tests for CPU partitions and memory-model HAL validation, and add `docs/adr/ADR-019-fail-closed-boot-profile-publication.md` to record the decision. 

### Testing

- Host/unit tests: `python3 -m pytest -q quality/tests/boot/test_kernel_boot_markers.py` passed (3 tests); compiling and running `quality/tests/host/sched/test_cpu_partition.c` and `quality/tests/host/test_mem_model_hal_validation.c` succeeded and all included host assertions passed. 
- x86_64 full build and smoke QEMU: `./tools/build.sh all --target-yaml delivery/targets/qemu/x86_64_desktop_headless.yaml --smoke` produced a packaged run and the QEMU smoke run observed the full userspace boot markers including `USER_INIT: ENTERED`, `STARTUP_ABI_OK`, `SERVICE_GRAPH_COMPLETE`, and `BOOT_RUNTIME: STABLE` (PASS). 
- Linters and dependency gates: `python3 tools/lint/check_layer_references.py` reported repository layer-reference violations (existing, 125 reported) and `python3 tools/lint/check_cmake_dependencies.py` reported upward CMake dependency issues (4 violations), so repository-level layering/CMake gates are BLOCKED. 
- Other architecture matrix status: `./tools/build.sh --target-yaml` results show ARM64 build blocked by a missing include (`lib/msg/crc.h`) (BLOCKED), RISC-V64 reached QEMU but failed in the loader with `PAGE_MAP`/`K_ERR_NO_MEMORY` and subsequent kernel panic (FAIL), ARM32 build is blocked by pre-existing compile/context-switch errors (BLOCKED), and RISC-V32 QEMU run is blocked by missing OpenSBI firmware (BLOCKED); therefore `python3 tools/run_qemu_matrix.py --headless --smoke --all-arch` could not complete the full five-arch matrix (BLOCKED).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a774889f77483209eb0e049eec4ac69)