### PR TITLE
Fail-closed defaults for uninstalled process/VM authority adapters; publish-only-after-authority

### DIFF
--- a/core/services/process_manager/process_manager.c
+++ b/core/services/process_manager/process_manager.c
@@ -54,42 +54,38 @@ static int g_fail_stage = 0;
 
 // Fail-closed defaults. Production builds must replace these authority operations.
 static int32_t default_create_process(void *ctx, const bh_pm_kernel_create_req_t *req, bh_pm_kernel_process_t *out_proc) {
-    (void)ctx; (void)req;
-    if (out_proc) out_proc->pid = 1;
-    return BHARAT_IPC_STATUS_OK;
+    (void)ctx; (void)req; (void)out_proc;
+    return BHARAT_IPC_STATUS_ERR_UNSUPPORTED;
 }
 
 static int32_t default_create_vm_space(void *ctx, bh_pm_kernel_process_t *proc, uint32_t memory_profile, bh_vm_kernel_space_t *out_space) {
     (void)ctx; (void)proc; (void)memory_profile;
-    if (out_space) out_space->space_id = 1;
-    return BHARAT_IPC_STATUS_OK;
+    (void)out_space;
+    return BHARAT_IPC_STATUS_ERR_UNSUPPORTED;
 }
 
 static int32_t default_realize_image(void *ctx, bh_pm_kernel_process_t *proc, bh_vm_kernel_space_t *space, const bh_user_image_plan_v1_t *plan, bh_pm_kernel_image_result_t *out_res) {
     (void)ctx; (void)proc; (void)space; (void)plan;
-    if (out_res) {
-        out_res->main_thread_id = 1;
-        out_res->entry_point = 0x1000;
-    }
-    return BHARAT_IPC_STATUS_OK;
+    (void)out_res;
+    return BHARAT_IPC_STATUS_ERR_UNSUPPORTED;
 }
 
 static int32_t default_start_process(void *ctx, bh_pm_kernel_process_t *proc) {
     (void)ctx; (void)proc;
-    return BHARAT_IPC_STATUS_OK;
+    return BHARAT_IPC_STATUS_ERR_UNSUPPORTED;
 }
 
 static int32_t default_request_terminate(void *ctx, bh_pm_kernel_process_t *proc) {
     (void)ctx; (void)proc;
-    return BHARAT_IPC_STATUS_OK;
+    return BHARAT_IPC_STATUS_ERR_UNSUPPORTED;
 }
 
 static int32_t default_reap_process(void *ctx, bh_pm_kernel_process_t *proc) {
     (void)ctx; (void)proc;
-    return BHARAT_IPC_STATUS_OK;
+    return BHARAT_IPC_STATUS_ERR_UNSUPPORTED;
 }
 
-static bh_pm_kernel_ops_t g_kernel_ops = {
+static const bh_pm_kernel_ops_t g_default_kernel_ops = {
     .ctx = NULL,
     .create_process = default_create_process,
     .create_vm_space = default_create_vm_space,
@@ -99,10 +95,21 @@ static bh_pm_kernel_ops_t g_kernel_ops = {
     .reap_process = default_reap_process
 };
 
-void bh_pm_set_kernel_ops(const bh_pm_kernel_ops_t *ops) {
-    if (ops) {
-        g_kernel_ops = *ops;
+/* Service-local adapter selection; configured during single-threaded startup. */
+static bh_pm_kernel_ops_t g_kernel_ops;
+
+int32_t bh_pm_set_kernel_ops(const bh_pm_kernel_ops_t *ops) {
+    if (!ops) {
+        g_kernel_ops = g_default_kernel_ops;
+        return BHARAT_IPC_STATUS_OK;
     }
+    if (!ops->create_process || !ops->create_vm_space || !ops->realize_image ||
+        !ops->start_process || !ops->request_terminate || !ops->reap_process) {
+        g_kernel_ops = g_default_kernel_ops;
+        return BHARAT_IPC_STATUS_ERR_UNSUPPORTED;
+    }
+    g_kernel_ops = *ops;
+    return BHARAT_IPC_STATUS_OK;
 }
 
 void bh_pm_set_failure_injection(int fail_stage) {
@@ -199,6 +206,7 @@ void process_manager_init(void) {
     local_memset(g_executables, 0, sizeof(g_executables));
 
     bh_user_handle_table_init(&g_pm_handle_table, g_pm_handle_slots, MAX_PROCESSES);
+    g_kernel_ops = g_default_kernel_ops;
     g_fail_stage = 0;
 }
 
@@ -376,8 +384,8 @@ int32_t bh_pm_handle_spawn_v1(const bh_pm_spawn_request_v1_t *req, bh_pm_spawn_r
         // Rollback
         bh_user_handle_revoke(&g_pm_handle_table, proc_handle);
         local_memset(proc, 0, sizeof(bh_pm_process_v1_t));
-        resp->status = BHARAT_IPC_STATUS_ERR_INTERNAL;
-        return BHARAT_IPC_STATUS_ERR_INTERNAL;
+        resp->status = k_res;
+        return k_res;
     }
 
     proc->kernel_process_id = k_proc.pid;
@@ -400,8 +408,8 @@ int32_t bh_pm_handle_spawn_v1(const bh_pm_spawn_request_v1_t *req, bh_pm_spawn_r
         g_kernel_ops.reap_process(g_kernel_ops.ctx, &k_proc);
         bh_user_handle_revoke(&g_pm_handle_table, proc_handle);
         local_memset(proc, 0, sizeof(bh_pm_process_v1_t));
-        resp->status = BHARAT_IPC_STATUS_ERR_INTERNAL;
-        return BHARAT_IPC_STATUS_ERR_INTERNAL;
+        resp->status = k_res;
+        return k_res;
     }
 
     proc->vm_space_handle = k_space.space_id;
@@ -424,8 +432,8 @@ int32_t bh_pm_handle_spawn_v1(const bh_pm_spawn_request_v1_t *req, bh_pm_spawn_r
         g_kernel_ops.reap_process(g_kernel_ops.ctx, &k_proc);
         bh_user_handle_revoke(&g_pm_handle_table, proc_handle);
         local_memset(proc, 0, sizeof(bh_pm_process_v1_t));
-        resp->status = BHARAT_IPC_STATUS_ERR_INTERNAL;
-        return BHARAT_IPC_STATUS_ERR_INTERNAL;
+        resp->status = k_res;
+        return k_res;
     }
 
     proc->main_thread_id = k_img_res.main_thread_id;
@@ -447,8 +455,8 @@ int32_t bh_pm_handle_spawn_v1(const bh_pm_spawn_request_v1_t *req, bh_pm_spawn_r
         g_kernel_ops.reap_process(g_kernel_ops.ctx, &k_proc);
         bh_user_handle_revoke(&g_pm_handle_table, proc_handle);
         local_memset(proc, 0, sizeof(bh_pm_process_v1_t));
-        resp->status = BHARAT_IPC_STATUS_ERR_INTERNAL;
-        return BHARAT_IPC_STATUS_ERR_INTERNAL;
+        resp->status = k_res;
+        return k_res;
     }
 
     proc->state = BH_PM_STATE_RUNNING_V1;
@@ -513,9 +521,13 @@ int32_t bh_pm_handle_terminate_v1(const bh_pm_terminate_request_v1_t *req, bh_pm
         return BHARAT_IPC_STATUS_OK;
     }
 
-    proc->state = BH_PM_STATE_TERMINATE_REQUESTED_V1;
     bh_pm_kernel_process_t k_proc = { .pid = proc->kernel_process_id };
-    g_kernel_ops.request_terminate(g_kernel_ops.ctx, &k_proc);
+    int32_t status = g_kernel_ops.request_terminate(g_kernel_ops.ctx, &k_proc);
+    if (status != BHARAT_IPC_STATUS_OK) {
+        resp->status = status;
+        return status;
+    }
+    proc->state = BH_PM_STATE_TERMINATE_REQUESTED_V1;
 
     resp->status = BHARAT_IPC_STATUS_OK;
     return BHARAT_IPC_STATUS_OK;
@@ -581,7 +593,11 @@ int32_t bh_pm_handle_reap_v1(const bh_pm_reap_request_v1_t *req, bh_pm_reap_resp
     }
 
     bh_pm_kernel_process_t k_proc = { .pid = proc->kernel_process_id };
-    g_kernel_ops.reap_process(g_kernel_ops.ctx, &k_proc);
+    int32_t status = g_kernel_ops.reap_process(g_kernel_ops.ctx, &k_proc);
+    if (status != BHARAT_IPC_STATUS_OK) {
+        resp->status = status;
+        return status;
+    }
 
     proc->state = BH_PM_STATE_REAPED_V1;
 

--- a/core/services/process_manager/process_manager.h
+++ b/core/services/process_manager/process_manager.h
@@ -103,7 +103,8 @@ int32_t process_manager_handle_query(const pm_req_query_t *req, pm_resp_query_t 
 int32_t process_manager_authorize(uint32_t opcode, const void *req, bharat_cap_handle_t caller_cap);
 
 // v1 Process Manager Interfaces
-void bh_pm_set_kernel_ops(const bh_pm_kernel_ops_t *ops);
+/* Installs one complete authority adapter. NULL restores the fail-closed adapter. */
+int32_t bh_pm_set_kernel_ops(const bh_pm_kernel_ops_t *ops);
 void bh_pm_set_failure_injection(int fail_stage); // 0 = none, 1-5 represent spawn phases
 int bh_pm_register_executable(uint64_t handle, const uint8_t *bytes, size_t size);
 int bh_pm_get_active_count(void);

--- a/core/services/vm_manager/vm_manager.c
+++ b/core/services/vm_manager/vm_manager.c
@@ -39,43 +39,37 @@ static const region_entry_t *vm_manager_find_region(uint32_t region_id) {
 // Fail-closed defaults. Production builds must replace these authority operations.
 static int32_t default_space_create(void *ctx, const bh_vm_create_space_request_v1_t *req, bh_vm_kernel_space_ref_t *out_ref) {
     (void)ctx; (void)req;
-    if (out_ref) out_ref->space_id = 1;
-    return BHARAT_IPC_STATUS_OK;
+    (void)out_ref;
+    return BHARAT_IPC_STATUS_ERR_UNSUPPORTED;
 }
 
 static int32_t default_space_destroy(void *ctx, bh_vm_kernel_space_ref_t ref) {
     (void)ctx; (void)ref;
-    return BHARAT_IPC_STATUS_OK;
+    return BHARAT_IPC_STATUS_ERR_UNSUPPORTED;
 }
 
 static int32_t default_map(void *ctx, bh_vm_kernel_space_ref_t ref, const bh_vm_map_request_v1_t *req) {
     (void)ctx; (void)ref; (void)req;
-    return BHARAT_IPC_STATUS_OK;
+    return BHARAT_IPC_STATUS_ERR_UNSUPPORTED;
 }
 
 static int32_t default_unmap(void *ctx, bh_vm_kernel_space_ref_t ref, uint64_t vaddr, uint64_t length) {
     (void)ctx; (void)ref; (void)vaddr; (void)length;
-    return BHARAT_IPC_STATUS_OK;
+    return BHARAT_IPC_STATUS_ERR_UNSUPPORTED;
 }
 
 static int32_t default_protect(void *ctx, bh_vm_kernel_space_ref_t ref, uint64_t vaddr, uint64_t length, uint64_t protection, uint64_t memory_type) {
     (void)ctx; (void)ref; (void)vaddr; (void)length; (void)protection; (void)memory_type;
-    return BHARAT_IPC_STATUS_OK;
+    return BHARAT_IPC_STATUS_ERR_UNSUPPORTED;
 }
 
 static int32_t default_query(void *ctx, bh_vm_kernel_space_ref_t ref, uint64_t vaddr, bh_vm_kernel_query_result_t *out_res) {
     (void)ctx; (void)ref; (void)vaddr;
-    if (out_res) {
-        out_res->state = 0;
-        out_res->vaddr = vaddr;
-        out_res->size = 4096;
-        out_res->protection = 0;
-        out_res->memory_type = 0;
-    }
-    return BHARAT_IPC_STATUS_OK;
+    (void)out_res;
+    return BHARAT_IPC_STATUS_ERR_UNSUPPORTED;
 }
 
-static bh_vm_authority_ops_t g_authority_ops = {
+static const bh_vm_authority_ops_t g_default_authority_ops = {
     .ctx = NULL,
     .space_create = default_space_create,
     .space_destroy = default_space_destroy,
@@ -85,10 +79,21 @@ static bh_vm_authority_ops_t g_authority_ops = {
     .query = default_query
 };
 
-void bh_vm_set_authority_ops(const bh_vm_authority_ops_t *ops) {
-    if (ops) {
-        g_authority_ops = *ops;
+/* Service-local adapter selection; configured during single-threaded startup. */
+static bh_vm_authority_ops_t g_authority_ops;
+
+int32_t bh_vm_set_authority_ops(const bh_vm_authority_ops_t *ops) {
+    if (!ops) {
+        g_authority_ops = g_default_authority_ops;
+        return BHARAT_IPC_STATUS_OK;
     }
+    if (!ops->space_create || !ops->space_destroy || !ops->map ||
+        !ops->unmap || !ops->protect || !ops->query) {
+        g_authority_ops = g_default_authority_ops;
+        return BHARAT_IPC_STATUS_ERR_UNSUPPORTED;
+    }
+    g_authority_ops = *ops;
+    return BHARAT_IPC_STATUS_OK;
 }
 
 int bh_vm_get_active_spaces_count(void) {
@@ -199,6 +204,7 @@ void vm_manager_init(void) {
 
     bh_user_handle_table_init(&g_vm_space_handle_table, g_vm_space_slots, MAX_SPACES);
     bh_user_handle_table_init(&g_vm_region_handle_table, g_vm_region_slots, MAX_REGIONS);
+    g_authority_ops = g_default_authority_ops;
 }
 
 int32_t vm_manager_handle_map(const vm_req_map_t *req, vm_resp_map_t *resp) {
@@ -312,8 +318,8 @@ int32_t bh_vm_handle_create_space_v1(const bh_vm_create_space_request_v1_t *req,
     bh_vm_kernel_space_ref_t k_ref;
     int k_res = g_authority_ops.space_create(g_authority_ops.ctx, req, &k_ref);
     if (k_res != 0) {
-        resp->status = BHARAT_IPC_STATUS_ERR_INTERNAL;
-        return BHARAT_IPC_STATUS_ERR_INTERNAL;
+        resp->status = k_res;
+        return k_res;
     }
 
     space->in_use = true;
@@ -357,14 +363,22 @@ int32_t bh_vm_handle_destroy_space_v1(const bh_vm_destroy_space_request_v1_t *re
     for (int i = 0; i < MAX_REGIONS; i++) {
         if (g_vm_regions[i].in_use && g_vm_regions[i].parent_space == req->vm_space_handle) {
             bh_vm_kernel_space_ref_t k_space = { .space_id = space->kernel_space_id };
-            g_authority_ops.unmap(g_authority_ops.ctx, k_space, g_vm_regions[i].vaddr, g_vm_regions[i].length);
+            int32_t status = g_authority_ops.unmap(g_authority_ops.ctx, k_space, g_vm_regions[i].vaddr, g_vm_regions[i].length);
+            if (status != BHARAT_IPC_STATUS_OK) {
+                resp->status = status;
+                return status;
+            }
             bh_user_handle_revoke(&g_vm_region_handle_table, g_vm_regions[i].public_handle);
             local_memset(&g_vm_regions[i], 0, sizeof(bh_vm_region_v1_t));
         }
     }
 
     bh_vm_kernel_space_ref_t k_space = { .space_id = space->kernel_space_id };
-    g_authority_ops.space_destroy(g_authority_ops.ctx, k_space);
+    int32_t status = g_authority_ops.space_destroy(g_authority_ops.ctx, k_space);
+    if (status != BHARAT_IPC_STATUS_OK) {
+        resp->status = status;
+        return status;
+    }
 
     bh_user_handle_revoke(&g_vm_space_handle_table, req->vm_space_handle);
     local_memset(space, 0, sizeof(bh_vm_space_v1_t));
@@ -465,8 +479,8 @@ int32_t bh_vm_handle_map_v1(const bh_vm_map_request_v1_t *req, bh_vm_map_respons
     bh_vm_kernel_space_ref_t k_space = { .space_id = space->kernel_space_id };
     int k_res = g_authority_ops.map(g_authority_ops.ctx, k_space, req);
     if (k_res != 0) {
-        resp->status = BHARAT_IPC_STATUS_ERR_INTERNAL;
-        return BHARAT_IPC_STATUS_ERR_INTERNAL;
+        resp->status = k_res;
+        return k_res;
     }
 
     region->in_use = true;
@@ -526,8 +540,8 @@ int32_t bh_vm_handle_unmap_v1(const bh_vm_unmap_request_v1_t *req, bh_vm_unmap_r
     bh_vm_kernel_space_ref_t k_space = { .space_id = space->kernel_space_id };
     int k_res = g_authority_ops.unmap(g_authority_ops.ctx, k_space, region->vaddr, region->length);
     if (k_res != 0) {
-        resp->status = BHARAT_IPC_STATUS_ERR_INTERNAL;
-        return BHARAT_IPC_STATUS_ERR_INTERNAL;
+        resp->status = k_res;
+        return k_res;
     }
 
     region->state = BH_VM_REGION_STATE_REVOKED_V1;
@@ -577,8 +591,8 @@ int32_t bh_vm_handle_protect_v1(const bh_vm_protect_request_v1_t *req, bh_vm_pro
     bh_vm_kernel_space_ref_t k_space = { .space_id = space->kernel_space_id };
     int k_res = g_authority_ops.protect(g_authority_ops.ctx, k_space, region->vaddr, region->length, req->new_protection, region->memory_type);
     if (k_res != 0) {
-        resp->status = BHARAT_IPC_STATUS_ERR_INTERNAL;
-        return BHARAT_IPC_STATUS_ERR_INTERNAL;
+        resp->status = k_res;
+        return k_res;
     }
 
     // Updatecached protection only after success
@@ -616,12 +630,22 @@ int32_t bh_vm_handle_query_v1(const bh_vm_query_request_v1_t *req, bh_vm_query_r
         return BHARAT_IPC_STATUS_ERR_INVALID;
     }
 
+    bh_vm_kernel_space_ref_t k_space = { .space_id = space->kernel_space_id };
+    bh_vm_kernel_query_result_t result;
+    local_memset(&result, 0, sizeof(result));
+    int32_t status = g_authority_ops.query(g_authority_ops.ctx, k_space,
+                                           region->vaddr, &result);
+    if (status != BHARAT_IPC_STATUS_OK) {
+        resp->status = status;
+        return status;
+    }
+
     resp->status = BHARAT_IPC_STATUS_OK;
-    resp->state = region->state;
-    resp->vaddr = region->vaddr;
-    resp->size = region->length;
-    resp->protection = region->protection;
-    resp->memory_type = region->memory_type;
+    resp->state = result.state;
+    resp->vaddr = result.vaddr;
+    resp->size = result.size;
+    resp->protection = result.protection;
+    resp->memory_type = result.memory_type;
 
     return BHARAT_IPC_STATUS_OK;
 }

--- a/core/services/vm_manager/vm_manager.h
+++ b/core/services/vm_manager/vm_manager.h
@@ -90,7 +90,8 @@ int32_t vm_manager_handle_fault(const vm_req_fault_t *req, vm_resp_fault_t *resp
 int32_t vm_manager_authorize(uint32_t opcode, const void *req, bharat_cap_handle_t caller_cap);
 
 // v1 global interfaces
-void bh_vm_set_authority_ops(const bh_vm_authority_ops_t *ops);
+/* Installs one complete authority adapter. NULL restores the fail-closed adapter. */
+int32_t bh_vm_set_authority_ops(const bh_vm_authority_ops_t *ops);
 int bh_vm_get_active_spaces_count(void);
 int bh_vm_get_active_regions_count(void);
 

--- a/docs/architecture/services/runtime_lifecycle_contract.md
+++ b/docs/architecture/services/runtime_lifecycle_contract.md
@@ -56,6 +56,16 @@ The `process_manager` handles high-level process lifecycle orchestration, polici
 - **State Tracking:** Maintains the active state of processes.
 - **Reaping and Teardown:** Cleans up processes that have terminated or failed.
 
+### Authority adapter invariant
+
+The v1 process lifecycle transaction publishes service metadata only after the
+corresponding kernel authority operation succeeds.  The adapter is installed as
+one complete operation table during single-threaded service startup; a missing
+or partial adapter selects an immutable fail-closed table whose operations
+return `BHARAT_STATUS_ERR_UNSUPPORTED` and never manufacture process, VM-space,
+or thread identifiers.  Termination and reaping likewise retain the prior
+service state when the kernel authority rejects the operation.
+
 ### State Machine
 `UNKNOWN -> CREATED -> READY -> RUNNING -> STOPPING -> EXITED -> FAILED`
 
@@ -76,6 +86,16 @@ The `vm_manager` manages address space lifecycles, virtual regions, and memory m
 - **Region Management:** Creates and tracks virtual memory regions for address spaces.
 - **Page Fault Handling:** Responds to kernel page fault notifications (`VM_OP_FAULT`).
 - **Memory Protection:** Manages memory protection flags (Read/Write/Execute).
+
+### VM authority adapter invariant
+
+The v1 VM service caches mapping metadata only after the canonical VM authority
+acknowledges create, map, unmap, protect, query, or destroy.  Adapter installation
+is all-or-nothing during single-threaded startup.  Missing and partial adapters
+return `BHARAT_STATUS_ERR_UNSUPPORTED`; they do not create synthetic spaces or
+mappings.  Destruction stops at the first failed unmap/destroy operation and
+keeps the affected service records live, so later recovery can retry without
+claiming that kernel state was removed.
 
 ### State Machine
 `UNKNOWN -> DECLARED -> VALIDATED -> PROGRAMMED -> ACTIVE -> REVOKED`

--- a/interface/contracts/implementation_maturity.json
+++ b/interface/contracts/implementation_maturity.json
@@ -5,13 +5,13 @@
       "id": "process_manager.authority_backend",
       "maturity": "PARTIAL",
       "sources": ["core/services/process_manager/process_manager.c"],
-      "evidence": "The default kernel authority operations are fail-closed placeholders; tests may register injected operations."
+      "evidence": "The default kernel authority operations return ERR_UNSUPPORTED without publishing synthetic identifiers; complete test adapters may be registered during startup. A production kernel adapter is not installed yet."
     },
     {
       "id": "vm_manager.authority_backend",
       "maturity": "PARTIAL",
       "sources": ["core/services/vm_manager/vm_manager.c"],
-      "evidence": "The default VM authority operations are fail-closed placeholders; tests may register injected operations."
+      "evidence": "The default VM authority operations return ERR_UNSUPPORTED without publishing synthetic spaces or mappings; complete test adapters may be registered during startup. A production VM authority adapter is not installed yet."
     },
     {
       "id": "filesystem.service",

--- a/quality/tests/host/process_vm/test_pm_spawn_transaction.c
+++ b/quality/tests/host/process_vm/test_pm_spawn_transaction.c
@@ -116,17 +116,6 @@ static int32_t track_reap_process(void *ctx, bh_pm_kernel_process_t *proc) {
 void test_spawn_rollback_failures(void) {
     process_manager_init();
 
-    bh_pm_kernel_ops_t ops = {
-        .ctx = NULL,
-        .create_process = track_create_process,
-        .create_vm_space = track_create_vm_space,
-        .realize_image = track_realize_image,
-        .start_process = track_start_process,
-        .request_terminate = track_request_terminate,
-        .reap_process = track_reap_process
-    };
-    bh_pm_set_kernel_ops(&ops);
-
     uint8_t elf_buf[1024];
     setup_test_elf(elf_buf, sizeof(elf_buf));
     int reg_res = bh_pm_register_executable(990011, elf_buf, sizeof(elf_buf));
@@ -139,12 +128,31 @@ void test_spawn_rollback_failures(void) {
     req.executable_handle = 990011;
     strcpy(req.process_name, "test_prog");
 
+    /* An uninstalled adapter must not manufacture process identifiers. */
+    bh_pm_spawn_response_v1_t unsupported_resp;
+    int status = bh_pm_handle_spawn_v1(&req, &unsupported_resp);
+    assert(status == BHARAT_IPC_STATUS_ERR_UNSUPPORTED);
+    assert(unsupported_resp.status == BHARAT_IPC_STATUS_ERR_UNSUPPORTED);
+    assert(unsupported_resp.kernel_process_id == 0);
+    assert(bh_pm_get_active_count() == 0);
+
+    bh_pm_kernel_ops_t ops = {
+        .ctx = NULL,
+        .create_process = track_create_process,
+        .create_vm_space = track_create_vm_space,
+        .realize_image = track_realize_image,
+        .start_process = track_start_process,
+        .request_terminate = track_request_terminate,
+        .reap_process = track_reap_process
+    };
+    assert(bh_pm_set_kernel_ops(&ops) == BHARAT_IPC_STATUS_OK);
+
     // Test failure injection at each stage
     for (int fail_stage = 1; fail_stage <= 5; fail_stage++) {
         bh_pm_set_failure_injection(fail_stage);
 
         bh_pm_spawn_response_v1_t resp;
-        int status = bh_pm_handle_spawn_v1(&req, &resp);
+        status = bh_pm_handle_spawn_v1(&req, &resp);
         assert(status != BHARAT_IPC_STATUS_OK);
         assert(resp.status != BHARAT_IPC_STATUS_OK);
 
@@ -158,7 +166,7 @@ void test_spawn_rollback_failures(void) {
     // Now test a successful spawn
     bh_pm_set_failure_injection(0);
     bh_pm_spawn_response_v1_t resp;
-    int status = bh_pm_handle_spawn_v1(&req, &resp);
+    status = bh_pm_handle_spawn_v1(&req, &resp);
     printf("Debug status: %d, resp.status: %d\n", status, resp.status);
     fflush(stdout);
     assert(status == BHARAT_IPC_STATUS_OK);

--- a/quality/tests/host/process_vm/test_vm_authority_integration.c
+++ b/quality/tests/host/process_vm/test_vm_authority_integration.c
@@ -38,12 +38,28 @@ static int32_t auth_protect(void *ctx, bh_vm_kernel_space_ref_t ref, uint64_t va
 }
 
 static int32_t auth_query(void *ctx, bh_vm_kernel_space_ref_t ref, uint64_t vaddr, bh_vm_kernel_query_result_t *out_res) {
-    (void)ctx; (void)ref; (void)vaddr;
+    (void)ctx; (void)ref;
+    out_res->state = BH_VM_REGION_STATE_MAPPED_V1;
+    out_res->vaddr = vaddr;
+    out_res->size = 0x2000;
+    out_res->protection = 1;
+    out_res->memory_type = 0;
     return 0;
 }
 
 void test_vm_authority_integration_v1(void) {
     vm_manager_init();
+
+    bh_vm_create_space_request_v1_t unsupported_req;
+    memset(&unsupported_req, 0, sizeof(unsupported_req));
+    unsupported_req.abi_version = BH_VM_INTERFACE_VERSION_V1;
+    unsupported_req.struct_size = sizeof(unsupported_req);
+    bh_vm_create_space_response_v1_t unsupported_resp;
+    int status = bh_vm_handle_create_space_v1(&unsupported_req, &unsupported_resp);
+    assert(status == BHARAT_IPC_STATUS_ERR_UNSUPPORTED);
+    assert(unsupported_resp.status == BHARAT_IPC_STATUS_ERR_UNSUPPORTED);
+    assert(unsupported_resp.vm_space_handle == 0);
+    assert(bh_vm_get_active_spaces_count() == 0);
 
     bh_vm_authority_ops_t ops = {
         .ctx = NULL,
@@ -54,7 +70,7 @@ void test_vm_authority_integration_v1(void) {
         .protect = auth_protect,
         .query = auth_query
     };
-    bh_vm_set_authority_ops(&ops);
+    assert(bh_vm_set_authority_ops(&ops) == BHARAT_IPC_STATUS_OK);
 
     g_mapped_count = 0;
     g_unmapped_count = 0;
@@ -69,7 +85,7 @@ void test_vm_authority_integration_v1(void) {
     c_req.timing_class = 2; // Soft RT
 
     bh_vm_create_space_response_v1_t c_resp;
-    int status = bh_vm_handle_create_space_v1(&c_req, &c_resp);
+    status = bh_vm_handle_create_space_v1(&c_req, &c_resp);
     assert(status == BHARAT_IPC_STATUS_OK);
     assert(c_resp.vm_space_handle != 0);
 


### PR DESCRIPTION
### Motivation

- Prevent synthetic-success plumbing from fabricating process/VM/thread identifiers and ensure the process/VM services cannot claim progress until a real kernel authority adapter is installed. 
- Force the services to be fail-closed so the HMEM/tensor userspace benchmark and shell must run through real process/VM authority paths rather than scaffold defaults.

### Description

- Replace the process-manager kernel authority defaults with an immutable fail-closed adapter whose operations return `BHARAT_IPC_STATUS_ERR_UNSUPPORTED` and never manufacture PIDs, VM-space ids, thread ids, or entry points.  (changes in `core/services/process_manager/process_manager.c/.h`).
- Replace the vm-manager authority defaults with fail-closed results and add an all-or-nothing adapter installation model; `bh_vm_set_authority_ops` and `bh_pm_set_kernel_ops` now validate a complete table and return status (NULL restores fail-closed). (changes in `core/services/vm_manager/vm_manager.c/.h` and `core/services/process_manager/process_manager.c/.h`).
- Propagate authority errors through spawn/map/unmap/protect/query/destroy call paths instead of masking them as internal success, and only publish process/space/mapping handles after the canonical authority acknowledges the operation (process and VM handlers updated).
- Add negative-path regression tests that assert an uninstalled adapter returns `ERR_UNSUPPORTED` without leaking handles or synthetic IDs and keep existing rollback tests intact; update `quality/tests/host/process_vm/test_pm_spawn_transaction.c` and `quality/tests/host/process_vm/test_vm_authority_integration.c` accordingly.
- Document the authority installation and publication invariants in the runtime lifecycle contract and update `interface/contracts/implementation_maturity.json` to reflect that production kernel adapters are not yet installed.

### Testing

- Ran the focused host unit tests by compiling and executing the modified tests directly, including `test_pm_spawn_transaction` and `test_vm_authority_integration`, with the result: PASS (both tests printed their success messages and assertions passed). (compiled/executed locally with `cc` and direct run).
- Ran repository linters and contract checks with `python3 tools/lint/check_layer_references.py`, `python3 tools/lint/check_cmake_dependencies.py`, and `python3 tools/abi/syscall_abi.py --check`, and `python3 tools/check_implementation_maturity.py --profile DEBUG`; all checks passed. (PASS).
- Built and smoke-tested the x86_64 QEMU target with `./tools/build.sh all --target-yaml delivery/targets/qemu/x86_64_desktop_headless.yaml --smoke`; x86_64 build/smoke completed successfully. (PASS).
- Attempted the full QEMU matrix and other architecture-target smoke builds (`arm64`, `riscv64`, `arm32`, `riscv32`) and started cross-architecture builds, but those longer builds did not finish within the execution window and are therefore BLOCKED pending full-matrix execution time/machine availability; `python3 tools/run_qemu_matrix.py --headless --smoke --all-arch` remains BLOCKED until the remaining target builds/runs complete. (BLOCKED).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7d580293e88320b097a27a8064d46c)