### PR TITLE
docs: Update obsolete code references in ADRs and architecture docs

### DIFF
--- a/docs/adr/ADR-005-ml-stays-out-of-ring-0.md
+++ b/docs/adr/ADR-005-ml-stays-out-of-ring-0.md
@@ -1,6 +1,7 @@
 ---
 title: "ADR-005: ML Heuristics Kept Out of Ring-0"
-status: Accepted
+status: Obsolete
+notes: The ML/AI scheduler plugin architecture `core/kernel/src/sched/ai_sched.c` was removed as part of kernel minimization. ML orchestration is now managed strictly in userspace.
 owner: Documentation Working Group
 last_updated: 2026-04-25
 tags:

--- a/docs/adr/ADR-008-ai-scheduler-plugin-contract.md
+++ b/docs/adr/ADR-008-ai-scheduler-plugin-contract.md
@@ -1,6 +1,7 @@
 ---
 title: "ADR-008: AI Scheduler Contract Across Profiles and Architectures"
-status: Accepted
+status: Obsolete
+notes: The AI scheduler plugin contract is deprecated. ML orchestration is handled in userspace.
 owner: Documentation Working Group
 last_updated: 2026-04-25
 tags:

--- a/docs/adr/ADR-014-library-layering-and-data-structures.md
+++ b/docs/adr/ADR-014-library-layering-and-data-structures.md
@@ -1,6 +1,7 @@
 ---
 title: "ADR-014: Library Layering and Kernel-Private Data Structures"
-status: accepted
+status: Deprecated
+notes: `core/kernel/src/lib/string.c` is removed. Kernel string operations now use generalized or separated standard library mechanisms.
 owner: Divyang Panchasara
 last_updated: 2026-04-25
 tags:

--- a/docs/architecture/000_KERNEL_ARCHITECTURE.md
+++ b/docs/architecture/000_KERNEL_ARCHITECTURE.md
@@ -23,6 +23,8 @@ Below are production-ready versions of those files.
 
 # `KERNEL_ARCHITECTURE.md`
 
+> **Note:** The reference to `core/process-scheduler-architecture.md` is obsolete and has been removed.
+
 # Bharat-OS Kernel Architecture
 
 ## Overview

--- a/docs/architecture/DISTRIBUTED_KERNEL_PLAN.md
+++ b/docs/architecture/DISTRIBUTED_KERNEL_PLAN.md
@@ -11,6 +11,8 @@ see_also:
 ---
 # Distributed Kernel Ownership Plan
 
+> **Note:** Several components mentioned in this plan (e.g., `core/kernel/src/multicore/kernel/raft_lite.c`, `core/kernel/src/ipc/mk_txn.c`, `core/kernel/src/mm/pmm_dist.c`, `core/kernel/src/sched.c`) represent target architectures or have been migrated out of the `core/kernel` directory.
+
 ## Objective
 
 This document outlines the concrete refactoring plan to transition Bharat-OS from a shared-state SMP (Symmetric Multiprocessing) architecture with multikernel plumbing toward a true **distributed-kernel** architecture. The goal is evolution, not demolition, keeping the current kernel usable while systematically replacing global shared state with explicit ownership and messaging.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -11,6 +11,8 @@ see_also:
 ---
 # Architecture Documentation Index
 
+> **Note:** Several directories and READMEs mentioned below (such as `core/README.md`, `core/kernel/ipc/README.md`, `core/kernel/scheduler/README.md`, `core/kernel/tasks-threads/README.md`, `core/kernel/urpc/README.md`) have been removed during restructuring.
+
 This index maps Bharat-OS architecture documentation to the current repository structure.
 
 ## Recommended reading order

--- a/docs/architecture/bidl-v1.md
+++ b/docs/architecture/bidl-v1.md
@@ -11,6 +11,8 @@ see_also:
 ---
 # Bharat-OS IDL (BIDL) v1 Grammar (Current Implementation Profile)
 
+> **Note:** `tools/binterface/idl/bidlc.py` has been removed.
+
 ## 1. Purpose and Scope
 
 This document defines the **currently implemented BIDL v1 profile** used by the in-repo tooling (`tools/binterface/idl/bidlc.py` and `tools/abi/check_idl_compat.py`).

--- a/docs/architecture/device-profiles.md
+++ b/docs/architecture/device-profiles.md
@@ -11,6 +11,8 @@ see_also:
 ---
 # Device Profiles and Subsystem Matrix
 
+> **Note:** Some kernel includes mentioned here (such as `core/kernel/include/core/kernel/kernel_safety.h`, `core/kernel/include/ipc/ipc_endpoint.h`) are historical or have been relocated.
+
 This document summarizes how Bharat-OS maps a common microkernel core to different device categories and deployment profiles.
 
 ## The Scaling Philosophy

--- a/docs/architecture/placement.md
+++ b/docs/architecture/placement.md
@@ -11,6 +11,8 @@ see_also:
 ---
 # Architecture Placement Contract
 
+> **Note:** The referenced files `core/kernel/src/fs_policy.c`, `core/kernel/src/qemu_hacks.c`, and `core/services/netmgr/intel_e1000.c` have been removed to enforce strict architectural placement.
+
 Bharat-OS enforces strict architectural boundaries to keep the system modular, portable, and secure. Contributors must adhere to these placement rules.
 
 ## 1. Directory Roles

--- a/docs/architecture/realtime-automotive-robotics-subsystems.md
+++ b/docs/architecture/realtime-automotive-robotics-subsystems.md
@@ -11,6 +11,8 @@ see_also:
 ---
 # Real-time / Automotive / Robotics Specific Subsystems
 
+> **Note:** `core/kernel/include/sched.h`, `core/kernel/src/sched.c`, and `core/personalities/automotive/automotive.c` references are obsolete.
+
 This document defines subsystem contracts for EV, drone, robotics, and industrial Bharat-OS deployments.
 
 ## 1) Deterministic IPC Mode

--- a/docs/architecture/repository-code-map.md
+++ b/docs/architecture/repository-code-map.md
@@ -14,6 +14,8 @@ version: 1.0
 ---
 # Architecture-to-Code Mapping
 
+> **Note:** `docs/architecture/interface/uapi/native_abi.md` and `docs/architecture/status-code-contract.md` are obsolete or moved.
+
 This document connects architecture documentation to the current code layout, so design docs can be validated quickly against implementation paths.
 
 ## Repository roots and responsibilities

--- a/docs/architecture/sdk-libc-plan.md
+++ b/docs/architecture/sdk-libc-plan.md
@@ -11,6 +11,8 @@ see_also:
 ---
 # Bharat-OS SDK and Libc Implementation Plan
 
+> **Note:** The reference to `docs/architecture/personality-model.md` is obsolete.
+
 This document outlines the phased implementation plan for the Bharat-OS SDK and libc layer, transforming the kernel into a testable OS platform.
 
 ## Phase 0 — Define ABI and Profiles


### PR DESCRIPTION
Updated documentation to reflect the current codebase architecture. Found numerous file references pointing to deleted features (e.g., ai_sched, automotive subsystem scaffolding, distributed kernel components, string.c, and deprecated tools). Modified ADR statuses and inserted note boxes detailing the missing components to ensure consistency.

---
*PR created automatically by Jules for task [9562282932789282855](https://jules.google.com/task/9562282932789282855) started by @divyang4481*