### PR TITLE
Harden scheduler thread lifecycle: use kstatus_t, fix reap-tail, and secure intent syscalls

### DIFF
--- a/core/kernel/include/sched/sched.h
+++ b/core/kernel/include/sched/sched.h
@@ -9,6 +9,7 @@
 #include "list.h"
 #include <lib/rbtree/rbtree.h>
 #include "kernel_safety.h"
+#include "kernel/status.h"
 #include "spinlock.h"
 #include "personality_ops.h"
 #include <stdbool.h>
@@ -548,7 +549,7 @@ struct bh_thread {
     uint32_t migration_epoch;
 };
 
-int thread_raise_fault(bh_thread_t *thread, thread_fault_t fault);
+kstatus_t thread_raise_fault(bh_thread_t *thread, thread_fault_t fault);
 int sched_mark_thread_terminated(bh_thread_t *thread);
 int sched_quarantine_thread(bh_thread_t *thread, uint32_t reason);
 
@@ -584,12 +585,12 @@ int sched_system_enable(void);
 
 // Create process and main thread
 bh_process_t* process_create(const char* name);
-int process_destroy(bh_process_t* process);
+kstatus_t process_destroy(bh_process_t* process);
 bh_thread_t* thread_create(bh_process_t* parent, void (*entry_point)(void));
 bh_thread_t* thread_create_detached(bh_process_t* parent, void (*entry_point)(void));
 bh_thread_t *thread_create_detached_arg(bh_process_t *parent, void (*entry_point)(void *), const arch_user_entry_t *arg_data);
 
-int thread_destroy(bh_thread_t* thread);
+kstatus_t thread_destroy(bh_thread_t* thread);
 
 // Current Context Helpers
 bh_process_t* sched_current_process(void);
@@ -633,7 +634,7 @@ int sched_migrate_task(bh_thread_t *thread, uint32_t new_node);
 int sched_migrate_tid(uint64_t tid, uint32_t target_cpu);
 int sched_set_priority(uint64_t tid, uint32_t priority);
 int sched_set_affinity(uint64_t tid, uint32_t mask);
-int sched_terminate_tid(uint64_t tid);
+kstatus_t sched_terminate_tid(uint64_t tid);
 int sched_quarantine_tid(uint64_t tid, uint32_t reason);
 int sched_throttle_core(uint32_t core_id);
 
@@ -650,13 +651,13 @@ int sched_get_constraints(uint64_t tid, bh_exec_constraints_k_t *c);
 bool sched_thread_exists(uint64_t tid);
 
 // System-call style entry points used by trap/syscall layer
-int sched_sys_thread_create(bh_process_t* parent, void (*entry_point)(void), uint64_t* out_tid);
-int sched_sys_thread_destroy(uint64_t tid);
+kstatus_t sched_sys_thread_create(bh_process_t* parent, void (*entry_point)(void), uint64_t* out_tid);
+kstatus_t sched_sys_thread_destroy(uint64_t tid);
 int sched_sys_sleep(uint64_t millis);
 int sched_sys_set_priority(uint64_t tid, uint32_t new_priority);
 int sched_sys_set_affinity(uint64_t tid, uint32_t affinity_mask);
-int sched_sys_intent_set(uint64_t tid, const void* intent);
-int sched_sys_intent_get(uint64_t tid, void* intent);
+kstatus_t sched_sys_intent_set(uint64_t tid, const void* intent);
+kstatus_t sched_sys_intent_get(uint64_t tid, void* intent);
 
 // Priority Inheritance support
 void sched_inherit_priority(bh_thread_t* thread, uint32_t new_priority);

--- a/core/kernel/src/personality/native/native_syscall_handlers.c
+++ b/core/kernel/src/personality/native/native_syscall_handlers.c
@@ -218,8 +218,6 @@ bh_operation_result_t bh_sys_cap_delegate(bh_syscall_ctx_t *ctx) {
     return bh_op_result_kstatus(res);
 }
 
-int sched_sys_intent_set(uint64_t tid, const void* intent);
-int sched_sys_intent_get(uint64_t tid, void* intent);
 #include <bharat/uapi/system/intent.h>
 
 bh_operation_result_t bh_sys_intent_set(bh_syscall_ctx_t *ctx) {

--- a/core/kernel/src/sched/sched_thread.c
+++ b/core/kernel/src/sched/sched_thread.c
@@ -1,10 +1,11 @@
 #include <bharat/uapi/system/intent.h>
+#include "lib/base/string.h"
 #include "sched/sched.h"
 #include "sched_internal.h"
 
-int process_destroy(bh_process_t *process) {
+kstatus_t process_destroy(bh_process_t *process) {
   if (!process) {
-    return -1;
+    return K_ERR_INVALID_ARG;
   }
 
   sched_rq_t *rq = sched_local_rq();
@@ -19,13 +20,13 @@ int process_destroy(bh_process_t *process) {
   }
 
   if (!slot) {
-    return -1;
+    return K_ERR_NOT_FOUND;
   }
 
   for (size_t i = 0; i < SCHED_MAX_THREADS; ++i) {
     thread_slot_t *ts = &((thread_slot_t*)rq->threads)[i];
     if (ts->in_use != 0U && ts->thread.process_id == slot->process.process_id) {
-      return -1;
+      return K_ERR_BUSY;
     }
   }
 
@@ -43,24 +44,24 @@ int process_destroy(bh_process_t *process) {
   uint32_t idx = (uint32_t)(slot - (process_slot_t*)rq->processes);
   slot->next_free = rq->free_process_head;
   rq->free_process_head = idx;
-  return 0;
+  return K_OK;
 }
 
-int thread_destroy(bh_thread_t *thread) {
+kstatus_t thread_destroy(bh_thread_t *thread) {
   // Reaper-only contract:
   // - call only from deferred reap context, never inline on the running thread.
   // - never destroy while executing on the victim thread's stack.
   if (!thread) {
-    return -1;
+    return K_ERR_INVALID_ARG;
   }
   if (thread == sched_current_thread()) {
-    return -1;
+    return K_ERR_BAD_STATE;
   }
 
   sched_rq_t *rq = sched_local_rq();
   thread_slot_t *slot = sched_find_thread_slot_by_tid_local(rq, thread->thread_id);
   if (!slot) {
-    return -1;
+    return K_ERR_BAD_THREAD;
   }
 
   // Prevent race with background reaper or other cores
@@ -68,11 +69,11 @@ int thread_destroy(bh_thread_t *thread) {
   
   spin_lock(&rq->lock);
   
-  if (slot->reap_pending && slot->reap_next != UINT32_MAX) {
+  if (slot->reap_pending != 0U) {
       // Thread is already being reaped, let the reaper finish it
       spin_unlock(&rq->lock);
       hal_cpu_enable_interrupts();
-      return 0;
+      return K_OK;
   }
   
   slot->reap_pending = 1U; // Mark as pending so reaper doesn't touch it
@@ -112,23 +113,23 @@ int thread_destroy(bh_thread_t *thread) {
   spin_unlock(&rq->lock);
 
   hal_cpu_enable_interrupts();
-  return 0;
+  return K_OK;
 }
 
-int sched_sys_thread_create(bh_process_t *parent, void (*entry_point)(void), uint64_t *out_tid) {
+kstatus_t sched_sys_thread_create(bh_process_t *parent, void (*entry_point)(void), uint64_t *out_tid) {
   bh_thread_t *t = thread_create(parent, entry_point);
   if (!t) {
-    return -1;
+    return K_ERR_NO_RESOURCES;
   }
   if (out_tid) {
     *out_tid = t->thread_id;
   }
-  return 0;
+  return K_OK;
 }
 
-int sched_terminate_tid(uint64_t tid) {
+kstatus_t sched_terminate_tid(uint64_t tid) {
   bh_thread_t *thread = sched_find_thread_by_id(tid);
-  if (!thread) return -1;
+  if (!thread) return K_ERR_BAD_THREAD;
 
   uint32_t current_core = sched_clamp_core(hal_cpu_get_id());
   uint32_t owner = __atomic_load_n(&thread->owner_cpu, __ATOMIC_ACQUIRE);
@@ -148,18 +149,18 @@ int sched_terminate_tid(uint64_t tid) {
           sched_remote_cmd_release(cmd);
           return status;
       }
-      return 0;
+      return K_OK;
   }
 
   return sched_mark_thread_terminated(thread);
 }
 
-int sched_sys_thread_destroy(uint64_t tid) {
+kstatus_t sched_sys_thread_destroy(uint64_t tid) {
   return sched_terminate_tid(tid);
 }
 
-int thread_raise_fault(bh_thread_t *thread, thread_fault_t fault) {
-    if (!thread) return -1; // -EINVAL mapped
+kstatus_t thread_raise_fault(bh_thread_t *thread, thread_fault_t fault) {
+    if (!thread) return K_ERR_INVALID_ARG;
 
     thread->pending_fault = fault;
     thread->fault_pending = true;
@@ -168,32 +169,28 @@ int thread_raise_fault(bh_thread_t *thread, thread_fault_t fault) {
     /* TODO(personality/linux): translate THREAD_FAULT_SEGV / STACK_OVERFLOW to SIGSEGV */
 
     sched_reschedule();
-    return 0;
+    return K_OK;
 }
 
-
-
-void *memcpy(void *dest, const void *src, size_t n);
-
-int sched_sys_intent_set(uint64_t tid, const void* intent) {
-    if (!intent) return -1;
+kstatus_t sched_sys_intent_set(uint64_t tid, const void* intent) {
+    if (!intent) return K_ERR_INVALID_ARG;
     bh_thread_t *thread = sched_find_thread_by_id(tid);
-    if (!thread) return -1;
+    if (!thread) return K_ERR_BAD_THREAD;
     // Basic validation and copy
     bharat_intent_t local_intent;
     memcpy(&local_intent, intent, sizeof(bharat_intent_t));
-    if (local_intent.version != BHARAT_INTENT_V1) return -1;
+    if (local_intent.version != BHARAT_INTENT_V1) return K_ERR_UNSUPPORTED;
 
-    // TODO: store intent somewhere
+    // Intent storage is not implemented; fail closed rather than report a no-op success.
     (void)thread;
-    return 0;
+    return K_ERR_UNSUPPORTED;
 }
 
-int sched_sys_intent_get(uint64_t tid, void* intent) {
-    if (!intent) return -1;
+kstatus_t sched_sys_intent_get(uint64_t tid, void* intent) {
+    if (!intent) return K_ERR_INVALID_ARG;
     bh_thread_t *thread = sched_find_thread_by_id(tid);
-    if (!thread) return -1;
-    // TODO: retrieve intent from somewhere
+    if (!thread) return K_ERR_BAD_THREAD;
+    // Never report success until the entire output can be initialized from stored state.
     (void)thread;
-    return 0;
+    return K_ERR_UNSUPPORTED;
 }

--- a/core/kernel/src/sched_stub.c
+++ b/core/kernel/src/sched_stub.c
@@ -336,11 +336,11 @@ int sched_unregister_process(bh_process_t* process) {
     return -1;
 }
 
-int process_destroy(bh_process_t* process) {
+kstatus_t process_destroy(bh_process_t* process) {
     if (!process) {
-        return -1;
+        return K_ERR_INVALID_ARG;
     }
-    return sched_unregister_process(process);
+    return sched_unregister_process(process) == 0 ? K_OK : K_ERR_NOT_FOUND;
 }
 
 bh_thread_t* thread_create(bh_process_t* parent, void (*entry_point)(void)) {
@@ -374,14 +374,13 @@ bh_thread_t* thread_create(bh_process_t* parent, void (*entry_point)(void)) {
     return &slot->thread;
 }
 
-int thread_destroy(bh_thread_t* thread) {
-    if (!thread) return -1;
+kstatus_t thread_destroy(bh_thread_t* thread) {
+    if (!thread) return K_ERR_INVALID_ARG;
     thread_slot_t* slot = sched_find_thread_slot_by_tid(thread->thread_id);
-    if (slot) {
-        slot->in_use = 0;
-    }
+    if (!slot) return K_ERR_BAD_THREAD;
+    slot->in_use = 0;
     // __builtin_free(thread); // Dummy for stub
-    return 0;
+    return K_OK;
 }
 
 void bh_thread_yield(void) {
@@ -514,11 +513,11 @@ address_space_t* sched_current_aspace(void) {
     return p ? p->addr_space : NULL;
 }
 
-int thread_raise_fault(bh_thread_t *thread, thread_fault_t fault) {
+kstatus_t thread_raise_fault(bh_thread_t *thread, thread_fault_t fault) {
     (void)thread;
     g_stub_thread_raise_fault_called++;
     g_stub_last_fault_code = fault;
-    return 0;
+    return K_OK;
 }
 
 int sched_sys_sleep(uint64_t millis) {
@@ -539,22 +538,22 @@ sched_policy_t sched_get_policy(void) {
     return g_cores[0].policy;
 }
 
-int sched_sys_thread_create(bh_process_t* parent, void (*entry_point)(void), uint64_t* out_tid) {
+kstatus_t sched_sys_thread_create(bh_process_t* parent, void (*entry_point)(void), uint64_t* out_tid) {
     bh_thread_t* t = thread_create(parent, entry_point);
     if (!t) {
-        return -1;
+        return K_ERR_NO_RESOURCES;
     }
 
     if (out_tid) {
         *out_tid = t->thread_id;
     }
-    return 0;
+    return K_OK;
 }
 
-int sched_sys_thread_destroy(uint64_t tid) {
+kstatus_t sched_sys_thread_destroy(uint64_t tid) {
     thread_slot_t* slot = sched_find_thread_slot_by_tid(tid);
     if (!slot) {
-        return -1;
+        return K_ERR_BAD_THREAD;
     }
 
     return thread_destroy(&slot->thread);

--- a/core/kernel/src/trap/trap.c
+++ b/core/kernel/src/trap/trap.c
@@ -1,8 +1,7 @@
 #include <stdint.h>
 #include <stddef.h>
+#include "sched/sched.h"
 
-int sched_sys_intent_set(uint64_t tid, const void* intent);
-int sched_sys_intent_get(uint64_t tid, void* intent);
 int sys_mem_alloc_class(size_t size, uint32_t mem_class, uint32_t flags, uint64_t* out_addr);
 int sys_fault_domain_create(const void* attr, uint64_t* out_domain);
 int sys_fault_domain_destroy(uint64_t domain);

--- a/quality/tests/test_sched_reap.c
+++ b/quality/tests/test_sched_reap.c
@@ -1,6 +1,7 @@
 #include <assert.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <bharat/uapi/system/intent.h>
 
 #include "../kernel/include/sched/sched.h"
 #include "../kernel/include/ipc_async.h"
@@ -68,6 +69,17 @@ int main(void) {
 
   assert(sched_sys_thread_destroy(t2->thread_id) == 0);
   assert(sched_find_thread_by_id(t2->thread_id) != NULL);
+
+  /* A one-element reap queue has reap_next == UINT32_MAX. Direct destruction
+   * must still defer to the reaper while reap_pending is set. */
+  assert(thread_destroy(t2) == K_OK);
+  assert(sched_find_thread_by_id(t2->thread_id) == t2);
+
+  bharat_intent_t intent = {.version = BHARAT_INTENT_V1};
+  assert(sched_sys_intent_set(t2->thread_id, &intent) == K_ERR_UNSUPPORTED);
+  assert(sched_sys_intent_get(t2->thread_id, &intent) == K_ERR_UNSUPPORTED);
+  assert(sched_sys_intent_get(t2->thread_id, NULL) == K_ERR_INVALID_ARG);
+
   sched_on_timer_tick();
   assert(sched_find_thread_by_id(t2->thread_id) == NULL);
   assert(process_destroy(p2) == 0);


### PR DESCRIPTION
### Motivation

- Normalize kernel-internal scheduler APIs to use the canonical `kstatus_t` error space for clearer semantics and safer syscall-boundary translation.  
- Fix correctness/security issues in thread lifecycle: prevent premature reclamation of reap-queued threads and stop returning success for unimplemented intent storage that could leak uninitialized stack data.  
- Keep the change narrow and owner-local: do not alter remote-reap protocol, interrupt save/restore, aspace lifecycle semantics, or public syscall ABI numbers in this patch. 

### Description

- Changed targeted scheduler/internal APIs from `int` to `kstatus_t` and added `#include "kernel/status.h"` to the scheduler header so callers use typed kernel status codes.  
- Replaced the local `memcpy` forward declaration with the kernel canonical `#include "lib/base/string.h"`.  
- Made `sched_sys_intent_set()` and `sched_sys_intent_get()` validate inputs and return `K_ERR_UNSUPPORTED` instead of reporting success with uninitialized output, preventing leaking uninitialized kernel stack data to userspace.  
- Fixed the reap-queue invariant: treat any slot with `reap_pending != 0` as owned by the reaper (covers the single-element/tail case where `reap_next == UINT32_MAX`), and added a regression assertion to `test_sched_reap`.  
- Updated `sched_stub.c`, trap/syscall handler references, and the host test to use the new `kstatus_t` returns and preserve equivalent behavior in stub/test builds.  

### Testing

- `python3 tools/lint/check_layer_references.py`: PASS (ran successfully; reported existing baseline debt unrelated to this change).  
- `python3 tools/lint/check_cmake_dependencies.py`: PASS (no new CMake dependency violations).  
- `python3 tools/abi/syscall_abi.py --check`: PASS (syscall/ABI generator check passed).  
- Focused host-test CMake generation for the full host-suite was BLOCKED by pre-existing host-test source path issues in the host CMakeLists (CMake could not generate some legacy host targets); the focused host-test build harness could not be completed end-to-end.  
- Targeted builds and smoke-runs (headless):  
  - `./tools/build.sh all --target-yaml delivery/targets/qemu/x86_64_desktop_headless.yaml --smoke`: PASS.  
  - `./tools/build.sh all --target-yaml delivery/targets/qemu/arm64_desktop_headless.yaml --smoke`: PASS.  
  - `./tools/build.sh all --target-yaml delivery/targets/qemu/riscv64_desktop_headless.yaml --smoke`: PASS.  
  - `./tools/build.sh all --target-yaml delivery/targets/qemu/arm32_mmu_lite_headless.yaml --smoke`: PASS.  
  - `./tools/build.sh all --target-yaml delivery/targets/qemu/riscv32_mmu_lite_headless.yaml --smoke`: FAIL (system reached stable runtime but then observed a RISC-V32 kernel panic during boot/runtime; this appears to be a pre-existing architecture/runtime trap and not caused by the narrow scheduler changes).  
- GUI/hosted targets (via Xvfb where necessary):  
  - `x86_64_desktop_gui`: PASS (built and smoke-run under Xvfb).  
  - `arm64_desktop_gui`: PASS (built and smoke-run under Xvfb).  
  - `riscv64_desktop_gui`: FAIL (runtime kernel panic observed; investigation shows an architecture runtime trap).  
  - `arm32_desktop_gui` and `riscv32_desktop_gui`: FAIL at build time due to pre-existing third-party LVGL preprocessing error related to `UINTPTR_MAX` being implemented as a casted macro in headers.  
- SMP lanes (where supported):  
  - `x86_64_desktop_smp_headless`: PASS.  
  - `arm64_desktop_smp_headless`: FAIL (runtime kernel panic observed during SMP boot; appears outside the narrow scheduler changes).  
  - `riscv64_desktop_smp_headless`: PASS.  
- QEMU matrix runner: `python3 tools/run_qemu_matrix.py --headless --smoke --all-arch` was executed and reproduced the above matrix: four headless targets passed and the RISC-V32 headless target failed with a runtime panic; the matrix runner confirmed `--all-arch` support.  

All code changes compile cleanly in the normal cross-compilation build; host/test harness generation for the legacy host test matrix is blocked by unrelated host CMake source path issues.  The changes preserve ownership and protocol contracts and intentionally avoid touching higher-risk cross-core or MM lifecycle logic; follow-up tickets are recommended for remote-reap allocation retry semantics, portable IRQ state save/restore, and aspace teardown error propagation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7c92cf4a4883209a46a62746ee9a31)