### PR TITLE
Introduce KPRIM capability API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,7 @@ endif()
 
 # Generate monitor service IDL
 execute_process(
-    COMMAND "${Python3_EXECUTABLE}" "${BHARAT_IDL_GEN_SCRIPT}"
+    COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${CMAKE_SOURCE_DIR} "${Python3_EXECUTABLE}" "${BHARAT_IDL_GEN_SCRIPT}"
             "${BHARAT_IDL_ROOT}/monitor_v1.bidl"
             "${BHARAT_GEN_INCLUDE_DIR}"
     WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
@@ -96,7 +96,7 @@ endif()
 
 # Generate cap service IDL
 execute_process(
-    COMMAND "${Python3_EXECUTABLE}" "${BHARAT_IDL_GEN_SCRIPT}"
+    COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${CMAKE_SOURCE_DIR} "${Python3_EXECUTABLE}" "${BHARAT_IDL_GEN_SCRIPT}"
             "${BHARAT_IDL_ROOT}/cap_v1.bidl"
             "${BHARAT_GEN_INCLUDE_DIR}"
     WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"

--- a/core/kernel/CMakeLists.txt
+++ b/core/kernel/CMakeLists.txt
@@ -490,6 +490,7 @@ set(KERNEL_SRCS
     $<$<STREQUAL:${ARCH},riscv32>:${BHARAT_ARCH_HAL_ROOT}/riscv/riscv32/hal_mm.c>
     ${ARCH_EXT_STATE_SRC}
     ${BHARAT_HAL_ROOT}/common/hal_mem_backend.c
+    ${BHARAT_HAL_ROOT}/common/cpu_features.c
     ${BHARAT_HAL_ROOT}/common/iommu_adapter.c
     ${BHARAT_HAL_ROOT}/common/hal_dma_coherency.c
     ${BHARAT_HAL_ROOT}/common/hal_interrupt_common.c

--- a/core/kernel/include/kernel/primitive_caps.h
+++ b/core/kernel/include/kernel/primitive_caps.h
@@ -1,0 +1,64 @@
+#ifndef BHARAT_KERNEL_PRIMITIVE_CAPS_H
+#define BHARAT_KERNEL_PRIMITIVE_CAPS_H
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "kernel/primitive.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Kernel Primitive Capabilities.
+ * Architecture-neutral capability descriptors for kernel algorithms to determine
+ * whether a hardware-assisted implementation exists.
+ */
+typedef enum {
+    /* Atomic */
+    BH_KPRIM_CAP_ATOMIC_64,
+
+    /* Memory Translation / TLB */
+    BH_KPRIM_CAP_TLB_PAGE_INVALIDATE,
+    BH_KPRIM_CAP_TLB_RANGE_INVALIDATE,
+    BH_KPRIM_CAP_TLB_CONTEXT_INVALIDATE,
+    BH_KPRIM_CAP_TLB_BROADCAST_INVALIDATE,
+    BH_KPRIM_CAP_LAZY_TLB_GENERATION,
+
+    /* Timer */
+    BH_KPRIM_CAP_HIGH_RES_TIMER,
+
+    /* DMA / Memory */
+    BH_KPRIM_CAP_IOMMU,
+
+    BH_KPRIM_CAP_COUNT
+} bh_kprim_capability_t;
+
+/**
+ * KPRIM capability check for SYSTEM_ALL.
+ * Safe for generic migratable kernel code. True only if ALL eligible CPUs support it.
+ */
+bool bh_kprim_has(bh_kprim_capability_t cap);
+
+/**
+ * KPRIM capability check for LOCAL CPU.
+ * Only safe for pinned/local dispatch. True if the CURRENT CPU supports it.
+ */
+bool bh_kprim_has_local(bh_kprim_capability_t cap);
+
+/**
+ * KPRIM capability check for SYSTEM_ANY.
+ * True if ANY CPU supports it. Used for discovery/diagnostics/special placement only.
+ */
+bool bh_kprim_has_any(bh_kprim_capability_t cap);
+
+/**
+ * Get the fine-grained implementation support level of a KPRIM capability.
+ */
+bh_primitive_support_level_t bh_kprim_get_support_level(bh_kprim_capability_t cap);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BHARAT_KERNEL_PRIMITIVE_CAPS_H */

--- a/core/kernel/src/core/primitive_registry.c
+++ b/core/kernel/src/core/primitive_registry.c
@@ -1,22 +1,138 @@
 #include "hal/hal_hw_caps.h"
+#include "hal/hal_cpu_features.h"
+#include "hal/hal_tlb.h"
 #include "kernel/primitive.h"
+#include "kernel/primitive_caps.h"
 #include "kernel/status.h"
 #include "profile/profile_policy.h"
+#include "bharat/kernel/ds/bh_bitmap.h"
+#include "lib/base/string.h"
 
-static hal_hw_caps_t g_discovered_caps;
-static bool g_registry_initialized = false;
+typedef enum {
+    KPRIM_STATE_UNINITIALIZED = 0,
+    KPRIM_STATE_DISCOVERING,
+    KPRIM_STATE_NORMALIZED,
+    KPRIM_STATE_FINALIZED
+} kprim_registry_state_t;
+
+typedef struct {
+    uint32_t version;
+    kprim_registry_state_t state;
+    hal_hw_caps_t hw_caps;
+    hal_tlb_caps_t tlb_caps;
+    hal_cpu_feature_set_t cpu_caps_all;
+    hal_cpu_feature_set_t cpu_caps_any;
+
+    bh_primitive_support_level_t cap_support[BH_KPRIM_CAP_COUNT];
+
+    // Extracted bitmaps for O(1) query
+    uint64_t system_all_bits[(BH_KPRIM_CAP_COUNT + 63) / 64];
+    uint64_t system_any_bits[(BH_KPRIM_CAP_COUNT + 63) / 64];
+} bh_kprim_registry_t;
+
+static bh_kprim_registry_t g_registry = {0};
+
+static inline void set_bit(uint64_t *bitmap, bh_kprim_capability_t cap) {
+    bitmap[cap / 64] |= (1ULL << (cap % 64));
+}
+
+static inline bool get_bit(const uint64_t *bitmap, bh_kprim_capability_t cap) {
+    return (bitmap[cap / 64] & (1ULL << (cap % 64))) != 0;
+}
 
 kstatus_t bh_kernel_primitive_registry_init(const hal_hw_caps_t *caps) {
     if (!caps) {
         return K_ERR_INVALID_ARG;
     }
-    g_discovered_caps = *caps;
-    g_registry_initialized = true;
+
+    if (g_registry.state == KPRIM_STATE_FINALIZED) {
+        return K_ERR_BAD_STATE; // Already finalized
+    }
+
+    g_registry.state = KPRIM_STATE_DISCOVERING;
+    g_registry.hw_caps = *caps;
+
+    // Fetch TLB capabilities
+    const hal_tlb_caps_t *tlb_caps = hal_tlb_caps();
+    if (tlb_caps) {
+        g_registry.tlb_caps = *tlb_caps;
+    } else {
+        memset(&g_registry.tlb_caps, 0, sizeof(hal_tlb_caps_t));
+    }
+
+    // Fetch CPU feature sets
+    bool cpu_all_ready = hal_cpu_feature_set_system(HAL_CPU_FEATURE_SCOPE_ALL, &g_registry.cpu_caps_all);
+    bool cpu_any_ready = hal_cpu_feature_set_system(HAL_CPU_FEATURE_SCOPE_ANY, &g_registry.cpu_caps_any);
+
+    if (!cpu_all_ready || !cpu_any_ready) {
+        g_registry.state = KPRIM_STATE_UNINITIALIZED;
+        return K_ERR_IN_PROGRESS;
+    }
+
+    g_registry.state = KPRIM_STATE_NORMALIZED;
+
+    // Normalize HAL truth into KPRIM capability truth
+    memset(g_registry.system_all_bits, 0, sizeof(g_registry.system_all_bits));
+    memset(g_registry.system_any_bits, 0, sizeof(g_registry.system_any_bits));
+    memset(g_registry.cap_support, 0, sizeof(g_registry.cap_support));
+
+    // Helper macro for capabilities
+    #define NORMALIZE_CAP(CAP, IS_ALL, IS_ANY, SUPPORT) \
+        do { \
+            if (IS_ALL) set_bit(g_registry.system_all_bits, CAP); \
+            if (IS_ANY) set_bit(g_registry.system_any_bits, CAP); \
+            g_registry.cap_support[CAP] = SUPPORT; \
+        } while(0)
+
+    // Helper to check CPU feature in a set
+    #define HAS_CPU_FEATURE(SET_PTR, FEAT) \
+        (((SET_PTR)->usable_bits[(FEAT) / 64] & (1ULL << ((FEAT) % 64))) != 0)
+
+    // ATOMIC_64
+    bool atomic64_all = HAS_CPU_FEATURE(&g_registry.cpu_caps_all, HAL_CPU_FEATURE_STRONG_ATOMICS) || g_registry.hw_caps.has_atomic_64;
+    bool atomic64_any = HAS_CPU_FEATURE(&g_registry.cpu_caps_any, HAL_CPU_FEATURE_STRONG_ATOMICS) || g_registry.hw_caps.has_atomic_64;
+    NORMALIZE_CAP(BH_KPRIM_CAP_ATOMIC_64, atomic64_all, atomic64_any,
+                  atomic64_any ? BH_PRIMITIVE_HARDWARE_ASSISTED : BH_PRIMITIVE_UNSUPPORTED);
+
+    // TLB_PAGE_INVALIDATE
+    NORMALIZE_CAP(BH_KPRIM_CAP_TLB_PAGE_INVALIDATE, g_registry.tlb_caps.supports_page_flush, g_registry.tlb_caps.supports_page_flush,
+                  g_registry.tlb_caps.supports_page_flush ? BH_PRIMITIVE_HARDWARE_ASSISTED : BH_PRIMITIVE_UNSUPPORTED);
+
+    // TLB_RANGE_INVALIDATE
+    NORMALIZE_CAP(BH_KPRIM_CAP_TLB_RANGE_INVALIDATE, g_registry.tlb_caps.supports_range_flush, g_registry.tlb_caps.supports_range_flush,
+                  g_registry.tlb_caps.supports_range_flush ? BH_PRIMITIVE_HARDWARE_ASSISTED : BH_PRIMITIVE_UNSUPPORTED);
+
+    // TLB_CONTEXT_INVALIDATE
+    NORMALIZE_CAP(BH_KPRIM_CAP_TLB_CONTEXT_INVALIDATE, g_registry.tlb_caps.supports_asid_selective_flush, g_registry.tlb_caps.supports_asid_selective_flush,
+                  g_registry.tlb_caps.supports_asid_selective_flush ? BH_PRIMITIVE_HARDWARE_ASSISTED : BH_PRIMITIVE_UNSUPPORTED);
+
+    // TLB_BROADCAST_INVALIDATE
+    NORMALIZE_CAP(BH_KPRIM_CAP_TLB_BROADCAST_INVALIDATE, g_registry.tlb_caps.supports_broadcast_flush, g_registry.tlb_caps.supports_broadcast_flush,
+                  g_registry.tlb_caps.supports_broadcast_flush ? BH_PRIMITIVE_HARDWARE_ASSISTED : BH_PRIMITIVE_UNSUPPORTED);
+
+    // LAZY_TLB_GENERATION
+    NORMALIZE_CAP(BH_KPRIM_CAP_LAZY_TLB_GENERATION, g_registry.tlb_caps.supports_lazy_generation_model, g_registry.tlb_caps.supports_lazy_generation_model,
+                  g_registry.tlb_caps.supports_lazy_generation_model ? BH_PRIMITIVE_HARDWARE_ASSISTED : BH_PRIMITIVE_UNSUPPORTED);
+
+    // HIGH_RES_TIMER
+    NORMALIZE_CAP(BH_KPRIM_CAP_HIGH_RES_TIMER, g_registry.hw_caps.has_high_res_timer, g_registry.hw_caps.has_high_res_timer,
+                  g_registry.hw_caps.has_high_res_timer ? BH_PRIMITIVE_HARDWARE_ASSISTED : BH_PRIMITIVE_UNSUPPORTED);
+
+    // IOMMU
+    NORMALIZE_CAP(BH_KPRIM_CAP_IOMMU, g_registry.hw_caps.has_iommu, g_registry.hw_caps.has_iommu,
+                  g_registry.hw_caps.has_iommu ? BH_PRIMITIVE_HARDWARE_ENFORCED : BH_PRIMITIVE_UNSUPPORTED);
+
+    #undef NORMALIZE_CAP
+    #undef HAS_CPU_FEATURE
+
+    g_registry.version = 1;
+    g_registry.state = KPRIM_STATE_FINALIZED;
+
     return K_OK;
 }
 
 bh_primitive_support_level_t bh_kernel_primitive_get_support_level(bh_kernel_primitive_class_t primitive) {
-    if (!g_registry_initialized) {
+    if (g_registry.state != KPRIM_STATE_FINALIZED) {
         return BH_PRIMITIVE_UNSUPPORTED;
     }
 
@@ -25,9 +141,9 @@ bh_primitive_support_level_t bh_kernel_primitive_get_support_level(bh_kernel_pri
             return BH_PRIMITIVE_SOFTWARE_FALLBACK; // Core scheduler is software
 
         case BH_PRIMITIVE_MEMORY:
-            if (g_discovered_caps.has_mmu) {
+            if (g_registry.hw_caps.has_mmu) {
                 return BH_PRIMITIVE_HARDWARE_ENFORCED;
-            } else if (g_discovered_caps.has_mpu) {
+            } else if (g_registry.hw_caps.has_mpu) {
                 return BH_PRIMITIVE_HARDWARE_ASSISTED;
             }
             return BH_PRIMITIVE_SOFTWARE_FALLBACK;
@@ -39,7 +155,7 @@ bh_primitive_support_level_t bh_kernel_primitive_get_support_level(bh_kernel_pri
             return BH_PRIMITIVE_SOFTWARE_FALLBACK;
 
         case BH_PRIMITIVE_TIMER:
-            if (g_discovered_caps.has_high_res_timer) {
+            if (g_registry.hw_caps.has_high_res_timer) {
                 return BH_PRIMITIVE_HARDWARE_ASSISTED;
             }
             return BH_PRIMITIVE_SOFTWARE_FALLBACK;
@@ -48,14 +164,14 @@ bh_primitive_support_level_t bh_kernel_primitive_get_support_level(bh_kernel_pri
             return BH_PRIMITIVE_HARDWARE_ENFORCED; // CPU traps
 
         case BH_PRIMITIVE_DMA:
-            if (g_discovered_caps.has_iommu) {
+            if (g_registry.hw_caps.has_iommu) {
                 return BH_PRIMITIVE_HARDWARE_ENFORCED;
             }
             // DMA fallback depends on policy, but level is software fallback if no IOMMU
             return BH_PRIMITIVE_SOFTWARE_FALLBACK;
 
         case BH_PRIMITIVE_ACCEL:
-            if (g_discovered_caps.has_accel_device) {
+            if (g_registry.hw_caps.has_accel_device) {
                 return BH_PRIMITIVE_HARDWARE_ASSISTED;
             }
             return BH_PRIMITIVE_UNSUPPORTED;
@@ -70,4 +186,57 @@ bh_primitive_support_level_t bh_kernel_primitive_get_support_level(bh_kernel_pri
 
 bool bh_kernel_primitive_available(bh_kernel_primitive_class_t primitive) {
     return bh_kernel_primitive_get_support_level(primitive) != BH_PRIMITIVE_UNSUPPORTED;
+}
+
+bool bh_kprim_has(bh_kprim_capability_t cap) {
+    if (g_registry.state != KPRIM_STATE_FINALIZED) {
+        return false;
+    }
+    if (cap >= BH_KPRIM_CAP_COUNT) {
+        return false;
+    }
+    return get_bit(g_registry.system_all_bits, cap);
+}
+
+bool bh_kprim_has_local(bh_kprim_capability_t cap) {
+    if (g_registry.state != KPRIM_STATE_FINALIZED) {
+        return false;
+    }
+    if (cap >= BH_KPRIM_CAP_COUNT) {
+        return false;
+    }
+
+    if (get_bit(g_registry.system_all_bits, cap)) {
+        return true;
+    }
+
+    if (!get_bit(g_registry.system_any_bits, cap)) {
+        return false;
+    }
+
+    if (cap == BH_KPRIM_CAP_ATOMIC_64) {
+        return hal_cpu_has_feature_current(HAL_CPU_FEATURE_STRONG_ATOMICS) || g_registry.hw_caps.has_atomic_64;
+    }
+
+    return get_bit(g_registry.system_any_bits, cap);
+}
+
+bool bh_kprim_has_any(bh_kprim_capability_t cap) {
+    if (g_registry.state != KPRIM_STATE_FINALIZED) {
+        return false;
+    }
+    if (cap >= BH_KPRIM_CAP_COUNT) {
+        return false;
+    }
+    return get_bit(g_registry.system_any_bits, cap);
+}
+
+bh_primitive_support_level_t bh_kprim_get_support_level(bh_kprim_capability_t cap) {
+    if (g_registry.state != KPRIM_STATE_FINALIZED) {
+        return BH_PRIMITIVE_UNSUPPORTED;
+    }
+    if (cap >= BH_KPRIM_CAP_COUNT) {
+        return BH_PRIMITIVE_UNSUPPORTED;
+    }
+    return g_registry.cap_support[cap];
 }

--- a/core/kernel/src/tests/ktest_kprim_caps.c
+++ b/core/kernel/src/tests/ktest_kprim_caps.c
@@ -1,0 +1,63 @@
+#include "kernel/primitive.h"
+#include "kernel/primitive_caps.h"
+#include "hal/hal_hw_caps.h"
+#include "tests/ktest.h"
+#include "boot/boot_selftest.h"
+
+// Note: Testing immutable finalized state requires mocking, but since we use
+// the real registry, we can test that calling bh_kernel_primitive_registry_init
+// AGAIN returns K_ERR_BAD_STATE (already finalized).
+// Because the boot process already initialized it, we can verify it rejects a second init.
+static int kprim_caps_selftest_reinit(void) {
+    hal_hw_caps_t caps = {0};
+    kstatus_t status = bh_kernel_primitive_registry_init(&caps);
+    KTEST_ASSERT(status == K_ERR_BAD_STATE, "kprim registry should reject duplicate initialization");
+    return 0;
+}
+
+static int kprim_caps_selftest_queries(void) {
+    // We assume the system initialized correctly (since we're running).
+    // Test capability queries for boundary capabilities.
+
+    // A valid capability ID should either be true or false without crashing
+    bool has_timer = bh_kprim_has(BH_KPRIM_CAP_HIGH_RES_TIMER);
+    bh_primitive_support_level_t timer_support = bh_kprim_get_support_level(BH_KPRIM_CAP_HIGH_RES_TIMER);
+
+    // If it has the timer, the support level should be > UNSUPPORTED
+    if (has_timer) {
+        KTEST_ASSERT(timer_support > BH_PRIMITIVE_UNSUPPORTED, "timer present but unsupported");
+    } else {
+        KTEST_ASSERT(timer_support == BH_PRIMITIVE_UNSUPPORTED, "timer absent but supported");
+    }
+
+    // Invalid capability ID should return false/unsupported
+    bool invalid_cap = bh_kprim_has((bh_kprim_capability_t)9999);
+    KTEST_ASSERT(invalid_cap == false, "invalid capability ID should return false");
+
+    bh_primitive_support_level_t invalid_support = bh_kprim_get_support_level((bh_kprim_capability_t)9999);
+    KTEST_ASSERT(invalid_support == BH_PRIMITIVE_UNSUPPORTED, "invalid capability ID should be unsupported");
+
+    bool invalid_cap_any = bh_kprim_has_any((bh_kprim_capability_t)9999);
+    KTEST_ASSERT(invalid_cap_any == false, "invalid capability ID any should return false");
+
+    bool invalid_cap_local = bh_kprim_has_local((bh_kprim_capability_t)9999);
+    KTEST_ASSERT(invalid_cap_local == false, "invalid capability ID local should return false");
+
+    return 0;
+}
+
+REGISTER_BOOT_SELFTEST("kprim_caps_reinit",
+                       "core",
+                       kprim_caps_selftest_reinit,
+                       BOOT_TEST_STAGE_RUNTIME,
+                       BOOT_TEST_MANDATORY,
+                       0,
+                       true);
+
+REGISTER_BOOT_SELFTEST("kprim_caps_queries",
+                       "core",
+                       kprim_caps_selftest_queries,
+                       BOOT_TEST_STAGE_RUNTIME,
+                       BOOT_TEST_MANDATORY,
+                       0,
+                       true);

--- a/quality/tests/host/test_kprim_caps.c
+++ b/quality/tests/host/test_kprim_caps.c
@@ -1,0 +1,81 @@
+#include <stdio.h>
+#include <assert.h>
+#include <string.h>
+
+#include "kernel/primitive.h"
+#include "kernel/primitive_caps.h"
+#include "hal/hal_hw_caps.h"
+#include "hal/hal_cpu_features.h"
+#include "hal/hal_tlb.h"
+
+// Stubs for HAL
+static hal_hw_caps_t mock_hw_caps = {0};
+static hal_tlb_caps_t mock_tlb_caps = {0};
+static hal_cpu_feature_set_t mock_cpu_caps_all = {0};
+static hal_cpu_feature_set_t mock_cpu_caps_any = {0};
+
+const hal_tlb_caps_t *hal_tlb_caps(void) {
+    return &mock_tlb_caps;
+}
+
+bool hal_cpu_feature_set_system(hal_cpu_feature_scope_t scope, hal_cpu_feature_set_t *out) {
+    if (scope == HAL_CPU_FEATURE_SCOPE_ALL) {
+        *out = mock_cpu_caps_all;
+    } else {
+        *out = mock_cpu_caps_any;
+    }
+    return true;
+}
+
+bool hal_cpu_has_feature_current(hal_cpu_feature_t feature) {
+    return false; // Not used in this test
+}
+
+void test_initialization(void) {
+    printf("Testing initialization...\n");
+
+    // Test that uninitialized registry returns false/unsupported
+    assert(bh_kprim_has(BH_KPRIM_CAP_ATOMIC_64) == false);
+    assert(bh_kprim_get_support_level(BH_KPRIM_CAP_ATOMIC_64) == BH_PRIMITIVE_UNSUPPORTED);
+
+    // Mock values
+    mock_hw_caps.has_atomic_64 = true;
+    mock_tlb_caps.supports_page_flush = true;
+
+    // Init
+    kstatus_t status = bh_kernel_primitive_registry_init(&mock_hw_caps);
+    assert(status == K_OK);
+
+    // Test double init fails
+    hal_hw_caps_t empty_caps = {0};
+    status = bh_kernel_primitive_registry_init(&empty_caps);
+    assert(status == K_ERR_BAD_STATE);
+}
+
+void test_queries(void) {
+    printf("Testing queries...\n");
+
+    // We expect ATOMIC_64 and TLB_PAGE_INVALIDATE to be true based on the mock
+    assert(bh_kprim_has(BH_KPRIM_CAP_ATOMIC_64) == true);
+    assert(bh_kprim_has_any(BH_KPRIM_CAP_ATOMIC_64) == true);
+    assert(bh_kprim_has_local(BH_KPRIM_CAP_ATOMIC_64) == true);
+    assert(bh_kprim_get_support_level(BH_KPRIM_CAP_ATOMIC_64) == BH_PRIMITIVE_HARDWARE_ASSISTED);
+
+    assert(bh_kprim_has(BH_KPRIM_CAP_TLB_PAGE_INVALIDATE) == true);
+
+    // Unset ones should be false
+    assert(bh_kprim_has(BH_KPRIM_CAP_TLB_RANGE_INVALIDATE) == false);
+    assert(bh_kprim_has(BH_KPRIM_CAP_IOMMU) == false);
+    assert(bh_kprim_get_support_level(BH_KPRIM_CAP_IOMMU) == BH_PRIMITIVE_UNSUPPORTED);
+
+    // Invalid ID should return false
+    assert(bh_kprim_has((bh_kprim_capability_t)999) == false);
+}
+
+int main(void) {
+    printf("Running KPRIM capability tests...\n");
+    test_initialization();
+    test_queries();
+    printf("All tests passed.\n");
+    return 0;
+}


### PR DESCRIPTION
This adds the KPRIM capability API, normalizing hal capabilities into kernel primitive capabilities.
- Added `bh_kprim_capability_t` and `bh_kprim_has()` to query KPRIM capabilities safely.
- Modified `primitive_registry.c` to transition through `KPRIM_STATE_UNINITIALIZED`, `KPRIM_STATE_DISCOVERING`, `KPRIM_STATE_NORMALIZED`, and `KPRIM_STATE_FINALIZED` ensuring immutability.
- Made it explicit that it fails to initialize if `hal_cpu_feature_set_system()` is not ready, maintaining CPU multiprocessor invariants.
- Included initial subset of well supported primitives.
- Provided self-tests and unit-tests.
- Added minimal integration wiring for `cpu_features.c` to provide it to the kernel targets for transitional builds, leaving complete HAL separation for a separate task.

---
*PR created automatically by Jules for task [12201880450640942420](https://jules.google.com/task/12201880450640942420) started by @divyang4481*