### PR TITLE
Fix freestanding `<string.h>` dependencies in kernel, arch, and hal

### DIFF
--- a/core/arch/arm/arm32/hw_caps.c
+++ b/core/arch/arm/arm32/hw_caps.c
@@ -1,6 +1,5 @@
 #include "hal/hal_hw_caps.h"
 #include "hal/hal_internal.h"
-#include <string.h>
 
 void arch_discover_hw_caps(void) {
     hal_hw_caps_t caps = {0};

--- a/core/arch/arm/arm64/hw_caps.c
+++ b/core/arch/arm/arm64/hw_caps.c
@@ -1,6 +1,5 @@
 #include "hal/hal_hw_caps.h"
 #include "hal/hal_internal.h"
-#include <string.h>
 
 void arch_discover_hw_caps(void) {
     hal_hw_caps_t caps = {0};

--- a/core/arch/hal/arc/arc32/hal_mm.c
+++ b/core/arch/hal/arc/arc32/hal_mm.c
@@ -2,12 +2,11 @@
 #include "hal/hal_capabilities.h"
 #include "hal/hal_mmu.h"
 #include "hal/hal_mm.h"
-#include <string.h>
 
 int hal_mem_get_caps(hal_mem_caps_t *caps) {
     if (!caps) return -1;
 
-    memset(caps, 0, sizeof(hal_mem_caps_t));
+    *caps = (hal_mem_caps_t){0};
 
     /* ARC HS3x/HS4x typical MMU configuration */
     caps->model = HAL_MEMORY_MODEL_MMU_FULL;

--- a/core/arch/hal/arm/arm32/hal_mm.c
+++ b/core/arch/hal/arm/arm32/hal_mm.c
@@ -2,12 +2,11 @@
 #include "hal/hal_capabilities.h"
 #include "hal/hal_mmu.h"
 #include "hal/hal_mm.h"
-#include <string.h>
 
 int hal_mem_get_caps(hal_mem_caps_t *caps) {
     if (!caps) return -1;
 
-    memset(caps, 0, sizeof(hal_mem_caps_t));
+    *caps = (hal_mem_caps_t){0};
 
     caps->model = HAL_MEMORY_MODEL_MMU_LITE;
     caps->va_bits = 32;

--- a/core/arch/hal/arm/arm64/hal_mm.c
+++ b/core/arch/hal/arm/arm64/hal_mm.c
@@ -2,12 +2,11 @@
 #include "hal/hal_capabilities.h"
 #include "hal/hal_mm.h"
 #include "hal/hal_mmu.h"
-#include <string.h>
 
 int hal_mem_get_caps(hal_mem_caps_t *caps) {
     if (!caps) return -1;
 
-    memset(caps, 0, sizeof(hal_mem_caps_t));
+    *caps = (hal_mem_caps_t){0};
 
     caps->model = HAL_MEMORY_MODEL_MMU_FULL;
     caps->va_bits = 48; // VMSAv8-48

--- a/core/arch/hal/riscv/riscv32/atomic64_shim.c
+++ b/core/arch/hal/riscv/riscv32/atomic64_shim.c
@@ -13,7 +13,6 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include <string.h>
 
 /* -----------------------------------------------------------------------
  * Inline interrupt control (no header deps)
@@ -37,7 +36,7 @@ uint64_t __atomic_load_8(const volatile void *ptr, int model) {
     (void)model;
     uint32_t s = irq_save();
     uint64_t val;
-    memcpy(&val, (const void *)ptr, 8);
+    val = *(const volatile uint64_t *)ptr;
     irq_restore(s);
     return val;
 }
@@ -48,7 +47,7 @@ uint64_t __atomic_load_8(const volatile void *ptr, int model) {
 void __atomic_store_8(volatile void *ptr, uint64_t val, int model) {
     (void)model;
     uint32_t s = irq_save();
-    memcpy((void *)ptr, &val, 8);
+    *(volatile uint64_t *)ptr = val;
     irq_restore(s);
 }
 
@@ -59,8 +58,8 @@ uint64_t __atomic_exchange_8(volatile void *ptr, uint64_t newval, int model) {
     (void)model;
     uint32_t s = irq_save();
     uint64_t old;
-    memcpy(&old, (const void *)ptr, 8);
-    memcpy((void *)ptr, &newval, 8);
+    old = *(const volatile uint64_t *)ptr;
+    *(volatile uint64_t *)ptr = newval;
     irq_restore(s);
     return old;
 }
@@ -80,16 +79,16 @@ bool __atomic_compare_exchange_8(volatile void *ptr,
 
     uint32_t s = irq_save();
     uint64_t cur;
-    memcpy(&cur, (const void *)ptr, 8);
+    cur = *(const volatile uint64_t *)ptr;
 
     uint64_t exp;
-    memcpy(&exp, expected, 8);
+    exp = *(const uint64_t *)expected;
 
     bool ok = (cur == exp);
     if (ok) {
-        memcpy((void *)ptr, &desired, 8);
+        *(volatile uint64_t *)ptr = desired;
     } else {
-        memcpy(expected, &cur, 8);
+        *(uint64_t *)expected = cur;
     }
     irq_restore(s);
     return ok;
@@ -102,9 +101,9 @@ uint64_t __atomic_fetch_or_8(volatile void *ptr, uint64_t val, int model) {
     (void)model;
     uint32_t s = irq_save();
     uint64_t old;
-    memcpy(&old, (const void *)ptr, 8);
+    old = *(const volatile uint64_t *)ptr;
     uint64_t newv = old | val;
-    memcpy((void *)ptr, &newv, 8);
+    *(volatile uint64_t *)ptr = newv;
     irq_restore(s);
     return old;
 }
@@ -116,9 +115,9 @@ uint64_t __atomic_fetch_add_8(volatile void *ptr, uint64_t val, int model) {
     (void)model;
     uint32_t s = irq_save();
     uint64_t old;
-    memcpy(&old, (const void *)ptr, 8);
+    old = *(const volatile uint64_t *)ptr;
     uint64_t newv = old + val;
-    memcpy((void *)ptr, &newv, 8);
+    *(volatile uint64_t *)ptr = newv;
     irq_restore(s);
     return old;
 }

--- a/core/arch/hal/riscv/riscv32/hal_mm.c
+++ b/core/arch/hal/riscv/riscv32/hal_mm.c
@@ -2,12 +2,11 @@
 #include "hal/hal_capabilities.h"
 #include "hal/hal_mm.h"
 #include "hal/hal_mmu.h"
-#include <string.h>
 
 int hal_mem_get_caps(hal_mem_caps_t *caps) {
     if (!caps) return -1;
 
-    memset(caps, 0, sizeof(hal_mem_caps_t));
+    *caps = (hal_mem_caps_t){0};
 
     caps->model = HAL_MEMORY_MODEL_MMU_LITE;
     caps->va_bits = 32; // Sv32

--- a/core/arch/hal/riscv/riscv64/hal_mm.c
+++ b/core/arch/hal/riscv/riscv64/hal_mm.c
@@ -2,12 +2,11 @@
 #include "hal/hal_capabilities.h"
 #include "hal/hal_mm.h"
 #include "hal/hal_mmu.h"
-#include <string.h>
 
 int hal_mem_get_caps(hal_mem_caps_t *caps) {
     if (!caps) return -1;
 
-    memset(caps, 0, sizeof(hal_mem_caps_t));
+    *caps = (hal_mem_caps_t){0};
     caps->model = HAL_MEMORY_MODEL_MMU_FULL;
     caps->va_bits = 48;
     caps->pa_bits = 56;

--- a/core/arch/hal/rx/rx32/hal_mm.c
+++ b/core/arch/hal/rx/rx32/hal_mm.c
@@ -2,11 +2,10 @@
 #include "hal/hal_capabilities.h"
 #include "hal/hal_mmu.h"
 #include "hal/hal_mm.h"
-#include <string.h>
 
 int hal_mem_get_caps(hal_mem_caps_t *caps) {
     if (!caps) return -1;
-    memset(caps, 0, sizeof(hal_mem_caps_t));
+    *caps = (hal_mem_caps_t){0};
 
     /* Renesas RX typical configuration (MPU based) */
     caps->model = HAL_MEMORY_MODEL_MPU;

--- a/core/arch/hal/tricore/tricore32/hal_mm.c
+++ b/core/arch/hal/tricore/tricore32/hal_mm.c
@@ -2,11 +2,10 @@
 #include "hal/hal_capabilities.h"
 #include "hal/hal_mmu.h"
 #include "hal/hal_mm.h"
-#include <string.h>
 
 int hal_mem_get_caps(hal_mem_caps_t *caps) {
     if (!caps) return -1;
-    memset(caps, 0, sizeof(hal_mem_caps_t));
+    *caps = (hal_mem_caps_t){0};
 
     /* TriCore typical Memory Protection Unit (MPU) configuration */
     caps->model = HAL_MEMORY_MODEL_MPU;

--- a/core/arch/hal/x86/x86_64/hal_mm.c
+++ b/core/arch/hal/x86/x86_64/hal_mm.c
@@ -2,12 +2,11 @@
 #include "hal/hal_capabilities.h"
 #include "hal/hal_mm.h"
 #include "hal/hal_mmu.h"
-#include <string.h>
 
 int hal_mem_get_caps(hal_mem_caps_t *caps) {
     if (!caps) return -1;
 
-    memset(caps, 0, sizeof(hal_mem_caps_t));
+    *caps = (hal_mem_caps_t){0};
 
     caps->model = HAL_MEMORY_MODEL_MMU_FULL;
     caps->va_bits = 48; // Standard 4-level paging

--- a/core/arch/riscv/riscv32/hw_caps.c
+++ b/core/arch/riscv/riscv32/hw_caps.c
@@ -1,6 +1,5 @@
 #include "hal/hal_hw_caps.h"
 #include "hal/hal_internal.h"
-#include <string.h>
 
 void arch_discover_hw_caps(void) {
     hal_hw_caps_t caps = {0};

--- a/core/arch/riscv/riscv64/hw_caps.c
+++ b/core/arch/riscv/riscv64/hw_caps.c
@@ -1,6 +1,5 @@
 #include "hal/hal_hw_caps.h"
 #include "hal/hal_internal.h"
-#include <string.h>
 
 void arch_discover_hw_caps(void) {
     hal_hw_caps_t caps = {0};

--- a/core/arch/x86/x86_64/hw_caps.c
+++ b/core/arch/x86/x86_64/hw_caps.c
@@ -1,6 +1,5 @@
 #include "hal/hal_hw_caps.h"
 #include "hal/hal_internal.h"
-#include <string.h>
 
 void arch_discover_hw_caps(void) {
     hal_hw_caps_t caps = {0};

--- a/core/hal/common/hw_caps.c
+++ b/core/hal/common/hw_caps.c
@@ -1,6 +1,5 @@
 #include "hal/hal_hw_caps.h"
 #include "hal/hal_internal.h"
-#include <string.h>
 
 static hal_hw_caps_t g_internal_hw_caps;
 static bool g_caps_initialized = false;


### PR DESCRIPTION
This PR cleans up the architecture boundaries by enforcing that freestanding `core/kernel/`, `core/arch/`, and `core/hal/` code does not depend on the host `<string.h>` libc header. 

Freestanding code must either use the kernel-private `"lib/base/string.h"` (only for `core/kernel/`), or use architecture-specific shared contracts or native C struct initialization.

---
*PR created automatically by Jules for task [14132886462343880904](https://jules.google.com/task/14132886462343880904) started by @divyang4481*