### PR TITLE
DEMO-P0-005: add virtual robotics hardware platform

### DIFF
--- a/core/drivers/actuator/virtual/virtual_motors.c
+++ b/core/drivers/actuator/virtual/virtual_motors.c
@@ -1,0 +1,54 @@
+#include "virtual_motors.h"
+
+void bh_virtual_motors_init(bh_virtual_motor_bank_t *bank)
+{
+    uint32_t index;
+    if (bank == 0) {
+        return;
+    }
+    for (index = 0u; index < BH_VIRTUAL_MOTOR_COUNT; index++) {
+        bank->motors[index] = (bh_virtual_motor_t){0};
+    }
+}
+
+bh_status_t bh_virtual_motor_write(bh_virtual_motor_bank_t *bank,
+                                   uint32_t instance,
+                                   const bh_actuator_command_t *command)
+{
+    bh_virtual_motor_t *motor;
+
+    if (bank == 0 || command == 0 || instance >= BH_VIRTUAL_MOTOR_COUNT ||
+        command->abi_version != BH_ACTUATOR_ABI_VERSION || command->reserved != 0u) {
+        return BH_ERR_INVALID_ARGUMENT;
+    }
+    motor = &bank->motors[instance];
+    if (command->request_id <= motor->last_request_id) {
+        return BH_ERR_STALE_CAPABILITY;
+    }
+    motor->last_request_id = command->request_id;
+    if ((command->flags & BH_ACTUATOR_COMMAND_DISARM) != 0u) {
+        motor->armed = 0u;
+        motor->output = 0.0f;
+        return BH_OK;
+    }
+    if ((command->flags & BH_ACTUATOR_COMMAND_ARM) != 0u) {
+        motor->armed = 1u;
+    }
+    if (motor->armed == 0u || (command->flags & BH_ACTUATOR_COMMAND_NORMALIZED) == 0u ||
+        command->value < 0.0f || command->value > 1.0f) {
+        motor->output = 0.0f;
+        return BH_ERR_ACCESS_DENIED;
+    }
+    motor->output = command->value;
+    return BH_OK;
+}
+
+bh_status_t bh_virtual_motor_safe(bh_virtual_motor_bank_t *bank, uint32_t instance)
+{
+    if (bank == 0 || instance >= BH_VIRTUAL_MOTOR_COUNT) {
+        return BH_ERR_INVALID_ARGUMENT;
+    }
+    bank->motors[instance].armed = 0u;
+    bank->motors[instance].output = 0.0f;
+    return BH_OK;
+}

--- a/core/drivers/actuator/virtual/virtual_motors.h
+++ b/core/drivers/actuator/virtual/virtual_motors.h
@@ -1,0 +1,25 @@
+#ifndef BHARAT_DRIVERS_VIRTUAL_MOTORS_H
+#define BHARAT_DRIVERS_VIRTUAL_MOTORS_H
+
+#include <bharat/uapi/device/actuator.h>
+#include <bharat/uapi/syscall/bh_syscall_status.h>
+
+#define BH_VIRTUAL_MOTOR_COUNT 4u
+
+typedef struct bh_virtual_motor {
+    float output;
+    uint64_t last_request_id;
+    uint8_t armed;
+} bh_virtual_motor_t;
+
+typedef struct bh_virtual_motor_bank {
+    bh_virtual_motor_t motors[BH_VIRTUAL_MOTOR_COUNT];
+} bh_virtual_motor_bank_t;
+
+void bh_virtual_motors_init(bh_virtual_motor_bank_t *bank);
+bh_status_t bh_virtual_motor_write(bh_virtual_motor_bank_t *bank,
+                                   uint32_t instance,
+                                   const bh_actuator_command_t *command);
+bh_status_t bh_virtual_motor_safe(bh_virtual_motor_bank_t *bank, uint32_t instance);
+
+#endif

--- a/core/drivers/sensor/virtual/virtual_sensors.c
+++ b/core/drivers/sensor/virtual/virtual_sensors.c
@@ -1,0 +1,66 @@
+#include "virtual_sensors.h"
+
+#define BH_VIRTUAL_SAMPLE_PERIOD_NS 10000000ull
+
+void bh_virtual_sensors_init(bh_virtual_sensor_bank_t *bank)
+{
+    if (bank != 0) {
+        bank->timestamp_ns = 0u;
+        bank->sequence = 0u;
+    }
+}
+
+bh_status_t bh_virtual_sensor_read(bh_virtual_sensor_bank_t *bank,
+                                   bh_sensor_type_t type,
+                                   bh_sensor_sample_t *sample)
+{
+    uint32_t phase;
+
+    if (bank == 0 || sample == 0) {
+        return BH_ERR_INVALID_ARGUMENT;
+    }
+    if (type < BH_SENSOR_IMU || type > BH_SENSOR_DISTANCE) {
+        return BH_ERR_NOT_FOUND;
+    }
+
+    bank->timestamp_ns += BH_VIRTUAL_SAMPLE_PERIOD_NS;
+    bank->sequence++;
+    phase = bank->sequence % 20u;
+    *sample = (bh_sensor_sample_t){
+        .sensor = (bh_sensor_id_t)type,
+        .type = (uint32_t)type,
+        .timestamp_ns = bank->timestamp_ns,
+        .flags = BH_SENSOR_SAMPLE_VALID,
+    };
+
+    switch (type) {
+    case BH_SENSOR_IMU:
+        sample->value_count = 3u;
+        sample->values[0] = 3.2f + ((float)phase * 0.01f);
+        sample->values[1] = -1.8f;
+        sample->values[2] = 128.4f;
+        break;
+    case BH_SENSOR_GPS:
+        sample->value_count = 3u;
+        sample->values[0] = 28.6139f;
+        sample->values[1] = 77.2090f;
+        sample->values[2] = 28.0f;
+        break;
+    case BH_SENSOR_TEMPERATURE:
+        sample->value_count = 1u;
+        sample->values[0] = 31.5f;
+        break;
+    case BH_SENSOR_BATTERY:
+        sample->value_count = 2u;
+        sample->values[0] = 78.0f - ((float)(bank->sequence / 100u));
+        sample->values[1] = 15.2f;
+        break;
+    case BH_SENSOR_DISTANCE:
+        sample->value_count = 1u;
+        sample->values[0] = 12.0f + ((float)phase * 0.05f);
+        break;
+    default:
+        return BH_ERR_NOT_FOUND;
+    }
+    return BH_OK;
+}

--- a/core/drivers/sensor/virtual/virtual_sensors.h
+++ b/core/drivers/sensor/virtual/virtual_sensors.h
@@ -1,0 +1,19 @@
+#ifndef BHARAT_DRIVERS_VIRTUAL_SENSORS_H
+#define BHARAT_DRIVERS_VIRTUAL_SENSORS_H
+
+#include <bharat/uapi/device/sensor.h>
+#include <bharat/uapi/syscall/bh_syscall_status.h>
+
+#define BH_VIRTUAL_SENSOR_COUNT 5u
+
+typedef struct bh_virtual_sensor_bank {
+    uint64_t timestamp_ns;
+    uint32_t sequence;
+} bh_virtual_sensor_bank_t;
+
+void bh_virtual_sensors_init(bh_virtual_sensor_bank_t *bank);
+bh_status_t bh_virtual_sensor_read(bh_virtual_sensor_bank_t *bank,
+                                   bh_sensor_type_t type,
+                                   bh_sensor_sample_t *sample);
+
+#endif

--- a/core/platform/qemu/robot/robot_platform.c
+++ b/core/platform/qemu/robot/robot_platform.c
@@ -1,0 +1,10 @@
+#include "robot_platform.h"
+
+void bh_qemu_robot_platform_init(bh_qemu_robot_platform_t *platform)
+{
+    if (platform == 0) {
+        return;
+    }
+    bh_virtual_sensors_init(&platform->sensors);
+    bh_virtual_motors_init(&platform->motors);
+}

--- a/core/platform/qemu/robot/robot_platform.h
+++ b/core/platform/qemu/robot/robot_platform.h
@@ -1,0 +1,15 @@
+#ifndef BHARAT_PLATFORM_QEMU_ROBOT_H
+#define BHARAT_PLATFORM_QEMU_ROBOT_H
+
+#include "../../../drivers/actuator/virtual/virtual_motors.h"
+#include "../../../drivers/sensor/virtual/virtual_sensors.h"
+
+/* QEMU robot hardware is instance-owned and contains no cross-core mutable state. */
+typedef struct bh_qemu_robot_platform {
+    bh_virtual_sensor_bank_t sensors;
+    bh_virtual_motor_bank_t motors;
+} bh_qemu_robot_platform_t;
+
+void bh_qemu_robot_platform_init(bh_qemu_robot_platform_t *platform);
+
+#endif

--- a/core/services/device/actuator_mgr/actuator_mgr.c
+++ b/core/services/device/actuator_mgr/actuator_mgr.c
@@ -1,0 +1,57 @@
+#include "actuator_mgr.h"
+
+void bh_actuator_mgr_init(bh_actuator_mgr_t *manager, bh_virtual_motor_bank_t *devices)
+{
+    uint32_t index;
+    if (manager == 0) {
+        return;
+    }
+    manager->devices = devices;
+    for (index = 0u; index < BH_VIRTUAL_MOTOR_COUNT; index++) {
+        manager->grants[index] = 1u;
+    }
+}
+
+bh_status_t bh_actuator_mgr_open(bh_actuator_mgr_t *manager,
+                             bh_actuator_type_t type,
+                             uint32_t instance,
+                             bh_actuator_handle_t *actuator)
+{
+    if (manager == 0 || manager->devices == 0 || actuator == 0) {
+        return BH_ERR_INVALID_ARGUMENT;
+    }
+    if (type != BH_ACTUATOR_MOTOR || instance >= BH_VIRTUAL_MOTOR_COUNT) {
+        return BH_ERR_NOT_FOUND;
+    }
+    if (manager->grants[instance] == 0u) {
+        return BH_ERR_INSUFFICIENT_RIGHTS;
+    }
+    *actuator = instance + 1u;
+    return BH_OK;
+}
+
+bh_status_t bh_actuator_mgr_write(bh_actuator_mgr_t *manager,
+                              bh_actuator_handle_t actuator,
+                              const bh_actuator_command_t *command)
+{
+    uint32_t instance;
+    if (manager == 0 || manager->devices == 0 || actuator == 0u) {
+        return BH_ERR_INVALID_ARGUMENT;
+    }
+    instance = actuator - 1u;
+    if (instance >= BH_VIRTUAL_MOTOR_COUNT || manager->grants[instance] == 0u) {
+        return BH_ERR_INSUFFICIENT_RIGHTS;
+    }
+    return bh_virtual_motor_write(manager->devices, instance, command);
+}
+
+void bh_actuator_mgr_enter_safe_state(bh_actuator_mgr_t *manager)
+{
+    uint32_t index;
+    if (manager == 0 || manager->devices == 0) {
+        return;
+    }
+    for (index = 0u; index < BH_VIRTUAL_MOTOR_COUNT; index++) {
+        (void)bh_virtual_motor_safe(manager->devices, index);
+    }
+}

--- a/core/services/device/actuator_mgr/actuator_mgr.h
+++ b/core/services/device/actuator_mgr/actuator_mgr.h
@@ -1,0 +1,23 @@
+#ifndef BHARAT_SERVICES_ACTUATOR_MGR_H
+#define BHARAT_SERVICES_ACTUATOR_MGR_H
+
+#include <bharat/uapi/device/actuator.h>
+#include <bharat/uapi/syscall/bh_syscall_status.h>
+#include "../../../drivers/actuator/virtual/virtual_motors.h"
+
+typedef struct bh_actuator_mgr {
+    bh_virtual_motor_bank_t *devices;
+    uint8_t grants[BH_VIRTUAL_MOTOR_COUNT];
+} bh_actuator_mgr_t;
+
+void bh_actuator_mgr_init(bh_actuator_mgr_t *manager, bh_virtual_motor_bank_t *devices);
+bh_status_t bh_actuator_mgr_open(bh_actuator_mgr_t *manager,
+                             bh_actuator_type_t type,
+                             uint32_t instance,
+                             bh_actuator_handle_t *actuator);
+bh_status_t bh_actuator_mgr_write(bh_actuator_mgr_t *manager,
+                              bh_actuator_handle_t actuator,
+                              const bh_actuator_command_t *command);
+void bh_actuator_mgr_enter_safe_state(bh_actuator_mgr_t *manager);
+
+#endif

--- a/core/services/device/sensormgr/sensormgr.c
+++ b/core/services/device/sensormgr/sensormgr.c
@@ -1,0 +1,102 @@
+#include "sensormgr.h"
+
+#define BH_STREAM_INDEX_MASK 0xffffu
+#define BH_STREAM_GENERATION_SHIFT 16u
+
+static bh_sensor_stream_t make_stream(uint32_t index, uint16_t generation)
+{
+    return ((uint32_t)generation << BH_STREAM_GENERATION_SHIFT) | (index + 1u);
+}
+
+static bh_sensormgr_stream_slot_t *lookup_stream(bh_sensormgr_t *manager,
+                                                  bh_sensor_stream_t stream)
+{
+    uint32_t encoded_index = stream & BH_STREAM_INDEX_MASK;
+    uint16_t generation = (uint16_t)(stream >> BH_STREAM_GENERATION_SHIFT);
+    bh_sensormgr_stream_slot_t *slot;
+
+    if (manager == 0 || encoded_index == 0u || encoded_index > BH_SENSORMGR_MAX_STREAMS) {
+        return 0;
+    }
+    slot = &manager->streams[encoded_index - 1u];
+    if (slot->active == 0u || slot->generation != generation) {
+        return 0;
+    }
+    return slot;
+}
+
+void bh_sensormgr_init(bh_sensormgr_t *manager, bh_virtual_sensor_bank_t *devices)
+{
+    uint32_t index;
+    if (manager == 0) {
+        return;
+    }
+    manager->devices = devices;
+    for (index = 0u; index < BH_SENSORMGR_MAX_STREAMS; index++) {
+        manager->streams[index] = (bh_sensormgr_stream_slot_t){.generation = 1u};
+    }
+}
+
+bh_status_t bh_sensormgr_open(bh_sensormgr_t *manager,
+                           bh_sensor_type_t type,
+                           bh_sensor_handle_t *sensor)
+{
+    if (manager == 0 || manager->devices == 0 || sensor == 0) {
+        return BH_ERR_INVALID_ARGUMENT;
+    }
+    if (type < BH_SENSOR_IMU || type > BH_SENSOR_DISTANCE) {
+        return BH_ERR_NOT_FOUND;
+    }
+    *sensor = (bh_sensor_handle_t)type;
+    return BH_OK;
+}
+
+bh_status_t bh_sensormgr_subscribe(bh_sensormgr_t *manager,
+                                bh_sensor_handle_t sensor,
+                                uint32_t rate_hz,
+                                bh_sensor_stream_t *stream)
+{
+    uint32_t index;
+    if (manager == 0 || stream == 0 || sensor < BH_SENSOR_IMU || sensor > BH_SENSOR_DISTANCE ||
+        rate_hz < BH_SENSORMGR_MIN_RATE_HZ || rate_hz > BH_SENSORMGR_MAX_RATE_HZ) {
+        return BH_ERR_INVALID_ARGUMENT;
+    }
+    for (index = 0u; index < BH_SENSORMGR_MAX_STREAMS; index++) {
+        if (manager->streams[index].active == 0u) {
+            manager->streams[index].active = 1u;
+            manager->streams[index].type = (bh_sensor_type_t)sensor;
+            manager->streams[index].rate_hz = rate_hz;
+            *stream = make_stream(index, manager->streams[index].generation);
+            return BH_OK;
+        }
+    }
+    return BH_ERR_BUFFER_FULL;
+}
+
+bh_status_t bh_sensormgr_read(bh_sensormgr_t *manager,
+                           bh_sensor_stream_t stream,
+                           bh_sensor_sample_t *sample)
+{
+    bh_sensormgr_stream_slot_t *slot = lookup_stream(manager, stream);
+    if (sample == 0) {
+        return BH_ERR_INVALID_ARGUMENT;
+    }
+    if (slot == 0) {
+        return BH_ERR_STALE_CAPABILITY;
+    }
+    return bh_virtual_sensor_read(manager->devices, slot->type, sample);
+}
+
+bh_status_t bh_sensormgr_unsubscribe(bh_sensormgr_t *manager, bh_sensor_stream_t stream)
+{
+    bh_sensormgr_stream_slot_t *slot = lookup_stream(manager, stream);
+    if (slot == 0) {
+        return BH_ERR_STALE_CAPABILITY;
+    }
+    slot->active = 0u;
+    slot->generation++;
+    if (slot->generation == 0u) {
+        slot->generation = 1u;
+    }
+    return BH_OK;
+}

--- a/core/services/device/sensormgr/sensormgr.h
+++ b/core/services/device/sensormgr/sensormgr.h
@@ -1,0 +1,38 @@
+#ifndef BHARAT_SERVICES_SENSORMGR_H
+#define BHARAT_SERVICES_SENSORMGR_H
+
+#include <bharat/uapi/device/sensor.h>
+#include <bharat/uapi/syscall/bh_syscall_status.h>
+#include "../../../drivers/sensor/virtual/virtual_sensors.h"
+
+#define BH_SENSORMGR_MAX_STREAMS 8u
+#define BH_SENSORMGR_MIN_RATE_HZ 1u
+#define BH_SENSORMGR_MAX_RATE_HZ 1000u
+
+typedef struct bh_sensormgr_stream_slot {
+    bh_sensor_type_t type;
+    uint32_t rate_hz;
+    uint16_t generation;
+    uint8_t active;
+} bh_sensormgr_stream_slot_t;
+
+/* A service instance owns this table; callers must serialize access to it. */
+typedef struct bh_sensormgr {
+    bh_virtual_sensor_bank_t *devices;
+    bh_sensormgr_stream_slot_t streams[BH_SENSORMGR_MAX_STREAMS];
+} bh_sensormgr_t;
+
+void bh_sensormgr_init(bh_sensormgr_t *manager, bh_virtual_sensor_bank_t *devices);
+bh_status_t bh_sensormgr_open(bh_sensormgr_t *manager,
+                           bh_sensor_type_t type,
+                           bh_sensor_handle_t *sensor);
+bh_status_t bh_sensormgr_subscribe(bh_sensormgr_t *manager,
+                                bh_sensor_handle_t sensor,
+                                uint32_t rate_hz,
+                                bh_sensor_stream_t *stream);
+bh_status_t bh_sensormgr_read(bh_sensormgr_t *manager,
+                           bh_sensor_stream_t stream,
+                           bh_sensor_sample_t *sample);
+bh_status_t bh_sensormgr_unsubscribe(bh_sensormgr_t *manager, bh_sensor_stream_t stream);
+
+#endif

--- a/core/stacks/robotics/robotics_demo.c
+++ b/core/stacks/robotics/robotics_demo.c
@@ -1,0 +1,102 @@
+#include "robotics_demo.h"
+
+#include <stdio.h>
+
+static bh_status_t open_stream(bh_sensormgr_t *manager,
+                               bh_sensor_type_t type,
+                               bh_sensor_stream_t *stream)
+{
+    bh_sensor_handle_t sensor;
+    bh_status_t status = bh_sensormgr_open(manager, type, &sensor);
+    if (status != BH_OK) {
+        return status;
+    }
+    return bh_sensormgr_subscribe(manager, sensor, 100u, stream);
+}
+
+bh_status_t bh_robotics_demo_init(bh_robotics_demo_t *demo)
+{
+    uint32_t index;
+    bh_status_t status;
+
+    if (demo == 0) {
+        return BH_ERR_INVALID_ARGUMENT;
+    }
+    *demo = (bh_robotics_demo_t){0};
+    bh_qemu_robot_platform_init(&demo->platform);
+    bh_sensormgr_init(&demo->sensor_manager, &demo->platform.sensors);
+    bh_actuator_mgr_init(&demo->actuator_manager, &demo->platform.motors);
+    status = open_stream(&demo->sensor_manager, BH_SENSOR_IMU, &demo->imu_stream);
+    if (status == BH_OK) {
+        status = open_stream(&demo->sensor_manager, BH_SENSOR_GPS, &demo->gps_stream);
+    }
+    if (status == BH_OK) {
+        status = open_stream(&demo->sensor_manager, BH_SENSOR_BATTERY, &demo->battery_stream);
+    }
+    if (status != BH_OK) {
+        bh_actuator_mgr_enter_safe_state(&demo->actuator_manager);
+        return status;
+    }
+    for (index = 0u; index < BH_VIRTUAL_MOTOR_COUNT; index++) {
+        bh_actuator_command_t command;
+        status = bh_actuator_mgr_open(&demo->actuator_manager, BH_ACTUATOR_MOTOR, index,
+                                  &demo->motors[index]);
+        if (status != BH_OK) {
+            bh_actuator_mgr_enter_safe_state(&demo->actuator_manager);
+            return status;
+        }
+        command = (bh_actuator_command_t){
+            .abi_version = BH_ACTUATOR_ABI_VERSION,
+            .flags = BH_ACTUATOR_COMMAND_ARM | BH_ACTUATOR_COMMAND_NORMALIZED,
+            .request_id = ++demo->next_request_id,
+            .value = 0.72f - ((float)index * 0.015f),
+        };
+        status = bh_actuator_mgr_write(&demo->actuator_manager, demo->motors[index], &command);
+        if (status != BH_OK) {
+            bh_actuator_mgr_enter_safe_state(&demo->actuator_manager);
+            return status;
+        }
+    }
+    return BH_OK;
+}
+
+bh_status_t bh_robotics_demo_render(bh_robotics_demo_t *demo, char *output, size_t output_size)
+{
+    bh_sensor_sample_t imu;
+    bh_sensor_sample_t gps;
+    bh_sensor_sample_t battery;
+    bh_status_t status;
+    int written;
+
+    if (demo == 0 || output == 0 || output_size == 0u) {
+        return BH_ERR_INVALID_ARGUMENT;
+    }
+    status = bh_sensormgr_read(&demo->sensor_manager, demo->imu_stream, &imu);
+    if (status == BH_OK) {
+        status = bh_sensormgr_read(&demo->sensor_manager, demo->gps_stream, &gps);
+    }
+    if (status == BH_OK) {
+        status = bh_sensormgr_read(&demo->sensor_manager, demo->battery_stream, &battery);
+    }
+    if (status != BH_OK) {
+        bh_actuator_mgr_enter_safe_state(&demo->actuator_manager);
+        return status;
+    }
+    written = snprintf(output, output_size,
+                       "+---- Bharat Robotics Demo ----+\n"
+                       " Pitch      %5.1f deg\n Roll       %5.1f deg\n Yaw        %5.1f deg\n"
+                       " Altitude   %5.0f m\n Battery    %5.0f %%\n"
+                       " Motor 1    %5.0f %%\n Motor 2    %5.0f %%\n"
+                       " Motor 3    %5.0f %%\n Motor 4    %5.0f %%\n"
+                       " Safety state: NORMAL\n+-------------------------------+\n",
+                       imu.values[0], imu.values[1], imu.values[2], gps.values[2], battery.values[0],
+                       demo->platform.motors.motors[0].output * 100.0f,
+                       demo->platform.motors.motors[1].output * 100.0f,
+                       demo->platform.motors.motors[2].output * 100.0f,
+                       demo->platform.motors.motors[3].output * 100.0f);
+    if (written < 0 || (size_t)written >= output_size) {
+        bh_actuator_mgr_enter_safe_state(&demo->actuator_manager);
+        return BH_ERR_OVERFLOW;
+    }
+    return BH_OK;
+}

--- a/core/stacks/robotics/robotics_demo.h
+++ b/core/stacks/robotics/robotics_demo.h
@@ -1,0 +1,23 @@
+#ifndef BHARAT_STACKS_ROBOTICS_DEMO_H
+#define BHARAT_STACKS_ROBOTICS_DEMO_H
+
+#include <stddef.h>
+#include "../../platform/qemu/robot/robot_platform.h"
+#include "../../services/device/actuator_mgr/actuator_mgr.h"
+#include "../../services/device/sensormgr/sensormgr.h"
+
+typedef struct bh_robotics_demo {
+    bh_qemu_robot_platform_t platform;
+    bh_sensormgr_t sensor_manager;
+    bh_actuator_mgr_t actuator_manager;
+    bh_sensor_stream_t imu_stream;
+    bh_sensor_stream_t gps_stream;
+    bh_sensor_stream_t battery_stream;
+    bh_actuator_handle_t motors[BH_VIRTUAL_MOTOR_COUNT];
+    uint64_t next_request_id;
+} bh_robotics_demo_t;
+
+bh_status_t bh_robotics_demo_init(bh_robotics_demo_t *demo);
+bh_status_t bh_robotics_demo_render(bh_robotics_demo_t *demo, char *output, size_t output_size);
+
+#endif

--- a/docs/adr/018-virtual-robotics-device-path.md
+++ b/docs/adr/018-virtual-robotics-device-path.md
@@ -1,0 +1,53 @@
+# ADR 018: Generic Virtual Robotics Device Path
+
+- **Status:** Accepted
+- **Date:** 2026-08-12
+
+## Context
+
+Bharat-OS needs a demonstrable robotics data path before physical board support is
+available.  A drone-specific API would couple applications to one product and
+would make later ground-robot and industrial use cases need parallel interfaces.
+
+## Decision
+
+The public boundary is two generic, fixed-width device UAPIs:
+`bharat/uapi/device/sensor.h` and `bharat/uapi/device/actuator.h`.  Sensor samples
+carry an explicit sensor identifier, type, monotonic timestamp, flags, value
+count, and four scalar values.  Actuator commands are versioned and carry a
+monotonic request identifier so a backend can reject replay.
+
+The QEMU robot platform owns one virtual-device instance containing an IMU, GPS,
+temperature sensor, battery sensor, distance sensor, and four motors.  It passes
+those device contexts to `sensormgr` and `actuator_mgr`; neither service nor
+driver introduces shared mutable global state.  A service instance and its
+caller are responsible for serializing access to its bounded tables.
+
+Sensor streams use a slot plus generation handle.  Subscription tables are
+bounded and report `BH_ERR_BUFFER_FULL`; a closed or recycled handle reports
+`BH_ERR_STALE_CAPABILITY`.  Motor outputs are denied until armed, normalized
+commands are range checked, and non-increasing request identifiers are rejected.
+Initialization or sampling failure puts all motors into the disarmed zero-output
+safe state.
+
+The robotics stack composes these mechanisms and renders the terminal dashboard.
+It remains application/service policy and does not add robotics policy to the
+kernel.  The implementation is backend-neutral C and has the same semantics on
+MMU, MMU-Lite, and MPU profiles.
+
+## Security and capability boundary
+
+The manager-issued sensor stream and actuator handles are opaque, fixed-width
+values rather than pointers.  `actuator_mgr` is the authority boundary for motor
+instances and denies an instance when its grant is absent.  This initial virtual
+transport is in-process; an eventual IPC binding must validate capability type,
+rights, scope, generation, and ownership before invoking these manager methods.
+
+## Consequences
+
+- QEMU/host demos can exercise a complete generic sensor and actuator path.
+- Queue capacity, stale handles, replay, ranges, and safe-state behavior are
+  deterministic and testable.
+- The virtual waveforms are deterministic demonstrations, not physical models.
+- Production IPC and physical I2C/SPI/PWM backends remain follow-up work and do
+  not change this UAPI.

--- a/docs/demo/virtual-robotics.md
+++ b/docs/demo/virtual-robotics.md
@@ -1,0 +1,39 @@
+# Bharat Virtual Robotics Demo
+
+The virtual robotics path supplies five generic sensor types (IMU, GPS,
+temperature, battery, and distance/LiDAR) and four normalized motor actuators.
+It is deliberately a hardware capability pack rather than a separate Bharat-OS
+kernel or a drone-specific API.
+
+## Layering
+
+```text
+robotics demo stack
+        |
+sensormgr / actuator_mgr
+        |
+generic sensor / actuator UAPI
+        |
+virtual sensor / motor drivers
+        |
+QEMU robot platform instance
+```
+
+Run the focused hosted data-path test with:
+
+```bash
+cmake -S . -B build/robotics-demo -DBHARAT_BUILD_HOST_TESTS=ON
+cmake --build build/robotics-demo --target host_test_robotics_demo
+ctest --test-dir build/robotics-demo -R host_test_robotics_demo --output-on-failure
+```
+
+The test initializes the virtual platform, opens and subscribes to generic
+sensors, arms four motors, renders the dashboard, rejects a stale stream and a
+replayed actuator command, and verifies explicit safe-state neutralization.
+
+## Scope
+
+This first increment is a deterministic hosted/QEMU device model. It does not
+claim physical BSP integration, flight control, sensor fusion, or production IPC
+transport. Hardware GPIO, I2C, SPI, PWM, UART, CAN, ADC, capture timer, and
+watchdog bindings can implement the same class boundaries incrementally.

--- a/interface/include/bharat/uapi/device/actuator.h
+++ b/interface/include/bharat/uapi/device/actuator.h
@@ -1,0 +1,32 @@
+#ifndef BHARAT_UAPI_DEVICE_ACTUATOR_H
+#define BHARAT_UAPI_DEVICE_ACTUATOR_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define BH_ACTUATOR_ABI_VERSION 1u
+
+typedef uint32_t bh_actuator_handle_t;
+
+typedef enum bh_actuator_type {
+    BH_ACTUATOR_MOTOR = 1
+} bh_actuator_type_t;
+
+enum {
+    BH_ACTUATOR_COMMAND_NORMALIZED = 1u << 0,
+    BH_ACTUATOR_COMMAND_ARM = 1u << 1,
+    BH_ACTUATOR_COMMAND_DISARM = 1u << 2
+};
+
+typedef struct bh_actuator_command {
+    uint32_t abi_version;
+    uint32_t flags;
+    uint64_t request_id;
+    float value;
+    uint32_t reserved;
+} bh_actuator_command_t;
+
+_Static_assert(sizeof(bh_actuator_command_t) == 24u, "actuator command ABI size");
+_Static_assert(offsetof(bh_actuator_command_t, request_id) == 8u, "actuator request ABI offset");
+
+#endif

--- a/interface/include/bharat/uapi/device/sensor.h
+++ b/interface/include/bharat/uapi/device/sensor.h
@@ -1,0 +1,41 @@
+#ifndef BHARAT_UAPI_DEVICE_SENSOR_H
+#define BHARAT_UAPI_DEVICE_SENSOR_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define BH_SENSOR_ABI_VERSION 1u
+#define BH_SENSOR_MAX_VALUES 4u
+
+typedef uint32_t bh_sensor_id_t;
+typedef uint32_t bh_sensor_handle_t;
+typedef uint32_t bh_sensor_stream_t;
+
+typedef enum bh_sensor_type {
+    BH_SENSOR_IMU = 1,
+    BH_SENSOR_GPS = 2,
+    BH_SENSOR_TEMPERATURE = 3,
+    BH_SENSOR_BATTERY = 4,
+    BH_SENSOR_DISTANCE = 5
+} bh_sensor_type_t;
+
+enum {
+    BH_SENSOR_SAMPLE_VALID = 1u << 0,
+    BH_SENSOR_SAMPLE_STALE = 1u << 1,
+    BH_SENSOR_SAMPLE_FAULT = 1u << 2
+};
+
+typedef struct bh_sensor_sample {
+    bh_sensor_id_t sensor;
+    uint32_t type;
+    uint64_t timestamp_ns;
+    uint32_t flags;
+    uint32_t value_count;
+    float values[BH_SENSOR_MAX_VALUES];
+} bh_sensor_sample_t;
+
+_Static_assert(sizeof(bh_sensor_sample_t) == 40u, "sensor sample ABI size");
+_Static_assert(offsetof(bh_sensor_sample_t, timestamp_ns) == 8u, "sensor timestamp ABI offset");
+_Static_assert(offsetof(bh_sensor_sample_t, values) == 24u, "sensor values ABI offset");
+
+#endif

--- a/interface/sdk/include/bharat/actuator.h
+++ b/interface/sdk/include/bharat/actuator.h
@@ -1,0 +1,13 @@
+#ifndef BHARAT_SDK_ACTUATOR_H
+#define BHARAT_SDK_ACTUATOR_H
+
+#include <bharat/types.h>
+#include <bharat/uapi/device/actuator.h>
+
+bh_status_t bh_actuator_open(bh_actuator_type_t type,
+                             uint32_t instance,
+                             bh_actuator_handle_t *actuator);
+bh_status_t bh_actuator_write(bh_actuator_handle_t actuator,
+                              const bh_actuator_command_t *command);
+
+#endif

--- a/interface/sdk/include/bharat/sensor.h
+++ b/interface/sdk/include/bharat/sensor.h
@@ -1,6 +1,16 @@
 #ifndef BHARAT_SDK_SENSOR_H
 #define BHARAT_SDK_SENSOR_H
-#include <bharat/device.h>
+
+#include <bharat/types.h>
+#include <bharat/uapi/device/sensor.h>
+
 enum { BH_DEVICE_CLASS_SENSOR = 0x00000020u };
-typedef struct bh_sensor_sample { uint64_t timestamp_ns; int32_t values[4]; uint32_t value_count; uint32_t reserved; } bh_sensor_sample_t;
+
+bh_status_t bh_sensor_open(bh_sensor_type_t type, bh_sensor_handle_t *sensor);
+bh_status_t bh_sensor_subscribe(bh_sensor_handle_t sensor,
+                                uint32_t rate_hz,
+                                bh_sensor_stream_t *stream);
+bh_status_t bh_sensor_read(bh_sensor_stream_t stream, bh_sensor_sample_t *sample);
+bh_status_t bh_sensor_unsubscribe(bh_sensor_stream_t stream);
+
 #endif

--- a/quality/tests/host/CMakeLists.txt
+++ b/quality/tests/host/CMakeLists.txt
@@ -169,6 +169,19 @@ target_include_directories(host_test_syscall_return_x86_64 PRIVATE
 add_test(NAME host_test_syscall_return_x86_64 COMMAND host_test_syscall_return_x86_64)
 add_test(NAME host_test_uapi_abi COMMAND test_uapi_abi)
 
+add_executable(host_test_robotics_demo
+    robotics/test_robotics_demo.c
+    ${CMAKE_SOURCE_DIR}/core/drivers/sensor/virtual/virtual_sensors.c
+    ${CMAKE_SOURCE_DIR}/core/drivers/actuator/virtual/virtual_motors.c
+    ${CMAKE_SOURCE_DIR}/core/services/device/sensormgr/sensormgr.c
+    ${CMAKE_SOURCE_DIR}/core/services/device/actuator_mgr/actuator_mgr.c
+    ${CMAKE_SOURCE_DIR}/core/platform/qemu/robot/robot_platform.c
+    ${CMAKE_SOURCE_DIR}/core/stacks/robotics/robotics_demo.c)
+target_include_directories(host_test_robotics_demo PRIVATE
+    ${CMAKE_SOURCE_DIR}
+    ${CMAKE_SOURCE_DIR}/interface/include)
+add_test(NAME host_test_robotics_demo COMMAND host_test_robotics_demo)
+
 add_executable(host_test_libmsg_crc
     test_libmsg_crc.c
     ${CMAKE_SOURCE_DIR}/core/lib/msg/crc.c

--- a/quality/tests/host/robotics/test_robotics_demo.c
+++ b/quality/tests/host/robotics/test_robotics_demo.c
@@ -1,0 +1,51 @@
+#include <assert.h>
+#include <string.h>
+
+#include "core/stacks/robotics/robotics_demo.h"
+
+static void test_demo_data_path(void)
+{
+    bh_robotics_demo_t demo;
+    char output[768];
+    uint32_t index;
+
+    assert(bh_robotics_demo_init(&demo) == BH_OK);
+    assert(bh_robotics_demo_render(&demo, output, sizeof(output)) == BH_OK);
+    assert(strstr(output, "Bharat Robotics Demo") != 0);
+    assert(strstr(output, "Safety state: NORMAL") != 0);
+    for (index = 0u; index < BH_VIRTUAL_MOTOR_COUNT; index++) {
+        assert(demo.platform.motors.motors[index].armed == 1u);
+        assert(demo.platform.motors.motors[index].output > 0.0f);
+    }
+}
+
+static void test_stale_stream_and_actuator_replay_fail_closed(void)
+{
+    bh_robotics_demo_t demo;
+    bh_sensor_sample_t sample;
+    bh_actuator_command_t replay = {
+        .abi_version = BH_ACTUATOR_ABI_VERSION,
+        .flags = BH_ACTUATOR_COMMAND_NORMALIZED,
+        .request_id = 1u,
+        .value = 1.0f,
+    };
+    bh_sensor_stream_t stale;
+
+    assert(bh_robotics_demo_init(&demo) == BH_OK);
+    stale = demo.imu_stream;
+    assert(bh_sensormgr_unsubscribe(&demo.sensor_manager, stale) == BH_OK);
+    assert(bh_sensormgr_read(&demo.sensor_manager, stale, &sample) == BH_ERR_STALE_CAPABILITY);
+    assert(bh_actuator_mgr_write(&demo.actuator_manager, demo.motors[0], &replay) ==
+           BH_ERR_STALE_CAPABILITY);
+    assert(demo.platform.motors.motors[0].output > 0.0f);
+    bh_actuator_mgr_enter_safe_state(&demo.actuator_manager);
+    assert(demo.platform.motors.motors[0].output == 0.0f);
+    assert(demo.platform.motors.motors[0].armed == 0u);
+}
+
+int main(void)
+{
+    test_demo_data_path();
+    test_stale_stream_and_actuator_replay_fail_closed();
+    return 0;
+}


### PR DESCRIPTION
### Motivation

- Provide a deterministic, host/QEMU-first robotics/drone demo and data path without waiting for BSPs or physical hardware.
- Define a small, generic sensor/actuator UAPI and a bounded manager/driver/stack layout that preserves capability, ownership, and fail-closed semantics.
- Enable focused host testing and a documented baseline for follow-up physical/I2C/SPI/PWM/CAN backends and IPC bindings.

### Description

- Add generic UAPIs `interface/include/bharat/uapi/device/sensor.h` and `.../actuator.h` with fixed-width handles, versioning, flags, and ABI `static_assert` checks. 
- Implement deterministic virtual device models: IMU, GPS, temperature, battery, distance/LiDAR and four virtual motors in `core/drivers/sensor/virtual/` and `core/drivers/actuator/virtual/` with replay/arm/range checks and monotonic timestamps.
- Add bounded, instance-owned managers `core/services/device/sensormgr/` and `core/services/device/actuator_mgr/` that expose generation-tagged stream handles, queue-full/stale semantics, grant checks, and safe-state neutralization.
- Wire an instance-owned QEMU robot platform and a robotics demo stack in `core/platform/qemu/robot/` and `core/stacks/robotics/` that initialize the path, arm motors, render a terminal dashboard, and neutralize on failures; include SDK header stubs and ADR and demo docs describing ownership and security boundaries.

### Testing

- `cc -std=c11 -Wall -Wextra -Werror -I. -Iinterface/include ...` (direct compile of focused sources + run): PASS (focused robotics host binary built and executed successfully).
- `printf '#include <bharat/sensor.h>\n#include <bharat/actuator.h>...' | cc -std=c11 -Iinterface/sdk/include -Iinterface/include -x c -` (validate SDK headers): PASS.
- `git diff --check`: PASS (no whitespace/patch errors).
- `python3 tools/lint/check_layer_references.py`: PASS (scanner completed; reported 4 findings covered by repository baseline debt and did not block the change).
- `python3 tools/lint/check_cmake_dependencies.py`: PASS (no violations reported).
- `python3 tools/abi/syscall_abi.py --check`: PASS (syscall ABI check succeeded).
- Per-target smoke builds: `./tools/build.sh all --target-yaml delivery/targets/qemu/<arch>_desktop_headless.yaml --smoke` for x86_64, arm64, riscv64, arm32_mmu_lite, riscv32_mmu_lite: all 5 targets PASS.
- QEMU matrix: `python3 tools/run_qemu_matrix.py --headless --smoke --all-arch`: PASS (all-architecture smoke gate passed).
- CMake host-test configure for the repository-level host tests using `-DBHARAT_BUILD_HOST_TESTS=ON` is BLOCKED by a pre-existing duplicate `test_servicemgr` target in `quality/tests/host/CMakeLists.txt`; the focused direct C build above provided equivalent test evidence for the robotics demo while this CMake conflict is resolved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7c68c63ac08320a1820a495d668ca3)