### PR TITLE
Validate and fix QEMU GUI showcase flow: preserve guest display in headless CI, FBUI event routing, boot contract & tests

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -323,6 +323,15 @@ Runtime command includes serial-first bring-up (`-nographic -monitor none -seria
 ./tools/build.sh all --target-yaml delivery/targets/qemu/x86_64_rtos_mmu_lite_headless.yaml --smoke
 ```
 
+The showcase target also supports a CI-friendly end-to-end check without a
+window server. It still creates the emulated display and requires the real
+framebuffer, splash/dashboard render, synthetic app interaction, and stable
+userspace boot markers before passing:
+
+```bash
+./tools/build.sh all --target-yaml delivery/targets/qemu/x86_64_showcase_gui.yaml --headless --smoke
+```
+
 ## 5.1 Canonical headless smoke-test commands (all 5 architectures)
 
 All commands verified with `[Run] PASS` on QEMU. Build + package + run in one shot.

--- a/experience/user/ui/fbui/CMakeLists.txt
+++ b/experience/user/ui/fbui/CMakeLists.txt
@@ -6,6 +6,10 @@ if(BHARAT_INPUT_SHOWCASE_GUI)
     add_compile_definitions(BHARAT_INPUT_SHOWCASE_GUI=1)
 endif()
 
+if(BHARAT_SHOWCASE_GUI)
+    add_compile_definitions(BHARAT_SHOWCASE_GUI=1)
+endif()
+
 add_library(fbui STATIC
     core/fb_render.c
     core/fb_events.c

--- a/experience/user/ui/fbui/widgets/fb_widgets.c
+++ b/experience/user/ui/fbui/widgets/fb_widgets.c
@@ -219,12 +219,12 @@ static bool button_handle_event(fbui_widget_t *w, const fbui_event_t *ev) {
     if (ev->type == FBUI_EVENT_TOUCH_DOWN && fbui_widget_hit_test(w, ev->x, ev->y)) {
         w->focused = true;
         return true; // Event consumed
-    } else if (ev->type == FBUI_EVENT_TOUCH_UP) {
-        if (w->focused && fbui_widget_hit_test(w, ev->x, ev->y)) {
+    } else if (ev->type == FBUI_EVENT_TOUCH_UP && w->focused) {
+        if (fbui_widget_hit_test(w, ev->x, ev->y)) {
             // Click callback placeholder logic
         }
         w->focused = false;
-        return true; // Consume if it was our button being released
+        return true;
     }
     return false;
 }
@@ -413,8 +413,8 @@ static bool checkbox_handle_event(fbui_widget_t *w, const fbui_event_t *ev) {
     if (ev->type == FBUI_EVENT_TOUCH_DOWN && fbui_widget_hit_test(w, ev->x, ev->y)) {
         w->focused = true;
         return true;
-    } else if (ev->type == FBUI_EVENT_TOUCH_UP) {
-        if (w->focused && fbui_widget_hit_test(w, ev->x, ev->y)) {
+    } else if (ev->type == FBUI_EVENT_TOUCH_UP && w->focused) {
+        if (fbui_widget_hit_test(w, ev->x, ev->y)) {
             cdata->checked = !cdata->checked; // Toggle
         }
         w->focused = false;

--- a/quality/contracts/boot/headless_boot_contract.yaml
+++ b/quality/contracts/boot/headless_boot_contract.yaml
@@ -16,6 +16,18 @@ common:
     - "BOOT_FAIL:"
 
 targets:
+  x86_64_showcase_gui:
+    description: "x86_64 graphical splash and FBUI interaction flow"
+    required:
+      - "BHARAT_GUI_DEMO:START"
+      - "BHARAT_GUI_DEMO:DISPLAY=REAL"
+      - "BHARAT_GUI_DEMO:RENDER=PASS"
+      - "BHARAT_GUI_DEMO:EVENT=PASS"
+      - "BHARAT_GUI_DEMO:COMPLETE"
+      - "BOOT_RUNTIME: STABLE"
+    forbidden: *common_forbidden
+    timeout_seconds: 45
+
   x86_64_desktop_headless:
     description: "x86_64 MMU-Full headless boot"
     required:

--- a/quality/tests/tools/test_runner_qemu.py
+++ b/quality/tests/tools/test_runner_qemu.py
@@ -1,0 +1,34 @@
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).parents[3]
+sys.path.insert(0, str(REPO_ROOT / "tools" / "run"))
+
+from runner_qemu import build_qemu_command  # noqa: E402
+
+
+def test_headless_override_keeps_gui_targets_display_capable():
+    manifest = {
+        "arch": "x86_64",
+        "run_config": {"nographic": False},
+        "artifacts": {},
+    }
+
+    command = build_qemu_command(manifest, display_override="headless")
+
+    assert "-nographic" in command
+    assert command.count("virtio-gpu-pci") == 1
+
+
+def test_native_headless_target_does_not_gain_display_device():
+    manifest = {
+        "arch": "x86_64",
+        "run_config": {"nographic": True},
+        "artifacts": {},
+    }
+
+    command = build_qemu_command(manifest)
+
+    assert "-nographic" in command
+    assert "virtio-gpu-pci" not in command

--- a/tools/run/runner_qemu.py
+++ b/tools/run/runner_qemu.py
@@ -88,6 +88,15 @@ def build_qemu_command(manifest: dict, mode_override: str = None, display_overri
 
     is_windows = sys.platform.startswith('win')
 
+    extra_args_list = run_config.get("extra_args", [])
+    has_display_dev = any("bochs-display" in str(arg) or "virtio-gpu" in str(arg) or "ramfb" in str(arg) for arg in extra_args_list)
+
+    # A GUI target forced headless for CI still needs its emulated display
+    # device.  Only the host window is suppressed; the guest framebuffer must
+    # remain available so graphical boot contracts cannot pass offscreen.
+    if not nographic_manifest and not has_display_dev:
+        cmd.extend(["-device", "virtio-gpu-pci"])
+
     if display_mode == "headless":
         if is_windows:
             cmd.extend(['-display', 'none', '-serial', 'stdio'])
@@ -95,10 +104,6 @@ def build_qemu_command(manifest: dict, mode_override: str = None, display_overri
             cmd.append('-nographic')
     else:
         cmd.extend(['-display', 'gtk'])
-        extra_args_list = run_config.get("extra_args", [])
-        has_display_dev = any("bochs-display" in str(arg) or "virtio-gpu" in str(arg) or "ramfb" in str(arg) for arg in extra_args_list)
-        if not has_display_dev:
-            cmd.extend(["-device", "virtio-gpu-pci"])
         # In GUI mode, keep serial output on stdout for the runner to parse
         # or use vc if preferred, but for headless parsing we need it on stdio
         cmd.extend(["-serial", "stdio"])


### PR DESCRIPTION
### Motivation
- Ensure GUI/QEMU showcase runs can be validated in CI without a host window by preserving the guest framebuffer device while still running headless, and make the graphical showcase fail-closed when no real display is available.
- Fix an FBUI event-routing bug where a sibling widget could swallow a touch-release, causing synthetic demo interactions to not complete.
- Add automated regression checks and documentation so the graphical showcase can be smoke-tested non-interactively and validated by boot-contract markers.

### Description
- Preserve the emulated display device for GUI targets when run headlessly by defaulting a `virtio-gpu-pci` device unless the manifest explicitly disables it, while leaving native headless targets unchanged (`tools/run/runner_qemu.py`).
- Change FBUI release-event handling so release handlers are only considered when the widget was previously focused, preventing unrelated siblings from intercepting release events (`experience/user/ui/fbui/widgets/fb_widgets.c`).
- Expose `BHARAT_SHOWCASE_GUI` to the FBUI build so showcase targets fail closed when a real display is required (`experience/user/ui/fbui/CMakeLists.txt`).
- Add a GUI showcase boot contract that requires real display, render, event, and completion markers (`quality/contracts/boot/headless_boot_contract.yaml`).
- Add a regression unit test for the QEMU runner behavior ensuring GUI-headless overrides keep the guest display while native headless targets do not (`quality/tests/tools/test_runner_qemu.py`).
- Document the CI-friendly headless showcase command and workflow in `BUILD.md`.

### Testing
- Ran the focused showcase flow: `./tools/build.sh all --target-yaml delivery/targets/qemu/x86_64_showcase_gui.yaml --headless --smoke`, and observed the required GUI markers `BHARAT_GUI_DEMO:START`, `DISPLAY=REAL`, `RENDER=PASS`, `EVENT=PASS`, `COMPLETE`, and `BOOT_RUNTIME: STABLE` (PASS).
- Unit tests: `python3 -m pytest -q quality/tests/tools/test_runner_qemu.py quality/tests/tools/test_boot_contract.py` — all tests passed (5 passed).
- Linters and checks: `python3 tools/lint/check_layer_references.py` — ran (baseline debt reported, 4 known violations remain), `python3 tools/lint/check_cmake_dependencies.py` — 0 violations, and `python3 tools/abi/syscall_abi.py --check` — passed cleanly.
- QEMU matrix: `python3 tools/run_qemu_matrix.py --headless --smoke --all-arch` — x86_64, arm64, arm32 (MMU-Lite), and riscv64 passed; riscv32 failed due to a pre-existing kernel panic during userspace entry (expected unrelated platform failure), so full five-arch gate is not fully green.
- Evidence: captured a QMP `screendump` of the guest framebuffer showing the rendered Bharat-OS dashboard and verified serial log markers confirming the GUI render and synthetic interaction sequence (render/event/complete).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7c8f5a751883209053da4702db1170)