### PR TITLE
sched: enforce dispatch admission, fix context-switch accounting, remove hot-path prints, and fail-closed cpu_partition_init

### DIFF
--- a/docs/architecture/kernel/scheduler_model.md
+++ b/docs/architecture/kernel/scheduler_model.md
@@ -29,6 +29,28 @@ The scheduler's job is purely localized:
 
 Load balancing and cross-core thread migration happen entirely through asynchronous **uRPC messages**.
 
+### 1.1 Dispatch correctness invariants
+
+The local dispatch path applies these rules on every architecture and memory
+protection backend:
+
+* A candidate is removed from its owner-local runqueue before it can be
+  dispatched, then must pass owner, CPU-partition class, affinity, and dynamic
+  CPU-mask checks. A failed check selects the local idle thread; it must never
+  execute the inadmissible candidate or mutate a remote runqueue directly.
+* A real switch updates the incoming thread counter and the owner-local
+  runqueue counter exactly once. A null target or a switch to the already
+  running thread is a no-op and is not counted.
+* The dispatch and context-switch hot path does not write unconditional console
+  diagnostics. Diagnostics must use an explicitly enabled, bounded tracing
+  mechanism outside the timing-critical path.
+* CPU partition initialization accepts only `GENERAL_PURPOSE`, `REALTIME`, or
+  `MIXED_CRITICAL`. `UNKNOWN` and values outside the execution-mode enum fail
+  closed before any partition mapping is published.
+
+These are backend-neutral scheduler mechanisms. They do not depend on an ISA,
+MMU, MMU-Lite, or MPU implementation.
+
 ---
 
 ## 2. Per-Core State Only

--- a/quality/tests/host/sched/test_sched_selection.c
+++ b/quality/tests/host/sched/test_sched_selection.c
@@ -74,6 +74,18 @@ static void test_owner_mismatch_fails_closed(void)
     assert(sched_validate_picked_candidate(&candidate, &idle, 0U) == &idle);
 }
 
+static void test_out_of_range_core_fails_closed(void)
+{
+    bh_thread_t candidate;
+    bh_thread_t idle;
+    init_candidate(&candidate, 32U);
+    init_candidate(&idle, 0U);
+    g_partition_allows = true;
+
+    /* Affinity and constraint masks are 32-bit, so core 32 is never valid. */
+    assert(sched_validate_picked_candidate(&candidate, &idle, 32U) == &idle);
+}
+
 static void test_context_switch_is_counted_once(void)
 {
     sched_rq_t rq;
@@ -85,6 +97,20 @@ static void test_context_switch_is_counted_once(void)
 
     assert(rq.context_switches == 1U);
     assert(next.context_switch_count == 1U);
+}
+
+static void test_invalid_context_switch_is_not_counted(void)
+{
+    sched_rq_t rq;
+    bh_thread_t next;
+    memset(&rq, 0, sizeof(rq));
+    memset(&next, 0, sizeof(next));
+
+    sched_account_context_switch(NULL, &next);
+    sched_account_context_switch(&rq, NULL);
+
+    assert(rq.context_switches == 0U);
+    assert(next.context_switch_count == 0U);
 }
 
 static void test_idle_remains_selectable_without_candidate(void)
@@ -102,7 +128,9 @@ int main(void)
     test_affinity_mismatch_fails_closed();
     test_partition_mismatch_fails_closed();
     test_owner_mismatch_fails_closed();
+    test_out_of_range_core_fails_closed();
     test_context_switch_is_counted_once();
+    test_invalid_context_switch_is_not_counted();
     test_idle_remains_selectable_without_candidate();
     puts("All scheduler selection host tests passed.");
     return 0;


### PR DESCRIPTION
### Motivation

- Address P0 scheduler correctness issues by ensuring the picked candidate is admissible to the local core and fails closed when it is not. 
- Ensure context-switch counters are updated exactly once per real switch and never on no-ops or invalid inputs. 
- Remove unconditional console output from the scheduler hot path to avoid timing/debug noise. 
- Prevent publishing CPU partition mappings for unknown execution modes by making `cpu_partition_init()` fail-closed on invalid/UNKNOWN modes.

### Description

- Added `sched_validate_picked_candidate()` which verifies owner CPU, CPU-partition/class allowance, affinity, and dynamic CPU-mask before accepting a candidate, returning the local idle thread on failure. 
- Introduced `sched_account_context_switch()` and replaced ad-hoc increment sites so the incoming thread and runqueue counters are incremented exactly once for a real switch and guarded against `NULL` inputs. 
- Removed unconditional `console_write_raw()` diagnostics from `sched_pick_next_ready()` and `sched_switch_to()` so the hot path is quiet unless an explicit tracing mechanism is enabled. 
- Made `cpu_partition_init()` reject `BHARAT_EXEC_MODE_UNKNOWN` and out-of-enum execution-mode values, returning `K_ERR_BAD_STATE` before publishing mappings. 
- Added host regression tests in `quality/tests/host/sched/test_sched_selection.c` covering: out-of-range core admission, owner/affinity/partition checks, and invalid context-switch accounting. 
- Documented the owner-local, fail-closed dispatch invariants and quiet hot-path requirement in `docs/architecture/kernel/scheduler_model.md`. 

### Testing

- Ran focused host unit tests by compiling and executing `test_sched_selection` and `test_cpu_partition` locally, and the new scheduler-selection tests passed. 
- Executed `python3 tools/abi/syscall_abi.py --check` which passed cleanly for syscall ABI. 
- Ran the five-target smoke builds via `./tools/build.sh all --target-yaml ... --smoke` and observed PASS for `x86_64`, `arm64`, `riscv64`, and `arm32`, while `riscv32` build/packaging succeeded but QEMU run failed due to missing OpenSBI riscv32 firmware (`opensbi-riscv32-generic-fw_dynamic.bin`), blocking the smoke run for that target. 
- Ran repository gates: `python3 tools/lint/check_layer_references.py` and `python3 tools/lint/check_cmake_dependencies.py` which reported pre-existing violations (not introduced by this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7c1bccbbf883209298612651030ea6)