### PR TITLE
sched: fail-closed dispatch, single context-switch accounting, and hot-path diagnostic cleanup

### DIFF
--- a/core/kernel/src/sched/constraint_apply.c
+++ b/core/kernel/src/sched/constraint_apply.c
@@ -29,7 +29,7 @@ static bharat_sched_class_mask_t sched_class_mask_from_thread(const bh_thread_t 
 
 bool sched_is_core_admissible(bh_thread_t *t, int cpu_id)
 {
-    if (!t) return false;
+    if (!t || cpu_id < 0 || cpu_id >= 32) return false;
 
     // Explicitly allow idle threads on any core.
     if ((t->flags & BH_THREAD_FLAG_IDLE) != 0) {
@@ -42,5 +42,41 @@ bool sched_is_core_admissible(bh_thread_t *t, int cpu_id)
         return false;
     }
 
-    return (t->constraints.cpu_mask & (1u << cpu_id)) != 0;
+    uint32_t cpu_bit = 1U << (uint32_t)cpu_id;
+    if ((t->affinity_mask & cpu_bit) == 0U) {
+        return false;
+    }
+
+    return (t->constraints.cpu_mask & cpu_bit) != 0U;
+}
+
+bh_thread_t *sched_validate_picked_candidate(bh_thread_t *candidate,
+                                             bh_thread_t *idle,
+                                             uint32_t core_id)
+{
+    if (!candidate) {
+        return idle;
+    }
+
+    /* Ownership is the first dispatch gate; foreign entities fail closed. */
+    if (__atomic_load_n(&candidate->owner_cpu, __ATOMIC_ACQUIRE) != core_id) {
+        return idle;
+    }
+
+    /* This checks class/partition before affinity and dynamic constraints. */
+    if (!sched_is_core_admissible(candidate, (int)core_id)) {
+        return idle;
+    }
+
+    return candidate;
+}
+
+void sched_account_context_switch(sched_rq_t *rq, bh_thread_t *next)
+{
+    if (!rq || !next) {
+        return;
+    }
+
+    next->context_switch_count++;
+    rq->context_switches++;
 }

--- a/core/kernel/src/sched/cpu_partition.c
+++ b/core/kernel/src/sched/cpu_partition.c
@@ -19,6 +19,12 @@ kstatus_t cpu_partition_init(bharat_execution_config_t *config) {
         return K_ERR_INVALID_ARG;
     }
 
+    if (config->execution_mode != BHARAT_EXEC_MODE_GENERAL_PURPOSE &&
+        config->execution_mode != BHARAT_EXEC_MODE_REALTIME &&
+        config->execution_mode != BHARAT_EXEC_MODE_MIXED_CRITICAL) {
+        return K_ERR_BAD_STATE;
+    }
+
     // Step 1: Strategy Resolution
     if (config->active_cpu_count <= 1) {
         config->partition_strategy = BHARAT_PARTITION_STRATEGY_TEMPORAL;
@@ -123,12 +129,6 @@ kstatus_t cpu_partition_init(bharat_execution_config_t *config) {
             for (uint32_t i = 1; i < config->active_cpu_count; i++) {
                 config->cpu_partitions[i].role = BHARAT_CPU_PARTITION_REALTIME;
                 config->cpu_partitions[i].allowed_sched_classes = BHARAT_SCHED_CLASS_FIFO_RT | BHARAT_SCHED_CLASS_DEADLINE_RT;
-            }
-        } else {
-            // Default fallback for unknown mode with >= 4 CPUs
-            for (uint32_t i = 0; i < config->active_cpu_count; i++) {
-                config->cpu_partitions[i].role = BHARAT_CPU_PARTITION_SYSTEM;
-                config->cpu_partitions[i].allowed_sched_classes = BHARAT_SCHED_CLASS_SYSTEM | BHARAT_SCHED_CLASS_FAIR;
             }
         }
     }

--- a/core/kernel/src/sched/cpu_partition_validate.c
+++ b/core/kernel/src/sched/cpu_partition_validate.c
@@ -10,6 +10,12 @@ kstatus_t cpu_partition_validate(const bharat_execution_config_t *config) {
         return K_ERR_INVALID_ARG;
     }
 
+    if (config->execution_mode != BHARAT_EXEC_MODE_GENERAL_PURPOSE &&
+        config->execution_mode != BHARAT_EXEC_MODE_REALTIME &&
+        config->execution_mode != BHARAT_EXEC_MODE_MIXED_CRITICAL) {
+        return K_ERR_BAD_STATE;
+    }
+
     bool has_system_role = false;
     bool has_rt_role = false;
     bool has_best_effort_role = false;

--- a/core/kernel/src/sched/execution_mode.c
+++ b/core/kernel/src/sched/execution_mode.c
@@ -3,6 +3,7 @@
 #include <sched/cpu_partition.h>
 #include <console/console_core.h>
 #include <stddef.h>
+#include "bharat_config.h"
 
 static bharat_execution_config_t g_exec_config = {0};
 static bool g_exec_config_initialized = false;
@@ -13,7 +14,15 @@ static bool g_exec_config_initialized = false;
 #endif
 
 #ifndef BHARAT_CONFIG_EXECUTION_MODE
+#if defined(BHARAT_KERNEL_PROFILE_RT)
+#define BHARAT_CONFIG_EXECUTION_MODE BHARAT_EXEC_MODE_REALTIME
+#elif defined(BHARAT_KERNEL_PROFILE_GP)
+#define BHARAT_CONFIG_EXECUTION_MODE BHARAT_EXEC_MODE_GENERAL_PURPOSE
+#elif defined(BHARAT_KERNEL_PROFILE_MIX)
+#define BHARAT_CONFIG_EXECUTION_MODE BHARAT_EXEC_MODE_MIXED_CRITICAL
+#else
 #define BHARAT_CONFIG_EXECUTION_MODE BHARAT_EXEC_MODE_UNKNOWN
+#endif
 #endif
 
 #ifndef BHARAT_CONFIG_LOGICAL_CPU_COUNT

--- a/core/kernel/src/sched/sched.c
+++ b/core/kernel/src/sched/sched.c
@@ -1,7 +1,6 @@
 #include "sched/sched.h"
 #include <bharat/cpu_local.h>
 #include "sched/sched_deg.h"
-#include "console/console_core.h"
 
 #include "sched/algo_matrix.h"
 #include "../../staging/formal/formal_verif.h"
@@ -883,34 +882,8 @@ bh_thread_t *sched_pick_next_ready(uint32_t core_id) {
   if (!next) {
       return rq->idle_thread;
   }
-  if (next != rq->idle_thread) {
-      console_write_raw("[PICK_NON_IDLE]\n", 17);
-  }
-  return next;
 
-  // Fallback: If not admissible on this core (e.g. from dynamic constraint update while queued),
-  // try to find a valid core, else fallback to idle.
-  if (!sched_is_core_admissible(next, core_id)) {
-      bool found = false;
-      for (uint32_t i = 0; i < g_active_core_count; ++i) {
-          if (sched_is_core_admissible(next, i)) {
-              sched_enqueue(next, i);
-              found = true;
-              break;
-          }
-      }
-      if (!found) {
-          // If no core is valid, put it back to sleep/deferred queue (simple drop for MVP)
-      }
-      return rq->idle_thread;
-  }
-
-  sched_entity_t *entity = sched_find_entity_by_thread(next);
-  if (entity) {
-      entity->is_on_runqueue = 0U;
-  }
-
-  return next;
+  return sched_validate_picked_candidate(next, rq->idle_thread, core_id);
 }
 
 
@@ -965,13 +938,10 @@ void sched_switch_to(bh_thread_t *next, uint32_t core_id) {
     }
   }
 
-  console_write_raw("[STEP_A]\n", 9);
   sched_invariant_on_switch(current, next, core_id);
 
   next->state = THREAD_STATE_RUNNING;
-  next->context_switch_count++;
-  rq->context_switches++;
-  g_cpu_locals[core_id].runqueue.context_switches++;
+  sched_account_context_switch(rq, next);
   g_cpu_locals[core_id].runqueue.current_thread = next;
   /* Owner-core state: privilege-entry assembly consumes this stack top. */
   g_cpu_locals[core_id].kernel_stack =
@@ -981,13 +951,11 @@ void sched_switch_to(bh_thread_t *next, uint32_t core_id) {
   cpu_context_t *next_ctx = (cpu_context_t*)next->cpu_context;
 
   if (current) {
-    console_write_raw("[STEP_B]\n", 9);
     arch_ext_state_save(current);
   }
 
   address_space_t *prev_as = current && current->process ? current->process->addr_space : NULL;
   address_space_t *next_as = next->process ? next->process->addr_space : NULL;
-  console_write_raw("[STEP_C]\n", 9);
   mm_switch_active_aspace(core_id, prev_as, next_as);
 
   #ifndef NDEBUG
@@ -996,14 +964,11 @@ void sched_switch_to(bh_thread_t *next, uint32_t core_id) {
 
     // Process incoming URPC messages before doing the switch
     extern void vmm_process_local_urpc_messages(uint32_t core_id);
-    console_write_raw("[STEP_D]\n", 9);
     vmm_process_local_urpc_messages(core_id);
 
   if (fv_secure_context_switch) {
     fv_secure_context_switch(next_ctx);
   } else {
-    console_write_raw("[STEP_E]\n", 9);
-    console_write_raw("[BEFORE_ARCH_CONTEXT_SWITCH]\n", 29);
     arch_context_switch(prev_ctx, next_ctx);
   }
 

--- a/core/kernel/src/sched/sched_internal.h
+++ b/core/kernel/src/sched/sched_internal.h
@@ -114,6 +114,10 @@ bh_thread_t *sched_find_thread_by_id(uint64_t tid);
 void sched_balance_once(void);
 void sched_detach_thread_from_queues(thread_slot_t *slot);
 bool sched_is_core_admissible(bh_thread_t *t, int cpu_id);
+bh_thread_t *sched_validate_picked_candidate(bh_thread_t *candidate,
+                                             bh_thread_t *idle,
+                                             uint32_t core_id);
+void sched_account_context_switch(sched_rq_t *rq, bh_thread_t *next);
 void sched_switch_to(bh_thread_t *next, uint32_t core_id);
 void sched_update_telemetry(bh_thread_t *thread);
 void sched_validate_rq(sched_rq_t *rq);

--- a/quality/tests/host/CMakeLists.txt
+++ b/quality/tests/host/CMakeLists.txt
@@ -24,6 +24,30 @@ target_compile_definitions(test_servicemgr PRIVATE BHARAT_HOST_TEST)
 
 add_test(NAME host_test_servicemgr COMMAND test_servicemgr)
 
+add_executable(host_test_sched_selection
+    sched/test_sched_selection.c
+    ${CMAKE_SOURCE_DIR}/core/kernel/src/sched/constraint_apply.c)
+target_include_directories(host_test_sched_selection PRIVATE
+    ${CMAKE_SOURCE_DIR}/core/kernel/include
+    ${CMAKE_SOURCE_DIR}/core/kernel/src/sched
+    ${CMAKE_SOURCE_DIR}/core/hal/include
+    ${CMAKE_SOURCE_DIR}/core/lib/include
+    ${CMAKE_SOURCE_DIR}/core/boot/include
+    ${CMAKE_SOURCE_DIR}/core/personalities/runtime/include
+    ${CMAKE_SOURCE_DIR}/interface/include
+    ${CMAKE_BINARY_DIR}/generated/include)
+target_compile_definitions(host_test_sched_selection PRIVATE TESTING=1)
+add_test(NAME host_test_sched_selection COMMAND host_test_sched_selection)
+
+add_executable(host_test_cpu_partition
+    sched/test_cpu_partition.c
+    ${CMAKE_SOURCE_DIR}/core/kernel/src/sched/cpu_partition.c
+    ${CMAKE_SOURCE_DIR}/core/kernel/src/sched/cpu_partition_validate.c)
+target_include_directories(host_test_cpu_partition PRIVATE
+    ${CMAKE_SOURCE_DIR}/core/kernel/include
+    ${CMAKE_SOURCE_DIR}/interface/include)
+add_test(NAME host_test_cpu_partition COMMAND host_test_cpu_partition)
+
 # Phase 3: Core IPC/Profile Tests
 add_executable(test_ipc_profile test_ipc_profile.c ../../kernel/src/profile/profile.c ../../kernel/src/ipc/ipc_traffic.c)
 target_include_directories(test_ipc_profile PRIVATE ../../kernel/include ../../include ../../core/lib/include)

--- a/quality/tests/host/sched/test_cpu_partition.c
+++ b/quality/tests/host/sched/test_cpu_partition.c
@@ -20,6 +20,14 @@ void test_cpu_partition_bounds(void) {
     // active_cpu_count > BHARAT_MAX_CPU_PARTITIONS
     config.active_cpu_count = BHARAT_MAX_CPU_PARTITIONS + 1;
     assert(cpu_partition_init(&config) == K_ERR_INVALID_ARG);
+
+    /* Unknown and out-of-range modes must not inherit the GP mapping. */
+    memset(&config, 0, sizeof(config));
+    config.active_cpu_count = 4;
+    config.execution_mode = BHARAT_EXEC_MODE_UNKNOWN;
+    assert(cpu_partition_init(&config) == K_ERR_BAD_STATE);
+    config.execution_mode = (bharat_execution_mode_t)UINT32_MAX;
+    assert(cpu_partition_init(&config) == K_ERR_BAD_STATE);
 }
 
 void test_cpu_partition_single_core(void) {

--- a/quality/tests/host/sched/test_sched_selection.c
+++ b/quality/tests/host/sched/test_sched_selection.c
@@ -1,0 +1,109 @@
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <sched/sched.h>
+#include <sched/cpu_partition.h>
+#include "sched_internal.h"
+
+sched_policy_t g_policy = SCHED_POLICY_CLOUD_FAIR;
+
+static bool g_partition_allows;
+
+bool cpu_partition_allows_class(uint32_t cpu_id,
+                                bharat_sched_class_mask_t class_mask)
+{
+    (void)cpu_id;
+    (void)class_mask;
+    return g_partition_allows;
+}
+
+static void init_candidate(bh_thread_t *thread, uint32_t owner_cpu)
+{
+    memset(thread, 0, sizeof(*thread));
+    thread->owner_cpu = owner_cpu;
+    thread->affinity_mask = UINT32_MAX;
+    thread->constraints.cpu_mask = UINT32_MAX;
+}
+
+static void test_inadmissible_task_is_never_selected(void)
+{
+    bh_thread_t candidate;
+    bh_thread_t idle;
+    init_candidate(&candidate, 0U);
+    init_candidate(&idle, 0U);
+    idle.flags = BH_THREAD_FLAG_IDLE;
+    g_partition_allows = false;
+
+    assert(sched_validate_picked_candidate(&candidate, &idle, 0U) == &idle);
+}
+
+static void test_affinity_mismatch_fails_closed(void)
+{
+    bh_thread_t candidate;
+    bh_thread_t idle;
+    init_candidate(&candidate, 0U);
+    init_candidate(&idle, 0U);
+    candidate.affinity_mask = 1U << 1U;
+    g_partition_allows = true;
+
+    assert(sched_validate_picked_candidate(&candidate, &idle, 0U) == &idle);
+}
+
+static void test_partition_mismatch_fails_closed(void)
+{
+    bh_thread_t candidate;
+    bh_thread_t idle;
+    init_candidate(&candidate, 0U);
+    init_candidate(&idle, 0U);
+    g_partition_allows = false;
+
+    assert(sched_validate_picked_candidate(&candidate, &idle, 0U) == &idle);
+}
+
+static void test_owner_mismatch_fails_closed(void)
+{
+    bh_thread_t candidate;
+    bh_thread_t idle;
+    init_candidate(&candidate, 1U);
+    init_candidate(&idle, 0U);
+    g_partition_allows = true;
+
+    assert(sched_validate_picked_candidate(&candidate, &idle, 0U) == &idle);
+}
+
+static void test_context_switch_is_counted_once(void)
+{
+    sched_rq_t rq;
+    bh_thread_t next;
+    memset(&rq, 0, sizeof(rq));
+    memset(&next, 0, sizeof(next));
+
+    sched_account_context_switch(&rq, &next);
+
+    assert(rq.context_switches == 1U);
+    assert(next.context_switch_count == 1U);
+}
+
+static void test_idle_remains_selectable_without_candidate(void)
+{
+    bh_thread_t idle;
+    init_candidate(&idle, 0U);
+    idle.flags = BH_THREAD_FLAG_IDLE;
+
+    assert(sched_validate_picked_candidate(NULL, &idle, 0U) == &idle);
+}
+
+int main(void)
+{
+    test_inadmissible_task_is_never_selected();
+    test_affinity_mismatch_fails_closed();
+    test_partition_mismatch_fails_closed();
+    test_owner_mismatch_fails_closed();
+    test_context_switch_is_counted_once();
+    test_idle_remains_selectable_without_candidate();
+    puts("All scheduler selection host tests passed.");
+    return 0;
+}


### PR DESCRIPTION
### Motivation

- Ensure schedulers never return an inadmissible candidate by enforcing owner → partition/class → affinity/constraint validation order. 
- Fix duplicate context-switch accounting observed when both `rq->context_switches` and `g_cpu_locals[core].runqueue.context_switches` were incremented for the same event. 
- Remove unconditional bring-up console writes from hot paths to avoid costly synchronous I/O on pick/switch/interrupt paths. 
- Harden execution-mode handling so unknown/out-of-range modes fail closed rather than silently falling back to a GP mapping.

### Description

- Validate picked candidate earlier and in the correct order by adding `sched_validate_picked_candidate()` and using it from `sched_pick_next_ready()`, returning the idle thread for any inadmissible candidate. (files: `core/kernel/src/sched/constraint_apply.c`, `core/kernel/src/sched/sched.c`).
- Consolidate context-switch accounting into a single helper `sched_account_context_switch()` so each real context switch increments the runqueue counter exactly once and the thread counter once. (files: `core/kernel/src/sched/constraint_apply.c`, `core/kernel/src/sched/sched.c`, `core/kernel/src/sched/sched_internal.h`).
- Remove unconditional `console_write_raw` markers (`[PICK_NON_IDLE]`, `[STEP_A]`..`[STEP_E]`, `[BEFORE_ARCH_CONTEXT_SWITCH]`) from hot paths; keep lightweight trace/diagnostics via existing trace hooks where appropriate. (file: `core/kernel/src/sched/sched.c`).
- Make execution-mode initialization and CPU-partition init/validate fail closed on unknown modes and derive default `BHARAT_CONFIG_EXECUTION_MODE` from generated profile defines when available. (files: `core/kernel/src/sched/execution_mode.c`, `core/kernel/src/sched/cpu_partition.c`, `core/kernel/src/sched/cpu_partition_validate.c`).
- Add focused host regression tests: `quality/tests/host/sched/test_sched_selection.c` (inadmissible selection, affinity, partition, ownership mismatch, idle fallback, context-switch count) and extended `test_cpu_partition.c` checks for unknown/out-of-range modes, and wire them into `quality/tests/host/CMakeLists.txt`.
- Commit summary: changes staged and committed under message: `fix(sched): fail closed on invalid dispatch candidates`.

### Testing

- Ran focused host selection test by compiling and executing the new host unit: `cc -std=c11 -DTESTING=1 -Icore/kernel/include -Icore/kernel/src/sched -Icore/hal/include -Icore/lib/include -Icore/boot/include -Icore/personalities/runtime/include -Iinterface/include -Ibuild/x86_64-dev/generated/include quality/tests/host/sched/test_sched_selection.c core/kernel/src/sched/constraint_apply.c -o /tmp/host_test_sched_selection && /tmp/host_test_sched_selection` — PASS (all selection assertions passed).
- Ran CPU-partition host suite: `cc -std=c11 -Icore/kernel/include -Iinterface/include quality/tests/host/sched/test_cpu_partition.c core/kernel/src/sched/cpu_partition.c core/kernel/src/sched/cpu_partition_validate.c -o /tmp/host_test_cpu_partition && /tmp/host_test_cpu_partition` — PASS (partition invariants and unknown-mode checks passed).
- Built and smoke-ran x86_64 QEMU target: `./tools/build.sh all --target-yaml delivery/targets/qemu/x86_64_desktop_headless.yaml --smoke` — PASS (boot markers and required runtime boot contract observed).
- Ran QEMU matrix runner: `python3 tools/run_qemu_matrix.py --headless --smoke --all-arch` — PARTIAL: x86_64, arm64, arm32, riscv64 all PASS; riscv32 failed to complete due to environment missing OpenSBI firmware (`opensbi-riscv32-generic-fw_dynamic.bin`) and is reported as BLOCKED by the environment, not by the change.
- Ran repo linters: `python3 tools/lint/check_layer_references.py` and `python3 tools/lint/check_cmake_dependencies.py` — completed but reported existing baseline violations (118 layer-reference items and 4 CMake dependency violations) that are outside the scope of this PR (warnings recorded). 
- Performed `git diff --check` and code grep for removed console markers: `rg -n "PICK_NON_IDLE|STEP_[A-E]|BEFORE_ARCH_CONTEXT_SWITCH" core/kernel/src/sched core/kernel/src` — PASS (markers removed from hot paths).

Commands, commit and status evidence are in the rollout: the change set modifies scheduler selection/validation, accounting, execution-mode handling, and adds host regression tests; CI/build evidence shows focused host tests and the x86_64 QEMU smoke target passed while the full matrix is BLOCKED only for riscv32 due to a missing firmware artifact in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7c14ea2a648320aaff4e38025f82bc)