### PR TITLE
P0-002: establish truthful hardware capability discovery and freeze authority

### DIFF
--- a/core/arch/arm/arm32/hw_caps.c
+++ b/core/arch/arm/arm32/hw_caps.c
@@ -6,17 +6,17 @@ void arch_discover_hw_caps(void) {
 
     // ARM32 typical capabilities
     caps.has_mmu = true;
-    caps.has_mpu = true;
+    caps.has_mpu = false; // Effective target selects MMU-Lite
     caps.has_iommu = false;
     caps.has_dma_coherent = false;
     caps.has_cache_maintenance = true;
     caps.has_local_apic_or_gic_or_plic = true;
     caps.has_high_res_timer = true;
     caps.has_atomic_64 = false; // May need LPAE
-    caps.has_vector = true;
+    caps.has_vector = false; // Published from SYSTEM_ALL CPU facts
     caps.has_crypto_accel = false;
     caps.has_accel_device = false;
-    caps.max_cpus = 4;
+    caps.max_cpus = 0; // Published from platform topology
     caps.page_granule = 4096;
     caps.cache_line_size = 32;
 

--- a/core/arch/arm/arm64/arch_caps.c
+++ b/core/arch/arm/arm64/arch_caps.c
@@ -10,7 +10,6 @@ arch_caps_t arch_get_caps(void) {
     arch_caps_set(&caps, ARCH_CAP_ASID);
     arch_caps_set(&caps, ARCH_CAP_GLOBAL_TLB_INVALIDATE);
     arch_caps_set(&caps, ARCH_CAP_FINE_GRAIN_PROTECT);
-    arch_caps_set(&caps, ARCH_CAP_DMA_COHERENT);
     arch_caps_set(&caps, ARCH_CAP_CACHE_MAINTENANCE);
     arch_caps_set(&caps, ARCH_CAP_DEVICE_MEMORY_ATTRS); // MAIR
     arch_caps_set(&caps, ARCH_CAP_ADV_IRQ_ROUTING);
@@ -26,7 +25,6 @@ const arch_cap_profile_t *arch_get_cap_profile(void) {
             ARCH_CAP_BIT(ARCH_CAP_64BIT_VA) |
             ARCH_CAP_BIT(ARCH_CAP_SMP) |
             ARCH_CAP_BIT(ARCH_CAP_MMU_FULL) |
-            ARCH_CAP_BIT(ARCH_CAP_DMA_COHERENT) |
             ARCH_CAP_BIT(ARCH_CAP_ADV_IRQ_ROUTING) |
             ARCH_CAP_BIT(ARCH_CAP_USERSPACE_HIGHHALF)
         },

--- a/core/arch/arm/arm64/hw_caps.c
+++ b/core/arch/arm/arm64/hw_caps.c
@@ -7,16 +7,16 @@ void arch_discover_hw_caps(void) {
     // ARM64 typical capabilities
     caps.has_mmu = true;
     caps.has_mpu = false;
-    caps.has_iommu = true; // SMMU
+    caps.has_iommu = false; // Platform discovery is authoritative
     caps.has_dma_coherent = false; // Often non-coherent on ARM
     caps.has_cache_maintenance = true;
     caps.has_local_apic_or_gic_or_plic = true; // GIC
     caps.has_high_res_timer = true;
-    caps.has_atomic_64 = true;
-    caps.has_vector = true; // NEON/SVE
-    caps.has_crypto_accel = true;
+    caps.has_atomic_64 = false; // Published from SYSTEM_ALL CPU facts
+    caps.has_vector = false; // Published from SYSTEM_ALL CPU facts
+    caps.has_crypto_accel = false; // Published from SYSTEM_ALL CPU facts
     caps.has_accel_device = false;
-    caps.max_cpus = 128;
+    caps.max_cpus = 0; // Published from platform topology
     caps.page_granule = 4096;
     caps.cache_line_size = 64;
 

--- a/core/arch/common/cpu_caps_state.c
+++ b/core/arch/common/cpu_caps_state.c
@@ -16,6 +16,7 @@ static arch_cpu_caps_record_t g_system_caps_any;
 static arch_cpu_caps_record_t g_per_cpu_caps[MAX_CPUS];
 static bool g_cpu_caps_present[MAX_CPUS];
 static size_t g_cpu_caps_present_count;
+static bool g_system_caps_finalized;
 
 static void cpu_caps_record_copy(arch_cpu_caps_record_t *dst,
                                  const arch_cpu_caps_record_t *src) {
@@ -83,11 +84,11 @@ const arch_cpu_caps_record_t *arch_cpu_caps_for_cpu(size_t cpu_index) {
 }
 
 const arch_cpu_caps_record_t *arch_cpu_caps_system_all(void) {
-    return &g_system_caps_all;
+    return g_system_caps_finalized ? &g_system_caps_all : NULL;
 }
 
 const arch_cpu_caps_record_t *arch_cpu_caps_system_any(void) {
-    return &g_system_caps_any;
+    return g_system_caps_finalized ? &g_system_caps_any : NULL;
 }
 
 bool arch_cpu_has(int feat) {
@@ -95,7 +96,7 @@ bool arch_cpu_has(int feat) {
 }
 
 bool arch_cpu_has_system_all(int feat) {
-    return arch_cpu_caps_test(&g_system_caps_all.usable, feat);
+    return g_system_caps_finalized && arch_cpu_caps_test(&g_system_caps_all.usable, feat);
 }
 
 bool arch_cpu_has_on(size_t cpu_index, int feat) {
@@ -103,14 +104,14 @@ bool arch_cpu_has_on(size_t cpu_index, int feat) {
 }
 
 bool arch_cpu_has_cpu(size_t cpu_index, int feat) {
-    if (cpu_index < MAX_CPUS) {
+    if (cpu_index < MAX_CPUS && g_cpu_caps_present[cpu_index]) {
         return arch_cpu_caps_test(&g_per_cpu_caps[cpu_index].usable, feat);
     }
     return false;
 }
 
 bool arch_cpu_has_system_any(int feat) {
-    return arch_cpu_caps_test(&g_system_caps_any.usable, feat);
+    return g_system_caps_finalized && arch_cpu_caps_test(&g_system_caps_any.usable, feat);
 }
 
 bool arch_cpu_has_current(int feat) {
@@ -121,6 +122,7 @@ bool arch_cpu_has_current(int feat) {
 void cpu_caps_state_set_boot(const arch_cpu_caps_record_t *caps) {
     memset(g_cpu_caps_present, 0, sizeof(g_cpu_caps_present));
     g_cpu_caps_present_count = 0;
+    g_system_caps_finalized = false;
 
     cpu_caps_record_copy(&g_boot_cpu_caps, caps);
     cpu_caps_record_copy(&g_per_cpu_caps[0], caps);
@@ -142,7 +144,13 @@ void cpu_caps_state_set_ap(unsigned int cpu_id, const arch_cpu_caps_record_t *ca
     }
 }
 
-void arch_cpu_caps_system_finalize(void) {
+kstatus_t arch_cpu_caps_system_finalize(void) {
+    if (g_system_caps_finalized) {
+        return K_ERR_BAD_STATE;
+    }
+    if (g_cpu_caps_present_count == 0U) {
+        return K_ERR_IN_PROGRESS;
+    }
     bool initialized = false;
     arch_cpu_caps_zero(&g_system_caps_all.raw);
     arch_cpu_caps_zero(&g_system_caps_all.usable);
@@ -167,9 +175,10 @@ void arch_cpu_caps_system_finalize(void) {
     }
 
     if (!initialized) {
-        cpu_caps_record_copy(&g_system_caps_all, &g_boot_cpu_caps);
-        cpu_caps_record_copy(&g_system_caps_any, &g_boot_cpu_caps);
+        return K_ERR_IN_PROGRESS;
     }
+    g_system_caps_finalized = true;
+    return K_OK;
 }
 
 size_t cpu_caps_state_online_count(void) {

--- a/core/arch/riscv/riscv32/arch_caps.c
+++ b/core/arch/riscv/riscv32/arch_caps.c
@@ -10,7 +10,6 @@ arch_caps_t arch_get_caps(void) {
     arch_caps_set(&caps, ARCH_CAP_SMP);
     arch_caps_set(&caps, ARCH_CAP_CACHE_MAINTENANCE);
     arch_caps_set(&caps, ARCH_CAP_DEVICE_MEMORY_ATTRS);
-    arch_caps_set(&caps, ARCH_CAP_DMA_COHERENT);
 
     return caps;
 }

--- a/core/arch/riscv/riscv32/hw_caps.c
+++ b/core/arch/riscv/riscv32/hw_caps.c
@@ -5,7 +5,7 @@ void arch_discover_hw_caps(void) {
     hal_hw_caps_t caps = {0};
 
     // RISC-V 32 typical capabilities
-    caps.has_mmu = true;
+    caps.has_mmu = false; // Effective MPU/MMU-Lite profile, not backend Sv32 ability
     caps.has_mpu = true; // PMP
     caps.has_iommu = false;
     caps.has_dma_coherent = false;
@@ -16,7 +16,7 @@ void arch_discover_hw_caps(void) {
     caps.has_vector = false;
     caps.has_crypto_accel = false;
     caps.has_accel_device = false;
-    caps.max_cpus = 4;
+    caps.max_cpus = 0; // Published from platform topology
     caps.page_granule = 4096;
     caps.cache_line_size = 32;
 

--- a/core/arch/riscv/riscv64/arch_caps.c
+++ b/core/arch/riscv/riscv64/arch_caps.c
@@ -10,7 +10,6 @@ arch_caps_t arch_get_caps(void) {
     arch_caps_set(&caps, ARCH_CAP_ASID);
     arch_caps_set(&caps, ARCH_CAP_GLOBAL_TLB_INVALIDATE);
     arch_caps_set(&caps, ARCH_CAP_FINE_GRAIN_PROTECT);
-    arch_caps_set(&caps, ARCH_CAP_DMA_COHERENT);
     arch_caps_set(&caps, ARCH_CAP_CACHE_MAINTENANCE);
     arch_caps_set(&caps, ARCH_CAP_DEVICE_MEMORY_ATTRS);
     arch_caps_set(&caps, ARCH_CAP_ADV_IRQ_ROUTING);
@@ -26,7 +25,6 @@ const arch_cap_profile_t *arch_get_cap_profile(void) {
             ARCH_CAP_BIT(ARCH_CAP_64BIT_VA) |
             ARCH_CAP_BIT(ARCH_CAP_SMP) |
             ARCH_CAP_BIT(ARCH_CAP_MMU_FULL) |
-            ARCH_CAP_BIT(ARCH_CAP_DMA_COHERENT) |
             ARCH_CAP_BIT(ARCH_CAP_ADV_IRQ_ROUTING) |
             ARCH_CAP_BIT(ARCH_CAP_USERSPACE_HIGHHALF)
         },

--- a/core/arch/riscv/riscv64/hw_caps.c
+++ b/core/arch/riscv/riscv64/hw_caps.c
@@ -7,16 +7,16 @@ void arch_discover_hw_caps(void) {
     // RISC-V 64 typical capabilities
     caps.has_mmu = true;
     caps.has_mpu = true; // PMP
-    caps.has_iommu = true;
+    caps.has_iommu = false; // Platform discovery is authoritative
     caps.has_dma_coherent = false;
     caps.has_cache_maintenance = true;
     caps.has_local_apic_or_gic_or_plic = true; // PLIC/CLIC
     caps.has_high_res_timer = true;
-    caps.has_atomic_64 = true;
-    caps.has_vector = true;
+    caps.has_atomic_64 = false; // Published from SYSTEM_ALL CPU facts
+    caps.has_vector = false; // Published from SYSTEM_ALL CPU facts
     caps.has_crypto_accel = false;
     caps.has_accel_device = false;
-    caps.max_cpus = 64;
+    caps.max_cpus = 0; // Published from platform topology
     caps.page_granule = 4096;
     caps.cache_line_size = 64;
 

--- a/core/arch/x86/x86_64/arch_caps.c
+++ b/core/arch/x86/x86_64/arch_caps.c
@@ -10,7 +10,6 @@ arch_caps_t arch_get_caps(void) {
     arch_caps_set(&caps, ARCH_CAP_ASID); // PCID
     arch_caps_set(&caps, ARCH_CAP_GLOBAL_TLB_INVALIDATE);
     arch_caps_set(&caps, ARCH_CAP_FINE_GRAIN_PROTECT);
-    arch_caps_set(&caps, ARCH_CAP_DMA_COHERENT);
     arch_caps_set(&caps, ARCH_CAP_CACHE_MAINTENANCE); // CLFLUSH, PAT
     arch_caps_set(&caps, ARCH_CAP_DEVICE_MEMORY_ATTRS);
     arch_caps_set(&caps, ARCH_CAP_ADV_IRQ_ROUTING);
@@ -29,7 +28,6 @@ const arch_cap_profile_t *arch_get_cap_profile(void) {
             ARCH_CAP_BIT(ARCH_CAP_64BIT_VA) |
             ARCH_CAP_BIT(ARCH_CAP_SMP) |
             ARCH_CAP_BIT(ARCH_CAP_MMU_FULL) |
-            ARCH_CAP_BIT(ARCH_CAP_DMA_COHERENT) |
             ARCH_CAP_BIT(ARCH_CAP_ADV_IRQ_ROUTING) |
             ARCH_CAP_BIT(ARCH_CAP_USERSPACE_HIGHHALF)
         },

--- a/core/arch/x86/x86_64/hw_caps.c
+++ b/core/arch/x86/x86_64/hw_caps.c
@@ -7,16 +7,16 @@ void arch_discover_hw_caps(void) {
     // x86_64 typical capabilities
     caps.has_mmu = true;
     caps.has_mpu = false;
-    caps.has_iommu = true; // Assume for now, or detect via ACPI/VT-d later
-    caps.has_dma_coherent = true;
+    caps.has_iommu = false; // Platform discovery is authoritative
+    caps.has_dma_coherent = false; // Conservative until a platform contract publishes it
     caps.has_cache_maintenance = true;
     caps.has_local_apic_or_gic_or_plic = true;
     caps.has_high_res_timer = true;
-    caps.has_atomic_64 = true;
-    caps.has_vector = true;
-    caps.has_crypto_accel = true;
+    caps.has_atomic_64 = false; // Published from SYSTEM_ALL CPU facts
+    caps.has_vector = false; // Published from SYSTEM_ALL CPU facts
+    caps.has_crypto_accel = false; // Published from SYSTEM_ALL CPU facts
     caps.has_accel_device = false;
-    caps.max_cpus = 64; // Default
+    caps.max_cpus = 0; // Published from platform topology
     caps.page_granule = 4096;
     caps.cache_line_size = 64;
 

--- a/core/hal/common/cpu_features.c
+++ b/core/hal/common/cpu_features.c
@@ -76,6 +76,10 @@ bool hal_cpu_feature_set_system(hal_cpu_feature_scope_t scope, hal_cpu_feature_s
     const arch_cpu_caps_record_t *arch = (scope == HAL_CPU_FEATURE_SCOPE_ANY)
                                              ? arch_cpu_caps_system_any()
                                              : arch_cpu_caps_system_all();
+    if (arch == NULL) {
+        memset(out, 0, sizeof(*out));
+        return false;
+    }
     map_arch_to_hal(arch, out);
     return true;
 }

--- a/core/hal/common/discovery.c
+++ b/core/hal/common/discovery.c
@@ -24,11 +24,14 @@ bool hal_cpu_topology_query(hal_cpu_topology_info_t *out) {
     if (discovery && discovery->topology.cpu_count > 0U) {
         discovered = discovery->topology.cpu_count;
     }
-    if (discovered > 32U) {
-        discovered = 32U;
+    if (discovered > BHARAT_MAX_CPUS) {
+        discovered = BHARAT_MAX_CPUS;
     }
 
-    uint32_t valid_cpu_mask = (discovered == 32U) ? UINT32_MAX : ((1U << discovered) - 1U);
+    /* These masks are a legacy 32-CPU consumer boundary; the authoritative
+     * topology count is not truncated to fit them. */
+    uint32_t mask_cpus = discovered > 32U ? 32U : discovered;
+    uint32_t valid_cpu_mask = (mask_cpus == 32U) ? UINT32_MAX : ((1U << mask_cpus) - 1U);
 
     out->discovered_cpu_count = discovered;
     out->valid_cpu_mask = valid_cpu_mask;

--- a/core/hal/common/hw_caps.c
+++ b/core/hal/common/hw_caps.c
@@ -1,17 +1,79 @@
 #include "hal/hal_hw_caps.h"
 #include "hal/hal_internal.h"
+#include "hal/hal_cpu_features.h"
+#include "hal/hal_discovery.h"
 
 static hal_hw_caps_t g_internal_hw_caps;
-static bool g_caps_initialized = false;
+/* BSP boot owns mutation.  Once frozen, all CPUs only read this snapshot. */
+static hal_caps_state_t g_caps_state = HAL_CAPS_UNINITIALIZED;
 
-const hal_hw_caps_t *hal_get_internal_hw_caps(void) {
-    return &g_internal_hw_caps;
+static bool feature_usable(const hal_cpu_feature_set_t *set, hal_cpu_feature_t feature) {
+    return feature < HAL_CPU_FEATURE__COUNT &&
+           (set->usable_bits[(size_t)feature / 64U] &
+            (1ULL << ((size_t)feature % 64U))) != 0U;
 }
 
-// Internal HAL-only API to set the caps during discovery
-void hal_set_internal_hw_caps(const hal_hw_caps_t *caps) {
-    if (caps) {
-        g_internal_hw_caps = *caps;
-        g_caps_initialized = true;
+const hal_hw_caps_t *hal_get_internal_hw_caps(void) {
+    return g_caps_state == HAL_CAPS_UNINITIALIZED ? NULL : &g_internal_hw_caps;
+}
+
+hal_caps_state_t hal_hw_caps_state(void) {
+    return g_caps_state;
+}
+
+bool hal_hw_caps_is_frozen(void) {
+    return g_caps_state == HAL_CAPS_FROZEN;
+}
+
+kstatus_t hal_hw_caps_publish_raw(const hal_hw_caps_t *caps) {
+    if (caps == NULL) {
+        return K_ERR_INVALID_ARG;
     }
+    if (g_caps_state != HAL_CAPS_UNINITIALIZED) {
+        return K_ERR_BAD_STATE;
+    }
+    g_internal_hw_caps = *caps;
+    g_caps_state = HAL_CAPS_RAW_DISCOVERED;
+    return K_OK;
+}
+
+kstatus_t hal_set_internal_hw_caps(const hal_hw_caps_t *caps) {
+    return hal_hw_caps_publish_raw(caps);
+}
+
+kstatus_t hal_hw_caps_publish_cpu(void) {
+    hal_cpu_feature_set_t all;
+    hal_cpu_feature_set_t any;
+    if (g_caps_state != HAL_CAPS_RAW_DISCOVERED) {
+        return K_ERR_BAD_STATE;
+    }
+    if (!hal_cpu_feature_set_system(HAL_CPU_FEATURE_SCOPE_ALL, &all) ||
+        !hal_cpu_feature_set_system(HAL_CPU_FEATURE_SCOPE_ANY, &any)) {
+        return K_ERR_IN_PROGRESS;
+    }
+
+    g_internal_hw_caps.has_atomic_64 =
+        feature_usable(&all, HAL_CPU_FEATURE_STRONG_ATOMICS);
+    g_internal_hw_caps.has_vector =
+        feature_usable(&all, HAL_CPU_FEATURE_VECTOR);
+    g_internal_hw_caps.has_crypto_accel =
+        feature_usable(&all, HAL_CPU_FEATURE_CRYPTO) ||
+        feature_usable(&all, HAL_CPU_FEATURE_AES) ||
+        feature_usable(&all, HAL_CPU_FEATURE_SHA);
+    g_caps_state = HAL_CAPS_CPU_FINALIZED;
+    return K_OK;
+}
+
+kstatus_t hal_hw_caps_finalize(void) {
+    if (g_caps_state != HAL_CAPS_CPU_FINALIZED) {
+        return K_ERR_BAD_STATE;
+    }
+
+    const system_discovery_t *discovery = hal_get_system_discovery();
+    g_internal_hw_caps.has_iommu = discovery != NULL && discovery->iommu_count != 0U;
+    if (discovery != NULL && discovery->topology.cpu_count != 0U) {
+        g_internal_hw_caps.max_cpus = discovery->topology.cpu_count;
+    }
+    g_caps_state = HAL_CAPS_FROZEN;
+    return K_OK;
 }

--- a/core/hal/include/hal/hal_cpu_topology.h
+++ b/core/hal/include/hal/hal_cpu_topology.h
@@ -10,6 +10,7 @@ extern "C" {
 
 typedef struct {
     uint32_t discovered_cpu_count;
+    /* Legacy service-placement masks cover CPUs 0..31 only. */
     uint32_t valid_cpu_mask;
     uint32_t performance_cluster_mask;
     uint32_t efficiency_cluster_mask;

--- a/core/hal/include/hal/hal_hw_caps.h
+++ b/core/hal/include/hal/hal_hw_caps.h
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "kernel/status.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -29,12 +30,25 @@ typedef struct hal_hw_caps {
     uint32_t cache_line_size;
 } hal_hw_caps_t;
 
+typedef enum {
+    HAL_CAPS_UNINITIALIZED = 0,
+    HAL_CAPS_RAW_DISCOVERED,
+    HAL_CAPS_CPU_FINALIZED,
+    HAL_CAPS_FROZEN
+} hal_caps_state_t;
+
 /**
  * Get the internal hardware capabilities.
  *
  * @return A pointer to the global hardware capabilities structure.
  */
 const hal_hw_caps_t *hal_get_internal_hw_caps(void);
+
+hal_caps_state_t hal_hw_caps_state(void);
+bool hal_hw_caps_is_frozen(void);
+kstatus_t hal_hw_caps_publish_raw(const hal_hw_caps_t *caps);
+kstatus_t hal_hw_caps_publish_cpu(void);
+kstatus_t hal_hw_caps_finalize(void);
 
 #ifdef __cplusplus
 }

--- a/core/hal/include/hal/hal_internal.h
+++ b/core/hal/include/hal/hal_internal.h
@@ -17,7 +17,7 @@ void arch_discover_hw_caps(void);
  * Internal HAL-only API to set the discovered capabilities.
  * Implemented in core/hal/common/hw_caps.c
  */
-void hal_set_internal_hw_caps(const hal_hw_caps_t *caps);
+kstatus_t hal_set_internal_hw_caps(const hal_hw_caps_t *caps);
 
 #ifdef __cplusplus
 }

--- a/core/kernel/include/arch/arch_cpu_caps.h
+++ b/core/kernel/include/arch/arch_cpu_caps.h
@@ -4,6 +4,7 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>
+#include "kernel/status.h"
 
 typedef enum {
     /* Common semantic features: portable meaning across ISAs */
@@ -56,7 +57,7 @@ typedef struct {
 
 void arch_cpu_caps_init(void);
 void arch_cpu_caps_init_ap(void); // For APs
-void arch_cpu_caps_system_finalize(void); // To calculate system_all and system_any
+kstatus_t arch_cpu_caps_system_finalize(void); // To calculate system_all and system_any
 
 const arch_cpu_caps_record_t *arch_cpu_caps_boot(void);
 const arch_cpu_caps_record_t *arch_cpu_caps_current(void);

--- a/core/kernel/include/hal/hal_cpu_topology.h
+++ b/core/kernel/include/hal/hal_cpu_topology.h
@@ -10,6 +10,7 @@ extern "C" {
 
 typedef struct {
     uint32_t discovered_cpu_count;
+    /* Legacy service-placement masks cover CPUs 0..31 only. */
     uint32_t valid_cpu_mask;
     uint32_t performance_cluster_mask;
     uint32_t efficiency_cluster_mask;

--- a/core/kernel/src/core/primitive_registry.c
+++ b/core/kernel/src/core/primitive_registry.c
@@ -45,6 +45,10 @@ kstatus_t bh_kernel_primitive_registry_init(const hal_hw_caps_t *caps) {
         return K_ERR_INVALID_ARG;
     }
 
+    if (!hal_hw_caps_is_frozen() || caps != hal_get_internal_hw_caps()) {
+        return K_ERR_IN_PROGRESS;
+    }
+
     if (g_registry.state == KPRIM_STATE_FINALIZED) {
         return K_ERR_BAD_STATE; // Already finalized
     }
@@ -89,8 +93,8 @@ kstatus_t bh_kernel_primitive_registry_init(const hal_hw_caps_t *caps) {
         (((SET_PTR)->usable_bits[(FEAT) / 64] & (1ULL << ((FEAT) % 64))) != 0)
 
     // ATOMIC_64
-    bool atomic64_all = HAS_CPU_FEATURE(&g_registry.cpu_caps_all, HAL_CPU_FEATURE_STRONG_ATOMICS) || g_registry.hw_caps.has_atomic_64;
-    bool atomic64_any = HAS_CPU_FEATURE(&g_registry.cpu_caps_any, HAL_CPU_FEATURE_STRONG_ATOMICS) || g_registry.hw_caps.has_atomic_64;
+    bool atomic64_all = HAS_CPU_FEATURE(&g_registry.cpu_caps_all, HAL_CPU_FEATURE_STRONG_ATOMICS);
+    bool atomic64_any = HAS_CPU_FEATURE(&g_registry.cpu_caps_any, HAL_CPU_FEATURE_STRONG_ATOMICS);
     NORMALIZE_CAP(BH_KPRIM_CAP_ATOMIC_64, atomic64_all, atomic64_any,
                   atomic64_any ? BH_PRIMITIVE_HARDWARE_ASSISTED : BH_PRIMITIVE_UNSUPPORTED);
 
@@ -215,7 +219,7 @@ bool bh_kprim_has_local(bh_kprim_capability_t cap) {
     }
 
     if (cap == BH_KPRIM_CAP_ATOMIC_64) {
-        return hal_cpu_has_feature_current(HAL_CPU_FEATURE_STRONG_ATOMICS) || g_registry.hw_caps.has_atomic_64;
+        return hal_cpu_has_feature_current(HAL_CPU_FEATURE_STRONG_ATOMICS);
     }
 
     return get_bit(g_registry.system_any_bits, cap);

--- a/core/kernel/src/kernel_boot.c
+++ b/core/kernel/src/kernel_boot.c
@@ -129,12 +129,8 @@ void boot_common_early(const boot_info_t *boot) {
 
     KPRINT("  [HAL] Initialising hardware on BSP...\n");
     hal_discovery_init(boot);
-    const hal_hw_caps_t *internal_caps = hal_get_internal_hw_caps();
-    print_hw_caps_summary(internal_caps);
+    print_hw_caps_summary(hal_get_internal_hw_caps());
     KPRINT("  [HAL] Ready.\n");
-
-    KPRINT("  [CORE] Initializing primitive registry...\n");
-    bh_kernel_primitive_registry_init(internal_caps);
 
     KPRINT("  [PROFILE] Applying hardware profile hooks...\n");
     profile_init();
@@ -266,8 +262,17 @@ void boot_common_platform_services(const boot_info_t *boot) {
     KPRINT("TIMER_GLOBAL_READY\n");
 
     arch_cpu_caps_init();
-    arch_cpu_caps_system_finalize();
+    if (arch_cpu_caps_system_finalize() != K_OK) {
+      kernel_panic("CPU capability aggregation failed");
+    }
     hal_discovery_publish_cpu_caps();
+    if (hal_hw_caps_publish_cpu() != K_OK || hal_hw_caps_finalize() != K_OK) {
+      kernel_panic("hardware capability freeze failed");
+    }
+    KPRINT("  [CORE] Initializing primitive registry...\n");
+    if (bh_kernel_primitive_registry_init(hal_get_internal_hw_caps()) != K_OK) {
+      kernel_panic("primitive registry initialization failed");
+    }
     arch_ext_state_boot_init();
 
     extern void bharat_algorithm_backends_init(void);

--- a/docs/adr/ADR-021-hardware-capability-freeze-authority.md
+++ b/docs/adr/ADR-021-hardware-capability-freeze-authority.md
@@ -1,0 +1,55 @@
+# ADR-021: Hardware Capability Discovery, Aggregation and Freeze Authority
+
+- **Status:** Accepted
+- **Date:** 2026-08-09
+
+## Context
+
+Architecture backend declarations, per-CPU probes, and the HAL hardware snapshot previously acted as overlapping authorities.  In particular, an unavailable system CPU record appeared to HAL consumers as a successfully initialized empty set, and the primitive registry ran before CPU aggregation.  Several architecture defaults also claimed platform facts such as IOMMU presence or DMA coherency without ACPI, FDT, or board evidence.
+
+## Decision
+
+Capability meanings are separated as follows:
+
+1. `arch_get_caps()` describes the selected architecture/profile mechanism contract.  It is not platform discovery.
+2. `arch_cpu_caps_*` records CPU-register or ISA-discovery facts.  `LOCAL` is the current CPU, `SYSTEM_ALL` is the intersection across participating CPUs, and `SYSTEM_ANY` is their union.
+3. HAL discovery owns platform facts such as topology and IOMMU presence.  Unknown platform facts are false.  The architecture hardware publishers provide conservative raw input and do not infer IOMMU or DMA coherency from ISA.
+4. `hal_hw_caps_t` is the effective snapshot consumed by mechanisms.  It moves monotonically through `UNINITIALIZED`, `RAW_DISCOVERED`, `CPU_FINALIZED`, and `FROZEN`.  The BSP boot path is its sole writer; after `FROZEN`, callers receive only a const pointer and every mutation/finalization attempt fails.
+5. Memory backend support remains distinct from the effective memory profile.  The snapshot reports the selected effective mechanism; supporting an MMU backend does not itself select `MMU_FULL`.
+6. The primitive registry accepts only the exact frozen HAL snapshot, normalizes it once, and rejects early or repeated initialization.  Generic migratable paths consume `SYSTEM_ALL`; specialized placement may inspect `SYSTEM_ANY`; CPU-local dispatch rechecks `LOCAL`.
+
+The implemented boot sequence is:
+
+```text
+hal_init / architecture raw publication
+        |
+HAL platform and topology discovery
+        |
+per-CPU architecture discovery
+        |
+SYSTEM_ALL intersection + SYSTEM_ANY union
+        |
+publish CPU facts into effective HAL snapshot
+        |
+publish platform facts and FREEZE
+        |
+primitive registry normalization (exactly once)
+        |
+algorithm backends, scheduler, and services
+```
+
+Profile validation remains the existing boot responsibility; this decision does not redesign memory policy.  The freeze boundary ensures later primitive and backend binding cannot observe partially aggregated hardware truth.
+
+## Failure behavior and synchronization
+
+Lifecycle transitions are fail closed: a missing CPU aggregate returns `K_ERR_IN_PROGRESS`; an out-of-order, backward, repeated, or post-freeze transition returns `K_ERR_BAD_STATE`.  No partial transition is published.  Mutation is BSP-owned during serial boot, then the object is immutable shared state, so no runtime lock is required.
+
+The generic discovered CPU count is bounded by the canonical `BHARAT_MAX_CPUS` rather than 32.  Existing 32-bit service-placement masks remain explicitly limited to CPUs 0 through 31; they no longer truncate the authoritative topology count.  Expanding that compatibility interface is a separate UAPI/service migration.
+
+## Consequences
+
+- An initialized empty CPU feature set is distinguishable from an unavailable aggregate.
+- Heterogeneous systems cannot accidentally enable an `ANY` instruction in migratable generic code.
+- IOMMU and DMA-coherency claims require platform evidence; absent evidence disables them.
+- Existing consumers that attempted early hardware dispatch now fail and must move after freeze.
+- Trap entry, syscalls, capabilities, scheduling policy, uRPC, TLB protocols, and memops are unchanged.

--- a/docs/architecture/core/hardware-capability-model.md
+++ b/docs/architecture/core/hardware-capability-model.md
@@ -53,8 +53,7 @@ Capabilities are not merely binary. Their state is captured as:
 - `REQUIRED`: System cannot boot or function properly without it.
 - `DEGRADED`: Hardware is present but failing, thermally throttled, or partially isolated.
 
-## Flow
-1. **Boot/Discovery:** `core/platform/` code queries the hardware/device tree.
-2. **Translation:** `core/platform/` maps raw discoveries into `bharat_hw_caps_t`.
-3. **Registration:** The populated capability structure is registered with the Kernel Capability Registry.
-4. **Consumption:** `core/services/` and `lib/runtime` query the registry to make dispatch and policy decisions.
+## Implemented authority and flow
+Architecture backend support, CPU runtime facts, and platform runtime facts are intentionally different authorities. CPU facts are aggregated as local, system-wide intersection (`SYSTEM_ALL`), and system-wide union (`SYSTEM_ANY`). Platform facts such as IOMMU presence and DMA coherency require platform evidence and are false when unknown.
+
+The effective `hal_hw_caps_t` snapshot progresses monotonically through raw discovery, CPU finalization, and freeze. The primitive registry may normalize only the frozen snapshot. See [ADR-021](../../adr/ADR-021-hardware-capability-freeze-authority.md) for the lifecycle, failure behavior, and current boot order.

--- a/quality/tests/host/CMakeLists.txt
+++ b/quality/tests/host/CMakeLists.txt
@@ -159,6 +159,20 @@ target_include_directories(test_hal_cpu_features PRIVATE
     ${CMAKE_SOURCE_DIR})
 add_test(NAME host_test_hal_cpu_features COMMAND test_hal_cpu_features)
 
+add_executable(test_hal_capability_lifecycle
+    test_hal_capability_lifecycle.c
+    ../../arch/common/cpu_caps_state.c
+    ../../hal/common/cpu_features.c
+    ../../hal/common/hw_caps.c
+    ../../kernel/src/core/primitive_registry.c)
+target_include_directories(test_hal_capability_lifecycle PRIVATE
+    ${CMAKE_SOURCE_DIR}/core/kernel/include
+    ${CMAKE_SOURCE_DIR}/core/hal/include
+    ${CMAKE_SOURCE_DIR}/interface/include
+    ${CMAKE_SOURCE_DIR}/core/lib/include
+    ${CMAKE_SOURCE_DIR})
+add_test(NAME host_test_hal_capability_lifecycle COMMAND test_hal_capability_lifecycle)
+
 # ---------------------------------------------------------
 # Phase 2: Runtime completeness Tests
 # ---------------------------------------------------------

--- a/quality/tests/host/test_hal_capability_lifecycle.c
+++ b/quality/tests/host/test_hal_capability_lifecycle.c
@@ -1,0 +1,77 @@
+#include <assert.h>
+#include <string.h>
+
+#include "arch/arch_cpu_caps.h"
+#include "arch/common/cpu_caps_state.h"
+#include "hal/hal_cpu_features.h"
+#include "hal/hal_discovery.h"
+#include "hal/hal_hw_caps.h"
+#include "hal/hal_internal.h"
+#include "hal/hal_tlb.h"
+#include "kernel/primitive.h"
+#include "kernel/primitive_caps.h"
+
+static uint32_t g_cpu_id;
+static system_discovery_t g_discovery;
+static hal_tlb_caps_t g_tlb_caps;
+
+uint32_t hal_cpu_get_id(void) { return g_cpu_id; }
+system_discovery_t *hal_get_system_discovery(void) { return &g_discovery; }
+const hal_tlb_caps_t *hal_tlb_caps(void) { return &g_tlb_caps; }
+void arch_cpu_caps_export_hal_features(const arch_cpu_caps_record_t *caps, void *out) {
+    (void)caps;
+    (void)out;
+}
+
+int main(void) {
+    hal_cpu_feature_set_t features = {0};
+    hal_hw_caps_t raw = {.has_mmu = false, .has_mpu = true, .has_dma_coherent = false};
+    arch_cpu_caps_record_t empty = {0};
+    arch_cpu_caps_record_t cpu0 = {0};
+    arch_cpu_caps_record_t cpu1 = {0};
+
+    assert(!hal_cpu_feature_set_system(HAL_CPU_FEATURE_SCOPE_ALL, &features));
+    assert(arch_cpu_caps_system_finalize() == K_ERR_IN_PROGRESS);
+
+    cpu_caps_state_set_boot(&empty);
+    assert(arch_cpu_caps_system_finalize() == K_OK);
+    memset(&features, 0xff, sizeof(features));
+    assert(hal_cpu_feature_set_system(HAL_CPU_FEATURE_SCOPE_ALL, &features));
+    assert(features.usable_bits[0] == 0U);
+
+    arch_cpu_caps_set(&cpu0.raw, ARCH_CPU_FEAT_COMMON_VECTOR);
+    arch_cpu_caps_set(&cpu0.usable, ARCH_CPU_FEAT_COMMON_VECTOR);
+    cpu_caps_state_set_boot(&cpu0);
+    cpu_caps_state_set_ap(1U, &cpu1);
+    assert(arch_cpu_caps_system_finalize() == K_OK);
+    assert(arch_cpu_caps_system_finalize() == K_ERR_BAD_STATE);
+    assert(!hal_cpu_has_system_feature_all(HAL_CPU_FEATURE_VECTOR));
+    assert(hal_cpu_has_system_feature_any(HAL_CPU_FEATURE_VECTOR));
+    g_cpu_id = 0U;
+    assert(hal_cpu_has_feature_current(HAL_CPU_FEATURE_VECTOR));
+    g_cpu_id = 1U;
+    assert(!hal_cpu_has_feature_current(HAL_CPU_FEATURE_VECTOR));
+
+    assert(hal_hw_caps_publish_cpu() == K_ERR_BAD_STATE);
+    assert(hal_hw_caps_publish_raw(&raw) == K_OK);
+    assert(hal_hw_caps_state() == HAL_CAPS_RAW_DISCOVERED);
+    assert(bh_kernel_primitive_registry_init(hal_get_internal_hw_caps()) == K_ERR_IN_PROGRESS);
+    assert(hal_hw_caps_publish_cpu() == K_OK);
+    assert(hal_hw_caps_state() == HAL_CAPS_CPU_FINALIZED);
+    g_discovery.topology.cpu_count = 48U;
+    g_discovery.iommu_count = 0U;
+    assert(hal_hw_caps_finalize() == K_OK);
+    assert(hal_hw_caps_is_frozen());
+    assert(!hal_get_internal_hw_caps()->has_iommu);
+    assert(!hal_get_internal_hw_caps()->has_dma_coherent);
+    assert(!hal_get_internal_hw_caps()->has_mmu);
+    assert(hal_get_internal_hw_caps()->has_mpu);
+    assert(hal_get_internal_hw_caps()->max_cpus == 48U);
+    assert(hal_set_internal_hw_caps(&raw) == K_ERR_BAD_STATE);
+    assert(hal_hw_caps_finalize() == K_ERR_BAD_STATE);
+
+    assert(bh_kernel_primitive_registry_init(hal_get_internal_hw_caps()) == K_OK);
+    assert(bh_kernel_primitive_registry_init(hal_get_internal_hw_caps()) == K_ERR_BAD_STATE);
+    assert(!bh_kprim_has(BH_KPRIM_CAP_ATOMIC_64));
+    return 0;
+}

--- a/quality/tests/test_boot_e2e.c
+++ b/quality/tests/test_boot_e2e.c
@@ -113,7 +113,7 @@ void hal_irq_init_boot(void) {}
 void hal_timer_init(void) {}
 int device_register_builtin_drivers(void) { return 0; }
 void arch_cpu_caps_init(void) {}
-void arch_cpu_caps_system_finalize(void) {}
+kstatus_t arch_cpu_caps_system_finalize(void) { return K_OK; }
 void hal_discovery_publish_cpu_caps(void) {}
 void arch_ext_state_boot_init(void) {}
 void ipc_async_init(void) {}


### PR DESCRIPTION
### Motivation

- Prevent early/faulty finalization of the primitive registry by ensuring CPU and platform facts are authoritative before runtime dispatch binds implementations.
- Make HAL capability truth deterministic, immutable after a well-defined freeze point, and consistent across the five required ISAs (x86_64, arm64, arm32, riscv64, riscv32).
- Remove misleading ISA-derived platform guesses (IOMMU, DMA coherency, some CPU-feature claims) and ensure conservative, evidence-driven platform reporting.

### Description

- Add a monotonic HAL capability lifecycle (`HAL_CAPS_UNINITIALIZED → HAL_CAPS_RAW_DISCOVERED → HAL_CAPS_CPU_FINALIZED → HAL_CAPS_FROZEN`) and APIs: `hal_hw_caps_state()`, `hal_hw_caps_is_frozen()`, `hal_hw_caps_publish_raw()`, `hal_hw_caps_publish_cpu()`, and `hal_hw_caps_finalize()`; callers fail closed on illegal transitions. (core/hal/common/hw_caps.c, core/hal/include/hal/hal_hw_caps.h)
- Require CPU-aggregation readiness by changing `arch_cpu_caps_system_finalize()` to return `kstatus_t` and only expose `SYSTEM_ALL`/`SYSTEM_ANY` when finalized; per-CPU accessors now fail-closed when records are unavailable. (core/arch/common/cpu_caps_state.c, core/kernel/include/arch/arch_cpu_caps.h)
- Make `hal_cpu_feature_set_system()` return `false` when the requested system aggregate is not ready, distinguishing “not initialized” from “initialized but feature absent.” (core/hal/common/cpu_features.c)
- Move primitive registry finalization after HAL freeze and require the registry to accept exactly the frozen snapshot; early or second initialization returns `K_ERR_IN_PROGRESS`/`K_ERR_BAD_STATE`. Also remove unsafe promotion of architecture-default bits into system-wide guarantees. (core/kernel/src/core/primitive_registry.c, core/kernel/src/kernel_boot.c)
- Replace ISA-driven platform claims with conservative defaults (set IOMMU/DMA/coherency/vector/atomic fields to platform/CPU-derived values) and rely on platform discovery for IOMMU/topology information; stop truncating topology to 32 CPUs (respect `BHARAT_MAX_CPUS` and keep 32-bit service-placement masks as an explicit compatibility boundary). (arch hw_caps.c for x86/ARM/RISCV, core/hal/common/discovery.c, hal_cpu_topology headers)
- Add a focused host test to cover lifecycle/readiness/heterogeneous-ALL/ANY/LOCAL semantics and primitive-registry ordering (quality/tests/host/test_hal_capability_lifecycle.c) and record the new authority model in ADR-021. (docs/adr/ADR-021-hardware-capability-freeze-authority.md)

### Testing

- Host unit: compiled and ran the focused lifecycle test (`quality/tests/host/test_hal_capability_lifecycle.c`) directly; test binary executed successfully and validated readiness, lifecycle transitions, freeze immutability, LOCAL/ALL/ANY distinctions, primitive-registry ordering, and heterogeneity behavior (PASS).
- Cross-builds: used CMake presets to build for all five required architectures and completed the builds: `x86_64-dev`, `arm64-edge`, `arm32-qemu-mmu-lite-headless`, `riscv64-edge`, `riscv32-qemu-mmu-lite-headless` (all CROSS-BUILD steps completed successfully).
- QEMU matrix: invoked `python3 tools/run_qemu_matrix.py --headless --smoke --all-arch`; x86_64 smoke run observed required boot markers and reached `BOOT_RUNTIME: STABLE` (PASS for x86_64); the matrix invocation was interrupted before all remaining QEMU members completed, so ARM64/ARM32/RISCV64/RISCV32 QEMU qualification is INCOMPLETE in this run.
- Linters and contract checks: `python3 tools/lint/check_layer_references.py` scanned repository and returned the existing baseline (118 layer-reference violations, unchanged by this change), `python3 tools/lint/check_cmake_dependencies.py` reported the existing baseline (4 violations, unchanged), and `python3 tools/abi/syscall_abi.py --check` passed (PASS).

Notes: an attempt to run host tests via a particular configure preset with `BHARAT_BUILD_HOST_TESTS=ON` hit a pre-existing duplicate `test_servicemgr` target in the repository configuration; the focused lifecycle test was still compiled and executed directly to provide evidence. The full QEMU/YAML matrix was started but not all target runs completed in this session, so this PR delivers a transparent partial result with successful builds and focused tests and with the x86_64 QEMU smoke evidence; remaining QEMU members should be re-run in CI to complete the full-matrix gate.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a786e77d02083209cc66fc60a617953)