### PR TITLE
Introduce typed boundary for syscall return handling

### DIFF
--- a/core/kernel/include/kernel/status.h
+++ b/core/kernel/include/kernel/status.h
@@ -119,6 +119,26 @@ typedef int32_t kstatus_t;
 #define K_ERR_AI_DEFERRED       ((kstatus_t)-2307)
 #define K_ERR_AI_THROTTLED      ((kstatus_t)-2308)
 
+typedef enum bh_status_domain {
+    BH_STATUS_DOMAIN_KSTATUS = 0,
+    BH_STATUS_DOMAIN_VALUE = 1,
+} bh_status_domain_t;
+
+typedef struct {
+    bh_status_domain_t domain;
+    int64_t value;
+} bh_operation_result_t;
+
+static inline bh_operation_result_t bh_op_result_kstatus(kstatus_t status) {
+    bh_operation_result_t res = { .domain = BH_STATUS_DOMAIN_KSTATUS, .value = status };
+    return res;
+}
+
+static inline bh_operation_result_t bh_op_result_value(int64_t value) {
+    bh_operation_result_t res = { .domain = BH_STATUS_DOMAIN_VALUE, .value = value };
+    return res;
+}
+
 /*
  * Canonical kernel-internal -> syscall boundary status translation.
  *

--- a/core/kernel/include/personality_ops.h
+++ b/core/kernel/include/personality_ops.h
@@ -5,6 +5,7 @@ typedef struct bh_thread bh_thread_t;
 
 // TODO: Needs refactor: #include directive placed mid-file for dependency/order compatibility.
 #include "trap_types.h"
+#include "kernel/status.h"
 
 // Forward declaration of trap_frame_t without typedef redefinition issues.
 struct trap_frame;
@@ -21,5 +22,5 @@ typedef struct personality_ops {
 
     int (*map_fault_to_signal)(const trap_info_t *info);
 
-    long (*normalize_syscall_return)(long result);
+    long (*normalize_syscall_return)(bh_operation_result_t result);
 } personality_ops_t;

--- a/core/kernel/include/trap/syscall_context.h
+++ b/core/kernel/include/trap/syscall_context.h
@@ -29,7 +29,9 @@ typedef struct bh_syscall_return_context {
 __attribute__((noreturn)) void
 bh_syscall_rejected_return_handoff(bh_syscall_return_disposition_t disposition);
 
-typedef long (*bh_syscall_handler_t)(bh_syscall_ctx_t *ctx);
+#include "kernel/status.h"
+
+typedef bh_operation_result_t (*bh_syscall_handler_t)(bh_syscall_ctx_t *ctx);
 
 /**
  * Syscall classification for auditing and policy enforcement.
@@ -83,7 +85,6 @@ typedef struct bh_personality_syscall_table {
     const bh_syscall_meta_t *table;
 } bh_personality_syscall_table_t;
 
-#include "kernel/status.h"
 kstatus_t bh_syscall_table_validate(const bh_personality_syscall_table_t *table);
 
 // Flags

--- a/core/kernel/include/trap/syscall_status.h
+++ b/core/kernel/include/trap/syscall_status.h
@@ -15,4 +15,9 @@ bh_status_t kstatus_to_bh_status(kstatus_t st);
  */
 long kstatus_to_native_sysret(kstatus_t st);
 
+/**
+ * Maps a bh_status_t back to an internal kstatus_t.
+ */
+kstatus_t bh_status_to_kstatus(bh_status_t st);
+
 #endif /* BHARAT_KERNEL_SYSCALL_STATUS_H */

--- a/core/kernel/src/personality/native/native_syscall_handlers.c
+++ b/core/kernel/src/personality/native/native_syscall_handlers.c
@@ -15,107 +15,107 @@
 
 #define TRAP_SUCCESS 0L
 
-long bh_sys_nop(bh_syscall_ctx_t *ctx) {
-    return (long)BH_OK;
+bh_operation_result_t bh_sys_nop(bh_syscall_ctx_t *ctx) {
+    return bh_op_result_kstatus(K_OK);
 }
 
-long bh_sys_thread_create(bh_syscall_ctx_t *ctx) {
+bh_operation_result_t bh_sys_thread_create(bh_syscall_ctx_t *ctx) {
     bharat_sys_thread_create_args_t args;
     bh_status_t st = bh_copy_from_user(&args, (const void *)ctx->regs.arg[0], sizeof(args));
-    if (st != BH_OK) return (long)st;
+    if (st != BH_OK) return bh_op_result_kstatus(bh_status_to_kstatus(st));
 
     bh_process_object_t target;
     kstatus_t kst = bh_syscall_cap_lookup_process(ctx, args.process_cap, CAP_RIGHT_RESOURCE_ALLOC, &target);
-    if (kst != K_OK) return kstatus_to_native_sysret(kst);
+    if (kst != K_OK) return bh_op_result_kstatus(kst);
 
     uint64_t out_tid;
     kstatus_t res = (kstatus_t)sched_sys_thread_create(target.process, (void (*)(void))(uintptr_t)args.entry_point, &out_tid);
     if (res == K_OK) {
         st = bh_copy_to_user((void *)args.out_tid_ptr, &out_tid, sizeof(out_tid));
-        if (st != BH_OK) return (long)st;
+        if (st != BH_OK) return bh_op_result_kstatus(bh_status_to_kstatus(st));
     }
-    return kstatus_to_native_sysret(res);
+    return bh_op_result_kstatus(res);
 }
 
-long bh_sys_thread_destroy(bh_syscall_ctx_t *ctx) {
+bh_operation_result_t bh_sys_thread_destroy(bh_syscall_ctx_t *ctx) {
     bh_thread_object_t target;
     kstatus_t kst = bh_syscall_cap_lookup_thread(ctx, (uint32_t)ctx->regs.arg[0], CAP_RIGHT_PROCESS_MANAGE, &target);
-    if (kst != K_OK) return kstatus_to_native_sysret(kst);
+    if (kst != K_OK) return bh_op_result_kstatus(kst);
 
-    return kstatus_to_native_sysret((kstatus_t)sched_sys_thread_destroy(target.tid));
+    return bh_op_result_kstatus((kstatus_t)sched_sys_thread_destroy(target.tid));
 }
 
-long bh_sys_sched_yield(bh_syscall_ctx_t *ctx) {
+bh_operation_result_t bh_sys_sched_yield(bh_syscall_ctx_t *ctx) {
     bh_thread_yield();
-    return (long)BH_OK;
+    return bh_op_result_kstatus(K_OK);
 }
 
-long bh_sys_sched_sleep(bh_syscall_ctx_t *ctx) {
-    return kstatus_to_native_sysret((kstatus_t)sched_sys_sleep((uint64_t)ctx->regs.arg[0]));
+bh_operation_result_t bh_sys_sched_sleep(bh_syscall_ctx_t *ctx) {
+    return bh_op_result_kstatus((kstatus_t)sched_sys_sleep((uint64_t)ctx->regs.arg[0]));
 }
 
-long bh_sys_sched_set_priority(bh_syscall_ctx_t *ctx) {
+bh_operation_result_t bh_sys_sched_set_priority(bh_syscall_ctx_t *ctx) {
     bharat_sys_sched_attr_args_t args;
     bh_status_t st = bh_copy_from_user(&args, (const void *)ctx->regs.arg[0], sizeof(args));
-    if (st != BH_OK) return (long)st;
+    if (st != BH_OK) return bh_op_result_kstatus(bh_status_to_kstatus(st));
 
     bh_thread_object_t target;
     kstatus_t kst = bh_syscall_cap_lookup_thread(ctx, args.thread_cap, CAP_RIGHT_SCHEDULE, &target);
-    if (kst != K_OK) return kstatus_to_native_sysret(kst);
+    if (kst != K_OK) return bh_op_result_kstatus(kst);
 
-    return kstatus_to_native_sysret((kstatus_t)sched_sys_set_priority(target.tid, (uint32_t)args.value));
+    return bh_op_result_kstatus((kstatus_t)sched_sys_set_priority(target.tid, (uint32_t)args.value));
 }
 
-long bh_sys_sched_set_affinity(bh_syscall_ctx_t *ctx) {
+bh_operation_result_t bh_sys_sched_set_affinity(bh_syscall_ctx_t *ctx) {
     bharat_sys_sched_attr_args_t args;
     bh_status_t st = bh_copy_from_user(&args, (const void *)ctx->regs.arg[0], sizeof(args));
-    if (st != BH_OK) return (long)st;
+    if (st != BH_OK) return bh_op_result_kstatus(bh_status_to_kstatus(st));
 
     bh_thread_object_t target;
     kstatus_t kst = bh_syscall_cap_lookup_thread(ctx, args.thread_cap, CAP_RIGHT_SCHEDULE, &target);
-    if (kst != K_OK) return kstatus_to_native_sysret(kst);
+    if (kst != K_OK) return bh_op_result_kstatus(kst);
 
-    return kstatus_to_native_sysret((kstatus_t)sched_sys_set_affinity(target.tid, (uint32_t)args.value));
+    return bh_op_result_kstatus((kstatus_t)sched_sys_set_affinity(target.tid, (uint32_t)args.value));
 }
 
-long bh_sys_vmm_map_page(bh_syscall_ctx_t *ctx) {
+bh_operation_result_t bh_sys_vmm_map_page(bh_syscall_ctx_t *ctx) {
     bharat_sys_vmm_map_page_args_t args;
     bh_status_t st = bh_copy_from_user(&args, (const void *)ctx->regs.arg[0], sizeof(args));
-    if (st != BH_OK) return (long)st;
+    if (st != BH_OK) return bh_op_result_kstatus(bh_status_to_kstatus(st));
 
     st = bh_user_range_validate((const void *)args.vaddr, PAGE_SIZE, BH_USER_ACCESS_READ);
-    if (st != BH_OK) return (long)st;
+    if (st != BH_OK) return bh_op_result_kstatus(bh_status_to_kstatus(st));
 
     bh_memory_object_t mem;
     kstatus_t kst = bh_syscall_cap_lookup_memory(ctx, args.cap_id, CAP_RIGHT_MEMORY_MAP, &mem);
-    if (kst != K_OK) return kstatus_to_native_sysret(kst);
+    if (kst != K_OK) return bh_op_result_kstatus(kst);
 
-    return kstatus_to_native_sysret((kstatus_t)vmm_map_page((virt_addr_t)args.vaddr, (phys_addr_t)mem.base, args.flags));
+    return bh_op_result_kstatus((kstatus_t)vmm_map_page((virt_addr_t)args.vaddr, (phys_addr_t)mem.base, args.flags));
 }
 
-long bh_sys_vmm_unmap_page(bh_syscall_ctx_t *ctx) {
+bh_operation_result_t bh_sys_vmm_unmap_page(bh_syscall_ctx_t *ctx) {
     bharat_sys_vmm_unmap_page_args_t args;
     bh_status_t st = bh_copy_from_user(&args, (const void *)ctx->regs.arg[0], sizeof(args));
-    if (st != BH_OK) return (long)st;
+    if (st != BH_OK) return bh_op_result_kstatus(bh_status_to_kstatus(st));
 
     st = bh_user_range_validate((const void *)args.vaddr, PAGE_SIZE, BH_USER_ACCESS_READ);
-    if (st != BH_OK) return (long)st;
+    if (st != BH_OK) return bh_op_result_kstatus(bh_status_to_kstatus(st));
 
     bh_memory_object_t mem;
     kstatus_t kst = bh_syscall_cap_lookup_memory(ctx, args.cap_id, CAP_RIGHT_MEMORY_UNMAP, &mem);
-    if (kst != K_OK) return kstatus_to_native_sysret(kst);
+    if (kst != K_OK) return bh_op_result_kstatus(kst);
 
-    return kstatus_to_native_sysret((kstatus_t)vmm_unmap_page((virt_addr_t)args.vaddr));
+    return bh_op_result_kstatus((kstatus_t)vmm_unmap_page((virt_addr_t)args.vaddr));
 }
 
 int cap_invoke(uintptr_t cap_id, uintptr_t opcode, uintptr_t arg0, uintptr_t arg1);
 
-long bh_sys_cap_invoke(bh_syscall_ctx_t *ctx) {
+bh_operation_result_t bh_sys_cap_invoke(bh_syscall_ctx_t *ctx) {
     bharat_sys_cap_invoke_args_t args;
     bh_status_t st = bh_copy_from_user(&args, (const void *)ctx->regs.arg[0], sizeof(args));
-    if (st != BH_OK) return (long)st;
+    if (st != BH_OK) return bh_op_result_kstatus(bh_status_to_kstatus(st));
 
-    return kstatus_to_native_sysret((kstatus_t)cap_invoke(args.cap_id, args.opcode, args.arg0, args.arg1));
+    return bh_op_result_kstatus((kstatus_t)cap_invoke(args.cap_id, args.opcode, args.arg0, args.arg1));
 }
 
 static kstatus_t ipc_status_to_kstatus(int ipc_status) {
@@ -133,54 +133,54 @@ static kstatus_t ipc_status_to_kstatus(int ipc_status) {
     }
 }
 
-long bh_sys_endpoint_create(bh_syscall_ctx_t *ctx) {
+bh_operation_result_t bh_sys_endpoint_create(bh_syscall_ctx_t *ctx) {
     bharat_sys_endpoint_create_args_t args;
     bh_status_t st = bh_copy_from_user(&args, (const void *)ctx->regs.arg[0], sizeof(args));
-    if (st != BH_OK) return (long)st;
+    if (st != BH_OK) return bh_op_result_kstatus(bh_status_to_kstatus(st));
 
     capability_table_t *table = (capability_table_t *)ctx->process->security_sandbox_ctx;
-    if (!table) return kstatus_to_native_sysret(K_ERR_DENIED);
+    if (!table) return bh_op_result_kstatus(K_ERR_DENIED);
 
     uint32_t send_cap, recv_cap;
     kstatus_t res = ipc_status_to_kstatus(ipc_endpoint_create(table, &send_cap, &recv_cap));
     if (res == K_OK) {
         st = bh_copy_to_user((void *)args.out_send_cap_ptr, &send_cap, sizeof(send_cap));
-        if (st != BH_OK) return (long)st;
+        if (st != BH_OK) return bh_op_result_kstatus(bh_status_to_kstatus(st));
         st = bh_copy_to_user((void *)args.out_recv_cap_ptr, &recv_cap, sizeof(recv_cap));
-        if (st != BH_OK) return (long)st;
+        if (st != BH_OK) return bh_op_result_kstatus(bh_status_to_kstatus(st));
     }
-    return kstatus_to_native_sysret(res);
+    return bh_op_result_kstatus(res);
 }
 
-long bh_sys_endpoint_send(bh_syscall_ctx_t *ctx) {
+bh_operation_result_t bh_sys_endpoint_send(bh_syscall_ctx_t *ctx) {
     bharat_sys_endpoint_send_args_t args;
     bh_status_t st = bh_copy_from_user(&args, (const void *)ctx->regs.arg[0], sizeof(args));
-    if (st != BH_OK) return (long)st;
+    if (st != BH_OK) return bh_op_result_kstatus(bh_status_to_kstatus(st));
 
     bh_endpoint_object_t ep;
     kstatus_t kst = bh_syscall_cap_lookup_endpoint(ctx, args.send_cap, CAP_RIGHT_ENDPOINT_SEND, &ep);
-    if (kst != K_OK) return kstatus_to_native_sysret(kst);
+    if (kst != K_OK) return bh_op_result_kstatus(kst);
 
     st = bh_user_range_validate((const void *)args.payload_ptr, args.payload_len, BH_USER_ACCESS_READ);
-    if (st != BH_OK) return (long)st;
+    if (st != BH_OK) return bh_op_result_kstatus(bh_status_to_kstatus(st));
 
     capability_table_t *table = (capability_table_t *)ctx->process->security_sandbox_ctx;
-    return kstatus_to_native_sysret(
+    return bh_op_result_kstatus(
         ipc_status_to_kstatus(ipc_endpoint_send(table, args.send_cap, (const void *)(uintptr_t)args.payload_ptr,
                           args.payload_len, args.timeout_ticks, args.cap_to_send, args.cap_send_rights)));
 }
 
-long bh_sys_endpoint_receive(bh_syscall_ctx_t *ctx) {
+bh_operation_result_t bh_sys_endpoint_receive(bh_syscall_ctx_t *ctx) {
     bharat_sys_endpoint_receive_args_t args;
     bh_status_t st = bh_copy_from_user(&args, (const void *)ctx->regs.arg[0], sizeof(args));
-    if (st != BH_OK) return (long)st;
+    if (st != BH_OK) return bh_op_result_kstatus(bh_status_to_kstatus(st));
 
     bh_endpoint_object_t ep;
     kstatus_t kst = bh_syscall_cap_lookup_endpoint(ctx, args.recv_cap, CAP_RIGHT_ENDPOINT_RECEIVE, &ep);
-    if (kst != K_OK) return kstatus_to_native_sysret(kst);
+    if (kst != K_OK) return bh_op_result_kstatus(kst);
 
     st = bh_user_range_validate((void *)args.out_payload_ptr, args.out_payload_capacity, BH_USER_ACCESS_WRITE);
-    if (st != BH_OK) return (long)st;
+    if (st != BH_OK) return bh_op_result_kstatus(bh_status_to_kstatus(st));
 
     capability_table_t *table = (capability_table_t *)ctx->process->security_sandbox_ctx;
     uint32_t len_received, cap_received;
@@ -189,91 +189,91 @@ long bh_sys_endpoint_receive(bh_syscall_ctx_t *ctx) {
 
     if (res == K_OK) {
         st = bh_copy_to_user((void *)args.out_len_ptr, &len_received, sizeof(len_received));
-        if (st != BH_OK) return (long)st;
+        if (st != BH_OK) return bh_op_result_kstatus(bh_status_to_kstatus(st));
         if (args.out_received_cap_ptr) {
             st = bh_copy_to_user((void *)args.out_received_cap_ptr, &cap_received, sizeof(cap_received));
-            if (st != BH_OK) return (long)st;
+            if (st != BH_OK) return bh_op_result_kstatus(bh_status_to_kstatus(st));
         }
     }
-    return kstatus_to_native_sysret(res);
+    return bh_op_result_kstatus(res);
 }
 
-long bh_sys_cap_delegate(bh_syscall_ctx_t *ctx) {
+bh_operation_result_t bh_sys_cap_delegate(bh_syscall_ctx_t *ctx) {
     bharat_sys_cap_delegate_args_t args;
     bh_status_t st = bh_copy_from_user(&args, (const void *)ctx->regs.arg[0], sizeof(args));
-    if (st != BH_OK) return (long)st;
+    if (st != BH_OK) return bh_op_result_kstatus(bh_status_to_kstatus(st));
 
     bh_status_t bh_st = bh_syscall_validate_capability(ctx, args.src_cap, CAP_TYPE_NONE, CAP_RIGHT_DELEGATE);
-    if (bh_st != BH_OK) return (long)bh_st;
+    if (bh_st != BH_OK) return bh_op_result_kstatus(bh_status_to_kstatus(bh_st));
 
     capability_table_t *table = (capability_table_t *)ctx->process->security_sandbox_ctx;
-    if (!table) return kstatus_to_native_sysret(K_ERR_DENIED);
+    if (!table) return bh_op_result_kstatus(K_ERR_DENIED);
 
     uint32_t out_cap;
     kstatus_t res = (kstatus_t)cap_table_delegate(table, table, args.src_cap, args.requested_rights, &out_cap);
     if (res == K_OK) {
         st = bh_copy_to_user((void *)args.out_cap_ptr, &out_cap, sizeof(out_cap));
-        if (st != BH_OK) return (long)st;
+        if (st != BH_OK) return bh_op_result_kstatus(bh_status_to_kstatus(st));
     }
-    return kstatus_to_native_sysret(res);
+    return bh_op_result_kstatus(res);
 }
 
 int sched_sys_intent_set(uint64_t tid, const void* intent);
 int sched_sys_intent_get(uint64_t tid, void* intent);
 #include <bharat/uapi/system/intent.h>
 
-long bh_sys_intent_set(bh_syscall_ctx_t *ctx) {
+bh_operation_result_t bh_sys_intent_set(bh_syscall_ctx_t *ctx) {
     bharat_sys_intent_args_t args;
     bh_status_t st = bh_copy_from_user(&args, (const void *)ctx->regs.arg[0], sizeof(args));
-    if (st != BH_OK) return (long)st;
+    if (st != BH_OK) return bh_op_result_kstatus(bh_status_to_kstatus(st));
 
     bh_thread_object_t target;
     kstatus_t kst = bh_syscall_cap_lookup_thread(ctx, args.thread_cap, CAP_RIGHT_PROCESS_MANAGE, &target);
-    if (kst != K_OK) return kstatus_to_native_sysret(kst);
+    if (kst != K_OK) return bh_op_result_kstatus(kst);
 
     bharat_intent_t intent;
     st = bh_copy_from_user(&intent, (const void *)args.intent_ptr, sizeof(intent));
-    if (st != BH_OK) return (long)st;
+    if (st != BH_OK) return bh_op_result_kstatus(bh_status_to_kstatus(st));
 
-    return kstatus_to_native_sysret((kstatus_t)sched_sys_intent_set(target.tid, &intent));
+    return bh_op_result_kstatus((kstatus_t)sched_sys_intent_set(target.tid, &intent));
 }
 
-long bh_sys_intent_get(bh_syscall_ctx_t *ctx) {
+bh_operation_result_t bh_sys_intent_get(bh_syscall_ctx_t *ctx) {
     bharat_sys_intent_args_t args;
     bh_status_t st = bh_copy_from_user(&args, (const void *)ctx->regs.arg[0], sizeof(args));
-    if (st != BH_OK) return (long)st;
+    if (st != BH_OK) return bh_op_result_kstatus(bh_status_to_kstatus(st));
 
     bh_thread_object_t target;
     kstatus_t kst = bh_syscall_cap_lookup_thread(ctx, args.thread_cap, CAP_RIGHT_PROCESS_MANAGE, &target);
-    if (kst != K_OK) return kstatus_to_native_sysret(kst);
+    if (kst != K_OK) return bh_op_result_kstatus(kst);
 
     bharat_intent_t intent;
     kstatus_t res = (kstatus_t)sched_sys_intent_get(target.tid, &intent);
     if (res == K_OK) {
         st = bh_copy_to_user((void *)args.intent_ptr, &intent, sizeof(intent));
-        if (st != BH_OK) return (long)st;
+        if (st != BH_OK) return bh_op_result_kstatus(bh_status_to_kstatus(st));
     }
-    return kstatus_to_native_sysret(res);
+    return bh_op_result_kstatus(res);
 }
 
 int sys_mem_alloc_class(size_t size, uint32_t mem_class, uint32_t flags, uint64_t* out_addr);
 
-long bh_sys_mem_alloc_class(bh_syscall_ctx_t *ctx) {
+bh_operation_result_t bh_sys_mem_alloc_class(bh_syscall_ctx_t *ctx) {
     bharat_sys_mem_alloc_args_t args;
     bh_status_t st = bh_copy_from_user(&args, (const void *)ctx->regs.arg[0], sizeof(args));
-    if (st != BH_OK) return (long)st;
+    if (st != BH_OK) return bh_op_result_kstatus(bh_status_to_kstatus(st));
 
     bh_process_object_t target;
     kstatus_t kst = bh_syscall_cap_lookup_process(ctx, args.resource_cap, CAP_RIGHT_RESOURCE_ALLOC, &target);
-    if (kst != K_OK) return kstatus_to_native_sysret(kst);
+    if (kst != K_OK) return bh_op_result_kstatus(kst);
 
     uint64_t out_addr;
     kstatus_t res = (kstatus_t)sys_mem_alloc_class((size_t)args.size, (uint32_t)args.mem_class, (uint32_t)args.flags, &out_addr);
     if (res == K_OK) {
         st = bh_copy_to_user((void *)args.out_addr_ptr, &out_addr, sizeof(out_addr));
-        if (st != BH_OK) return (long)st;
+        if (st != BH_OK) return bh_op_result_kstatus(bh_status_to_kstatus(st));
     }
-    return kstatus_to_native_sysret(res);
+    return bh_op_result_kstatus(res);
 }
 
 int sys_fault_domain_create(const void* attr, uint64_t* out_domain);
@@ -281,57 +281,57 @@ int sys_fault_domain_destroy(uint64_t domain);
 int sys_fault_domain_attach(uint64_t domain, uint64_t tid);
 #include <bharat/uapi/system/fault_domain.h>
 
-long bh_sys_fault_domain_create(bh_syscall_ctx_t *ctx) {
+bh_operation_result_t bh_sys_fault_domain_create(bh_syscall_ctx_t *ctx) {
     bharat_sys_fault_domain_args_t args;
     bh_status_t st = bh_copy_from_user(&args, (const void *)ctx->regs.arg[0], sizeof(args));
-    if (st != BH_OK) return (long)st;
+    if (st != BH_OK) return bh_op_result_kstatus(bh_status_to_kstatus(st));
 
     bh_process_object_t target;
     kstatus_t kst = bh_syscall_cap_lookup_process(ctx, args.cap_id, CAP_RIGHT_RESOURCE_ALLOC, &target);
-    if (kst != K_OK) return kstatus_to_native_sysret(kst);
+    if (kst != K_OK) return bh_op_result_kstatus(kst);
 
     bharat_fault_domain_attr_t attr;
     st = bh_copy_from_user(&attr, (const void *)args.attr_ptr, sizeof(attr));
-    if (st != BH_OK) return (long)st;
+    if (st != BH_OK) return bh_op_result_kstatus(bh_status_to_kstatus(st));
 
     uint64_t out_domain;
     kstatus_t res = (kstatus_t)sys_fault_domain_create(&attr, &out_domain);
     if (res == K_OK) {
         st = bh_copy_to_user((void *)args.out_domain_ptr, &out_domain, sizeof(out_domain));
-        if (st != BH_OK) return (long)st;
+        if (st != BH_OK) return bh_op_result_kstatus(bh_status_to_kstatus(st));
     }
-    return kstatus_to_native_sysret(res);
+    return bh_op_result_kstatus(res);
 }
 
-long bh_sys_fault_domain_destroy(bh_syscall_ctx_t *ctx) {
+bh_operation_result_t bh_sys_fault_domain_destroy(bh_syscall_ctx_t *ctx) {
     void *domain_ref;
     kstatus_t kst = bh_syscall_cap_lookup_fault_domain(ctx, (uint32_t)ctx->regs.arg[0], CAP_RIGHT_FAULT_DOMAIN_MANAGE, &domain_ref);
-    if (kst != K_OK) return kstatus_to_native_sysret(kst);
+    if (kst != K_OK) return bh_op_result_kstatus(kst);
 
-    return kstatus_to_native_sysret((kstatus_t)sys_fault_domain_destroy((uintptr_t)domain_ref));
+    return bh_op_result_kstatus((kstatus_t)sys_fault_domain_destroy((uintptr_t)domain_ref));
 }
 
-long bh_sys_fault_domain_attach(bh_syscall_ctx_t *ctx) {
+bh_operation_result_t bh_sys_fault_domain_attach(bh_syscall_ctx_t *ctx) {
     bharat_sys_fault_domain_args_t args;
     bh_status_t st = bh_copy_from_user(&args, (const void *)ctx->regs.arg[0], sizeof(args));
-    if (st != BH_OK) return (long)st;
+    if (st != BH_OK) return bh_op_result_kstatus(bh_status_to_kstatus(st));
 
     void *domain_ref;
     kstatus_t kst = bh_syscall_cap_lookup_fault_domain(ctx, args.cap_id, CAP_RIGHT_FAULT_DOMAIN_MANAGE, &domain_ref);
-    if (kst != K_OK) return kstatus_to_native_sysret(kst);
+    if (kst != K_OK) return bh_op_result_kstatus(kst);
 
     bh_thread_object_t target_thread;
     kst = bh_syscall_cap_lookup_thread(ctx, args.thread_cap, CAP_RIGHT_PROCESS_MANAGE, &target_thread);
-    if (kst != K_OK) return kstatus_to_native_sysret(kst);
+    if (kst != K_OK) return bh_op_result_kstatus(kst);
 
-    return kstatus_to_native_sysret((kstatus_t)sys_fault_domain_attach((uintptr_t)domain_ref, target_thread.tid));
+    return bh_op_result_kstatus((kstatus_t)sys_fault_domain_attach((uintptr_t)domain_ref, target_thread.tid));
 }
 
-long bh_sys_read(bh_syscall_ctx_t *ctx) {
-    return (long)BH_ERR_NOT_SUPPORTED;
+bh_operation_result_t bh_sys_read(bh_syscall_ctx_t *ctx) {
+    return bh_op_result_kstatus(K_ERR_UNSUPPORTED);
 }
 
-long bh_sys_thread_exit(bh_syscall_ctx_t *ctx) {
+bh_operation_result_t bh_sys_thread_exit(bh_syscall_ctx_t *ctx) {
     bh_thread_t *current = sched_current_thread();
     if (current) {
         (void)sched_mark_thread_terminated(current);
@@ -341,22 +341,22 @@ long bh_sys_thread_exit(bh_syscall_ctx_t *ctx) {
         bh_thread_yield();
         while(1);
     }
-    return (long)BH_ERR_BAD_STATE;
+    return bh_op_result_kstatus(K_ERR_BAD_STATE);
 }
 
 #include "console/console_core.h"
 #define BH_CONSOLE_WRITE_MAX_BYTES 4096
 
-long bh_sys_write(bh_syscall_ctx_t *ctx) {
+bh_operation_result_t bh_sys_write(bh_syscall_ctx_t *ctx) {
     int fd = (int)ctx->regs.arg[0];
     uintptr_t user_buf = ctx->regs.arg[1];
     size_t count = (size_t)ctx->regs.arg[2];
 
     if (fd != 1 && fd != 2)
-        return (long)BH_ERR_NOT_SUPPORTED;
+        return bh_op_result_kstatus(K_ERR_UNSUPPORTED);
 
     if (count > BH_CONSOLE_WRITE_MAX_BYTES)
-        return (long)BH_ERR_INVALID_ARGUMENT;
+        return bh_op_result_kstatus(K_ERR_INVALID_ARG);
 
     size_t done = 0;
 
@@ -373,15 +373,15 @@ long bh_sys_write(bh_syscall_ctx_t *ctx) {
                               n);
 
         if (st != BH_OK)
-            return done ? (long)done : (long)st;
+            return done ? bh_op_result_value((long)done) : bh_op_result_kstatus(bh_status_to_kstatus(st));
 
         console_write_raw(temp, n);
         done += n;
     }
 
-    return (long)done;
+    return bh_op_result_value((long)done);
 }
 
-long bh_sys_get_subsystem_caps(bh_syscall_ctx_t *ctx) {
-    return (long)BH_ERR_NOT_SUPPORTED;
+bh_operation_result_t bh_sys_get_subsystem_caps(bh_syscall_ctx_t *ctx) {
+    return bh_op_result_kstatus(K_ERR_UNSUPPORTED);
 }

--- a/core/kernel/src/trap/syscall_gate.c
+++ b/core/kernel/src/trap/syscall_gate.c
@@ -253,18 +253,21 @@ long bh_syscall_gate(trap_frame_t *frame, const trap_info_t *info) {
     }
 
     /* Personality-specific translation */
-    long result = desc->handler(&ctx);
+    bh_operation_result_t op_res = desc->handler(&ctx);
 
     const personality_ops_t *ops = bh_personality_registry_get_ops(ctx.personality);
     if (ops && ops->normalize_syscall_return) {
-        return ops->normalize_syscall_return(result);
+        return ops->normalize_syscall_return(op_res);
     }
 
     if (ctx.personality == BH_PERSONALITY_NATIVE) {
-        return result;
+        return op_res.value;
     } else {
         /* Compatibility personality: result should be translated to personality-specific errno */
         /* If no explicit normalization hook, use native fallback but this might be wrong for Linux */
-        return kstatus_to_native_sysret((kstatus_t)result);
+        if (op_res.domain == BH_STATUS_DOMAIN_KSTATUS) {
+            return kstatus_to_native_sysret((kstatus_t)op_res.value);
+        }
+        return op_res.value;
     }
 }

--- a/core/kernel/src/trap/syscall_status.c
+++ b/core/kernel/src/trap/syscall_status.c
@@ -39,3 +39,30 @@ long kstatus_to_native_sysret(kstatus_t st) {
     if (st >= 0) return (long)st;
     return (long)kstatus_to_bh_status(st);
 }
+
+kstatus_t bh_status_to_kstatus(bh_status_t st) {
+    if (st >= 0) return K_OK;
+
+    switch (st) {
+        case BH_ERR_INVALID_ARGUMENT:    return K_ERR_INVALID_ARG;
+        case BH_ERR_INVALID_SYSCALL:     return K_ERR_INVALID_SYSCALL;
+        case BH_ERR_BAD_STATE:           return K_ERR_BAD_STATE;
+        case BH_ERR_NOT_FOUND:           return K_ERR_NOT_FOUND;
+        case BH_ERR_NOT_SUPPORTED:       return K_ERR_UNSUPPORTED;
+        case BH_ERR_TIMEOUT:             return K_ERR_TIMEOUT;
+        case BH_ERR_TRY_AGAIN:           return K_ERR_AGAIN;
+        case BH_ERR_INTERRUPTED:         return K_ERR_INTERRUPTED;
+        case BH_ERR_FAULT:               return K_ERR_FAULT;
+        case BH_ERR_ACCESS_DENIED:       return K_ERR_DENIED;
+        case BH_ERR_OVERFLOW:            return K_ERR_OVERFLOW;
+        case BH_ERR_NO_MEMORY:           return K_ERR_NO_MEMORY;
+        case BH_ERR_BAD_CAPABILITY:      return K_ERR_CAP_INVALID;
+        case BH_ERR_WRONG_TYPE:          return K_ERR_CAP_WRONG_TYPE;
+        case BH_ERR_INSUFFICIENT_RIGHTS: return K_ERR_CAP_DENIED;
+        case BH_ERR_STALE_CAPABILITY:    return K_ERR_CAP_STALE;
+        case BH_ERR_CHANNEL_CLOSED:      return K_ERR_IPC_CLOSED;
+        case BH_ERR_BUFFER_FULL:         return K_ERR_IPC_QUEUE_FULL;
+        case BH_ERR_RESOURCE_EXHAUSTED:  return K_ERR_PMM_EXHAUSTED;
+        default:                         return K_ERR_INTERNAL_BUG;
+    }
+}

--- a/core/personalities/compat/linux/linux_personality.c
+++ b/core/personalities/compat/linux/linux_personality.c
@@ -26,13 +26,11 @@ static int linux_map_fault_to_signal(const trap_info_t *info) {
     return 11; // SIGSEGV
 }
 
-static long linux_normalize_syscall_return(long result) {
-    // If result is in the range of kernel status codes (negative),
-    // translate it to negative linux errno.
-    if (result < 0 && result > -1000) { // Assuming kstatus codes are in this range
-        return -linux_errno_from_bh_status((kstatus_t)result);
+static long linux_normalize_syscall_return(bh_operation_result_t result) {
+    if (result.domain == BH_STATUS_DOMAIN_KSTATUS) {
+        return -linux_errno_from_bh_status((kstatus_t)result.value);
     }
-    return result;
+    return result.value;
 }
 
 static const personality_ops_t linux_personality_ops = {

--- a/core/personalities/compat/linux/linux_syscall.c
+++ b/core/personalities/compat/linux/linux_syscall.c
@@ -5,24 +5,24 @@
 #include "kernel/status.h"
 #include "sched/sched.h"
 
-static long linux_sys_getpid(bh_syscall_ctx_t *ctx) {
-    if (!ctx || !ctx->process) return -LINUX_EINVAL;
-    return (long)ctx->process->process_id;
+static bh_operation_result_t linux_sys_getpid(bh_syscall_ctx_t *ctx) {
+    if (!ctx || !ctx->process) return bh_op_result_kstatus(K_ERR_INVALID_ARG);
+    return bh_op_result_value((long)ctx->process->process_id);
 }
 
-static long linux_sys_gettid(bh_syscall_ctx_t *ctx) {
-    if (!ctx || !ctx->thread) return -LINUX_EINVAL;
-    return (long)ctx->thread->thread_id;
+static bh_operation_result_t linux_sys_gettid(bh_syscall_ctx_t *ctx) {
+    if (!ctx || !ctx->thread) return bh_op_result_kstatus(K_ERR_INVALID_ARG);
+    return bh_op_result_value((long)ctx->thread->thread_id);
 }
 
-static long linux_sys_futex(bh_syscall_ctx_t *ctx) {
+static bh_operation_result_t linux_sys_futex(bh_syscall_ctx_t *ctx) {
     (void)ctx;
-    return -LINUX_ENOSYS;
+    return bh_op_result_kstatus(K_ERR_UNSUPPORTED);
 }
 
-extern long bh_sys_read(bh_syscall_ctx_t *ctx);
-extern long bh_sys_write(bh_syscall_ctx_t *ctx);
-extern long bh_sys_thread_exit(bh_syscall_ctx_t *ctx);
+extern bh_operation_result_t bh_sys_read(bh_syscall_ctx_t *ctx);
+extern bh_operation_result_t bh_sys_write(bh_syscall_ctx_t *ctx);
+extern bh_operation_result_t bh_sys_thread_exit(bh_syscall_ctx_t *ctx);
 
 static const bh_syscall_meta_t linux_syscall_table_x86_64[] = {
     [LINUX_X86_64_SYS_READ]       = { .nr = LINUX_X86_64_SYS_READ, .name = "read", .class_id = BH_SYS_CLASS_IO, .arg_count = 3, .flags = BH_SYSCALL_F_BLOCKING | BH_SYSCALL_F_USER_WRITE, .handler = bh_sys_read },

--- a/core/personalities/native/native_syscall.c
+++ b/core/personalities/native/native_syscall.c
@@ -4,30 +4,30 @@
 #include "capability.h"
 
 
-extern long bh_sys_nop(bh_syscall_ctx_t *ctx);
-extern long bh_sys_thread_create(bh_syscall_ctx_t *ctx);
-extern long bh_sys_thread_destroy(bh_syscall_ctx_t *ctx);
-extern long bh_sys_sched_yield(bh_syscall_ctx_t *ctx);
-extern long bh_sys_sched_sleep(bh_syscall_ctx_t *ctx);
-extern long bh_sys_sched_set_priority(bh_syscall_ctx_t *ctx);
-extern long bh_sys_sched_set_affinity(bh_syscall_ctx_t *ctx);
-extern long bh_sys_vmm_map_page(bh_syscall_ctx_t *ctx);
-extern long bh_sys_vmm_unmap_page(bh_syscall_ctx_t *ctx);
-extern long bh_sys_cap_invoke(bh_syscall_ctx_t *ctx);
-extern long bh_sys_endpoint_create(bh_syscall_ctx_t *ctx);
-extern long bh_sys_endpoint_send(bh_syscall_ctx_t *ctx);
-extern long bh_sys_endpoint_receive(bh_syscall_ctx_t *ctx);
-extern long bh_sys_cap_delegate(bh_syscall_ctx_t *ctx);
-extern long bh_sys_intent_set(bh_syscall_ctx_t *ctx);
-extern long bh_sys_intent_get(bh_syscall_ctx_t *ctx);
-extern long bh_sys_mem_alloc_class(bh_syscall_ctx_t *ctx);
-extern long bh_sys_fault_domain_create(bh_syscall_ctx_t *ctx);
-extern long bh_sys_fault_domain_destroy(bh_syscall_ctx_t *ctx);
-extern long bh_sys_fault_domain_attach(bh_syscall_ctx_t *ctx);
-extern long bh_sys_read(bh_syscall_ctx_t *ctx);
-extern long bh_sys_write(bh_syscall_ctx_t *ctx);
-extern long bh_sys_get_subsystem_caps(bh_syscall_ctx_t *ctx);
-extern long bh_sys_thread_exit(bh_syscall_ctx_t *ctx);
+extern bh_operation_result_t bh_sys_nop(bh_syscall_ctx_t *ctx);
+extern bh_operation_result_t bh_sys_thread_create(bh_syscall_ctx_t *ctx);
+extern bh_operation_result_t bh_sys_thread_destroy(bh_syscall_ctx_t *ctx);
+extern bh_operation_result_t bh_sys_sched_yield(bh_syscall_ctx_t *ctx);
+extern bh_operation_result_t bh_sys_sched_sleep(bh_syscall_ctx_t *ctx);
+extern bh_operation_result_t bh_sys_sched_set_priority(bh_syscall_ctx_t *ctx);
+extern bh_operation_result_t bh_sys_sched_set_affinity(bh_syscall_ctx_t *ctx);
+extern bh_operation_result_t bh_sys_vmm_map_page(bh_syscall_ctx_t *ctx);
+extern bh_operation_result_t bh_sys_vmm_unmap_page(bh_syscall_ctx_t *ctx);
+extern bh_operation_result_t bh_sys_cap_invoke(bh_syscall_ctx_t *ctx);
+extern bh_operation_result_t bh_sys_endpoint_create(bh_syscall_ctx_t *ctx);
+extern bh_operation_result_t bh_sys_endpoint_send(bh_syscall_ctx_t *ctx);
+extern bh_operation_result_t bh_sys_endpoint_receive(bh_syscall_ctx_t *ctx);
+extern bh_operation_result_t bh_sys_cap_delegate(bh_syscall_ctx_t *ctx);
+extern bh_operation_result_t bh_sys_intent_set(bh_syscall_ctx_t *ctx);
+extern bh_operation_result_t bh_sys_intent_get(bh_syscall_ctx_t *ctx);
+extern bh_operation_result_t bh_sys_mem_alloc_class(bh_syscall_ctx_t *ctx);
+extern bh_operation_result_t bh_sys_fault_domain_create(bh_syscall_ctx_t *ctx);
+extern bh_operation_result_t bh_sys_fault_domain_destroy(bh_syscall_ctx_t *ctx);
+extern bh_operation_result_t bh_sys_fault_domain_attach(bh_syscall_ctx_t *ctx);
+extern bh_operation_result_t bh_sys_read(bh_syscall_ctx_t *ctx);
+extern bh_operation_result_t bh_sys_write(bh_syscall_ctx_t *ctx);
+extern bh_operation_result_t bh_sys_get_subsystem_caps(bh_syscall_ctx_t *ctx);
+extern bh_operation_result_t bh_sys_thread_exit(bh_syscall_ctx_t *ctx);
 
 static const bh_syscall_meta_t native_syscall_table[] = {
 #include <kernel/syscall/native_syscall_table.inc>

--- a/core/personalities/native/personality_native.c
+++ b/core/personalities/native/personality_native.c
@@ -2,6 +2,7 @@
 #include "trap_frame_ops.h"
 #include "trap/syscall_regs.h"
 #include "trap/syscall_context.h"
+#include "trap/syscall_status.h"
 #include "bh_personality_registry.h"
 #include "bh_personality.h"
 
@@ -31,10 +32,11 @@ static int default_map_fault_to_signal(const trap_info_t *info) {
     return 11; // SIGSEGV
 }
 
-static long native_normalize_syscall_return(long result) {
-    // Native already returns kstatus_to_native_sysret internally in handlers
-    // or through the gate.
-    return result;
+static long native_normalize_syscall_return(bh_operation_result_t result) {
+    if (result.domain == BH_STATUS_DOMAIN_KSTATUS) {
+        return kstatus_to_native_sysret((kstatus_t)result.value);
+    }
+    return result.value;
 }
 
 const personality_ops_t default_personality_ops = {


### PR DESCRIPTION
Resolves item 37 in the PR by introducing a typed boundary (`bh_operation_result_t`) for syscall return values. This eliminates the ad-hoc integer magnitude heuristic previously used to determine if a return value was a kernel status code that needed translation.

The changes involve updating the syscall handler signature, modifying all existing handlers across native and Linux compat personalities to return the new typed struct, and updating the normalization paths in `bh_syscall_gate.c` and personality adapters to utilize the explicit status domains for robust errno mapping.

---
*PR created automatically by Jules for task [16000484198000062229](https://jules.google.com/task/16000484198000062229) started by @divyang4481*