### PR TITLE
fix(arm64): complete userspace smoke boot

### DIFF
--- a/core/arch/arm/arm64/usercopy.c
+++ b/core/arch/arm/arm64/usercopy.c
@@ -1,26 +1,37 @@
 #include "trap/usercopy.h"
 #include "kernel/status.h"
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
 #define BH_EX_UACCESS_RD 2
 #define BH_EX_UACCESS_WR 3
 
+static bool arm64_pan_supported(void) {
+    uint64_t mmfr1;
+
+    __asm__ __volatile__("mrs %0, id_aa64mmfr1_el1" : "=r"(mmfr1));
+    return ((mmfr1 >> 20U) & 0xFU) != 0U;
+}
+
 kstatus_t arch_copy_from_user_nofault(void *dst, const void *src, size_t len) {
     if (len == 0) return K_OK;
 
-    uint64_t prev_pan = 1;
+    uint64_t prev_pan = 0;
+    bool has_pan = arm64_pan_supported();
     #if defined(__aarch64__)
-    __asm__ __volatile__(
-        ".arch_extension pan\n\t"
-        "mrs %0, pan"
-        : "=r"(prev_pan) :: "memory"
-    );
-    __asm__ __volatile__(
-        ".arch_extension pan\n\t"
-        "msr pan, #0"
-        ::: "memory"
-    );
+    if (has_pan) {
+        __asm__ __volatile__(
+            ".arch_extension pan\n\t"
+            "mrs %0, pan"
+            : "=r"(prev_pan) :: "memory"
+        );
+        __asm__ __volatile__(
+            ".arch_extension pan\n\t"
+            "msr pan, #0"
+            ::: "memory"
+        );
+    }
     #endif
 
     kstatus_t status = K_OK;
@@ -52,11 +63,13 @@ kstatus_t arch_copy_from_user_nofault(void *dst, const void *src, size_t len) {
     }
 
     #if defined(__aarch64__)
-    __asm__ __volatile__(
-        ".arch_extension pan\n\t"
-        "msr pan, %0"
-        :: "r"(prev_pan) : "memory"
-    );
+    if (has_pan) {
+        __asm__ __volatile__(
+            ".arch_extension pan\n\t"
+            "msr pan, %0"
+            :: "r"(prev_pan) : "memory"
+        );
+    }
     #endif
 
     return status;
@@ -65,18 +78,21 @@ kstatus_t arch_copy_from_user_nofault(void *dst, const void *src, size_t len) {
 kstatus_t arch_copy_to_user_nofault(void *dst, const void *src, size_t len) {
     if (len == 0) return K_OK;
 
-    uint64_t prev_pan = 1;
+    uint64_t prev_pan = 0;
+    bool has_pan = arm64_pan_supported();
     #if defined(__aarch64__)
-    __asm__ __volatile__(
-        ".arch_extension pan\n\t"
-        "mrs %0, pan"
-        : "=r"(prev_pan) :: "memory"
-    );
-    __asm__ __volatile__(
-        ".arch_extension pan\n\t"
-        "msr pan, #0"
-        ::: "memory"
-    );
+    if (has_pan) {
+        __asm__ __volatile__(
+            ".arch_extension pan\n\t"
+            "mrs %0, pan"
+            : "=r"(prev_pan) :: "memory"
+        );
+        __asm__ __volatile__(
+            ".arch_extension pan\n\t"
+            "msr pan, #0"
+            ::: "memory"
+        );
+    }
     #endif
 
     kstatus_t status = K_OK;
@@ -107,11 +123,13 @@ kstatus_t arch_copy_to_user_nofault(void *dst, const void *src, size_t len) {
     }
 
     #if defined(__aarch64__)
-    __asm__ __volatile__(
-        ".arch_extension pan\n\t"
-        "msr pan, %0"
-        :: "r"(prev_pan) : "memory"
-    );
+    if (has_pan) {
+        __asm__ __volatile__(
+            ".arch_extension pan\n\t"
+            "msr pan, %0"
+            :: "r"(prev_pan) : "memory"
+        );
+    }
     #endif
 
     return status;

--- a/core/arch/hal/arm/arm64/hal_pt_arm64.c
+++ b/core/arch/hal/arm/arm64/hal_pt_arm64.c
@@ -64,6 +64,7 @@ static arm64_kernel_map_state_t g_arm64_kernel_map = {
 #define ARM64_PT_AF          (1ULL << 10)
 
 #define ARM64_PAGE_MASK      (0x0000FFFFFFFFF000ULL)
+#define ARM64_PMD_BLOCK_SIZE (1ULL << 21)
 
 // Arch-private raw descriptor
 typedef uint64_t pte_raw_t;
@@ -74,6 +75,28 @@ typedef struct {
 
 static inline void arm64_pt_zero_table(void *tbl, size_t sz) {
     hal_memset(tbl, 0, sz, BH_MEMCTX_F_DEFAULT);
+}
+
+static phys_addr_t arm64_pt_split_block(uint64_t block, uint64_t child_size,
+                                        bool child_is_page) {
+    phys_addr_t child_pa = mm_alloc_page(NUMA_NODE_ANY);
+    if (child_pa == 0U) {
+        return 0U;
+    }
+
+    pt_t *child = (pt_t *)physmap_phys_to_virt(child_pa);
+    uint64_t block_size = child_size * 512U;
+    uint64_t base = (block & ARM64_PAGE_MASK) & ~(block_size - 1U);
+    uint64_t attributes = block & ~ARM64_PAGE_MASK;
+
+    arm64_pt_zero_table(child, sizeof(*child));
+    for (uint64_t i = 0; i < 512U; ++i) {
+        child->entries[i] = (base + (i * child_size)) | attributes;
+        if (child_is_page) {
+            child->entries[i] |= ARM64_PT_PAGE;
+        }
+    }
+    return child_pa;
 }
 
 static virt_addr_t align_down(virt_addr_t value) {
@@ -180,10 +203,11 @@ static phys_addr_t arm64_pt_create_address_space(phys_addr_t kernel_root_table) 
     if (kernel_root_table != 0U) {
         pt_t* kernel_pgd = (pt_t*)physmap_phys_to_virt(kernel_root_table);
         
-        // For user process spaces, allocate a separate PUD table for pgd->entries[0]
-        // so user space can map 0x00000000..0x3FFFFFFF with fine-grained 4KB PMD/PTE tables,
-        // while preserving kernel RAM block mappings at user_pud->entries[1..3] (0x40000000+)
-        // so kernel execution at 0x40080000 remains active in TTBR0_EL1.
+        // User roots retain the kernel's privileged low-half mappings because
+        // the kernel currently executes there after TTBR0 switches.  Split the
+        // first inherited 1 GiB block into 2 MiB blocks so user mappings can be
+        // refined without dropping unrelated privileged MMIO (notably the
+        // runtime console).  EL0 cannot access the inherited AP_EL1 mappings.
         phys_addr_t user_pud_pa = mm_alloc_page(NUMA_NODE_ANY);
         if (user_pud_pa) {
             pt_t* user_pud = (pt_t*)physmap_phys_to_virt(user_pud_pa);
@@ -191,6 +215,17 @@ static phys_addr_t arm64_pt_create_address_space(phys_addr_t kernel_root_table) 
             
             if (kernel_pgd->entries[0] & ARM64_PT_VALID) {
                 pt_t* kernel_pud = (pt_t*)physmap_phys_to_virt(kernel_pgd->entries[0] & ARM64_PAGE_MASK);
+                user_pud->entries[0] = kernel_pud->entries[0];
+                if ((user_pud->entries[0] & ARM64_PT_TABLE) == 0U) {
+                    phys_addr_t user_pmd_pa = arm64_pt_split_block(
+                        user_pud->entries[0], ARM64_PMD_BLOCK_SIZE, false);
+                    if (user_pmd_pa == 0U) {
+                        mm_free_page(user_pud_pa);
+                        mm_free_page(root);
+                        return 0U;
+                    }
+                    user_pud->entries[0] = user_pmd_pa | ARM64_PT_VALID | ARM64_PT_TABLE;
+                }
                 for (int i = 1; i < 512; i++) {
                     user_pud->entries[i] = kernel_pud->entries[i];
                 }
@@ -303,6 +338,11 @@ static int arm64_pt_map_4k(phys_addr_t root_pt, virt_addr_t vaddr, phys_addr_t p
         pt_t* pmd_ptr = (pt_t*)physmap_phys_to_virt(new_pmd);
         arm64_pt_zero_table(pmd_ptr, sizeof(*pmd_ptr));
         pud->entries[pud_idx] = new_pmd | table_flags;
+    } else if ((pud->entries[pud_idx] & ARM64_PT_TABLE) == 0U) {
+        phys_addr_t new_pmd = arm64_pt_split_block(
+            pud->entries[pud_idx], ARM64_PMD_BLOCK_SIZE, false);
+        if (new_pmd == 0U) return -2;
+        pud->entries[pud_idx] = new_pmd | table_flags;
     }
 
     pt_t* pmd = (pt_t*)physmap_phys_to_virt(pud->entries[pud_idx] & ARM64_PAGE_MASK);
@@ -311,6 +351,11 @@ static int arm64_pt_map_4k(phys_addr_t root_pt, virt_addr_t vaddr, phys_addr_t p
         if (!new_pte) return -2;
         pt_t* pte_ptr = (pt_t*)physmap_phys_to_virt(new_pte);
         arm64_pt_zero_table(pte_ptr, sizeof(*pte_ptr));
+        pmd->entries[pmd_idx] = new_pte | table_flags;
+    } else if ((pmd->entries[pmd_idx] & ARM64_PT_TABLE) == 0U) {
+        phys_addr_t new_pte = arm64_pt_split_block(
+            pmd->entries[pmd_idx], 4096U, true);
+        if (new_pte == 0U) return -2;
         pmd->entries[pmd_idx] = new_pte | table_flags;
     }
 

--- a/core/kernel/src/trap/trap.c
+++ b/core/kernel/src/trap/trap.c
@@ -1,6 +1,5 @@
 #include <stdint.h>
 #include <stddef.h>
-#include "console/console_core.h"
 
 int sched_sys_intent_set(uint64_t tid, const void* intent);
 int sched_sys_intent_get(uint64_t tid, void* intent);
@@ -233,10 +232,6 @@ kstatus_t bh_trap_decode(const trap_frame_t *frame, bh_trap_context_t *out) {
 
 long trap_handle(trap_frame_t *frame) {
   if (!frame) return TRAP_ERR_INVAL;
-
-  if (frame->from_user) {
-    console_write_raw("[USER_TRAP]\n", 13);
-  }
 
   bh_trap_context_t context;
   if (bh_trap_decode(frame, &context) != K_OK) {

--- a/core/lib/runtime/src/runtime.c
+++ b/core/lib/runtime/src/runtime.c
@@ -11,11 +11,20 @@ static bharat_handle_t g_bootstrap_cap = BHARAT_INVALID_HANDLE;
 static const bharat_user_startup_t *g_startup_ptr = NULL;
 
 void bharat_runtime_init(const void *startup_ptr) {
+    /* The startup block is an ABI structure, so reject obviously malformed
+     * pointers before reading capability-bearing fields from it. */
+    uintptr_t startup_addr = (uintptr_t)startup_ptr;
+    if (startup_addr < 4096U ||
+        (startup_addr % _Alignof(bharat_user_startup_t)) != 0U) {
+        startup_ptr = NULL;
+    }
     // Initialize memory, TLS, thread structs
     g_startup_ptr = (const bharat_user_startup_t *)startup_ptr;
     const bharat_user_startup_t *startup = (const bharat_user_startup_t *)startup_ptr;
     if (startup) {
         g_bootstrap_cap = startup->bootstrap.bootstrap_cap;
+    } else {
+        g_bootstrap_cap = BHARAT_INVALID_HANDLE;
     }
 }
 

--- a/quality/tests/host/CMakeLists.txt
+++ b/quality/tests/host/CMakeLists.txt
@@ -328,6 +328,16 @@ add_executable(test_e2e_service_runtime test_e2e_service_runtime.c ../../core/se
 target_include_directories(test_e2e_service_runtime PRIVATE ../../include ../../core/lib/ipc/include ../../core/lib/cap/include ../../kernel/include)
 add_test(NAME host_test_e2e_service_runtime COMMAND test_e2e_service_runtime)
 
+add_executable(test_runtime_startup
+    test_runtime_startup.c
+    ../../core/lib/runtime/src/runtime.c
+)
+target_include_directories(test_runtime_startup PRIVATE
+    ../../interface/include
+    ../../core/lib/runtime/include
+)
+add_test(NAME host_test_runtime_startup COMMAND test_runtime_startup)
+
 if(BHARAT_BUILD_HOST_TESTS)
     # I2C Core Host Tests
     add_executable(test_i2c_registry ${CMAKE_SOURCE_DIR}/core/tests/host/drivers/test_i2c_registry.c ${CMAKE_SOURCE_DIR}/core/drivers/bus/i2c/i2c_core.c ${CMAKE_SOURCE_DIR}/core/drivers/bus/i2c/i2c_registry.c)

--- a/quality/tests/host/test_runtime_startup.c
+++ b/quality/tests/host/test_runtime_startup.c
@@ -1,0 +1,40 @@
+#include <assert.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <bharat/runtime/runtime.h>
+#include <bharat/uapi/init/bootstrap.h>
+#include <bharat/uapi/syscall/bh_syscall.h>
+
+extern const bharat_user_startup_t *bharat_runtime_get_startup(void);
+
+int64_t bharat_syscall(int64_t number, int64_t arg0, int64_t arg1,
+                       int64_t arg2, int64_t arg3, int64_t arg4,
+                       int64_t arg5) {
+    (void)number;
+    (void)arg0;
+    (void)arg1;
+    (void)arg2;
+    (void)arg3;
+    (void)arg4;
+    (void)arg5;
+    return 0;
+}
+
+int main(void) {
+    bharat_user_startup_t startup = {0};
+    startup.bootstrap.bootstrap_cap = 42;
+
+    bharat_runtime_init((const void *)(uintptr_t)19U);
+    assert(bharat_runtime_get_startup() == NULL);
+    assert(bharat_runtime_get_bootstrap_cap() == BHARAT_INVALID_HANDLE);
+
+    bharat_runtime_init(&startup);
+    assert(bharat_runtime_get_startup() == &startup);
+    assert(bharat_runtime_get_bootstrap_cap() == 42);
+
+    bharat_runtime_init((const void *)(uintptr_t)19U);
+    assert(bharat_runtime_get_startup() == NULL);
+    assert(bharat_runtime_get_bootstrap_cap() == BHARAT_INVALID_HANDLE);
+    return 0;
+}


### PR DESCRIPTION
### Motivation

- Address ARM64 userspace boot hangs and runtime failures caused by inherited TTBR0 mappings, PAN handling on CPUs without PAN support, and unsafe startup pointer handling.

### Description

- Preserve necessary privileged low-half kernel mappings for user address-space roots by splitting inherited block descriptors into finer-grained tables when userspace needs to refine mappings, and fail cleanly if page-table allocation fails (`core/arch/hal/arm/arm64/hal_pt_arm64.c`).
- Make ARM64 usercopy PAN handling conditional on hardware support by probing `ID_AA64MMFR1_EL1` and toggling PAN only when available (`core/arch/arm/arm64/usercopy.c`).
- Harden runtime initialization by rejecting obviously malformed or misaligned low startup pointers and ensuring the bootstrap capability is cleared when startup data is invalid (`core/lib/runtime/src/runtime.c`).
- Remove noisy per-syscall console writes that flooded serial output and could prevent boot markers from being observed (`core/kernel/src/trap/trap.c`).
- Add a focused host regression test that validates startup-pointer handling and bootstrap-cap publication/clearing, and register it in the host test CMake list (`quality/tests/host/test_runtime_startup.c`, `quality/tests/host/CMakeLists.txt`).
- Small helper and robustness fixes in ARM64 page-table code to split block descriptors when needed and to handle allocation failures gracefully (`core/arch/hal/arm/arm64/hal_pt_arm64.c`).

### Testing

- Ran a compiled unit-style host regression for the new runtime startup test using a local compile-and-run; the test passed locally (compiled with `clang` and executed). (PASS)
- Verified syscall ABI generator: `python3 tools/abi/syscall_abi.py --check`. (PASS)
- Ran ARM64 userspace smoke: `./tools/build.sh all --target-yaml delivery/targets/qemu/arm64_desktop_headless.yaml --smoke` and observed all 11 required boot markers and no forbidden markers. (PASS)
- Ran x86_64 userspace smoke: `./tools/build.sh all --target-yaml delivery/targets/qemu/x86_64_desktop_headless.yaml --smoke` and observed all required boot markers. (PASS)
- Ran full QEMU matrix via `python3 tools/run_qemu_matrix.py --headless --smoke --all-arch`; recorded results: x86_64=PASS, arm64=PASS, arm32=FAIL (MODULE_MAPPED/ELF_PLAN failure), riscv64=FAIL (timeout in protection-domain activation), riscv32=BLOCKED (missing OpenSBI firmware). These failures reflect pre-existing non-ARM64 issues and environment firmware gaps, not regressions introduced here. (PARTIAL: matrix shows mixed results)
- Ran repository linters: `python3 tools/lint/check_layer_references.py` and `python3 tools/lint/check_cmake_dependencies.py` which reported existing violations unrelated to this change (recorded as failing gates per repo policy). (REPORTED)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a79de75312c83209e92fa7bce57a5c6)