### PR TITLE
Enforce canonical core/ placement in placement linter; rename display MMIO helper and neutralize GUI strings

### DIFF
--- a/core/kernel/src/display/boot_gui.c
+++ b/core/kernel/src/display/boot_gui.c
@@ -333,11 +333,11 @@ static void draw_splash(void) {
     boot_gui_draw_rect_outline(content_x, cur_y, box_w, box_h, COLOR_CARD_HDR);
 
 #if defined(__x86_64__)
-    const char *arch_str = "x86_64 (Generic PC / QEMU virt)";
+    const char *arch_str = "x86_64 (Generic PC)";
 #elif defined(__aarch64__)
-    const char *arch_str = "ARM64 (Cortex-A72 / QEMU virt)";
+    const char *arch_str = "ARM64 (Generic Platform)";
 #elif defined(__riscv)
-    const char *arch_str = "RISC-V 64 (RV64GC / QEMU virt)";
+    const char *arch_str = "RISC-V 64 (RV64GC Platform)";
 #else
     const char *arch_str = "Generic Architecture";
 #endif

--- a/core/kernel/src/display/boot_video_map.c
+++ b/core/kernel/src/display/boot_video_map.c
@@ -122,7 +122,7 @@ int boot_video_map(const boot_info_t *boot) {
     return 0;
 }
 
-int qemu_display_map_mmio(uint64_t phys, size_t size, uintptr_t *out_virt) {
+int bh_display_map_mmio(uint64_t phys, size_t size, uintptr_t *out_virt) {
     if (phys == 0 || size == 0 || !out_virt) {
         return -1;
     }

--- a/core/platform/boards/qemu-virt-arm64/machine_display.c
+++ b/core/platform/boards/qemu-virt-arm64/machine_display.c
@@ -110,7 +110,7 @@ static void virt_scan_pci_ecam_for_vga(system_discovery_t *discovery) {
     hal_serial_write("\n");
 
     uintptr_t virt_ecam = 0;
-    if (qemu_display_map_mmio(phys_ecam, scan_ecam_size, &virt_ecam) != 0) {
+    if (bh_display_map_mmio(phys_ecam, scan_ecam_size, &virt_ecam) != 0) {
         hal_serial_write("BHARAT_DISPLAY:FAIL=ECAM_MAP\n");
         return;
     }
@@ -223,7 +223,7 @@ static void virt_scan_pci_ecam_for_vga(system_discovery_t *discovery) {
 
                     // Map control BAR
                     uintptr_t virt_mmio = 0;
-                    if (qemu_display_map_mmio(mmio_phys, size2, &virt_mmio) != 0) {
+                    if (bh_display_map_mmio(mmio_phys, size2, &virt_mmio) != 0) {
                         hal_serial_write("BHARAT_DISPLAY:FAIL=CTRL_MAP\n");
                         return;
                     }
@@ -241,7 +241,7 @@ static void virt_scan_pci_ecam_for_vga(system_discovery_t *discovery) {
 
                     // Map Framebuffer BAR
                     uintptr_t virt_fb = 0;
-                    if (qemu_display_map_mmio(fb_phys, size0, &virt_fb) != 0) {
+                    if (bh_display_map_mmio(fb_phys, size0, &virt_fb) != 0) {
                         hal_serial_write("BHARAT_DISPLAY:FAIL=FB_MAP\n");
                         return;
                     }

--- a/core/platform/boards/qemu-virt-riscv64/machine_display.c
+++ b/core/platform/boards/qemu-virt-riscv64/machine_display.c
@@ -61,7 +61,7 @@ static void virt_scan_pci_ecam_for_vga(system_discovery_t *discovery) {
     hal_serial_write("\n");
 
     uintptr_t virt_ecam = 0;
-    if (qemu_display_map_mmio(phys_ecam, ecam_size, &virt_ecam) != 0) {
+    if (bh_display_map_mmio(phys_ecam, ecam_size, &virt_ecam) != 0) {
         hal_serial_write("BHARAT_DISPLAY:FAIL=ECAM_MAP\n");
         return;
     }
@@ -170,7 +170,7 @@ static void virt_scan_pci_ecam_for_vga(system_discovery_t *discovery) {
 
                     // Map control BAR
                     uintptr_t virt_mmio = 0;
-                    if (qemu_display_map_mmio(mmio_phys, size2, &virt_mmio) != 0) {
+                    if (bh_display_map_mmio(mmio_phys, size2, &virt_mmio) != 0) {
                         hal_serial_write("BHARAT_DISPLAY:FAIL=CTRL_MAP\n");
                         return;
                     }
@@ -188,7 +188,7 @@ static void virt_scan_pci_ecam_for_vga(system_discovery_t *discovery) {
 
                     // Map Framebuffer BAR
                     uintptr_t virt_fb = 0;
-                    if (qemu_display_map_mmio(fb_phys, size0, &virt_fb) != 0) {
+                    if (bh_display_map_mmio(fb_phys, size0, &virt_fb) != 0) {
                         hal_serial_write("BHARAT_DISPLAY:FAIL=FB_MAP\n");
                         return;
                     }

--- a/docs/architecture/placement.md
+++ b/docs/architecture/placement.md
@@ -2,7 +2,7 @@
 title: Architecture Placement Contract
 status: Proposed
 owner: Documentation Working Group
-last_updated: 2026-04-25
+last_updated: 2026-08-12
 tags:
   - docs
   - architecture
@@ -52,3 +52,8 @@ The codebase includes an automated lint script to catch obvious boundary violati
 ```bash
 python3 tools/lint/check_placement.py
 ```
+
+The linter evaluates the canonical `core/kernel/` and `core/services/` trees.
+Moving a source file to a legacy repository-root `kernel/` or `services/` path does
+not make that path a supported layer; the canonical `core/` layout is the only
+placement authority.

--- a/interface/include/bharat/display/display_caps.h
+++ b/interface/include/bharat/display/display_caps.h
@@ -48,7 +48,7 @@ typedef struct display_probe_result {
 int machine_get_display_caps(machine_display_caps_t *out);
 int machine_probe_boot_video(display_probe_result_t *out, boot_video_handoff_t *video);
 
-// QEMU Display MMIO mapping helper
-int qemu_display_map_mmio(uint64_t phys, size_t size, uintptr_t *out_virt);
+// Architecture-neutral early display MMIO mapping helper.
+int bh_display_map_mmio(uint64_t phys, size_t size, uintptr_t *out_virt);
 
 #endif // BHARAT_DISPLAY_CAPS_H

--- a/tools/lint/check_placement.py
+++ b/tools/lint/check_placement.py
@@ -3,8 +3,8 @@
 Bharat-OS Architecture Placement Linter
 
 This script enforces basic architectural boundaries:
-1. No emulator/runner logic inside `kernel/` (e.g. qemu, renode).
-2. No hardware drivers inside `services/`.
+1. No emulator/runner logic inside `core/kernel/` (e.g. qemu, renode).
+2. No hardware drivers inside `core/services/`.
 3. No arch-specific code hidden under generic `hal/` (except inside designated subdirs).
 """
 
@@ -48,8 +48,8 @@ def main():
     memops_excluded = {"tools", "docs", "build", ".git"}
 
     # Pre-calculate kernel and services paths for fast prefix checking
-    kernel_dir = os.path.join(REPO_ROOT, "kernel")
-    services_dir = os.path.join(REPO_ROOT, "services")
+    kernel_dir = os.path.join(REPO_ROOT, "core", "kernel")
+    services_dir = os.path.join(REPO_ROOT, "core", "services")
 
     for root, _, files in os.walk(REPO_ROOT):
         parts = set(root.split(os.sep))

--- a/tools/lint/tests/test_check_placement.py
+++ b/tools/lint/tests/test_check_placement.py
@@ -13,8 +13,8 @@ class TestCheckPlacement(unittest.TestCase):
         self.temp_dir = tempfile.mkdtemp()
 
         # Create minimal directory structure mocking the repo
-        self.kernel_dir = os.path.join(self.temp_dir, "kernel")
-        self.services_dir = os.path.join(self.temp_dir, "services")
+        self.kernel_dir = os.path.join(self.temp_dir, "core", "kernel")
+        self.services_dir = os.path.join(self.temp_dir, "core", "services")
         self.tools_dir = os.path.join(self.temp_dir, "tools")
         self.my_tools_dir = os.path.join(self.temp_dir, "my_tools_component")
 


### PR DESCRIPTION
### Motivation
- The placement linter was scanning legacy repo-root `kernel`/`services` paths and therefore missed canonical locations under `core/`, allowing placement violations to be unnoticed. 
- Emulator-branded identifiers and user-visible strings leaked into kernel interfaces and platform code and risked conflating platform/test helpers with architecture-neutral mechanism APIs. 
- Update the placement enforcement, tests, and documentation so CI/linters reflect the repository's canonical layout and fail-closed on violations. 

### Description
- Changed the placement linter to scan `core/kernel/` and `core/services/` as the authoritative paths by updating `tools/lint/check_placement.py` to use `os.path.join(REPO_ROOT, "core", "kernel")` and `os.path.join(REPO_ROOT, "core", "services")`. 
- Updated regression fixtures in `tools/lint/tests/test_check_placement.py` to exercise the canonical `core/` layout. 
- Renamed the display MMIO mapping helper from the emulator-specific `qemu_display_map_mmio` to the architecture-neutral `bh_display_map_mmio` and updated the declaration in `interface/include/bharat/display/display_caps.h` plus usages in `core/kernel/src/display/boot_video_map.c` and platform boards `core/platform/boards/*/machine_display.c`. 
- Neutralized kernel GUI strings that referenced emulator platforms by replacing QEMU-specific labels with generic architecture/platform strings, and added a short placement-note to `docs/architecture/placement.md` documenting the canonical `core/` authority. 

### Testing
- ✅ `python3 -m unittest tools.lint.tests.test_check_placement` ran the updated placement unit tests and passed. 
- ✅ `python3 tools/lint/check_placement.py` executed the linter across the tree and reported zero new violations after the change. 
- ✅ Repository static gates `python3 tools/lint/check_layer_references.py` and `python3 tools/lint/check_cmake_dependencies.py` were executed and reported no violations. 
- ✅ Full five-target smoke builds and the QEMU matrix were executed (`./tools/build.sh all --target-yaml ... --smoke` for each required YAML and `python3 tools/run_qemu_matrix.py --headless --smoke --all-arch`) and all required architecture smoke runs passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7cc052be148320a2776e056bec9eee)