### PR TITLE
BHCF-P0-001: Add HMEM kernel object, HAL ops, UAPI and Tensor SDK foundation

### DIFF
--- a/core/hal/common/CMakeLists.txt
+++ b/core/hal/common/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(hal_common OBJECT
     ../common/discovery.c
     ../common/cpu_features.c
     ../common/hal_unsupported.c
+    hmem.c
     ../interrupt_common.c
     ../timer_common.c
     iommu_adapter.c

--- a/core/hal/common/hmem.c
+++ b/core/hal/common/hmem.c
@@ -1,0 +1,51 @@
+#include "hal/hal_hmem.h"
+
+/* Installed once during boot discovery; immutable afterwards on production
+ * systems. */
+static const hal_hmem_ops_t *hmem_ops;
+
+hal_hmem_status_t hal_hmem_install_ops(const hal_hmem_ops_t *ops) {
+  if (ops == NULL || ops->sync_range == NULL)
+    return HAL_HMEM_ERR_INVALID;
+  if (__atomic_load_n(&hmem_ops, __ATOMIC_ACQUIRE) != NULL)
+    return HAL_HMEM_ERR_ALREADY_EXISTS;
+  __atomic_store_n(&hmem_ops, ops, __ATOMIC_RELEASE);
+  return HAL_HMEM_OK;
+}
+
+hal_hmem_status_t hal_hmem_sync_range(uintptr_t addr, size_t length,
+                                      hal_hmem_sync_direction_t direction) {
+  const hal_hmem_ops_t *ops = __atomic_load_n(&hmem_ops, __ATOMIC_ACQUIRE);
+  if (length == 0U || direction > HAL_HMEM_SYNC_BIDIRECTIONAL)
+    return HAL_HMEM_ERR_INVALID;
+  if (ops == NULL) {
+    __atomic_thread_fence(__ATOMIC_SEQ_CST);
+    return HAL_HMEM_OK;
+  }
+  return ops->sync_range(addr, length, direction);
+}
+
+hal_hmem_status_t hal_hmem_map_device(const hal_hmem_device_map_req_t *req,
+                                      hal_hmem_device_map_result_t *out) {
+  const hal_hmem_ops_t *ops = __atomic_load_n(&hmem_ops, __ATOMIC_ACQUIRE);
+  if (req == NULL || out == NULL)
+    return HAL_HMEM_ERR_INVALID;
+  out->device_address = 0U;
+  return ops != NULL && ops->map_device != NULL ? ops->map_device(req, out)
+                                                : HAL_HMEM_ERR_UNSUPPORTED;
+}
+
+hal_hmem_status_t
+hal_hmem_unmap_device(const hal_hmem_device_unmap_req_t *req) {
+  const hal_hmem_ops_t *ops = __atomic_load_n(&hmem_ops, __ATOMIC_ACQUIRE);
+  if (req == NULL)
+    return HAL_HMEM_ERR_INVALID;
+  return ops != NULL && ops->unmap_device != NULL ? ops->unmap_device(req)
+                                                  : HAL_HMEM_ERR_UNSUPPORTED;
+}
+
+bool hal_hmem_is_cpu_device_coherent(bh_device_id_t device) {
+  const hal_hmem_ops_t *ops = __atomic_load_n(&hmem_ops, __ATOMIC_ACQUIRE);
+  return ops != NULL && ops->is_cpu_device_coherent != NULL &&
+         ops->is_cpu_device_coherent(device);
+}

--- a/core/hal/include/hal/hal_hmem.h
+++ b/core/hal/include/hal/hal_hmem.h
@@ -1,0 +1,55 @@
+#ifndef BHARAT_HAL_HMEM_H
+#define BHARAT_HAL_HMEM_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+typedef uint64_t bh_device_id_t;
+typedef int32_t hal_hmem_status_t;
+
+#define HAL_HMEM_OK INT32_C(0)
+#define HAL_HMEM_ERR_INVALID INT32_C(-1)
+#define HAL_HMEM_ERR_ALREADY_EXISTS INT32_C(-4)
+#define HAL_HMEM_ERR_UNSUPPORTED INT32_C(-5)
+
+typedef enum hal_hmem_sync_direction {
+  HAL_HMEM_SYNC_TO_CPU = 0,
+  HAL_HMEM_SYNC_TO_DEVICE = 1,
+  HAL_HMEM_SYNC_BIDIRECTIONAL = 2,
+} hal_hmem_sync_direction_t;
+
+typedef struct hal_hmem_device_map_req {
+  bh_device_id_t device;
+  uintptr_t cpu_address;
+  uint64_t length;
+  uint32_t access;
+  uint32_t reserved;
+} hal_hmem_device_map_req_t;
+
+typedef struct hal_hmem_device_map_result {
+  uint64_t device_address;
+} hal_hmem_device_map_result_t;
+typedef struct hal_hmem_device_unmap_req {
+  bh_device_id_t device;
+  uint64_t device_address;
+  uint64_t length;
+} hal_hmem_device_unmap_req_t;
+
+typedef struct hal_hmem_ops {
+  hal_hmem_status_t (*sync_range)(uintptr_t, size_t, hal_hmem_sync_direction_t);
+  hal_hmem_status_t (*map_device)(const hal_hmem_device_map_req_t *,
+                                  hal_hmem_device_map_result_t *);
+  hal_hmem_status_t (*unmap_device)(const hal_hmem_device_unmap_req_t *);
+  bool (*is_cpu_device_coherent)(bh_device_id_t);
+} hal_hmem_ops_t;
+
+hal_hmem_status_t hal_hmem_install_ops(const hal_hmem_ops_t *ops);
+hal_hmem_status_t hal_hmem_sync_range(uintptr_t addr, size_t length,
+                                      hal_hmem_sync_direction_t direction);
+hal_hmem_status_t hal_hmem_map_device(const hal_hmem_device_map_req_t *req,
+                                      hal_hmem_device_map_result_t *out);
+hal_hmem_status_t hal_hmem_unmap_device(const hal_hmem_device_unmap_req_t *req);
+bool hal_hmem_is_cpu_device_coherent(bh_device_id_t device);
+
+#endif

--- a/core/kernel/CMakeLists.txt
+++ b/core/kernel/CMakeLists.txt
@@ -42,6 +42,7 @@ target_include_directories(bharat_kernel_includes INTERFACE
     ${CMAKE_SOURCE_DIR}/core/personalities/runtime/include
     ${BHARAT_HAL_ROOT}/include
     ${CMAKE_SOURCE_DIR}/interface/include
+    ${CMAKE_SOURCE_DIR}/interface/uapi
     ${BHARAT_LIB_ROOT}/include
     ${BHARAT_BOOT_INCLUDE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/src
@@ -323,6 +324,7 @@ target_compile_options(bharat_mm_iommu PRIVATE $<$<COMPILE_LANGUAGE:C>:-ffreesta
 
 # Accelerator Memory Support
 add_library(bharat_mm_accel OBJECT
+    src/mm/hmem.c
     src/mm/accel/accel_mem.c
     src/mm/accel/accel_sg.c
     src/mm/accel/accel_iova.c
@@ -509,6 +511,7 @@ set(KERNEL_SRCS
 
     ${ARCH_EXT_STATE_SRC}
     ${BHARAT_HAL_ROOT}/common/hal_mem_backend.c
+    ${BHARAT_HAL_ROOT}/common/hmem.c
     ${BHARAT_HAL_ROOT}/common/cpu_features.c
     ${BHARAT_HAL_ROOT}/common/iommu_adapter.c
     ${BHARAT_HAL_ROOT}/common/hal_dma_coherency.c

--- a/core/kernel/include/capability.h
+++ b/core/kernel/include/capability.h
@@ -61,6 +61,7 @@ typedef enum {
     CAP_TYPE_DMA_DOMAIN = 19,
     CAP_TYPE_DMA_GRANT = 20,
     CAP_TYPE_THREAD = 21,
+    CAP_TYPE_HMEM = 22,
 } cap_type_t;
 
 typedef uint64_t cap_rights_mask_t;

--- a/core/kernel/include/mm/hmem.h
+++ b/core/kernel/include/mm/hmem.h
@@ -1,0 +1,34 @@
+#ifndef BHARAT_MM_HMEM_H
+#define BHARAT_MM_HMEM_H
+
+#include "hal/hal_hmem.h"
+#include "kernel/status.h"
+#include <bharat/memory/hmem.h>
+#include <stdint.h>
+
+#define BH_HMEM_MAX_DEVICE_MAPPINGS 4U
+
+typedef enum bh_hmem_state {
+  BH_HMEM_LIVE = 0,
+  BH_HMEM_DYING = 1,
+  BH_HMEM_DEAD = 2
+} bh_hmem_state_t;
+
+kstatus_t bh_hmem_create(const bharat_hmem_desc_v1_t *desc, uint64_t rights,
+                         bharat_hmem_handle_t *out);
+kstatus_t bh_hmem_destroy(bharat_hmem_handle_t handle);
+kstatus_t bh_hmem_get_info(bharat_hmem_handle_t handle,
+                           bharat_hmem_info_v1_t *out);
+kstatus_t bh_hmem_map_cpu(bharat_hmem_handle_t handle, uint32_t access,
+                          uintptr_t *out_addr);
+kstatus_t bh_hmem_unmap_cpu(bharat_hmem_handle_t handle);
+kstatus_t bh_hmem_sync_for_cpu(bharat_hmem_handle_t handle, uint64_t offset,
+                               uint64_t length);
+kstatus_t bh_hmem_sync_for_device(bharat_hmem_handle_t handle, uint64_t offset,
+                                  uint64_t length);
+kstatus_t bh_hmem_map_device(bharat_hmem_handle_t handle, bh_device_id_t device,
+                             uint32_t access, uint64_t *device_addr);
+kstatus_t bh_hmem_unmap_device(bharat_hmem_handle_t handle,
+                               bh_device_id_t device);
+
+#endif

--- a/core/kernel/src/mm/hmem.c
+++ b/core/kernel/src/mm/hmem.c
@@ -1,0 +1,334 @@
+#include "mm/hmem.h"
+#include "lib/base/string.h"
+#include "slab.h"
+#include "spinlock.h"
+
+#define HMEM_SLOT_COUNT 64U
+
+typedef struct bh_hmem_device_mapping {
+  bh_device_id_t device;
+  uint64_t device_address;
+  uint64_t visible_generation;
+  uint32_t access;
+  uint32_t flags;
+} bh_hmem_device_mapping_t;
+
+typedef struct bh_hmem {
+  uint64_t object_id;
+  uint32_t generation;
+  uint32_t slot;
+  uint64_t size;
+  uint64_t alignment;
+  uint64_t usage_flags;
+  uint64_t property_flags;
+  uint64_t rights;
+  uint32_t preferred_domain;
+  uint32_t cpu_map_count;
+  void *cpu_va;
+  uint64_t content_generation;
+  bh_hmem_state_t state;
+  spinlock_t lock;
+  bh_hmem_device_mapping_t mappings[BH_HMEM_MAX_DEVICE_MAPPINGS];
+} bh_hmem_t;
+
+/* Transitional lock-protected shared registry. Slots are bounded; a later
+ * per-core object registry migration must preserve the generation-bearing
+ * handle contract. */
+static bh_hmem_t *hmem_slots[HMEM_SLOT_COUNT];
+static uint32_t hmem_generations[HMEM_SLOT_COUNT];
+static spinlock_t hmem_registry_lock;
+static uint64_t hmem_next_object_id = 1U;
+
+static bool power_of_two(uint64_t value) {
+  return value != 0U && (value & (value - 1U)) == 0U;
+}
+static bharat_hmem_handle_t make_handle(uint32_t slot, uint32_t generation) {
+  return ((uint64_t)generation << 32) | (uint64_t)(slot + 1U);
+}
+
+static kstatus_t lookup_locked(bharat_hmem_handle_t handle, bh_hmem_t **out) {
+  uint32_t encoded_slot = (uint32_t)handle;
+  uint32_t generation = (uint32_t)(handle >> 32);
+  if (encoded_slot == 0U || encoded_slot > HMEM_SLOT_COUNT || generation == 0U)
+    return K_ERR_CAP_INVALID;
+  bh_hmem_t *object = hmem_slots[encoded_slot - 1U];
+  if (object == NULL)
+    return hmem_generations[encoded_slot - 1U] == generation ? K_ERR_NOT_FOUND
+                                                             : K_ERR_CAP_STALE;
+  if (object->generation != generation)
+    return K_ERR_CAP_STALE;
+  if (object->state != BH_HMEM_LIVE)
+    return K_ERR_BAD_STATE;
+  *out = object;
+  return K_OK;
+}
+
+static kstatus_t validate_desc(const bharat_hmem_desc_v1_t *desc) {
+  uint32_t i;
+  if (desc == NULL || desc->version != BH_HMEM_DESC_VERSION_1 ||
+      desc->struct_size != sizeof(*desc) || desc->size == 0U)
+    return K_ERR_INVALID_ARG;
+  if (!power_of_two(desc->alignment) || desc->alignment < sizeof(void *) ||
+      desc->alignment > (uint64_t)(size_t)-1)
+    return K_ERR_ALIGNMENT;
+  if (desc->size > (uint64_t)(size_t)-1 ||
+      desc->size > (uint64_t)(size_t)-1 - desc->alignment - sizeof(void *))
+    return K_ERR_OVERFLOW;
+  if ((desc->usage_flags & ~BH_HMEM_USAGE_ALL) != 0U ||
+      (desc->property_flags & ~BH_HMEM_PROP_ALL) != 0U ||
+      desc->preferred_domain > BH_HMEM_DOMAIN_SECURE || desc->reserved0 != 0U)
+    return K_ERR_INVALID_ARG;
+  for (i = 0U; i < 4U; ++i)
+    if (desc->reserved[i] != 0U)
+      return K_ERR_INVALID_ARG;
+  if (desc->preferred_domain != BH_HMEM_DOMAIN_SYSTEM &&
+      desc->preferred_domain != BH_HMEM_DOMAIN_SHARED)
+    return K_ERR_UNSUPPORTED;
+  return K_OK;
+}
+
+kstatus_t bh_hmem_create(const bharat_hmem_desc_v1_t *desc, uint64_t rights,
+                         bharat_hmem_handle_t *out) {
+  bh_hmem_t *object;
+  uint32_t slot;
+  kstatus_t status = validate_desc(desc);
+  if (status != K_OK || out == NULL)
+    return status != K_OK ? status : K_ERR_INVALID_ARG;
+  object = kmem_aligned_alloc(desc->alignment, sizeof(*object));
+  if (object == NULL)
+    return K_ERR_NO_MEMORY;
+  memset(object, 0, sizeof(*object));
+  object->cpu_va = kmem_aligned_alloc(desc->alignment, (size_t)desc->size);
+  if (object->cpu_va == NULL) {
+    kmem_aligned_free(object);
+    return K_ERR_NO_MEMORY;
+  }
+  if ((desc->property_flags & BH_HMEM_PROP_ZERO_ON_ALLOC) != 0U)
+    memset(object->cpu_va, 0, (size_t)desc->size);
+  spin_lock_init(&object->lock);
+  object->size = desc->size;
+  object->alignment = desc->alignment;
+  object->usage_flags = desc->usage_flags;
+  object->property_flags = desc->property_flags;
+  object->preferred_domain = desc->preferred_domain;
+  object->rights = rights;
+  object->content_generation = 1U;
+  object->state = BH_HMEM_LIVE;
+  spin_lock(&hmem_registry_lock);
+  for (slot = 0U; slot < HMEM_SLOT_COUNT && hmem_slots[slot] != NULL; ++slot) {
+  }
+  if (slot == HMEM_SLOT_COUNT) {
+    spin_unlock(&hmem_registry_lock);
+    kmem_aligned_free(object->cpu_va);
+    kmem_aligned_free(object);
+    return K_ERR_NO_RESOURCES;
+  }
+  if (++hmem_generations[slot] == 0U)
+    ++hmem_generations[slot];
+  object->slot = slot;
+  object->generation = hmem_generations[slot];
+  object->object_id = hmem_next_object_id++;
+  hmem_slots[slot] = object;
+  *out = make_handle(slot, object->generation);
+  spin_unlock(&hmem_registry_lock);
+  return K_OK;
+}
+
+kstatus_t bh_hmem_destroy(bharat_hmem_handle_t handle) {
+  bh_hmem_t *object;
+  kstatus_t status;
+  spin_lock(&hmem_registry_lock);
+  status = lookup_locked(handle, &object);
+  if (status != K_OK) {
+    spin_unlock(&hmem_registry_lock);
+    return status;
+  }
+  spin_lock(&object->lock);
+  if (object->cpu_map_count != 0U) {
+    spin_unlock(&object->lock);
+    spin_unlock(&hmem_registry_lock);
+    return K_ERR_BUSY;
+  }
+  for (uint32_t i = 0U; i < BH_HMEM_MAX_DEVICE_MAPPINGS; ++i)
+    if (object->mappings[i].flags != 0U) {
+      spin_unlock(&object->lock);
+      spin_unlock(&hmem_registry_lock);
+      return K_ERR_BUSY;
+    }
+  object->state = BH_HMEM_DYING;
+  hmem_slots[object->slot] = NULL;
+  spin_unlock(&object->lock);
+  spin_unlock(&hmem_registry_lock);
+  if ((object->property_flags & BH_HMEM_PROP_ZERO_ON_FREE) != 0U)
+    secure_memzero(object->cpu_va, (size_t)object->size);
+  object->state = BH_HMEM_DEAD;
+  kmem_aligned_free(object->cpu_va);
+  kmem_aligned_free(object);
+  return K_OK;
+}
+
+kstatus_t bh_hmem_get_info(bharat_hmem_handle_t handle,
+                           bharat_hmem_info_v1_t *out) {
+  bh_hmem_t *o;
+  kstatus_t s;
+  if (out == NULL)
+    return K_ERR_INVALID_ARG;
+  spin_lock(&hmem_registry_lock);
+  s = lookup_locked(handle, &o);
+  if (s == K_OK) {
+    memset(out, 0, sizeof(*out));
+    out->version = 1U;
+    out->struct_size = sizeof(*out);
+    out->size = o->size;
+    out->alignment = o->alignment;
+    out->usage_flags = o->usage_flags;
+    out->property_flags = o->property_flags;
+    out->content_generation = o->content_generation;
+    out->preferred_domain = o->preferred_domain;
+    out->cpu_map_count = o->cpu_map_count;
+  }
+  spin_unlock(&hmem_registry_lock);
+  return s;
+}
+
+kstatus_t bh_hmem_map_cpu(bharat_hmem_handle_t handle, uint32_t access,
+                          uintptr_t *out_addr) {
+  bh_hmem_t *o;
+  kstatus_t s;
+  if (out_addr == NULL || access == 0U ||
+      (access & ~(BH_HMEM_ACCESS_READ | BH_HMEM_ACCESS_WRITE |
+                  BH_HMEM_ACCESS_EXECUTE)) != 0U)
+    return K_ERR_INVALID_ARG;
+  spin_lock(&hmem_registry_lock);
+  s = lookup_locked(handle, &o);
+  if (s == K_OK) {
+    if ((o->rights & BH_HMEM_RIGHT_MAP_CPU) == 0U ||
+        ((access & BH_HMEM_ACCESS_READ) != 0U &&
+         (o->rights & BH_HMEM_RIGHT_READ) == 0U) ||
+        ((access & BH_HMEM_ACCESS_WRITE) != 0U &&
+         (o->rights & BH_HMEM_RIGHT_WRITE) == 0U))
+      s = K_ERR_CAP_DENIED;
+    else {
+      spin_lock(&o->lock);
+      if (o->cpu_map_count != 0U)
+        s = K_ERR_BUSY;
+      else {
+        o->cpu_map_count = 1U;
+        *out_addr = (uintptr_t)o->cpu_va;
+      }
+      spin_unlock(&o->lock);
+    }
+  }
+  spin_unlock(&hmem_registry_lock);
+  return s;
+}
+
+kstatus_t bh_hmem_unmap_cpu(bharat_hmem_handle_t handle) {
+  bh_hmem_t *o;
+  kstatus_t s;
+  spin_lock(&hmem_registry_lock);
+  s = lookup_locked(handle, &o);
+  if (s == K_OK) {
+    spin_lock(&o->lock);
+    if (o->cpu_map_count == 0U)
+      s = K_ERR_BAD_STATE;
+    else {
+      o->cpu_map_count = 0U;
+      o->content_generation++;
+    }
+    spin_unlock(&o->lock);
+  }
+  spin_unlock(&hmem_registry_lock);
+  return s;
+}
+
+static kstatus_t sync_range(bharat_hmem_handle_t h, uint64_t off, uint64_t len,
+                            hal_hmem_sync_direction_t dir) {
+  bh_hmem_t *o;
+  kstatus_t s;
+  spin_lock(&hmem_registry_lock);
+  s = lookup_locked(h, &o);
+  if (s == K_OK) {
+    if (len == 0U || off > o->size || len > o->size - off)
+      s = K_ERR_INVALID_ARG;
+    else if ((dir == HAL_HMEM_SYNC_TO_CPU &&
+              (o->rights & BH_HMEM_RIGHT_READ) == 0U) ||
+             (dir == HAL_HMEM_SYNC_TO_DEVICE &&
+              (o->rights & BH_HMEM_RIGHT_WRITE) == 0U))
+      s = K_ERR_CAP_DENIED;
+    else if ((o->property_flags & BH_HMEM_PROP_CPU_COHERENT) != 0U) {
+      __atomic_thread_fence(__ATOMIC_SEQ_CST);
+      s = K_OK;
+    } else
+      s = hal_hmem_sync_range((uintptr_t)o->cpu_va + (uintptr_t)off,
+                              (size_t)len, dir);
+  }
+  spin_unlock(&hmem_registry_lock);
+  return s;
+}
+kstatus_t bh_hmem_sync_for_cpu(bharat_hmem_handle_t h, uint64_t o, uint64_t l) {
+  return sync_range(h, o, l, HAL_HMEM_SYNC_TO_CPU);
+}
+kstatus_t bh_hmem_sync_for_device(bharat_hmem_handle_t h, uint64_t o,
+                                  uint64_t l) {
+  return sync_range(h, o, l, HAL_HMEM_SYNC_TO_DEVICE);
+}
+
+kstatus_t bh_hmem_map_device(bharat_hmem_handle_t h, bh_device_id_t d,
+                             uint32_t a, uint64_t *out) {
+  bh_hmem_t *o;
+  kstatus_t s;
+  if (out == NULL)
+    return K_ERR_INVALID_ARG;
+  spin_lock(&hmem_registry_lock);
+  s = lookup_locked(h, &o);
+  if (s == K_OK) {
+    if ((o->rights & BH_HMEM_RIGHT_MAP_DEVICE) == 0U)
+      s = K_ERR_CAP_DENIED;
+    else {
+      hal_hmem_device_map_req_t r = {d, (uintptr_t)o->cpu_va, o->size, a, 0U};
+      hal_hmem_device_map_result_t x;
+      s = hal_hmem_map_device(&r, &x);
+      if (s == K_OK) {
+        uint32_t i;
+        for (i = 0;
+             i < BH_HMEM_MAX_DEVICE_MAPPINGS && o->mappings[i].flags != 0U;
+             i++) {
+        }
+        if (i == BH_HMEM_MAX_DEVICE_MAPPINGS)
+          s = K_ERR_NO_RESOURCES;
+        else {
+          o->mappings[i] = (bh_hmem_device_mapping_t){
+              d, x.device_address, o->content_generation, a, 1U};
+          *out = x.device_address;
+        }
+      }
+    }
+  }
+  spin_unlock(&hmem_registry_lock);
+  return s;
+}
+kstatus_t bh_hmem_unmap_device(bharat_hmem_handle_t h, bh_device_id_t d) {
+  bh_hmem_t *o;
+  kstatus_t s;
+  spin_lock(&hmem_registry_lock);
+  s = lookup_locked(h, &o);
+  if (s == K_OK) {
+    uint32_t i;
+    for (i = 0; i < BH_HMEM_MAX_DEVICE_MAPPINGS &&
+                (o->mappings[i].flags == 0U || o->mappings[i].device != d);
+         i++) {
+    }
+    if (i == BH_HMEM_MAX_DEVICE_MAPPINGS)
+      s = K_ERR_NOT_FOUND;
+    else {
+      hal_hmem_device_unmap_req_t r = {d, o->mappings[i].device_address,
+                                       o->size};
+      s = hal_hmem_unmap_device(&r);
+      if (s == K_OK)
+        memset(&o->mappings[i], 0, sizeof(o->mappings[i]));
+    }
+  }
+  spin_unlock(&hmem_registry_lock);
+  return s;
+}

--- a/docs/adr/ADR-024-hmem-tensor-boundary.md
+++ b/docs/adr/ADR-024-hmem-tensor-boundary.md
@@ -1,0 +1,14 @@
+# ADR-024: HMEM kernel mechanism and tensor SDK boundary
+
+- Status: Accepted
+- Date: 2026-08-12
+
+## Decision
+
+Bharat-OS defines HMEM as a capability-scoped kernel memory object with a fixed-width Native UAPI descriptor and opaque generation-bearing handle. Cache synchronization and device mapping are semantic HAL operations; ISA mechanics stay in architecture backends. Tensor metadata and ownership remain exclusively in the SDK/runtime.
+
+P0 supports aligned CPU-backed SYSTEM/SHARED memory, bounded CPU/device mapping metadata, and truthful unsupported device mapping. It does not add compute queues, fences, placement, graph operations, or accelerator scheduling.
+
+## Consequences
+
+The same memory primitive can serve compute and non-compute consumers. HAL never authorizes capabilities. Device-local and noncoherent support cannot be claimed until discovery selects a safe backend. The transitional bounded registry must move to the canonical owner-local object/CSpace registry before distributed device mapping, without changing UAPI layout or stale-generation behavior.

--- a/docs/architecture/CONTRACTS.md
+++ b/docs/architecture/CONTRACTS.md
@@ -55,3 +55,10 @@ Every contract entry should identify:
 ## Update rule
 
 Any PR changing an external interface, wire layout, public kernel API, ownership protocol, capability requirement, memory backend behavior, target definition, or required validation gate must update this index and the underlying authority/ADR in the same change.
+
+## BHCF heterogeneous memory and tensor contracts
+
+- Native HMEM ABI authority: `interface/uapi/bharat/memory/hmem.h`.
+- Kernel/HAL lifecycle and coherency contract: `docs/architecture/compute/BHCF-001-heterogeneous-memory.md`.
+- Tensor SDK semantic contract: `docs/architecture/compute/BHCF-002-tensor-sdk.md`.
+- Boundary decision: `docs/adr/ADR-024-hmem-tensor-boundary.md`.

--- a/docs/architecture/compute/BHCF-001-heterogeneous-memory.md
+++ b/docs/architecture/compute/BHCF-001-heterogeneous-memory.md
@@ -1,0 +1,66 @@
+---
+title: BHCF-001 Heterogeneous Memory
+status: Experimental P0
+owner: Kernel Memory and Compute Teams
+last_updated: 2026-08-12
+---
+# BHCF-001: Heterogeneous Memory
+
+HMEM is Bharat-OS's capability-scoped, device-neutral memory mechanism. It is not AI memory: media buffers, packet storage, DMA payloads, sensor frames, and tensors can all refer to the same object model. The ABI authority is `interface/uapi/bharat/memory/hmem.h`; its fixed-width handle never exposes a kernel pointer, physical address, page, or IOVA.
+
+```text
+Tensor / Media / Network / AI runtime
+                 │
+                 ▼
+                HMEM
+                 │
+       ┌─────────┼─────────┐
+       │         │         │
+      CPU       GPU       NPU
+       │         │         │
+       └─────────┼─────────┘
+                 │
+            HAL / drivers
+                 │
+        cache / DMA / IOMMU
+```
+
+## Responsibility and lifecycle
+
+The kernel validates descriptors, owns CPU backing storage, bounds ranges, enforces rights, tracks content generations and bounded mappings, and implements `LIVE → DYING → DEAD`. The current bounded registry is a documented lock-protected migration exception; handles carry slot generations and stale handles fail closed. Destruction rejects mapped objects, publishes `DYING` before releasing storage, and wipes storage when `ZERO_ON_FREE` is requested. There is no remote wait or cross-core message in P0.
+
+HAL accepts already-authorized semantic sync/map requests. It performs no capability checks. Boot discovery may install one immutable backend operations table; absent device mapping returns `K_ERR_UNSUPPORTED` and never invents an address. The common coherent sync path is an ordering barrier. ISA cache mechanics remain below HAL; P0 emits no unqualified ARM or RISC-V cache instruction and therefore remains safe on MMU, MMU-Lite, and MPU targets.
+
+## Rights and mapping
+
+HMEM defines independent read, write, CPU-map, device-map, share, derive, pin, and migrate rights. Derivation must only attenuate these rights. CPU mapping checks requested access and permits one mapping in P0; double map, double unmap, mapping after destruction, and destruction while mapped fail closed. A four-entry device mapping table is deliberately bounded. Each entry records device identity, device address returned by a registered backend, access, and visible content generation.
+
+Usage flags express caller intent; property flags express requested/established memory behavior. They are not hardware discovery. P0 supports CPU-backed SYSTEM and SHARED domains. DEVICE_LOCAL, PERSISTENT, and SECURE allocations return unsupported until a truthful allocator exists.
+
+## Coherency and errors
+
+Every sync range uses subtraction-based bounds checks so `offset + length` cannot wrap. Coherent memory uses a barrier fast path. Noncoherent memory routes to `hal_hmem_sync_range`; an installed architecture/driver backend must provide the maintenance. Invalid descriptors, permissions, stale generations, busy mappings, overflow, and absent backends retain distinct canonical errors.
+
+Future IOMMU work will make device mappings owner-local transactions with rollback and quarantine on unsafe partial failure. Peer DMA and migration will require explicit visibility generations, acknowledgements, bounded retries, and no object lock held across remote completion.
+
+## Security
+
+Users cannot supply a physical address, IOVA, page pointer, kernel VA, or MMIO address. Authorization occurs above HAL. Unsupported domains and mappings fail closed. Execute access requires explicit usage and rights. Reserved ABI fields must be zero.
+
+## Roadmap (documentation only)
+
+```text
+BHCF-P0-001   HMEM + Tensor SDK           ← this task
+BHCF-P0-002   ENGINE object
+BHCF-P0-003   FENCE/timeline primitive
+BHCF-P0-004   asynchronous compute queue
+BHCF-P1-001   IOMMU/device mapping
+BHCF-P1-002   DMA/copy engine
+BHCF-P1-003   Virtual NPU HMEM integration
+BHCF-P1-004   accelmgr placement service
+BHCF-P2-001   real GPU/NPU provider
+BHCF-P2-002   tensor graph runtime
+BHCF-P2-003   heterogeneous memory migration
+BHCF-P3-001   KV-cache service
+BHCF-P3-002   deadline/energy-aware accelerator QoS
+```

--- a/docs/architecture/compute/BHCF-002-tensor-sdk.md
+++ b/docs/architecture/compute/BHCF-002-tensor-sdk.md
@@ -1,0 +1,17 @@
+---
+title: BHCF-002 Tensor SDK
+status: Experimental P0
+owner: SDK and Compute Runtime Teams
+last_updated: 2026-08-12
+---
+# BHCF-002: Tensor SDK
+
+> Tensor is an SDK/runtime semantic object. HMEM is the kernel memory mechanism.
+
+`bh_tensor_t` is public metadata: an opaque HMEM handle, dtype, rank (maximum eight), shape, byte strides, byte range, layout, and ownership flags. It contains no kernel, HAL, driver, physical, GPU, or NPU pointer. F32/F16/BF16, signed I8/I16/I32, U8, and BOOL have explicitly defined element widths.
+
+Rank zero is a scalar with one element. All non-scalar dimensions must be nonzero. Validation uses checked multiplication, validates dense or explicit byte strides, checks range addition for overflow, queries HMEM size, and rejects a range outside that object. Dense tensors receive canonical row-major byte strides. Strided tensors permit non-contiguous storage but no stride smaller than one element.
+
+An owning tensor creates and destroys its HMEM. A view shares the parent's handle, changes only shape/stride/range, and never destroys storage. Applications must keep the owning tensor alive for every view; P0 deliberately does not introduce an unsafe implicit reference. Future runtime integration will adapt the existing tensor dispatcher and Virtual NPU backend to this representation rather than create another executor.
+
+Backend selection, graph operations, placement, queues, and scheduling remain runtime/service policy. A later compute queue can consume the same HMEM without changing tensor semantics.

--- a/docs/guides/heterogeneous-memory-and-tensor.md
+++ b/docs/guides/heterogeneous-memory-and-tensor.md
@@ -1,0 +1,34 @@
+# Heterogeneous memory and tensor quick start
+
+Link `Bharat::compute` (or `Bharat::sdk`) and include the public SDK headers:
+
+```c
+#include <bharat/compute/tensor.h>
+
+bh_tensor_desc_t desc = {
+    .dtype = BH_DTYPE_F32,
+    .rank = 2,
+    .shape = {64, 128},
+    .layout = BH_TENSOR_LAYOUT_DENSE,
+};
+bh_tensor_t tensor;
+bh_status_t st = bh_tensor_create(&desc, &tensor);
+if (st != BH_OK) {
+    /* handle error */
+}
+
+void *ptr = NULL;
+st = bh_hmem_map_cpu(tensor.memory, BH_HMEM_ACCESS_WRITE, &ptr);
+if (st == BH_OK) {
+    float *values = ptr;
+    values[0] = 1.0f;
+    st = bh_hmem_unmap_cpu(tensor.memory);
+}
+if (st == BH_OK) {
+    st = bh_hmem_sync_for_device(tensor.memory, 0, tensor.byte_length);
+}
+/* A future GPU/NPU/DPU queue consumes the same HMEM handle. */
+(void)bh_tensor_destroy(&tensor);
+```
+
+The hosted SDK backend allocates aligned CPU memory for tests and development. Zero-on-allocation is always requested by `bh_tensor_create`. Sync validates ranges and supplies ordering. It does not claim accelerator support or manufacture an IOVA. Views are non-owning, so destroy them before the owning tensor and never use a view after its owner is destroyed.

--- a/interface/sdk/CMakeLists.txt
+++ b/interface/sdk/CMakeLists.txt
@@ -11,6 +11,7 @@ set_target_properties(bharat_core PROPERTIES EXPORT_NAME core)
 target_compile_features(bharat_core PUBLIC c_std_11)
 target_include_directories(bharat_core PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../uapi>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 target_include_directories(bharat_core PRIVATE lib/internal)
 
@@ -35,11 +36,20 @@ foreach(component process ipc device cap)
     target_link_libraries(bharat_${component} PUBLIC bharat_core)
 endforeach()
 
+add_library(bharat_compute STATIC lib/memory/hmem.c lib/compute/tensor.c)
+add_library(Bharat::compute ALIAS bharat_compute)
+set_target_properties(bharat_compute PROPERTIES EXPORT_NAME compute)
+target_compile_features(bharat_compute PUBLIC c_std_11)
+target_include_directories(bharat_compute PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../uapi>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+
 add_library(bharat_sdk INTERFACE)
 add_library(Bharat::sdk ALIAS bharat_sdk)
 set_target_properties(bharat_sdk PROPERTIES EXPORT_NAME sdk)
 target_link_libraries(bharat_sdk INTERFACE
-    bharat_core bharat_process bharat_ipc bharat_device bharat_cap)
+    bharat_core bharat_process bharat_ipc bharat_device bharat_cap bharat_compute)
 
 if(BHARAT_SDK_BUILD_EXAMPLES)
     add_subdirectory(examples)
@@ -50,7 +60,8 @@ if(BHARAT_SDK_BUILD_TESTS)
 endif()
 
 install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-install(TARGETS bharat_core bharat_process bharat_ipc bharat_device bharat_cap bharat_sdk
+install(FILES ../uapi/bharat/memory/hmem.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/bharat/memory)
+install(TARGETS bharat_core bharat_process bharat_ipc bharat_device bharat_cap bharat_compute bharat_sdk
     EXPORT BharatSDKTargets ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 install(EXPORT BharatSDKTargets NAMESPACE Bharat:: DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/BharatSDK)
 include(CMakePackageConfigHelpers)

--- a/interface/sdk/include/bharat/compute/tensor.h
+++ b/interface/sdk/include/bharat/compute/tensor.h
@@ -1,0 +1,62 @@
+#ifndef BHARAT_SDK_COMPUTE_TENSOR_H
+#define BHARAT_SDK_COMPUTE_TENSOR_H
+
+#include <bharat/hmem.h>
+
+#define BH_TENSOR_MAX_RANK 8U
+#define BH_TENSOR_F_OWNS_MEMORY (UINT32_C(1) << 0)
+#define BH_TENSOR_F_VIEW (UINT32_C(1) << 1)
+
+typedef enum bh_dtype {
+  BH_DTYPE_INVALID = 0,
+  BH_DTYPE_F32,
+  BH_DTYPE_F16,
+  BH_DTYPE_BF16,
+  BH_DTYPE_I8,
+  BH_DTYPE_U8,
+  BH_DTYPE_I16,
+  BH_DTYPE_I32,
+  BH_DTYPE_BOOL
+} bh_dtype_t;
+typedef enum bh_tensor_layout {
+  BH_TENSOR_LAYOUT_DENSE = 0,
+  BH_TENSOR_LAYOUT_STRIDED = 1
+} bh_tensor_layout_t;
+
+typedef struct bh_tensor {
+  bharat_hmem_handle_t memory;
+  uint32_t rank;
+  uint32_t dtype;
+  uint64_t shape[BH_TENSOR_MAX_RANK];
+  uint64_t stride[BH_TENSOR_MAX_RANK];
+  uint64_t byte_offset;
+  uint64_t byte_length;
+  uint32_t layout;
+  uint32_t flags;
+} bh_tensor_t;
+
+typedef struct bh_tensor_desc {
+  uint32_t dtype;
+  uint32_t rank;
+  uint64_t shape[BH_TENSOR_MAX_RANK];
+  uint64_t stride[BH_TENSOR_MAX_RANK];
+  uint32_t layout;
+  uint32_t reserved;
+  uint64_t hmem_property_flags;
+} bh_tensor_desc_t;
+
+typedef struct bh_tensor_view_desc {
+  uint32_t rank;
+  uint32_t layout;
+  uint64_t shape[BH_TENSOR_MAX_RANK];
+  uint64_t stride[BH_TENSOR_MAX_RANK];
+  uint64_t byte_offset;
+} bh_tensor_view_desc_t;
+
+bh_status_t bh_tensor_validate(const bh_tensor_t *tensor);
+bh_status_t bh_tensor_create(const bh_tensor_desc_t *desc, bh_tensor_t *out);
+bh_status_t bh_tensor_destroy(bh_tensor_t *tensor);
+bh_status_t bh_tensor_view(const bh_tensor_t *parent,
+                           const bh_tensor_view_desc_t *view, bh_tensor_t *out);
+
+#endif

--- a/interface/sdk/include/bharat/hmem.h
+++ b/interface/sdk/include/bharat/hmem.h
@@ -1,0 +1,20 @@
+#ifndef BHARAT_SDK_HMEM_H
+#define BHARAT_SDK_HMEM_H
+
+#include <bharat/memory/hmem.h>
+#include <bharat/types.h>
+
+bh_status_t bh_hmem_create(const bharat_hmem_desc_v1_t *desc,
+                           bharat_hmem_handle_t *out);
+bh_status_t bh_hmem_destroy(bharat_hmem_handle_t handle);
+bh_status_t bh_hmem_get_info(bharat_hmem_handle_t handle,
+                             bharat_hmem_info_v1_t *out);
+bh_status_t bh_hmem_map_cpu(bharat_hmem_handle_t handle, uint32_t access,
+                            void **out);
+bh_status_t bh_hmem_unmap_cpu(bharat_hmem_handle_t handle);
+bh_status_t bh_hmem_sync_for_cpu(bharat_hmem_handle_t handle, uint64_t offset,
+                                 uint64_t length);
+bh_status_t bh_hmem_sync_for_device(bharat_hmem_handle_t handle,
+                                    uint64_t offset, uint64_t length);
+
+#endif

--- a/interface/sdk/include/bharat/types.h
+++ b/interface/sdk/include/bharat/types.h
@@ -20,6 +20,9 @@ enum {
     BH_ERR_ACCESS_DENIED = -4,
     BH_ERR_BUSY = -5,
     BH_ERR_IO = -6
+    ,BH_ERR_NO_MEMORY = -7
+    ,BH_ERR_OVERFLOW = -8
+    ,BH_ERR_BAD_STATE = -9
 };
 
 #endif

--- a/interface/sdk/lib/compute/tensor.c
+++ b/interface/sdk/lib/compute/tensor.c
@@ -1,0 +1,169 @@
+#include <bharat/compute/tensor.h>
+#include <string.h>
+
+static uint64_t dtype_size(uint32_t d) {
+  switch (d) {
+  case BH_DTYPE_F32:
+  case BH_DTYPE_I32:
+    return 4;
+  case BH_DTYPE_F16:
+  case BH_DTYPE_BF16:
+  case BH_DTYPE_I16:
+    return 2;
+  case BH_DTYPE_I8:
+  case BH_DTYPE_U8:
+  case BH_DTYPE_BOOL:
+    return 1;
+  default:
+    return 0;
+  }
+}
+static int mul(uint64_t a, uint64_t b, uint64_t *out) {
+  if (a && b > UINT64_MAX / a)
+    return 0;
+  *out = a * b;
+  return 1;
+}
+static bh_status_t tensor_bytes(uint32_t dtype, uint32_t rank,
+                                const uint64_t *shape, uint64_t *out) {
+  uint64_t n = 1, s = dtype_size(dtype);
+  if (!s || rank > BH_TENSOR_MAX_RANK)
+    return BH_ERR_INVALID_ARGUMENT;
+  for (uint32_t i = 0; i < rank; i++) {
+    if (shape[i] == 0U)
+      return BH_ERR_INVALID_ARGUMENT;
+    if (!mul(n, shape[i], &n))
+      return BH_ERR_OVERFLOW;
+  }
+  if (!mul(n, s, out))
+    return BH_ERR_OVERFLOW;
+  return BH_OK;
+}
+static bh_status_t validate_strides(uint32_t layout, uint32_t rank,
+                                    const uint64_t *shape,
+                                    const uint64_t *stride, uint64_t elem,
+                                    uint64_t *span) {
+  uint64_t expected = elem, max = elem;
+  if (layout > BH_TENSOR_LAYOUT_STRIDED)
+    return BH_ERR_INVALID_ARGUMENT;
+  for (uint32_t i = rank; i > 0; i--) {
+    uint32_t j = i - 1;
+    if (stride[j] < elem)
+      return BH_ERR_INVALID_ARGUMENT;
+    if (layout == BH_TENSOR_LAYOUT_DENSE && stride[j] != expected)
+      return BH_ERR_INVALID_ARGUMENT;
+    uint64_t add;
+    if (!mul(shape[j] - 1U, stride[j], &add) || max > UINT64_MAX - add)
+      return BH_ERR_OVERFLOW;
+    max += add;
+    if (!mul(expected, shape[j], &expected))
+      return BH_ERR_OVERFLOW;
+  }
+  *span = max;
+  return BH_OK;
+}
+bh_status_t bh_tensor_validate(const bh_tensor_t *t) {
+  bharat_hmem_info_v1_t info;
+  uint64_t bytes, span, elem;
+  if (!t || t->memory == 0U || t->rank > BH_TENSOR_MAX_RANK ||
+      ((t->flags & BH_TENSOR_F_OWNS_MEMORY) && (t->flags & BH_TENSOR_F_VIEW)))
+    return BH_ERR_INVALID_ARGUMENT;
+  bh_status_t s = tensor_bytes(t->dtype, t->rank, t->shape, &bytes);
+  if (s != BH_OK)
+    return s;
+  elem = dtype_size(t->dtype);
+  s = validate_strides(t->layout, t->rank, t->shape, t->stride, elem, &span);
+  if (s != BH_OK)
+    return s;
+  if (t->byte_length < span || t->byte_offset > UINT64_MAX - t->byte_length)
+    return BH_ERR_INVALID_ARGUMENT;
+  s = bh_hmem_get_info(t->memory, &info);
+  if (s != BH_OK)
+    return s;
+  if (t->byte_offset > info.size || t->byte_length > info.size - t->byte_offset)
+    return BH_ERR_INVALID_ARGUMENT;
+  (void)bytes;
+  return BH_OK;
+}
+bh_status_t bh_tensor_create(const bh_tensor_desc_t *d, bh_tensor_t *out) {
+  uint64_t bytes, elem;
+  if (!d || !out || d->reserved || d->rank > BH_TENSOR_MAX_RANK)
+    return BH_ERR_INVALID_ARGUMENT;
+  bh_status_t s = tensor_bytes(d->dtype, d->rank, d->shape, &bytes);
+  if (s != BH_OK)
+    return s;
+  memset(out, 0, sizeof(*out));
+  out->rank = d->rank;
+  out->dtype = d->dtype;
+  out->layout = d->layout;
+  out->flags = BH_TENSOR_F_OWNS_MEMORY;
+  memcpy(out->shape, d->shape, sizeof(out->shape));
+  elem = dtype_size(d->dtype);
+  uint64_t next = elem;
+  for (uint32_t i = d->rank; i > 0; i--) {
+    uint32_t j = i - 1;
+    out->stride[j] =
+        d->layout == BH_TENSOR_LAYOUT_STRIDED ? d->stride[j] : next;
+    if (!mul(next, d->shape[j], &next))
+      return BH_ERR_OVERFLOW;
+  }
+  if (d->rank == 0U)
+    out->stride[0] = 0U;
+  out->byte_length = bytes;
+  bharat_hmem_desc_v1_t hd = {
+      .version = 1,
+      .struct_size = sizeof(hd),
+      .size = bytes,
+      .alignment = sizeof(void *) < 16U ? 16U : sizeof(void *),
+      .usage_flags = BH_HMEM_USAGE_CPU_READ | BH_HMEM_USAGE_CPU_WRITE |
+                     BH_HMEM_USAGE_DEVICE_READ | BH_HMEM_USAGE_DEVICE_WRITE,
+      .property_flags = d->hmem_property_flags | BH_HMEM_PROP_ZERO_ON_ALLOC,
+      .preferred_domain = BH_HMEM_DOMAIN_SYSTEM};
+  s = bh_hmem_create(&hd, &out->memory);
+  if (s != BH_OK) {
+    memset(out, 0, sizeof(*out));
+    return s;
+  }
+  s = bh_tensor_validate(out);
+  if (s != BH_OK) {
+    bh_hmem_destroy(out->memory);
+    memset(out, 0, sizeof(*out));
+  }
+  return s;
+}
+bh_status_t bh_tensor_destroy(bh_tensor_t *t) {
+  if (!t)
+    return BH_ERR_INVALID_ARGUMENT;
+  bh_status_t s = BH_OK;
+  if ((t->flags & BH_TENSOR_F_OWNS_MEMORY) && t->memory)
+    s = bh_hmem_destroy(t->memory);
+  if (s == BH_OK)
+    memset(t, 0, sizeof(*t));
+  return s;
+}
+bh_status_t bh_tensor_view(const bh_tensor_t *p, const bh_tensor_view_desc_t *v,
+                           bh_tensor_t *out) {
+  if (!p || !v || !out || v->rank > BH_TENSOR_MAX_RANK)
+    return BH_ERR_INVALID_ARGUMENT;
+  bh_status_t s = bh_tensor_validate(p);
+  if (s != BH_OK)
+    return s;
+  memset(out, 0, sizeof(*out));
+  out->memory = p->memory;
+  out->rank = v->rank;
+  out->dtype = p->dtype;
+  out->layout = v->layout;
+  out->flags = BH_TENSOR_F_VIEW;
+  memcpy(out->shape, v->shape, sizeof(out->shape));
+  memcpy(out->stride, v->stride, sizeof(out->stride));
+  if (p->byte_offset > UINT64_MAX - v->byte_offset)
+    return BH_ERR_OVERFLOW;
+  out->byte_offset = p->byte_offset + v->byte_offset;
+  uint64_t span;
+  s = validate_strides(out->layout, out->rank, out->shape, out->stride,
+                       dtype_size(out->dtype), &span);
+  if (s != BH_OK)
+    return s;
+  out->byte_length = span;
+  return bh_tensor_validate(out);
+}

--- a/interface/sdk/lib/memory/hmem.c
+++ b/interface/sdk/lib/memory/hmem.c
@@ -1,0 +1,191 @@
+#define _POSIX_C_SOURCE 200112L
+#include <bharat/hmem.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define HOST_HMEM_SLOTS 64U
+typedef struct {
+  void *data;
+  uint64_t size, alignment, usage, properties, generation;
+  uint32_t domain, mapped, slot_generation;
+} host_hmem_t;
+static host_hmem_t slots[HOST_HMEM_SLOTS];
+static volatile unsigned char registry_lock;
+static void lock_registry(void) {
+  while (__atomic_test_and_set(&registry_lock, __ATOMIC_ACQUIRE)) {
+  }
+}
+static void unlock_registry(void) {
+  __atomic_clear(&registry_lock, __ATOMIC_RELEASE);
+}
+static int pow2(uint64_t x) { return x != 0U && (x & (x - 1U)) == 0U; }
+static host_hmem_t *lookup(bharat_hmem_handle_t h) {
+  uint32_t s = (uint32_t)h, g = (uint32_t)(h >> 32);
+  if (s == 0U || s > HOST_HMEM_SLOTS || g == 0U)
+    return NULL;
+  host_hmem_t *o = &slots[s - 1U];
+  return o->data != NULL && o->slot_generation == g ? o : NULL;
+}
+static int reserved_zero(const bharat_hmem_desc_v1_t *d) {
+  for (unsigned i = 0; i < 4; i++)
+    if (d->reserved[i])
+      return 0;
+  return d->reserved0 == 0U;
+}
+bh_status_t bh_hmem_create(const bharat_hmem_desc_v1_t *d,
+                           bharat_hmem_handle_t *out) {
+  void *p = NULL;
+  uint32_t i;
+  if (!d || !out || d->version != 1U || d->struct_size != sizeof(*d) ||
+      d->size == 0U || !pow2(d->alignment) || d->alignment < sizeof(void *) ||
+      d->size > SIZE_MAX - d->alignment || !reserved_zero(d))
+    return BH_ERR_INVALID_ARGUMENT;
+  if ((d->usage_flags & ~BH_HMEM_USAGE_ALL) ||
+      (d->property_flags & ~BH_HMEM_PROP_ALL) ||
+      d->preferred_domain > BH_HMEM_DOMAIN_SECURE)
+    return BH_ERR_INVALID_ARGUMENT;
+  if (d->preferred_domain != BH_HMEM_DOMAIN_SYSTEM &&
+      d->preferred_domain != BH_HMEM_DOMAIN_SHARED)
+    return BH_ERR_UNSUPPORTED;
+  if (posix_memalign(&p, (size_t)d->alignment, (size_t)d->size) != 0)
+    return BH_ERR_NO_MEMORY;
+  if (d->property_flags & BH_HMEM_PROP_ZERO_ON_ALLOC)
+    memset(p, 0, (size_t)d->size);
+  lock_registry();
+  for (i = 0; i < HOST_HMEM_SLOTS && slots[i].data; i++) {
+  }
+  if (i == HOST_HMEM_SLOTS) {
+    unlock_registry();
+    free(p);
+    return BH_ERR_BUSY;
+  }
+  uint32_t g = slots[i].slot_generation + 1U;
+  if (g == 0U)
+    g = 1U;
+  slots[i] = (host_hmem_t){p,
+                           d->size,
+                           d->alignment,
+                           d->usage_flags,
+                           d->property_flags,
+                           1U,
+                           d->preferred_domain,
+                           0U,
+                           g};
+  *out = ((uint64_t)g << 32) | (i + 1U);
+  unlock_registry();
+  return BH_OK;
+}
+bh_status_t bh_hmem_destroy(bharat_hmem_handle_t h) {
+  lock_registry();
+  host_hmem_t *o = lookup(h);
+  if (!o) {
+    unlock_registry();
+    return BH_ERR_NOT_FOUND;
+  }
+  if (o->mapped) {
+    unlock_registry();
+    return BH_ERR_BUSY;
+  }
+  void *p = o->data;
+  uint64_t n = o->size, props = o->properties;
+  uint32_t g = o->slot_generation;
+  memset(o, 0, sizeof(*o));
+  o->slot_generation = g;
+  unlock_registry();
+  if (props & BH_HMEM_PROP_ZERO_ON_FREE) {
+    volatile unsigned char *v = p;
+    while (n--)
+      *v++ = 0;
+  }
+  free(p);
+  return BH_OK;
+}
+bh_status_t bh_hmem_get_info(bharat_hmem_handle_t h,
+                             bharat_hmem_info_v1_t *out) {
+  if (!out)
+    return BH_ERR_INVALID_ARGUMENT;
+  lock_registry();
+  host_hmem_t *o = lookup(h);
+  if (!o) {
+    unlock_registry();
+    return BH_ERR_NOT_FOUND;
+  }
+  memset(out, 0, sizeof(*out));
+  out->version = 1;
+  out->struct_size = sizeof(*out);
+  out->size = o->size;
+  out->alignment = o->alignment;
+  out->usage_flags = o->usage;
+  out->property_flags = o->properties;
+  out->content_generation = o->generation;
+  out->preferred_domain = o->domain;
+  out->cpu_map_count = o->mapped;
+  unlock_registry();
+  return BH_OK;
+}
+bh_status_t bh_hmem_map_cpu(bharat_hmem_handle_t h, uint32_t a, void **out) {
+  if (!out || a == 0U ||
+      (a &
+       ~(BH_HMEM_ACCESS_READ | BH_HMEM_ACCESS_WRITE | BH_HMEM_ACCESS_EXECUTE)))
+    return BH_ERR_INVALID_ARGUMENT;
+  lock_registry();
+  host_hmem_t *o = lookup(h);
+  if (!o) {
+    unlock_registry();
+    return BH_ERR_NOT_FOUND;
+  }
+  if (((a & BH_HMEM_ACCESS_READ) && !(o->usage & BH_HMEM_USAGE_CPU_READ)) ||
+      ((a & BH_HMEM_ACCESS_WRITE) && !(o->usage & BH_HMEM_USAGE_CPU_WRITE)) ||
+      ((a & BH_HMEM_ACCESS_EXECUTE) && !(o->usage & BH_HMEM_USAGE_EXECUTE))) {
+    unlock_registry();
+    return BH_ERR_ACCESS_DENIED;
+  }
+  if (o->mapped) {
+    unlock_registry();
+    return BH_ERR_BUSY;
+  }
+  o->mapped = 1;
+  *out = o->data;
+  unlock_registry();
+  return BH_OK;
+}
+bh_status_t bh_hmem_unmap_cpu(bharat_hmem_handle_t h) {
+  lock_registry();
+  host_hmem_t *o = lookup(h);
+  if (!o) {
+    unlock_registry();
+    return BH_ERR_NOT_FOUND;
+  }
+  if (!o->mapped) {
+    unlock_registry();
+    return BH_ERR_BAD_STATE;
+  }
+  o->mapped = 0;
+  o->generation++;
+  unlock_registry();
+  return BH_OK;
+}
+static bh_status_t sync_hmem(bharat_hmem_handle_t h, uint64_t off,
+                             uint64_t len) {
+  lock_registry();
+  host_hmem_t *o = lookup(h);
+  if (!o) {
+    unlock_registry();
+    return BH_ERR_NOT_FOUND;
+  }
+  if (len == 0U || off > o->size || len > o->size - off) {
+    unlock_registry();
+    return BH_ERR_INVALID_ARGUMENT;
+  }
+  __atomic_thread_fence(__ATOMIC_SEQ_CST);
+  unlock_registry();
+  return BH_OK;
+}
+bh_status_t bh_hmem_sync_for_cpu(bharat_hmem_handle_t h, uint64_t o,
+                                 uint64_t l) {
+  return sync_hmem(h, o, l);
+}
+bh_status_t bh_hmem_sync_for_device(bharat_hmem_handle_t h, uint64_t o,
+                                    uint64_t l) {
+  return sync_hmem(h, o, l);
+}

--- a/interface/sdk/tests/CMakeLists.txt
+++ b/interface/sdk/tests/CMakeLists.txt
@@ -1,6 +1,9 @@
 add_executable(bharat_sdk_core_test core_test.c)
 target_link_libraries(bharat_sdk_core_test PRIVATE Bharat::sdk)
 add_test(NAME bharat_sdk_core COMMAND bharat_sdk_core_test)
+add_executable(bharat_sdk_hmem_tensor_test hmem_tensor_test.c)
+target_link_libraries(bharat_sdk_hmem_tensor_test PRIVATE Bharat::sdk)
+add_test(NAME bharat_sdk_hmem_tensor COMMAND bharat_sdk_hmem_tensor_test)
 add_test(NAME bharat_sdk_public_headers COMMAND ${CMAKE_COMMAND}
     -DSDK_SOURCE=${CMAKE_CURRENT_SOURCE_DIR}/.. -DBUILD_DIR=${CMAKE_CURRENT_BINARY_DIR}/header-check
     -DC_COMPILER=${CMAKE_C_COMPILER} -P ${CMAKE_CURRENT_SOURCE_DIR}/check_public_headers.cmake)

--- a/interface/sdk/tests/check_public_headers.cmake
+++ b/interface/sdk/tests/check_public_headers.cmake
@@ -1,11 +1,13 @@
 file(REMOVE_RECURSE "${BUILD_DIR}")
 file(MAKE_DIRECTORY "${BUILD_DIR}")
-file(GLOB headers "${SDK_SOURCE}/include/bharat/*.h")
+file(GLOB_RECURSE headers "${SDK_SOURCE}/include/bharat/*.h")
 foreach(header IN LISTS headers)
-    get_filename_component(name "${header}" NAME_WE)
-    file(WRITE "${BUILD_DIR}/${name}.c" "#include <bharat/${name}.h>\nint main(void) { return 0; }\n")
+    file(RELATIVE_PATH relative "${SDK_SOURCE}/include" "${header}")
+    string(REPLACE "/" "_" name "${relative}")
+    file(WRITE "${BUILD_DIR}/${name}.c" "#include <${relative}>\nint main(void) { return 0; }\n")
     execute_process(COMMAND "${C_COMPILER}" -std=c11 -Wall -Wextra -Werror
-        -I "${SDK_SOURCE}/include" -c "${BUILD_DIR}/${name}.c" -o "${BUILD_DIR}/${name}.o"
+        -I "${SDK_SOURCE}/include" -I "${SDK_SOURCE}/../uapi" -I "${SDK_SOURCE}/../include"
+        -c "${BUILD_DIR}/${name}.c" -o "${BUILD_DIR}/${name}.o"
         RESULT_VARIABLE result ERROR_VARIABLE error)
     if(NOT result EQUAL 0)
         message(FATAL_ERROR "Public header ${name}.h is not standalone:\n${error}")

--- a/interface/sdk/tests/hmem_tensor_test.c
+++ b/interface/sdk/tests/hmem_tensor_test.c
@@ -1,0 +1,111 @@
+#include <assert.h>
+#include <bharat/compute/tensor.h>
+#include <stdint.h>
+#include <string.h>
+
+static void hmem_lifecycle(void) {
+  bharat_hmem_desc_v1_t d = {
+      .version = 1,
+      .struct_size = sizeof(d),
+      .size = 128,
+      .alignment = 64,
+      .usage_flags = BH_HMEM_USAGE_CPU_READ | BH_HMEM_USAGE_CPU_WRITE,
+      .property_flags = BH_HMEM_PROP_ZERO_ON_ALLOC | BH_HMEM_PROP_CPU_COHERENT,
+      .preferred_domain = BH_HMEM_DOMAIN_SYSTEM};
+  bharat_hmem_handle_t h;
+  void *p;
+  assert(bh_hmem_create(&d, &h) == BH_OK);
+  assert(bh_hmem_map_cpu(h, BH_HMEM_ACCESS_READ | BH_HMEM_ACCESS_WRITE, &p) ==
+         BH_OK);
+  assert(((uintptr_t)p & 63U) == 0U);
+  for (unsigned i = 0; i < 128; i++)
+    assert(((unsigned char *)p)[i] == 0U);
+  assert(bh_hmem_map_cpu(h, BH_HMEM_ACCESS_READ, &p) == BH_ERR_BUSY);
+  memset(p, 0xa5, 128);
+  assert(bh_hmem_sync_for_device(h, 0, 128) == BH_OK);
+  assert(bh_hmem_sync_for_cpu(h, 127, 2) == BH_ERR_INVALID_ARGUMENT);
+  assert(bh_hmem_sync_for_cpu(h, UINT64_MAX, 2) == BH_ERR_INVALID_ARGUMENT);
+  assert(bh_hmem_destroy(h) == BH_ERR_BUSY);
+  assert(bh_hmem_unmap_cpu(h) == BH_OK);
+  assert(bh_hmem_unmap_cpu(h) == BH_ERR_BAD_STATE);
+  assert(bh_hmem_destroy(h) == BH_OK);
+  assert(bh_hmem_destroy(h) == BH_ERR_NOT_FOUND);
+  assert(bh_hmem_get_info(h, (bharat_hmem_info_v1_t *)&d) == BH_ERR_NOT_FOUND);
+}
+static void hmem_negative(void) {
+  bharat_hmem_desc_v1_t d = {.version = 1,
+                             .struct_size = sizeof(d),
+                             .size = 1,
+                             .alignment = 3,
+                             .usage_flags = BH_HMEM_USAGE_CPU_READ,
+                             .preferred_domain = BH_HMEM_DOMAIN_SYSTEM};
+  bharat_hmem_handle_t h;
+  assert(bh_hmem_create(&d, &h) == BH_ERR_INVALID_ARGUMENT);
+  d.alignment = 16;
+  d.size = 0;
+  assert(bh_hmem_create(&d, &h) == BH_ERR_INVALID_ARGUMENT);
+  d.size = 16;
+  d.reserved[2] = 1;
+  assert(bh_hmem_create(&d, &h) == BH_ERR_INVALID_ARGUMENT);
+  d.reserved[2] = 0;
+  d.preferred_domain = BH_HMEM_DOMAIN_DEVICE_LOCAL;
+  assert(bh_hmem_create(&d, &h) == BH_ERR_UNSUPPORTED);
+}
+static void tensors(void) {
+  bh_tensor_desc_t d = {.dtype = BH_DTYPE_F32,
+                        .rank = 2,
+                        .shape = {4, 8},
+                        .layout = BH_TENSOR_LAYOUT_DENSE};
+  bh_tensor_t t, v;
+  void *p;
+  assert(bh_tensor_create(&d, &t) == BH_OK);
+  assert(t.byte_length == 128 && t.stride[0] == 32 && t.stride[1] == 4);
+  assert(bh_tensor_validate(&t) == BH_OK);
+  assert(bh_hmem_map_cpu(t.memory, BH_HMEM_ACCESS_WRITE, &p) == BH_OK);
+  ((float *)p)[0] = 1.0f;
+  assert(bh_hmem_unmap_cpu(t.memory) == BH_OK);
+  bh_tensor_view_desc_t vd = {.rank = 1,
+                              .layout = BH_TENSOR_LAYOUT_STRIDED,
+                              .shape = {8},
+                              .stride = {4},
+                              .byte_offset = 32};
+  assert(bh_tensor_view(&t, &vd, &v) == BH_OK);
+  assert(v.memory == t.memory && v.byte_offset == 32 && v.byte_length == 32);
+  assert(bh_tensor_destroy(&v) == BH_OK);
+  vd.byte_offset = 120;
+  assert(bh_tensor_view(&t, &vd, &v) == BH_ERR_INVALID_ARGUMENT);
+  assert(bh_tensor_destroy(&t) == BH_OK);
+  assert(t.memory == 0);
+}
+static void tensor_negative(void) {
+  bh_tensor_desc_t d = {.dtype = BH_DTYPE_F32,
+                        .rank = 9,
+                        .shape = {1},
+                        .layout = BH_TENSOR_LAYOUT_DENSE};
+  bh_tensor_t t;
+  assert(bh_tensor_create(&d, &t) == BH_ERR_INVALID_ARGUMENT);
+  d.rank = 2;
+  d.shape[0] = UINT64_MAX;
+  d.shape[1] = 2;
+  assert(bh_tensor_create(&d, &t) == BH_ERR_OVERFLOW);
+  d.rank = 0;
+  d.dtype = BH_DTYPE_F32;
+  assert(bh_tensor_create(&d, &t) == BH_OK);
+  assert(t.byte_length == 4);
+  assert(bh_tensor_destroy(&t) == BH_OK);
+  d.rank = 1;
+  d.dtype = BH_DTYPE_INVALID;
+  d.shape[0] = 1;
+  assert(bh_tensor_create(&d, &t) == BH_ERR_INVALID_ARGUMENT);
+  d.dtype = BH_DTYPE_F32;
+  d.layout = BH_TENSOR_LAYOUT_STRIDED;
+  d.stride[0] = 2;
+  assert(bh_tensor_create(&d, &t) == BH_ERR_INVALID_ARGUMENT);
+}
+int main(void) {
+  hmem_lifecycle();
+  hmem_negative();
+  tensors();
+  tensor_negative();
+  return 0;
+}

--- a/interface/uapi/bharat/memory/hmem.h
+++ b/interface/uapi/bharat/memory/hmem.h
@@ -1,0 +1,78 @@
+#ifndef BHARAT_UAPI_MEMORY_HMEM_H
+#define BHARAT_UAPI_MEMORY_HMEM_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+typedef uint64_t bharat_hmem_handle_t;
+
+#define BH_HMEM_DESC_VERSION_1 UINT32_C(1)
+
+#define BH_HMEM_DOMAIN_SYSTEM UINT32_C(0)
+#define BH_HMEM_DOMAIN_DEVICE_LOCAL UINT32_C(1)
+#define BH_HMEM_DOMAIN_SHARED UINT32_C(2)
+#define BH_HMEM_DOMAIN_PERSISTENT UINT32_C(3)
+#define BH_HMEM_DOMAIN_SECURE UINT32_C(4)
+
+#define BH_HMEM_USAGE_CPU_READ (UINT64_C(1) << 0)
+#define BH_HMEM_USAGE_CPU_WRITE (UINT64_C(1) << 1)
+#define BH_HMEM_USAGE_DEVICE_READ (UINT64_C(1) << 2)
+#define BH_HMEM_USAGE_DEVICE_WRITE (UINT64_C(1) << 3)
+#define BH_HMEM_USAGE_DMA (UINT64_C(1) << 4)
+#define BH_HMEM_USAGE_SHARED (UINT64_C(1) << 5)
+#define BH_HMEM_USAGE_EXECUTE (UINT64_C(1) << 6)
+#define BH_HMEM_USAGE_ALL ((UINT64_C(1) << 7) - 1)
+
+#define BH_HMEM_PROP_CPU_COHERENT (UINT64_C(1) << 0)
+#define BH_HMEM_PROP_DEVICE_COHERENT (UINT64_C(1) << 1)
+#define BH_HMEM_PROP_CACHEABLE (UINT64_C(1) << 2)
+#define BH_HMEM_PROP_PINNED (UINT64_C(1) << 3)
+#define BH_HMEM_PROP_SECURE (UINT64_C(1) << 4)
+#define BH_HMEM_PROP_ZERO_ON_ALLOC (UINT64_C(1) << 5)
+#define BH_HMEM_PROP_ZERO_ON_FREE (UINT64_C(1) << 6)
+#define BH_HMEM_PROP_ALL ((UINT64_C(1) << 7) - 1)
+
+#define BH_HMEM_ACCESS_READ (UINT32_C(1) << 0)
+#define BH_HMEM_ACCESS_WRITE (UINT32_C(1) << 1)
+#define BH_HMEM_ACCESS_EXECUTE (UINT32_C(1) << 2)
+
+#define BH_HMEM_RIGHT_READ (UINT64_C(1) << 0)
+#define BH_HMEM_RIGHT_WRITE (UINT64_C(1) << 1)
+#define BH_HMEM_RIGHT_MAP_CPU (UINT64_C(1) << 2)
+#define BH_HMEM_RIGHT_MAP_DEVICE (UINT64_C(1) << 3)
+#define BH_HMEM_RIGHT_SHARE (UINT64_C(1) << 4)
+#define BH_HMEM_RIGHT_DERIVE (UINT64_C(1) << 5)
+#define BH_HMEM_RIGHT_PIN (UINT64_C(1) << 6)
+#define BH_HMEM_RIGHT_MIGRATE (UINT64_C(1) << 7)
+
+typedef struct bharat_hmem_desc_v1 {
+  uint32_t version;
+  uint32_t struct_size;
+  uint64_t size;
+  uint64_t alignment;
+  uint64_t usage_flags;
+  uint64_t property_flags;
+  uint32_t preferred_domain;
+  uint32_t reserved0;
+  uint64_t reserved[4];
+} bharat_hmem_desc_v1_t;
+
+typedef struct bharat_hmem_info_v1 {
+  uint32_t version;
+  uint32_t struct_size;
+  uint64_t size;
+  uint64_t alignment;
+  uint64_t usage_flags;
+  uint64_t property_flags;
+  uint64_t content_generation;
+  uint32_t preferred_domain;
+  uint32_t cpu_map_count;
+  uint64_t reserved[3];
+} bharat_hmem_info_v1_t;
+
+_Static_assert(sizeof(bharat_hmem_desc_v1_t) == 80U, "HMEM v1 descriptor ABI");
+_Static_assert(offsetof(bharat_hmem_desc_v1_t, reserved) == 48U,
+               "HMEM v1 reserved offset");
+_Static_assert(sizeof(bharat_hmem_info_v1_t) == 80U, "HMEM v1 info ABI");
+
+#endif


### PR DESCRIPTION
### Motivation

- Provide a minimal, production-oriented Heterogeneous Memory (HMEM) primitive that is capability-scoped, generation-safe, and device-neutral as the foundation for BHCF P0.  
- Keep kernel responsibilities limited to mechanisms (memory, ownership, mapping, coherency) and place tensor semantics in the SDK/runtime.  
- Enable host-driven development and validation with a hosted HMEM backend and SDK tests so accelerator integration can be added later without changing the kernel object model.

### Description

- Added a stable Native UAPI for HMEM under `interface/uapi/bharat/memory/hmem.h` with a versioned, fixed-width descriptor, reserved fields, opaque 64-bit handles, usage/property/access/right flags, and ABI assertions.  
- Introduced a HAL HMEM contract (`core/hal/include/hal/hal_hmem.h`) and a common fallback implementation (`core/hal/common/hmem.c`) that expose semantic `sync_range`, `map_device`, `unmap_device`, and `is_cpu_device_coherent` operations while failing closed when backends are absent.  
- Implemented the kernel HMEM object and mechanism in `core/kernel/include/mm/hmem.h` and `core/kernel/src/mm/hmem.c`, including CPU-backed aligned allocation, bounded slot-based registry with generation protection, zero-on-alloc/free, CPU map/unmap, content-generation tracking, bounded device mapping table (4 entries), robust descriptor and overflow checks, and HAL-based cache/coherency sync.  
- Extended capability vocabulary minimally to cover HMEM object semantics and ensured authorization remains at the syscall/kernel-object layer (HAL receives already-authorized requests).  
- Added Tensor SDK public headers and implementation: `interface/sdk/include/bharat/compute/tensor.h` and `interface/sdk/lib/compute/tensor.c` with dtype list, rank limit, checked sizing, stride/span validation, owning/view semantics, safe creation/destruction, and a hosted HMEM-backed allocation path.  
- Added a hosted SDK HMEM backend for development/tests at `interface/sdk/lib/memory/hmem.c` that allocates aligned host memory and implements map/unmap/sync semantics without inventing device addresses.  
- Added focused host tests `interface/sdk/tests/hmem_tensor_test.c` covering lifecycle, bounds, coherency/sync ranges, capability-like permission checks, tensor validation, views, and overflow cases.  
- Updated SDK/CMake integration to build the compute component and to make the UAPI header available to SDK builds; added documentation/ADR and a developer quick-start in `docs/architecture/compute/` and `docs/guides/`.  

### Testing

- Built and ran SDK tests: `cmake -S interface/sdk -B build/sdk-hmem -DBHARAT_SDK_BUILD_EXAMPLES=OFF -DBHARAT_SDK_BUILD_TESTS=ON && cmake --build build/sdk-hmem -j2 && ctest --test-dir build/sdk-hmem --output-on-failure` — PASS (SDK hmem/tensor tests and public-header checks passed).  
- Ran static and contract checks: `python3 tools/lint/check_layer_references.py --strict`, `python3 tools/lint/check_cmake_dependencies.py`, and `python3 tools/abi/syscall_abi.py --check` — PASS.  
- Per-architecture kernel build + smoke tests for the five required QEMU targets were executed using the repository gates and all targets passed:  
  - `./tools/build.sh all --target-yaml delivery/targets/qemu/x86_64_desktop_headless.yaml --smoke` — PASS  
  - `./tools/build.sh all --target-yaml delivery/targets/qemu/arm64_desktop_headless.yaml --smoke` — PASS  
  - `./tools/build.sh all --target-yaml delivery/targets/qemu/riscv64_desktop_headless.yaml --smoke` — PASS  
  - `./tools/build.sh all --target-yaml delivery/targets/qemu/arm32_mmu_lite_headless.yaml --smoke` — PASS  
  - `./tools/build.sh all --target-yaml delivery/targets/qemu/riscv32_mmu_lite_headless.yaml --smoke` — PASS  
- Ran the recommended full matrix runner: `python3 tools/run_qemu_matrix.py --headless --smoke --all-arch` — PASS (all five required architectures reported qualifying boot markers).  

All focused tests and repository validation gates listed above completed successfully on the change; unsupported device mapping returns the documented `K_ERR_UNSUPPORTED` fallback and no accelerator/device backends were fabricated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7cc3e6c34c8320b2282d5d878b290e)