### PR TITLE
docs: add architecture documentation for hardware-adaptive kernel algorithms

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -26,6 +26,7 @@ This index maps Bharat-OS architecture documentation to the current repository s
    - [`core/kernel/tasks-threads/README.md`](core/kernel/tasks-threads/README.md)
    - [`core/kernel/ipc/README.md`](core/kernel/ipc/README.md)
    - [`core/kernel/urpc/README.md`](core/kernel/urpc/README.md)
+   - [`kernel/hardware-adaptive/README.md`](kernel/hardware-adaptive/README.md) - Hardware-Adaptive Algorithms Phase
 6. [`memory/memory-architecture-comprehensive.md`](memory/memory-architecture-comprehensive.md)
 7. [`storage/README.md`](storage/README.md)
 8. [`security/crypto/overview.md`](security/crypto/overview.md)

--- a/docs/architecture/kernel/hardware-adaptive/KDS-RCU-002-epoch-rcu-lite.md
+++ b/docs/architecture/kernel/hardware-adaptive/KDS-RCU-002-epoch-rcu-lite.md
@@ -1,0 +1,80 @@
+---
+title: KDS-RCU-002 - Epoch RCU-lite
+status: Draft
+owner: Architecture Working Group
+last_updated: 2026-05-15
+tags:
+  - docs
+  - architecture
+  - kernel
+  - data-structures
+see_also:
+  - README.md
+---
+
+# KDS-RCU-002: Epoch RCU-lite
+
+## Context
+Bharat-OS currently has `bh_rcu_stub` where operations are no-ops. To support read-mostly lockless lookups (capabilities, metadata, registries), a real non-preemptible epoch/QSBR RCU-lite implementation is needed.
+
+## Design
+A simplified RCU-lite using an epoch-based quiescent state model.
+
+### Data Structures
+
+```c
+struct bh_rcu_state {
+    atomic_u64 global_epoch;
+};
+
+struct bh_rcu_cpu_state {
+    uint32_t nesting;
+    uint64_t observed_epoch;
+    uint64_t quiescent_epoch;
+    struct bh_rcu_retire_queue retire_queue;
+};
+
+struct bh_rcu_head {
+    void (*callback)(struct bh_rcu_head *head);
+    uint64_t retirement_epoch;
+    struct bh_rcu_head *next;
+};
+```
+
+### Hardware Acceleration
+* **ARM:** LSE atomics, fallback to LL/SC.
+* **RISC-V:** Zacas, fallback to LR/SC.
+* **x86:** CMPXCHG/locked instructions.
+
+## Architecture Models
+
+### Read Path
+
+```mermaid
+flowchart TD
+    A[read_lock] --> B[nesting++]
+    B --> C[Read object]
+    C --> D[read_unlock]
+    D --> E[nesting--]
+    E --> F{nesting == 0?}
+    F -->|Yes| G[Publish quiescent epoch]
+    F -->|No| H[Return]
+```
+
+### Write/Reclamation Path
+
+```mermaid
+flowchart TD
+    A[Remove object from visible index] --> B[Advance epoch]
+    B --> C[Place object in owner-local retire queue]
+    C --> D[Wait until relevant CPUs pass quiescent point]
+    D --> E[Execute deferred destructor]
+```
+
+## Execution Plan
+1. **State Implementation**: Implement global `bh_rcu_state` and per-CPU `bh_rcu_cpu_state`.
+2. **Read/Write Paths**: Implement reader enter/exit without global lock contention and writer object retirement.
+3. **Grace Period Logic**: Implement wait mechanism tracking per-CPU quiescent states.
+4. **Hardware Dispatch**: Wire atomic operations to hardware-accelerated variants (LSE, Zacas) via `hal_hw_caps_t`.
+5. **Migration**: Migrate capability revocation metadata, IRQ-domain read-side lookup, and immutable registry lookup as initial consumers.
+6. **Testing**: Write delayed reader tests, callback batching, and concurrent revoke/lookup scenarios.

--- a/docs/architecture/kernel/hardware-adaptive/KDS-SEQLK-002-production-seqlock.md
+++ b/docs/architecture/kernel/hardware-adaptive/KDS-SEQLK-002-production-seqlock.md
@@ -1,0 +1,89 @@
+---
+title: KDS-SEQLK-002 - Production Seqlock
+status: Draft
+owner: Architecture Working Group
+last_updated: 2026-05-15
+tags:
+  - docs
+  - architecture
+  - kernel
+  - data-structures
+see_also:
+  - README.md
+---
+
+# KDS-SEQLK-002: Production Seqlock
+
+## Context
+The current seqlock implementation modifies and reads the sequence using ordinary loads and increments. It lacks acquire/release semantics and memory barriers, making it unsafe for cross-CPU synchronization.
+
+## Design
+Introduce a production-grade seqlock with proper memory ordering, atomic acquire/release semantics, and writer serialization.
+
+### Target Semantics
+
+#### Reader
+```text
+reader:
+    seq = acquire(sequence)
+    reject if odd
+    read snapshot
+    acquire(sequence)
+    retry if changed
+```
+
+#### Writer
+```text
+writer:
+    serialize writers
+    publish odd
+    release/barrier
+    modify snapshot
+    release
+    publish even
+```
+
+### Data Structure
+
+```c
+typedef struct {
+    atomic_u64 sequence;
+    spinlock_t writer_lock;
+} bh_seqlock_t;
+```
+
+### Consumer Candidates
+* Scheduler load snapshots
+* Global time conversion parameters
+* Topology snapshots
+* IRQ statistics
+* Diagnostic counters
+
+## Architecture
+```mermaid
+sequenceDiagram
+    participant Writer
+    participant Seqlock
+    participant Reader
+
+    Writer->>Seqlock: Acquire Writer Lock
+    Writer->>Seqlock: sequence = sequence | 1 (Release)
+    Note over Writer,Seqlock: Memory Barrier
+    Writer->>Seqlock: Modify Data
+    Note over Writer,Seqlock: Memory Barrier
+    Writer->>Seqlock: sequence = sequence + 1 (Release)
+    Writer->>Seqlock: Release Writer Lock
+
+    Reader->>Seqlock: seq1 = sequence (Acquire)
+    Note right of Reader: Check if seq1 is odd
+    Reader->>Seqlock: Read Data
+    Reader->>Seqlock: seq2 = sequence (Acquire)
+    Note right of Reader: Check if seq1 == seq2
+```
+
+## Execution Plan
+1. **Define `bh_seqlock_t`**: Create the structure with an atomic sequence counter and writer lock.
+2. **Implement Writer Logic**: Add memory barriers and atomic increments with release semantics.
+3. **Implement Reader Logic**: Add atomic loads with acquire semantics and retry loop.
+4. **Migrate Consumers**: Convert existing scheduler telemetry/timekeeping snapshots to use the new seqlock.
+5. **Testing**: Write adversarial concurrency tests and verify cross-CPU visibility.

--- a/docs/architecture/kernel/hardware-adaptive/KHARDEN-001-hardware-assisted-safety.md
+++ b/docs/architecture/kernel/hardware-adaptive/KHARDEN-001-hardware-assisted-safety.md
@@ -1,0 +1,60 @@
+---
+title: KHARDEN-001 - Hardware-Assisted Kernel Memory Safety
+status: Draft
+owner: Architecture Working Group
+last_updated: 2026-05-15
+tags:
+  - docs
+  - architecture
+  - kernel
+  - security
+see_also:
+  - README.md
+---
+
+# KHARDEN-001: Hardware-Assisted Kernel Memory Safety
+
+## Context
+Bharat-OS can leverage advanced hardware features for kernel hardening. This should be an optional acceleration of a common hardening contract, not a separate kernel design.
+
+## Design
+Establish a unified kernel hardening contract with a software baseline and hardware-enhanced options based on capability discovery.
+
+### Hardening Contract
+
+#### Software Baseline
+* Slab redzones
+* Allocation generation
+* Delayed reuse/quarantine
+* Freelist corruption protection
+* Stack canaries
+
+#### Hardware-Enhanced (Dispatched via `hal_hw_caps_t`)
+* Memory tagging
+* Pointer authentication
+* Branch target protection
+* Shadow stack
+
+### ISA Mapping
+* **Arm**: MTE (Memory Tagging Extension), PAC/BTI (Pointer Authentication / Branch Target Identification).
+* **RISC-V**: Zicfiss (shadow stack), Zicfilp (landing-pad CFI).
+* **x86**: CET (Control-flow Enforcement Technology).
+
+## Architecture Model
+
+```mermaid
+flowchart TD
+    A[Kernel Hardening Request] --> B{Hardware Support Available?}
+    B -->|Yes - Arm MTE| C[Apply Tagging/PAC]
+    B -->|Yes - RISC-V CFI| D[Enable Shadow Stack / Landing Pads]
+    B -->|Yes - x86 CET| E[Enable CET / Indirect Branch Tracking]
+    B -->|No| F[Apply Software Baseline]
+    F --> F1(Redzones, Canaries, Quarantine)
+```
+
+## Execution Plan
+1. **Define Hardening API**: Create the neutral interface for applying memory and control-flow protection.
+2. **Software Baseline**: Universally enable software redzones and quarantine mechanisms.
+3. **Hardware Capability Hooks**: Tie the API to the new granular capabilities in `hal_hw_caps_t` (e.g., `memory_tagging`, `shadow_stack`).
+4. **Architecture Backends**: Implement ISA-specific enablement for MTE, PAC/BTI, Zicfiss/Zicfilp, and CET.
+5. **Testing**: Write security tests targeting UAF, buffer overflows, and ROP/JOP attempts to verify both software and hardware defenses.

--- a/docs/architecture/kernel/hardware-adaptive/KMEM-ACCEL-001-hw-memops.md
+++ b/docs/architecture/kernel/hardware-adaptive/KMEM-ACCEL-001-hw-memops.md
@@ -1,0 +1,55 @@
+---
+title: KMEM-ACCEL-001 - Hardware-Assisted Secure Memops
+status: Draft
+owner: Architecture Working Group
+last_updated: 2026-05-15
+tags:
+  - docs
+  - architecture
+  - kernel
+  - memory
+see_also:
+  - README.md
+---
+
+# KMEM-ACCEL-001: Hardware-Assisted Secure Zero/Copy/Cache Operations
+
+## Context
+PMM and slab allocators can benefit from hardware acceleration for zeroing and cache maintenance without exposing ISA details.
+
+## Design
+Add neutral operations dispatched through the capability layer to optimized hardware implementations.
+
+### Neutral API
+
+```c
+void bh_mem_zero_page(void *addr);
+void bh_mem_zero_secure(void *addr, size_t len);
+void bh_cache_clean_range(void *addr, size_t len);
+void bh_cache_invalidate_range(void *addr, size_t len);
+void bh_cache_flush_range(void *addr, size_t len);
+```
+
+### ISA Mapping
+* **RISC-V**: CMO extensions (Zicboz for zeroing, block clean/flush).
+* **Arm**: Architectural cache zero, cache maintenance operations.
+* **x86**: Optimized string memops (e.g., ERMS).
+
+## Architecture Dispatch
+
+```mermaid
+flowchart TD
+    A[Neutral Memory API Call] --> B{Hardware Implementation Available?}
+    B -->|Yes| C[Hardware Implementation]
+    B -->|No| D{Optimized Arch Implementation?}
+    D -->|Yes| E[Optimized Architecture Implementation]
+    D -->|No| F[Freestanding Scalar Fallback]
+```
+
+## Execution Plan
+1. **Define Neutral API**: Create the standard functions for zeroing and cache maintenance.
+2. **Capability Hooks**: Map `hal_hw_caps_t` flags (like `cache_block_zero`) to the dispatch logic.
+3. **Hardware Implementations**: Implement assembly/intrinsic routines for supported ISAs (Zicboz, ERMS, etc.).
+4. **Fallback Routines**: Ensure freestanding scalar implementations exist for unsupported targets.
+5. **Security Check**: Enforce that the kernel mediates all raw cache maintenance operations; do not expose directly to userspace unless explicitly authorized.
+6. **Testing**: Verify cache coherency after operations and measure zeroing performance improvements.

--- a/docs/architecture/kernel/hardware-adaptive/KMM-HUGEPAGE-001-multi-granule-mapping.md
+++ b/docs/architecture/kernel/hardware-adaptive/KMM-HUGEPAGE-001-multi-granule-mapping.md
@@ -1,0 +1,67 @@
+---
+title: KMM-HUGEPAGE-001 - Multi-granule Mapping Mechanism
+status: Draft
+owner: Architecture Working Group
+last_updated: 2026-05-15
+tags:
+  - docs
+  - architecture
+  - kernel
+  - memory
+see_also:
+  - README.md
+---
+
+# KMM-HUGEPAGE-001: Huge-Page Promotion Mechanism
+
+## Context
+The existing x86 page-table backend supports 2 MiB mappings. This needs to be generalized into an explicit neutral kernel mechanism for large page promotion across architectures, reducing TLB pressure.
+
+## Design
+Attach metadata to VM regions to support hardware-assisted large mapping promotion/demotion.
+
+### Region Metadata
+
+```c
+struct bh_vm_region_metadata {
+    uint32_t allowed_page_sizes;
+    uint32_t current_page_size;
+    bool physical_contiguity;
+    uint64_t alignment;
+    bool protection_uniformity;
+};
+```
+
+### Promotion Criteria
+Mapping selects a larger page only when:
+* VA alignment is correct
+* PA alignment is correct
+* Sufficient contiguous range exists
+* Identical permissions apply across the range
+* Hardware supports it (via `hal_hw_caps_t`)
+
+## Architecture
+
+```mermaid
+flowchart TD
+    A[Map Request] --> B{Check Criteria}
+    B --> C{VA/PA Aligned?}
+    C -->|Yes| D{Contiguous Range?}
+    D -->|Yes| E{Uniform Permissions?}
+    E -->|Yes| F{Hardware Support?}
+    F -->|Yes| G[Map Large Page]
+
+    C -->|No| H[Map Standard Page]
+    D -->|No| H
+    E -->|No| H
+    F -->|No| H
+```
+
+## Execution Plan
+1. **Generalize API**: Extract the x86 2 MiB logic into a neutral multi-granule mapping mechanism.
+2. **Metadata Extension**: Add necessary constraints (alignment, contiguity, permissions) to VM region metadata.
+3. **Promotion Logic**: Implement the criteria checking before committing to a page table update.
+4. **Demotion Logic**: Implement safe splitting/demotion when parts of a large mapping require different permissions.
+5. **Architecture Support**: Add ARM/RISC-V equivalents based on their page table structures.
+6. **Policy Separation**: Ensure that the kernel only provides the mechanism; huge page preference policy remains outside.
+7. **Testing**: Validate TLB pressure reduction and verify correctness during demotion (e.g., mprotect on a sub-region).

--- a/docs/architecture/kernel/hardware-adaptive/KMM-TLBCTX-001-lazy-tlb.md
+++ b/docs/architecture/kernel/hardware-adaptive/KMM-TLBCTX-001-lazy-tlb.md
@@ -1,0 +1,61 @@
+---
+title: KMM-TLBCTX-001 - PCID/ASID-aware Lazy TLB Algorithm
+status: Draft
+owner: Architecture Working Group
+last_updated: 2026-05-15
+tags:
+  - docs
+  - architecture
+  - kernel
+  - memory
+see_also:
+  - README.md
+---
+
+# KMM-TLBCTX-001: PCID/ASID-aware Lazy TLB Algorithm
+
+## Context
+The existing TLB interface declares lazy-generation capability, but it is incomplete. x86 enables PCID dynamically but lacks the higher-level lazy model. A full PCID/ASID-aware algorithm reduces cross-core disruption.
+
+## Design
+Build above the existing bounded TLB protocol to track generations and hardware context IDs, deferring invalidations for non-active CPUs.
+
+### Data Structures
+
+```c
+struct bh_address_space {
+    atomic_u64 tlb_generation;
+    uint32_t hardware_context_id;
+    uint64_t context_generation;
+};
+
+struct bh_cpu_tlb_state {
+    struct bh_address_space *current_aspace;
+    uint64_t last_seen_tlb_generation[MAX_HW_CONTEXTS];
+};
+```
+
+### ISA Mapping
+* **x86**: PCID, INVPCID/selective invalidation.
+* **Arm**: ASID, TLBI.
+* **RISC-V**: ASID, Svinval.
+
+## Architecture
+
+```mermaid
+flowchart TD
+    A[Address Space Mutation] --> B[aspace.tlb_generation++]
+    B --> C{CPU active?}
+    C -->|Yes| D[Immediate targeted invalidation]
+    C -->|No| E[No IPI sent]
+    E --> F[Next context entry detects stale generation]
+    F --> G[Local invalidate before execution]
+```
+
+## Execution Plan
+1. **Extend Structures**: Update `bh_address_space` with generation counters and context IDs. Add per-CPU `last_seen_tlb_generation`.
+2. **Context ID Allocation**: Implement ID allocator for ASIDs/PCIDs.
+3. **Lazy Invalidation Logic**: Modify the address-space mutation path to only IPI active CPUs and rely on lazy detection for others.
+4. **Context Switch Integration**: Update context switch path to check generations and invalidate locally if stale.
+5. **Hardware Dispatch**: Use ISA-specific features (PCID, ASID, Svinval) through the HAL capability layer.
+6. **Testing**: Stress test concurrent address space mutations and context switches.

--- a/docs/architecture/kernel/hardware-adaptive/KPRIM-002-primitive-dispatch.md
+++ b/docs/architecture/kernel/hardware-adaptive/KPRIM-002-primitive-dispatch.md
@@ -1,0 +1,71 @@
+---
+title: KPRIM-002 - Hardware-Adaptive Primitive Dispatch
+status: Draft
+owner: Architecture Working Group
+last_updated: 2026-05-15
+tags:
+  - docs
+  - architecture
+  - kernel
+  - hardware-adaptive
+see_also:
+  - README.md
+---
+
+# KPRIM-002: Hardware-Adaptive Primitive Dispatch
+
+## Context
+The goal is to provide granular mechanism-level capabilities for hardware-adaptive primitives. The existing architecture supports coarse features (`has_atomic_64`, `has_mmu`), which is insufficient for dispatching optimal algorithmic variants.
+
+## Design
+Extend the existing capability structure (`hal_hw_caps_t`) and primitive registry with granular capabilities that remain architecture-neutral.
+
+### Extended Capability Model (`hal_hw_caps_t`)
+
+```c
+typedef struct {
+    // Existing broad capabilities...
+
+    // New fine-grained capabilities:
+    bool atomic_cas64;            // Native 64-bit CAS
+    bool atomic_cas128;           // Native 128-bit CAS
+    bool atomic_fetch_add;        // Native atomic RMW
+    bool wait_on_memory;          // Efficient CPU wait until memory changes
+    bool tlb_context_id;          // ASID/PCID-style context identifiers
+    bool tlb_addr_context_flush;  // Address + context-specific invalidation
+    bool tlb_range_flush;         // Hardware-efficient range invalidation
+    bool timer_absolute_deadline; // Absolute per-core comparator
+    bool cache_block_zero;        // Fast cache-line/block zero
+    bool cache_clean;             // Explicit clean operation
+    bool cache_invalidate;        // Explicit invalidate
+    bool large_page_2m;           // Large mapping size
+    bool large_page_1g;           // Larger mapping size
+    bool memory_tagging;          // Memory tag enforcement
+    bool pointer_auth;            // Authenticated control pointers
+    bool branch_target_guard;     // Indirect branch target enforcement
+    bool shadow_stack;            // Hardware shadow stack
+} hal_hw_caps_t;
+```
+
+### Dispatch Architecture
+
+```mermaid
+flowchart TD
+    A[x86 CPUID / ARM ID Registers / RISC-V ISA Exts] --> B[HAL Capability Discovery]
+    B --> C{Populate hal_hw_caps_t}
+    C --> D[Kernel Primitive Registry]
+    D --> E[Hardware-Assisted Implementation]
+    D --> F[Software Fallback Implementation]
+```
+
+## ISA Mapping
+* **x86-64:** CMPXCHG16B, PCID, INVLPG, WAITPKG/MONITOR, CET
+* **ARM64:** LSE atomics (CASP), ASID, TLBI, WFE, MTE, PAC/BTI
+* **RISC-V64:** Zacas, Zawrs, ASID/Svinval, Sstc, Zicboz, Zicfiss/Zicfilp
+
+## Execution Plan
+1. **Extend `hal_hw_caps_t`**: Add the boolean flags for new neutral capabilities.
+2. **Architecture Discovery**: Update `arch/x86`, `arch/arm`, and `arch/riscv` to translate CPU registers into these neutral features.
+3. **Primitive Registry Update**: Adapt the registry for boot-time immutable dispatch based on these granular capabilities.
+4. **Audit Rule Enforcement**: Implement the P0 audit rule checking for direct enablement of optional features without discovery.
+5. **Testing**: Add feature-present and feature-absent tests for all three 64-bit architectures.

--- a/docs/architecture/kernel/hardware-adaptive/KSYNC-EVENT-001-eventcount.md
+++ b/docs/architecture/kernel/hardware-adaptive/KSYNC-EVENT-001-eventcount.md
@@ -1,0 +1,57 @@
+---
+title: KSYNC-EVENT-001 - Eventcount Adaptive Wait
+status: Draft
+owner: Architecture Working Group
+last_updated: 2026-05-15
+tags:
+  - docs
+  - architecture
+  - kernel
+  - synchronization
+see_also:
+  - README.md
+---
+
+# KSYNC-EVENT-001: Eventcount Adaptive Wait
+
+## Context
+Need a primitive for transaction completion, IPC receive, and scheduler completion cells that adapts between spinning, low-power waiting, and parking.
+
+## Design
+The `bh_eventcount` acts as an adaptive wait primitive, complementing MPSC queues, utilizing hardware wait instructions when available.
+
+### Data Structure
+
+```c
+struct bh_eventcount {
+    atomic_u64 sequence;
+    bh_waitq_t waiters;
+};
+```
+
+### ISA Mapping
+* **RISC-V**: Zawrs
+* **Arm**: WFE / event mechanisms
+* **x86**: WAITPKG / PAUSE
+
+## Architecture Model
+
+```mermaid
+flowchart TD
+    A[Read sequence] --> B[Try condition]
+    B -->|False| C[Short adaptive spin]
+    C --> D{Hardware wait supported?}
+    D -->|Yes| E[Hardware low-power wait]
+    D -->|No| F[Scheduler park]
+    E --> G[Wakeup]
+    F --> G
+    G --> A
+```
+
+## Execution Plan
+1. **Define `bh_eventcount`**: Implement structure with sequence and wait queue.
+2. **Adaptive Spin**: Implement the initial short spin loop.
+3. **Hardware Wait**: Dispatch to ISA-specific low-power wait instructions (Zawrs, WFE, WAITPKG) using the HAL capability layer.
+4. **Scheduler Fallback**: Implement the final fallback to scheduler park.
+5. **Producer Wake**: Implement sequence increment and waiter wake logic.
+6. **Testing**: Verify contention behavior and power efficiency improvements.

--- a/docs/architecture/kernel/hardware-adaptive/KTIMER-001-deadline-engine.md
+++ b/docs/architecture/kernel/hardware-adaptive/KTIMER-001-deadline-engine.md
@@ -1,0 +1,46 @@
+---
+title: KTIMER-001 - Hybrid Timer Engine
+status: Draft
+owner: Architecture Working Group
+last_updated: 2026-05-15
+tags:
+  - docs
+  - architecture
+  - kernel
+  - timers
+see_also:
+  - README.md
+---
+
+# KTIMER-001: Hybrid Timer Engine
+
+## Context
+Bharat-OS requires an efficient timer engine for distributed deadlines, EDF scheduling, and timeouts. A hybrid structure (min-heap + timing wheel) per core provides O(1)-like efficiency for long timers and precise resolution for imminent ones.
+
+## Design
+A per-core hybrid timer combining a small min-heap and a hierarchical timing wheel.
+
+### Hardware Backend
+The hardware comparator is programmed only for the earliest required deadline.
+* **x86**: Architectural deadline timer.
+* **Arm64**: Generic Timer comparator.
+* **RISC-V**: Sstc `stimecmp`.
+
+## Architecture Model
+
+```mermaid
+flowchart TD
+    A[Per-Core Timer Engine] --> B(Small Min-Heap)
+    A --> C(Hierarchical Wheel)
+    B -->|Imminent Timers| D(Precise Deadline)
+    C -->|Longer-lived Timers| E(O 1 Buckets)
+    D --> F[Next Hardware Deadline]
+```
+
+## Execution Plan
+1. **Absolute Deadline Contract**: Extend the generic timer contract to support absolute deadlines.
+2. **Hybrid Structure Implementation**: Build the min-heap and hierarchical wheel data structures.
+3. **Timer Insertion/Removal**: Implement logic to route imminent timers to the heap and others to the wheel.
+4. **Hardware Backend Dispatch**: Wire the engine to the earliest deadline using `hal_hw_caps_t` to select architectural timers.
+5. **Tickless Idle**: Integrate with the scheduler to enable tickless idle behavior based on the next deadline.
+6. **Testing**: Validate timer firing order, stress test insertion/removal, and test boundary conditions across the heap/wheel interface.

--- a/docs/architecture/kernel/hardware-adaptive/KURPC-FAST-001-spsc-lanes.md
+++ b/docs/architecture/kernel/hardware-adaptive/KURPC-FAST-001-spsc-lanes.md
@@ -1,0 +1,50 @@
+---
+title: KURPC-FAST-001 - SPSC Peer Lanes
+status: Draft
+owner: Architecture Working Group
+last_updated: 2026-05-15
+tags:
+  - docs
+  - architecture
+  - kernel
+  - ipc
+see_also:
+  - README.md
+---
+
+# KURPC-FAST-001: Per-peer SPSC Fast Lanes for uRPC
+
+## Context
+While MPSC handles generic many-to-one communication, stable peer-to-peer pairs benefit from uncontended SPSC rings, lowering cross-core communication cost while preserving the "no direct remote mutation" rule.
+
+## Design
+Introduce cacheline-separated SPSC channels with doorbell coalescing for stable peer pairs.
+
+### Channel Structure
+
+```text
+CPU 0 ───── SPSC ─────> CPU 3
+CPU 3 ───── SPSC ─────> CPU 0
+```
+
+### Properties
+* No contended atomic producer head.
+* Producer owns `head`, consumer owns `tail`.
+* Release when publishing, acquire when consuming.
+* Cache-line separation of producer/consumer metadata.
+
+## Architecture: Doorbell Coalescing
+
+```mermaid
+flowchart TD
+    A[Producer publishes message] --> B{Pending transitioned 0 -> 1?}
+    B -->|Yes| C[Send IPI]
+    B -->|No| D[Do not send another IPI]
+```
+
+## Execution Plan
+1. **Define SPSC Ring**: Implement cache-aligned, separation of head and tail pointers.
+2. **Memory Ordering**: Apply explicit acquire/release semantics to head/tail updates.
+3. **Doorbell Coalescing**: Implement the `0 -> 1` pending transition check to minimize IPIs.
+4. **Integration**: Allow setup of SPSC fast lanes alongside the generic MPSC fallback.
+5. **Testing**: Benchmark IPI reduction and throughput increases for stable peer communication.

--- a/docs/architecture/kernel/hardware-adaptive/KVM-RANGE-002-mmu-full-index.md
+++ b/docs/architecture/kernel/hardware-adaptive/KVM-RANGE-002-mmu-full-index.md
@@ -1,0 +1,62 @@
+---
+title: KVM-RANGE-002 - MMU_FULL VM Linear Range Index
+status: Draft
+owner: Architecture Working Group
+last_updated: 2026-05-15
+tags:
+  - docs
+  - architecture
+  - kernel
+  - memory
+see_also:
+  - README.md
+---
+
+# KVM-RANGE-002: MMU_FULL VM Linear Range Index
+
+## Context
+The current `bh_range_tree` is a sorted fixed array. While suitable for MPU/MMU_LITE, linear search and shift operations do not scale for MMU_FULL profiles.
+
+## Design
+Introduce two implementations behind one unified API: a sorted fixed array for constrained profiles and an RB-tree (progressing to a multiway range tree) for scalable configurations.
+
+### Profile Implementations
+| Profile | Index Implementation |
+|---|---|
+| MPU_ONLY | Sorted fixed array |
+| MMU_LITE | Sorted fixed array |
+| MMU_FULL (small) | RB tree |
+| MMU_FULL (scalable)| Cache-friendly multiway range tree |
+
+### Future Multiway Node Concept
+
+```c
+struct bh_vm_range_node_internal {
+    uint64_t pivots[N];
+    struct bh_vm_range_node *children[N+1];
+    uint32_t gap_metadata;
+};
+
+struct bh_vm_range_leaf {
+    struct bh_vm_region regions[N]; // start, end, region ptr
+};
+```
+
+## Architecture
+
+```mermaid
+flowchart TD
+    A[VM Region API Request] --> B{Profile Selected?}
+    B -->|MPU_ONLY / MMU_LITE| C[Sorted Fixed Array]
+    B -->|MMU_FULL| D[RB Tree / Multiway Tree]
+    C --> E[Return Result]
+    D --> E
+```
+
+## Execution Plan
+1. **Abstract API**: Ensure the `bh_range_tree` API cleanly hides the underlying implementation.
+2. **Preserve Fallback**: Maintain the sorted fixed array implementation for MPU_ONLY/MMU_LITE.
+3. **Implement RB Tree**: Add the RB-tree backend for MMU_FULL configurations.
+4. **Node Allocation**: Ensure tree nodes are allocated from a bounded slab reserve, avoiding arbitrary `kalloc` in fault paths.
+5. **RCU Integration**: Prepare the tree structure for owner-local writers and RCU read sides.
+6. **Testing**: Profile performance improvements for MMU_FULL and verify correctness against the fixed-array baseline.

--- a/docs/architecture/kernel/hardware-adaptive/README.md
+++ b/docs/architecture/kernel/hardware-adaptive/README.md
@@ -1,0 +1,88 @@
+---
+title: Hardware-Adaptive Kernel Algorithms Reference
+status: Active
+owner: Architecture Working Group
+last_updated: 2026-05-15
+tags:
+  - docs
+  - architecture
+  - kernel
+  - hardware-adaptive
+see_also:
+  - ../kernel-algorithmic-foundations.md
+  - ../../../reviews/gap_analysis/latest_gap_analysis.md
+---
+
+# Hardware-Adaptive Kernel Algorithms
+
+This directory contains the design documentation, architecture details, and execution plans for the next phase of Bharat-OS kernel evolution: **Hardware-Adaptive Kernel Algorithms**.
+
+## 1. Vision and Goal
+
+The goal is to provide one portable kernel algorithm, a safe software baseline, and optional hardware-assisted implementations selected from truthful boot-time capabilities. This fits the Bharat-OS architecture rule:
+* **Kernel** owns mechanism.
+* **`arch/`** owns ISA implementation.
+* **HAL** owns neutral contracts.
+* **Platform** owns discovery.
+* **Services** own policy.
+
+The result is a distinctive model: the same kernel algorithms run from small ARM/RISC-V controllers through desktop/server-class SMP, with deterministic software fallbacks on minimal hardware and transparent acceleration on richer CPUs—without violating the multikernel ownership model or contaminating the kernel with hardware policy.
+
+## 2. P0 Audit Rule
+
+> **No optional CPU feature may be enabled or executed unless the architecture capability layer has positively discovered it, except features that the supported architecture baseline formally guarantees.**
+
+## 3. Recommended Architecture Model
+
+```mermaid
+flowchart TD
+    A[PLATFORM DISCOVERY] --> B[ARCH CPU DISCOVERY]
+    B -->|x86 CPUID / ARM ID_* / RISC-V ISA| C[HAL NORMALIZATION]
+    C -->|hal_hw_caps_t| D[Hardware Primitives]
+    D --> D1(Atomics)
+    D --> D2(MMU)
+    D --> D3(Timer)
+    D1 -.->|CAS128, wait, RMW| E[KERNEL PRIMITIVE REGISTRY]
+    D2 -.->|ctx-id, range-TLB, large-page| E
+    D3 -.->|absolute deadline, per-CPU| E
+    E -->|boot-time immutable dispatch| F[Kernel Algorithms]
+    F --> F1(RCU, seqlock, queues)
+    F --> F2(TLB algorithm, VM index, PMM)
+    F --> F3(Timer engine, eventcount, uRPC)
+```
+
+## 4. Execution Plan & Documentation Index
+
+The following tasks comprise the detailed design for this phase:
+
+### Core Capabilities
+1. [**KPRIM-002** — Hardware-Adaptive Primitive Dispatch](KPRIM-002-primitive-dispatch.md)
+
+### Concurrency & Synchronization
+2. [**KDS-SEQLK-002** — Production Seqlock](KDS-SEQLK-002-production-seqlock.md)
+3. [**KDS-RCU-002** — Epoch RCU-lite](KDS-RCU-002-epoch-rcu-lite.md)
+4. [**KSYNC-EVENT-001** — Eventcount Adaptive Wait](KSYNC-EVENT-001-eventcount.md)
+5. [**KURPC-FAST-001** — Per-peer SPSC fast lanes for uRPC](KURPC-FAST-001-spsc-lanes.md)
+
+### Memory & TLB
+6. [**KMM-TLBCTX-001** — PCID/ASID-aware Lazy TLB Algorithm](KMM-TLBCTX-001-lazy-tlb.md)
+7. [**KVM-RANGE-002** — MMU_FULL VM Linear Range Index](KVM-RANGE-002-mmu-full-index.md)
+8. [**KMEM-ACCEL-001** — Hardware-Assisted Secure Zero/Copy/Cache Operations](KMEM-ACCEL-001-hw-memops.md)
+9. [**KMM-HUGEPAGE-001** — Huge-Page Promotion Mechanism](KMM-HUGEPAGE-001-multi-granule-mapping.md)
+10. [**KHARDEN-001** — Hardware-Assisted Kernel Memory Safety](KHARDEN-001-hardware-assisted-safety.md)
+
+### Timing
+11. [**KTIMER-001** — Hybrid Timer Engine](KTIMER-001-deadline-engine.md)
+
+## 5. Required Verification Evidence
+
+For every new concurrent primitive, the following evidence must be provided:
+* **Functional:** Expected lookup/enqueue/reclamation results.
+* **Adversarial concurrency:** 2/4/8-core races, delayed cores, lost notifications.
+* **Memory ordering:** Publish-before-visible, no torn snapshots, no premature reclamation.
+* **Hardware fallback equivalence:** Hardware and software paths produce identical semantics.
+* **Fault injection:** Stalled core, queue full, timer late, invalid feature report.
+* **Cross-architecture:** x86_64 + ARM64 + RISC-V64.
+* **Constrained profile:** ARM32/RV32 compile and explicit fallback/unsupported truth.
+* **Performance:** Cycles/op, cache misses, IPIs, TLB flushes, wakeups.
+* **Security:** Stale handle, UAF, tag failure, invalid TLB generation tests.


### PR DESCRIPTION
This pull request adds detailed design, execution plan, and architecture documentation for the hardware-adaptive kernel algorithms as proposed in the recent gap analysis.

The following documentation has been added under `docs/architecture/kernel/hardware-adaptive/`:

1.  **Hardware-Adaptive Primitive Dispatch (KPRIM-002)**
2.  **Production Seqlock (KDS-SEQLK-002)**
3.  **Epoch RCU-lite (KDS-RCU-002)**
4.  **Per-core deadline engine (KTIMER-001)**
5.  **Context-ID/lazy TLB generation (KMM-TLBCTX-001)**
6.  **MMU_FULL range index (KVM-RANGE-002)**
7.  **Eventcount/wait primitive (KSYNC-EVENT-001)**
8.  **SPSC peer lanes (KURPC-FAST-001)**
9.  **Hardware-assisted page zero/cache memops (KMEM-ACCEL-001)**
10. **Huge-Page Promotion Mechanism (KMM-HUGEPAGE-001)**
11. **Hardware-Assisted Kernel Memory Safety (KHARDEN-001)**

All documents follow the existing standard for YAML frontmatter (tags, owner, status) and include Mermaid diagrams for architectural models. `docs/architecture/README.md` has been updated to point to the new main index document (`docs/architecture/kernel/hardware-adaptive/README.md`).

---
*PR created automatically by Jules for task [3215545354435901113](https://jules.google.com/task/3215545354435901113) started by @divyang4481*