### PR TITLE
P0-003A: close 32-bit-safe bounded MPSC queue invariants

### DIFF
--- a/core/kernel/include/bharat/kernel/ds/bh_mpsc_queue.h
+++ b/core/kernel/include/bharat/kernel/ds/bh_mpsc_queue.h
@@ -28,9 +28,11 @@
  * 4. Consumer calls bh_mpsc_queue_pop(&q, &value);
  */
 
+#define BH_MPSC_MAX_CAPACITY (1U << 30)
+
 typedef struct {
     /** @brief Slot sequence number for synchronization. */
-    volatile uint64_t seq;
+    atomic32_t seq;
     /** @brief Pointer to the payload. */
     void *value;
 } bh_mpsc_slot_t;
@@ -42,10 +44,10 @@ typedef struct {
     uint32_t capacity;
     /** @brief Mask for index wrap-around (capacity - 1). */
     uint32_t mask;
-    /** @brief Producer head index (shared/atomic). */
-    volatile uint64_t head;
+    /** @brief Shared producer reservation cursor. */
+    atomic32_t head;
     /** @brief Consumer tail index (owned by single consumer). */
-    uint64_t tail;
+    uint32_t tail;
 } bh_mpsc_queue_t;
 
 /**
@@ -75,6 +77,13 @@ kstatus_t bh_mpsc_queue_pop(bh_mpsc_queue_t *q, void **out_value);
 
 /**
  * @brief Check if the queue is empty.
+ *
+ * Snapshot only.
+ *
+ * false means producer reservations may exist; it does not guarantee
+ * that the next reserved slot has completed RELEASE publication.
+ * Callers must use bh_mpsc_queue_pop() as the authoritative availability
+ * check.
  */
 bool bh_mpsc_queue_empty(const bh_mpsc_queue_t *q);
 

--- a/core/kernel/src/ds/bh_mpsc_queue.c
+++ b/core/kernel/src/ds/bh_mpsc_queue.c
@@ -4,19 +4,29 @@ static inline bool is_power_of_two(uint32_t n) {
     return n > 0 && (n & (n - 1)) == 0;
 }
 
+/*
+ * Sequence comparison uses modulo-2^32 arithmetic.
+ * Queue capacity is constrained below 2^31 so occupied/free
+ * positions remain unambiguous under signed half-range comparison.
+ */
+
 kstatus_t bh_mpsc_queue_init(bh_mpsc_queue_t *q, bh_mpsc_slot_t *slots, uint32_t capacity) {
-    if (!q || !slots || capacity < 2 || !is_power_of_two(capacity)) {
+    if (!q ||
+        !slots ||
+        capacity < 2U ||
+        !is_power_of_two(capacity) ||
+        capacity > BH_MPSC_MAX_CAPACITY) {
         return K_ERR_INVALID_ARG;
     }
 
     q->slots = slots;
     q->capacity = capacity;
     q->mask = capacity - 1;
-    q->head = 0;
+    atomic32_store_relaxed(&q->head, 0);
     q->tail = 0;
 
     for (uint32_t i = 0; i < capacity; i++) {
-        q->slots[i].seq = i;
+        atomic32_store_relaxed(&q->slots[i].seq, i);
         q->slots[i].value = NULL;
     }
 
@@ -24,49 +34,60 @@ kstatus_t bh_mpsc_queue_init(bh_mpsc_queue_t *q, bh_mpsc_slot_t *slots, uint32_t
 }
 
 kstatus_t bh_mpsc_queue_push(bh_mpsc_queue_t *q, void *value) {
+    if (!q || !q->slots) {
+        return K_ERR_INVALID_ARG;
+    }
+
     bh_mpsc_slot_t *slot;
-    uint64_t pos = q->head;
+    uint32_t pos = atomic32_load_relaxed(&q->head);
 
     while (true) {
         slot = &q->slots[pos & q->mask];
-        uint64_t seq = __atomic_load_n(&slot->seq, __ATOMIC_ACQUIRE);
-        int64_t diff = (int64_t)seq - (int64_t)pos;
+        uint32_t seq = atomic32_load_acquire(&slot->seq);
+        int32_t diff = (int32_t)(seq - pos);
 
         if (diff == 0) {
             /* Slot is ready to be written */
-            if (__atomic_compare_exchange_n(&q->head, &pos, pos + 1, false, __ATOMIC_RELAXED, __ATOMIC_RELAXED)) {
+            uint32_t expected = pos;
+            if (atomic32_compare_exchange_relaxed(&q->head, &expected, pos + 1U)) {
                 break;
             }
+            /* CAS failed, 'expected' contains the updated head */
+            pos = expected;
         } else if (diff < 0) {
             /* Queue is full */
             return K_ERR_AGAIN;
         } else {
             /* Another producer beat us, or we are looking at an old 'pos' */
-            pos = __atomic_load_n(&q->head, __ATOMIC_RELAXED);
+            pos = atomic32_load_relaxed(&q->head);
         }
     }
 
     slot->value = value;
-    __atomic_store_n(&slot->seq, pos + 1, __ATOMIC_RELEASE);
+    atomic32_store_release(&slot->seq, pos + 1U);
 
     return K_OK;
 }
 
 kstatus_t bh_mpsc_queue_pop(bh_mpsc_queue_t *q, void **out_value) {
+    if (!q || !q->slots) {
+        return K_ERR_INVALID_ARG;
+    }
+
     bh_mpsc_slot_t *slot;
-    uint64_t pos = q->tail;
+    uint32_t pos = q->tail;
 
     slot = &q->slots[pos & q->mask];
-    uint64_t seq = __atomic_load_n(&slot->seq, __ATOMIC_ACQUIRE);
-    int64_t diff = (int64_t)seq - (int64_t)(pos + 1);
+    uint32_t seq = atomic32_load_acquire(&slot->seq);
+    int32_t diff = (int32_t)(seq - (pos + 1U));
 
     if (diff == 0) {
         /* Slot has data ready to be read */
-        q->tail = pos + 1;
+        q->tail = pos + 1U;
         if (out_value) {
             *out_value = slot->value;
         }
-        __atomic_store_n(&slot->seq, pos + q->mask + 1, __ATOMIC_RELEASE);
+        atomic32_store_release(&slot->seq, pos + q->capacity);
         return K_OK;
     }
 
@@ -76,7 +97,7 @@ kstatus_t bh_mpsc_queue_pop(bh_mpsc_queue_t *q, void **out_value) {
 
 bool bh_mpsc_queue_empty(const bh_mpsc_queue_t *q) {
     if (!q) return true;
-    uint64_t head = __atomic_load_n(&q->head, __ATOMIC_RELAXED);
+    uint32_t head = atomic32_load_relaxed(&q->head);
     return q->tail == head;
 }
 

--- a/quality/tests/core/ds/test_bh_mpsc_queue.c
+++ b/quality/tests/core/ds/test_bh_mpsc_queue.c
@@ -111,9 +111,130 @@ void test_mpsc_threaded() {
     printf("test_mpsc_threaded passed\n");
 }
 
+void test_mpsc_wraparound() {
+    bh_mpsc_queue_t q;
+    bh_mpsc_slot_t slots[TEST_CAPACITY];
+
+    assert(bh_mpsc_queue_init(&q, slots, TEST_CAPACITY) == K_OK);
+
+    // Manually advance state to near UINT32_MAX
+    uint32_t near_max = 0xFFFFFFFC;
+    atomic32_store_relaxed(&q.head, near_max);
+    q.tail = near_max;
+    for (int i = 0; i < TEST_CAPACITY; i++) {
+        atomic32_store_relaxed(&q.slots[(near_max + i) & q.mask].seq, near_max + i);
+    }
+
+    int data[TEST_CAPACITY];
+    for (int i = 0; i < TEST_CAPACITY; i++) {
+        data[i] = i;
+    }
+
+    // Push until full around wrap boundary
+    for (int i = 0; i < TEST_CAPACITY; i++) {
+        assert(bh_mpsc_queue_push(&q, &data[i]) == K_OK);
+    }
+
+    // Full condition
+    assert(bh_mpsc_queue_push(&q, &data[0]) == K_ERR_AGAIN);
+
+    // Pop across wrap
+    void *val;
+    for (int i = 0; i < TEST_CAPACITY; i++) {
+        assert(bh_mpsc_queue_pop(&q, &val) == K_OK);
+        assert(*(int *)val == i);
+    }
+
+    // Empty condition
+    assert(bh_mpsc_queue_pop(&q, &val) == K_ERR_AGAIN);
+
+    // Reuse slot after wrap
+    assert(bh_mpsc_queue_push(&q, &data[0]) == K_OK);
+    assert(bh_mpsc_queue_pop(&q, &val) == K_OK);
+    assert(*(int *)val == 0);
+
+    printf("test_mpsc_wraparound passed\n");
+}
+
+#define RACE_CAPACITY 4
+#define RACE_PRODUCERS 8
+#define RACE_COUNT 10000
+
+void *race_producer_fn(void *arg) {
+    producer_args_t *args = (producer_args_t *)arg;
+    for (int i = 0; i < RACE_COUNT; i++) {
+        while (bh_mpsc_queue_push(args->q, (void *)(intptr_t)((args->id << 20) | i)) == K_ERR_AGAIN) {
+            // spin
+        }
+    }
+    return NULL;
+}
+
+void test_mpsc_producer_race() {
+    bh_mpsc_queue_t q;
+    bh_mpsc_slot_t slots[RACE_CAPACITY];
+    bh_mpsc_queue_init(&q, slots, RACE_CAPACITY);
+
+    pthread_t producers[RACE_PRODUCERS];
+    producer_args_t args[RACE_PRODUCERS];
+
+    for (int i = 0; i < RACE_PRODUCERS; i++) {
+        args[i].q = &q;
+        args[i].id = i + 1;
+        pthread_create(&producers[i], NULL, race_producer_fn, &args[i]);
+    }
+
+    int received_counts[RACE_PRODUCERS + 1] = {0};
+    int total_to_receive = RACE_PRODUCERS * RACE_COUNT;
+    int received = 0;
+
+    while (received < total_to_receive) {
+        void *val;
+        if (bh_mpsc_queue_pop(&q, &val) == K_OK) {
+            intptr_t v = (intptr_t)val;
+            int id = v >> 20;
+            assert(id > 0 && id <= RACE_PRODUCERS);
+            received_counts[id]++;
+            received++;
+        }
+    }
+
+    for (int i = 1; i <= RACE_PRODUCERS; i++) {
+        assert(received_counts[i] == RACE_COUNT);
+    }
+
+    for (int i = 0; i < RACE_PRODUCERS; i++) {
+        pthread_join(producers[i], NULL);
+    }
+
+    printf("test_mpsc_producer_race passed\n");
+}
+
+void test_mpsc_null_args() {
+    bh_mpsc_queue_t q;
+    bh_mpsc_slot_t slots[TEST_CAPACITY];
+
+    assert(bh_mpsc_queue_init(NULL, slots, TEST_CAPACITY) == K_ERR_INVALID_ARG);
+    assert(bh_mpsc_queue_init(&q, NULL, TEST_CAPACITY) == K_ERR_INVALID_ARG);
+
+    assert(bh_mpsc_queue_init(&q, slots, TEST_CAPACITY) == K_OK);
+
+    int val = 42;
+    assert(bh_mpsc_queue_push(NULL, &val) == K_ERR_INVALID_ARG);
+
+    void *out_val;
+    assert(bh_mpsc_queue_pop(NULL, &out_val) == K_ERR_INVALID_ARG);
+
+    printf("test_mpsc_null_args passed\n");
+}
+
+
 int main() {
     test_mpsc_basic();
     test_mpsc_full();
     test_mpsc_threaded();
+    test_mpsc_wraparound();
+    test_mpsc_producer_race();
+    test_mpsc_null_args();
     return 0;
 }


### PR DESCRIPTION
Files changed
- `core/kernel/include/bharat/kernel/ds/bh_mpsc_queue.h`
- `core/kernel/src/ds/bh_mpsc_queue.c`
- `quality/tests/core/ds/test_bh_mpsc_queue.c`

Old MPSC synchronization layout
- `volatile uint64_t seq` for slot sequences.
- `volatile uint64_t head` for the producer position.
- `uint64_t tail` for the single consumer position.
- Uses C11 64-bit primitives directly on `volatile uint64_t` (`__atomic_load_n`, etc.).

New MPSC synchronization layout
- `atomic32_t seq` for slots.
- `atomic32_t head` for producers.
- `uint32_t tail` for the consumer.
- Uses canonical BharatOS `atomic32_*` synchronization wrappers (`atomic32_load_acquire`, `atomic32_store_release`, `atomic32_compare_exchange_relaxed`).

Memory-ordering rationale
- Reservation (`head` advancement): `atomic32_compare_exchange_relaxed` is sufficient because the data hasn't been written to the slot yet.
- Publication (`seq` set): `atomic32_store_release` to make payload visible.
- Observation (`seq` read): `atomic32_load_acquire` to ensure payload loads only happen after publication.
- Release (`seq` reset by consumer): `atomic32_store_release` to make the slot available again.

Wraparound algorithm
- Uses 32-bit unsigned modular arithmetic differences cast to `int32_t`: `int32_t diff = (int32_t)(seq - pos)`.

Capacity bound
- Restricts capacity to a maximum of `(1U << 30)` via `BH_MPSC_MAX_CAPACITY` to prevent overlap failures during sequence comparison.

Host test results
- basic pass
- full pass
- threaded pass
- wraparound pass
- producer_race pass
- null_args pass

Atomic symbol inspection result
- Inspected using `nm` on x86 test compilation; no 64-bit explicit runtime atomic helpers are invoked for queue synchronization (`atomic32_load_acquire`, `atomic32_store_release` are used).

Known remaining issues
- Top-level CMake integration for the tests in `quality/tests/core/ds/` is currently missing/disconnected; requires follow-up.

---
*PR created automatically by Jules for task [10884966271033752390](https://jules.google.com/task/10884966271033752390) started by @divyang4481*