### PR TITLE
build: factor product configuration out of build instrumentation and add variant-equivalence checker

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -179,6 +179,48 @@ Output layout uses CMake preset name:
 - `build/<preset>/manifests/flash-manifest.json`
 - `build/<preset>/manifests/debug-manifest.json`
 
+### Build instrumentation versus product configuration
+
+`CMAKE_BUILD_TYPE` selects one of three instrumentation values and does not
+select an OS target or profile:
+
+| CMake build type | Instrumentation value | Symbols | Optimization | Assertions/invariant checks |
+|---|---|---|---|---|
+| `Debug` | `DEBUG` | on | unoptimized | on |
+| `RelWithDebInfo` | `RELWITHDEBINFO` | on | optimized | off |
+| `Release` | `RELEASE` | off | optimized | off |
+
+The canonical x86_64 QEMU desktop target is factored through the hidden
+`x86_64-qemu-desktop-base` preset. Its Debug, RelWithDebInfo, and Release
+presets inherit exactly the same x86_64 / QEMU / DESKTOP / MMU_FULL / GP /
+NATIVE product selection. Each configure writes
+`build/<preset>/generated/build-configuration.json`; CI compares variants with:
+
+```bash
+python3 tools/check_build_variant_equivalence.py \
+  build/x86_64-qemu-desktop-debug/generated/build-configuration.json \
+  build/x86_64-qemu-desktop-release/generated/build-configuration.json
+```
+
+The checker fails on any functional difference. Differences are permitted only
+inside the explicit instrumentation object (`variant`, assertions, symbols,
+optimization, tracing, test hooks, poisoning, and invariant checking).
+
+Audit findings retained outside this P0 canonical-target change:
+
+- The older `x86_64-debug` preset selects board `host` and host tests while
+  `x86_64-dev` selects QEMU; they are distinct products and must not be treated
+  as a Debug/Release pair.
+- `tiny-mpu-debug` enables allocation classes while `tiny-mpu-release` disables
+  them. A follow-up must factor that target through a shared product preset.
+- No build-type condition in target YAML resolution changes architecture,
+  memory model, scheduler profile, personality, runtime model, or services.
+  YAML supplies a preset plus explicit CMake definitions independent of build
+  type.
+- `HARDENED_RELEASE` is not defined: hardening flags and their supported
+  toolchain/backend matrix need a separate contract rather than scope expansion
+  in this task.
+
 ---
 
 ## 4) QEMU usage (desktop/headless/emulator targets)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,26 @@
 cmake_minimum_required(VERSION 3.20)
 project(BharatOS VERSION 0.8.0 LANGUAGES C ASM)
 
+# Build type selects compiler instrumentation only. Product behavior is selected
+# independently by the target/profile cache variables recorded below.
+string(TOUPPER "${CMAKE_BUILD_TYPE}" BHARAT_BUILD_INSTRUMENTATION)
+if(BHARAT_BUILD_INSTRUMENTATION STREQUAL "RELWITHDEBINFO")
+    set(BHARAT_BUILD_SYMBOLS ON)
+    set(BHARAT_BUILD_OPTIMIZATION "OPTIMIZED")
+    set(BHARAT_BUILD_ASSERTIONS OFF)
+elseif(BHARAT_BUILD_INSTRUMENTATION STREQUAL "RELEASE")
+    set(BHARAT_BUILD_SYMBOLS OFF)
+    set(BHARAT_BUILD_OPTIMIZATION "OPTIMIZED")
+    set(BHARAT_BUILD_ASSERTIONS OFF)
+elseif(BHARAT_BUILD_INSTRUMENTATION STREQUAL "DEBUG")
+    set(BHARAT_BUILD_SYMBOLS ON)
+    set(BHARAT_BUILD_OPTIMIZATION "UNOPTIMIZED")
+    set(BHARAT_BUILD_ASSERTIONS ON)
+else()
+    message(FATAL_ERROR
+        "CMAKE_BUILD_TYPE must select DEBUG, RELWITHDEBINFO, or RELEASE instrumentation")
+endif()
+
 enable_testing()
 
 set(BHARAT_CMAKE_ROOT "${CMAKE_SOURCE_DIR}/delivery/cmake")
@@ -282,6 +302,14 @@ endif()
 
 option(BHARAT_ENABLE_CLANG_TIDY "Enable clang-tidy static analysis for C targets" OFF)
 option(BHARAT_BUILD_HOST_TESTS "Build host-side unit tests" OFF)
+
+# Deterministic, machine-readable evidence for variant-equivalence checks. This
+# is generated in the build tree and is never a source-controlled artifact.
+configure_file(
+    "${CMAKE_SOURCE_DIR}/delivery/cmake/templates/build-configuration.json.in"
+    "${CMAKE_BINARY_DIR}/generated/build-configuration.json"
+    @ONLY
+)
 
 if(BHARAT_ENABLE_CLANG_TIDY)
     find_program(BHARAT_CLANG_TIDY NAMES clang-tidy)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -7,6 +7,40 @@
   },
   "configurePresets": [
     {
+      "name": "x86_64-qemu-desktop-base",
+      "hidden": true,
+      "generator": "Ninja",
+      "toolchainFile": "${sourceDir}/delivery/cmake/toolchains/x86_64-elf-clang.cmake",
+      "cacheVariables": {
+        "BHARAT_DEVICE_PROFILE": "DESKTOP",
+        "BHARAT_PERSONALITY_PROFILE": "NATIVE",
+        "BHARAT_TARGET_BOARD": "qemu-virt",
+        "BHARAT_USERSPACE_RUNTIME_MODEL": "FULL",
+        "BHARAT_ENABLE_ADVANCED_VM": "ON"
+      }
+    },
+    {
+      "name": "x86_64-qemu-desktop-debug",
+      "inherits": "x86_64-qemu-desktop-base",
+      "displayName": "x86_64 QEMU Desktop (Debug)",
+      "binaryDir": "${sourceDir}/build/x86_64-qemu-desktop-debug",
+      "cacheVariables": { "CMAKE_BUILD_TYPE": "Debug" }
+    },
+    {
+      "name": "x86_64-qemu-desktop-relwithdebinfo",
+      "inherits": "x86_64-qemu-desktop-base",
+      "displayName": "x86_64 QEMU Desktop (RelWithDebInfo)",
+      "binaryDir": "${sourceDir}/build/x86_64-qemu-desktop-relwithdebinfo",
+      "cacheVariables": { "CMAKE_BUILD_TYPE": "RelWithDebInfo" }
+    },
+    {
+      "name": "x86_64-qemu-desktop-release",
+      "inherits": "x86_64-qemu-desktop-base",
+      "displayName": "x86_64 QEMU Desktop (Release)",
+      "binaryDir": "${sourceDir}/build/x86_64-qemu-desktop-release",
+      "cacheVariables": { "CMAKE_BUILD_TYPE": "Release" }
+    },
+    {
       "name": "host-test",
       "displayName": "Host Tests (Debug)",
       "description": "Host build for tests on Linux using Clang",
@@ -869,6 +903,18 @@
     }
   ],
   "buildPresets": [
+    {
+      "name": "x86_64-qemu-desktop-debug",
+      "configurePreset": "x86_64-qemu-desktop-debug"
+    },
+    {
+      "name": "x86_64-qemu-desktop-relwithdebinfo",
+      "configurePreset": "x86_64-qemu-desktop-relwithdebinfo"
+    },
+    {
+      "name": "x86_64-qemu-desktop-release",
+      "configurePreset": "x86_64-qemu-desktop-release"
+    },
     {
       "name": "host-test",
       "configurePreset": "host-test"

--- a/delivery/cmake/templates/build-configuration.json.in
+++ b/delivery/cmake/templates/build-configuration.json.in
@@ -1,0 +1,29 @@
+{
+  "schema_version": 1,
+  "functional": {
+    "architecture_family": "@BHARAT_ARCH_FAMILY@",
+    "architecture_bits": "@BHARAT_ARCH_BITS@",
+    "architecture_variant": "@BHARAT_ARCH_VARIANT@",
+    "board": "@BHARAT_TARGET_BOARD@",
+    "device_profile": "@BHARAT_DEVICE_PROFILE@",
+    "memory_mmu": "@BHARAT_ENABLE_MMU@",
+    "memory_mpu": "@BHARAT_ENABLE_MPU@",
+    "memory_advanced_vm": "@BHARAT_ENABLE_ADVANCED_VM@",
+    "scheduler_profile": "@BHARAT_KERNEL_PROFILE_RESOLVED@",
+    "personality": "@BHARAT_PERSONALITY_PROFILE@",
+    "userspace_runtime_model": "@BHARAT_USERSPACE_RUNTIME_MODEL@",
+    "service_network": "@BHARAT_ENABLE_SERVICE_NETWORK@",
+    "service_boot_display": "@BHARAT_ENABLE_SERVICE_BOOT_DISPLAYD@",
+    "service_can": "@BHARAT_ENABLE_SERVICE_CAN@"
+  },
+  "instrumentation": {
+    "variant": "@BHARAT_BUILD_INSTRUMENTATION@",
+    "assertions": "@BHARAT_BUILD_ASSERTIONS@",
+    "symbols": "@BHARAT_BUILD_SYMBOLS@",
+    "optimization": "@BHARAT_BUILD_OPTIMIZATION@",
+    "tracing": "OFF",
+    "test_hooks": "@BHARAT_BUILD_HOST_TESTS@",
+    "poisoning": "OFF",
+    "invariant_checking": "@BHARAT_BUILD_ASSERTIONS@"
+  }
+}

--- a/delivery/targets/qemu/x86_64_desktop_headless.yaml
+++ b/delivery/targets/qemu/x86_64_desktop_headless.yaml
@@ -8,7 +8,7 @@ personality_profile: native
 execution_profile: gp
 
 build:
-  cmake_preset: x86_64-dev
+  cmake_preset: x86_64-qemu-desktop-release
   cmake_defs:
     BHARAT_ARCH_FAMILY: X86_64
     BHARAT_DEVICE_PROFILE: DESKTOP

--- a/quality/tests/tools/test_build_variant_equivalence.py
+++ b/quality/tests/tools/test_build_variant_equivalence.py
@@ -1,0 +1,40 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+TOOL = Path(__file__).parents[3] / "tools" / "check_build_variant_equivalence.py"
+
+
+def config(board="qemu-virt", extra_instrumentation=None):
+    instrumentation = {
+        "variant": "DEBUG", "assertions": "ON", "symbols": "ON",
+        "optimization": "UNOPTIMIZED", "tracing": "OFF", "test_hooks": "OFF",
+        "poisoning": "OFF", "invariant_checking": "ON",
+    }
+    instrumentation.update(extra_instrumentation or {})
+    return {"schema_version": 1, "functional": {"board": board}, "instrumentation": instrumentation}
+
+
+def run(tmp_path, left, right):
+    paths = [tmp_path / "debug.json", tmp_path / "release.json"]
+    for path, value in zip(paths, (left, right)):
+        path.write_text(json.dumps(value), encoding="utf-8")
+    return subprocess.run([sys.executable, str(TOOL), *map(str, paths)], capture_output=True, text=True)
+
+
+def test_allows_only_whitelisted_instrumentation_differences(tmp_path):
+    release = config(extra_instrumentation={"variant": "RELEASE", "assertions": "OFF", "symbols": "OFF", "optimization": "OPTIMIZED", "invariant_checking": "OFF"})
+    assert run(tmp_path, config(), release).returncode == 0
+
+
+def test_rejects_functional_difference(tmp_path):
+    result = run(tmp_path, config(), config(board="different-board"))
+    assert result.returncode == 1
+    assert "board" in result.stdout
+
+
+def test_rejects_unlisted_instrumentation_key(tmp_path):
+    result = run(tmp_path, config(extra_instrumentation={"production_service": "OFF"}), config())
+    assert result.returncode != 0
+    assert "non-whitelisted" in result.stderr

--- a/tools/check_build_variant_equivalence.py
+++ b/tools/check_build_variant_equivalence.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Fail unless two resolved build configurations differ only in instrumentation."""
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+ALLOWED_INSTRUMENTATION = {
+    "variant", "assertions", "symbols", "optimization", "tracing",
+    "test_hooks", "poisoning", "invariant_checking",
+}
+
+
+def load(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ValueError(f"cannot read {path}: {error}") from error
+    if data.get("schema_version") != 1:
+        raise ValueError(f"{path}: unsupported schema_version")
+    if not isinstance(data.get("functional"), dict) or not isinstance(data.get("instrumentation"), dict):
+        raise ValueError(f"{path}: functional and instrumentation objects are required")
+    unknown = set(data["instrumentation"]) - ALLOWED_INSTRUMENTATION
+    if unknown:
+        raise ValueError(f"{path}: non-whitelisted instrumentation keys: {', '.join(sorted(unknown))}")
+    return data
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("debug_config", type=Path)
+    parser.add_argument("release_config", type=Path)
+    args = parser.parse_args()
+    try:
+        left, right = load(args.debug_config), load(args.release_config)
+    except ValueError as error:
+        parser.error(str(error))
+    if left["functional"] != right["functional"]:
+        keys = sorted(set(left["functional"]) | set(right["functional"]))
+        changed = [key for key in keys if left["functional"].get(key) != right["functional"].get(key)]
+        print(json.dumps({"equivalent": False, "unexpected_functional_differences": changed}, sort_keys=True))
+        return 1
+    print(json.dumps({"equivalent": True, "allowed_difference_class": "instrumentation"}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation

- Ensure `Debug`/`RelWithDebInfo`/`Release` only change instrumentation (symbols, asserts, optimization, tracing, test hooks, etc.) and do not silently change OS product configuration (arch, board, memory model, personality, scheduler profile, userspace runtime, or production services).
- Provide machine-readable, deterministic evidence from configure so CI can reject unexpected functional differences between build variants.
- Add a small CI-callable checker to enforce the allowed instrumentation-only delta for canonical targets.

### Description

- Introduced an explicit instrumentation classification in `CMakeLists.txt` so `CMAKE_BUILD_TYPE` maps to `DEBUG`, `RELWITHDEBINFO`, or `RELEASE` instrumentation flags (symbols, optimization, assertions) and is separated from product selection.
- Added hidden/derived CMake presets for a canonical x86_64 QEMU desktop product (`x86_64-qemu-desktop-base`) and three derived presets that differ only in `CMAKE_BUILD_TYPE` (`-debug`, `-relwithdebinfo`, `-release`) in `CMakePresets.json` and corresponding build presets for convenient `cmake --preset` usage.
- Emit a deterministic JSON configuration artifact via `configure_file` (`build/<preset>/generated/build-configuration.json`) produced from `delivery/cmake/templates/build-configuration.json.in` that separates `functional` (architecture, board, memory/profile, personality, services) and `instrumentation` fields.
- Added a small checker `tools/check_build_variant_equivalence.py` that fails if two resolved configs differ in any `functional` field or contain non-whitelisted instrumentation keys; it prints machine-readable JSON on success/failure.
- Added focused unit tests `quality/tests/tools/test_build_variant_equivalence.py` to exercise allowed and disallowed differences.
- Updated the canonical x86_64 QEMU target YAML (`delivery/targets/qemu/x86_64_desktop_headless.yaml`) to use the new canonical `x86_64-qemu-desktop-release` preset, and documented the instrumentation-vs-product contract in `BUILD.md`.

### Testing

- Ran unit tests: `python3 -m pytest quality/tests/tools/test_build_variant_equivalence.py -q` — PASS (3 tests passed).
- Configured and validated presets: `cmake --preset x86_64-qemu-desktop-debug` and `cmake --preset x86_64-qemu-desktop-release`, and generated `build-configuration.json` for both; then ran the checker `python3 tools/check_build_variant_equivalence.py build/x86_64-qemu-desktop-debug/generated/build-configuration.json build/x86_64-qemu-desktop-release/generated/build-configuration.json` — PASS (reported `{"equivalent": true}`).
- Built both variants: `cmake --build --preset x86_64-qemu-desktop-debug -j2` and `cmake --build --preset x86_64-qemu-desktop-release -j2` — PASS (both builds completed).
- Repository gates and contract checks: `python3 tools/lint/check_layer_references.py`, `python3 tools/lint/check_cmake_dependencies.py`, and `python3 tools/abi/syscall_abi.py --check` were executed and completed; they reported existing repository findings but did not fail the validation run.
- Smoke-run matrix (QEMU): executed `./tools/build.sh all --target-yaml ... --smoke` for the five required targets: x86_64, arm64, riscv64, arm32 (MMU-Lite), riscv32 (MMU-Lite); four targets completed their build/package/run smoke steps successfully, while `riscv32_mmu_lite_headless` is BLOCKED by a missing OpenSBI RISC-V firmware (`opensbi-riscv32-generic-fw_dynamic.bin`) on the runner.
- Attempted `python3 tools/run_qemu_matrix.py --headless --smoke --all-arch` to verify the mandatory all-architecture gate, but the full-matrix gate was not completed in this environment (interrupted / partial evidence only); mark as BLOCKED for full-matrix verification until the missing firmware/emulator support is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7c1b5ad4ac832099f5d7a7e8b34818)