### PR TITLE
Harden process_manager lifecycle validation

### DIFF
--- a/core/services/process_manager/process_manager.c
+++ b/core/services/process_manager/process_manager.c
@@ -15,21 +15,6 @@ static void *local_memset(void *s, int c, size_t n) {
     return s;
 }
 
-static void *local_memcpy(void *dest, const void *src, size_t n) {
-    unsigned char *d = (unsigned char *)dest;
-    const unsigned char *s = (const unsigned char *)src;
-    while (n--) {
-        *d++ = *s++;
-    }
-    return dest;
-}
-
-static size_t local_strlen(const char *s) {
-    size_t len = 0;
-    while (s[len]) len++;
-    return len;
-}
-
 static char *local_strncpy(char *dest, const char *src, size_t n) {
     size_t i;
     for (i = 0; i < n && src[i] != '\0'; i++) {
@@ -117,6 +102,16 @@ void bh_pm_set_failure_injection(int fail_stage) {
 }
 
 int bh_pm_register_executable(uint64_t handle, const uint8_t *bytes, size_t size) {
+    if (handle == 0 || !bytes || size == 0) {
+        return -1;
+    }
+
+    for (int i = 0; i < MAX_EXECUTABLES; i++) {
+        if (g_executables[i].in_use && g_executables[i].handle == handle) {
+            return -1;
+        }
+    }
+
     for (int i = 0; i < MAX_EXECUTABLES; i++) {
         if (!g_executables[i].in_use) {
             g_executables[i].in_use = true;
@@ -164,7 +159,7 @@ int32_t process_manager_authorize(
     const void *req,
     bharat_cap_handle_t caller_cap)
 {
-    if (caller_cap == BHARAT_CAP_INVALID_HANDLE) {
+    if (!req || caller_cap == BHARAT_CAP_INVALID_HANDLE) {
         return BHARAT_IPC_STATUS_ERR_PERM;
     }
 
@@ -211,6 +206,9 @@ void process_manager_init(void) {
 }
 
 int32_t process_manager_handle_create(const pm_req_create_t *req, pm_resp_create_t *resp) {
+    if (!req || !resp) {
+        return BHARAT_IPC_STATUS_ERR_INVALID;
+    }
     for (int i = 0; i < MAX_PROCESSES; i++) {
         if (!process_table[i].in_use) {
             process_table[i].in_use = true;
@@ -229,6 +227,9 @@ int32_t process_manager_handle_create(const pm_req_create_t *req, pm_resp_create
 }
 
 int32_t process_manager_handle_start(const pm_req_start_t *req, pm_resp_start_t *resp) {
+    if (!req || !resp) {
+        return BHARAT_IPC_STATUS_ERR_INVALID;
+    }
     for (int i = 0; i < MAX_PROCESSES; i++) {
         if (process_table[i].in_use && process_table[i].process_id == req->process_id) {
             if (process_table[i].state == PM_STATE_CREATED || process_table[i].state == PM_STATE_STOPPING) {
@@ -246,6 +247,9 @@ int32_t process_manager_handle_start(const pm_req_start_t *req, pm_resp_start_t 
 }
 
 int32_t process_manager_handle_stop(const pm_req_stop_t *req, pm_resp_stop_t *resp) {
+    if (!req || !resp) {
+        return BHARAT_IPC_STATUS_ERR_INVALID;
+    }
     for (int i = 0; i < MAX_PROCESSES; i++) {
         if (process_table[i].in_use && process_table[i].process_id == req->process_id) {
             if (process_table[i].state == PM_STATE_RUNNING) {
@@ -263,6 +267,9 @@ int32_t process_manager_handle_stop(const pm_req_stop_t *req, pm_resp_stop_t *re
 }
 
 int32_t process_manager_handle_query(const pm_req_query_t *req, pm_resp_query_t *resp) {
+    if (!req || !resp) {
+        return BHARAT_IPC_STATUS_ERR_INVALID;
+    }
     for (int i = 0; i < MAX_PROCESSES; i++) {
         if (process_table[i].in_use && process_table[i].process_id == req->process_id) {
             resp->process_id = process_table[i].process_id;
@@ -279,6 +286,12 @@ int32_t process_manager_handle_query(const pm_req_query_t *req, pm_resp_query_t 
 // v1 APIs Implementation
 // -----------------------------------------------------------------------------
 
+static bool valid_v1_request(uint32_t abi_version, uint32_t struct_size,
+                             size_t expected_size) {
+    return abi_version == BH_PM_INTERFACE_VERSION_V1 &&
+           struct_size == expected_size;
+}
+
 int32_t bh_pm_handle_spawn_v1(const bh_pm_spawn_request_v1_t *req, bh_pm_spawn_response_v1_t *resp) {
     if (!req || !resp) {
         return BHARAT_IPC_STATUS_ERR_INVALID;
@@ -288,7 +301,8 @@ int32_t bh_pm_handle_spawn_v1(const bh_pm_spawn_request_v1_t *req, bh_pm_spawn_r
     resp->abi_version = BH_PM_INTERFACE_VERSION_V1;
     resp->struct_size = sizeof(bh_pm_spawn_response_v1_t);
 
-    if (req->abi_version != BH_PM_INTERFACE_VERSION_V1 || req->struct_size != sizeof(bh_pm_spawn_request_v1_t)) {
+    if (!valid_v1_request(req->abi_version, req->struct_size, sizeof(*req)) ||
+        req->reserved != 0 || req->executable_handle == 0) {
         resp->status = BHARAT_IPC_STATUS_ERR_INVALID;
         return BHARAT_IPC_STATUS_ERR_INVALID;
     }
@@ -311,11 +325,9 @@ int32_t bh_pm_handle_spawn_v1(const bh_pm_spawn_request_v1_t *req, bh_pm_spawn_r
 
     // Phase 1: Reserve slot in handle table
     bh_pm_process_v1_t *proc = NULL;
-    int slot_index = -1;
     for (int i = 0; i < MAX_PROCESSES; i++) {
         if (g_pm_processes[i].state == BH_PM_STATE_FREE_V1) {
             proc = &g_pm_processes[i];
-            slot_index = i;
             break;
         }
     }
@@ -374,18 +386,18 @@ int32_t bh_pm_handle_spawn_v1(const bh_pm_spawn_request_v1_t *req, bh_pm_spawn_r
     }
 
     // Phase 3: Create Process in Kernel
-    bh_pm_kernel_create_req_t k_req;
+    bh_pm_kernel_create_req_t k_req = {0};
     local_strncpy(k_req.name, proc->name, 32);
     k_req.priority = proc->priority;
 
-    bh_pm_kernel_process_t k_proc;
+    bh_pm_kernel_process_t k_proc = {0};
     int k_res = g_kernel_ops.create_process(g_kernel_ops.ctx, &k_req, &k_proc);
-    if (k_res != 0) {
+    if (k_res != BHARAT_IPC_STATUS_OK || k_proc.pid == 0) {
         // Rollback
         bh_user_handle_revoke(&g_pm_handle_table, proc_handle);
         local_memset(proc, 0, sizeof(bh_pm_process_v1_t));
-        resp->status = k_res;
-        return k_res;
+        resp->status = k_res != BHARAT_IPC_STATUS_OK ? k_res : BHARAT_IPC_STATUS_ERR_INTERNAL;
+        return resp->status;
     }
 
     proc->kernel_process_id = k_proc.pid;
@@ -401,15 +413,15 @@ int32_t bh_pm_handle_spawn_v1(const bh_pm_spawn_request_v1_t *req, bh_pm_spawn_r
     }
 
     // Phase 4: Create VM Space
-    bh_vm_kernel_space_t k_space;
+    bh_vm_kernel_space_t k_space = {0};
     k_res = g_kernel_ops.create_vm_space(g_kernel_ops.ctx, &k_proc, proc->memory_profile, &k_space);
-    if (k_res != 0) {
+    if (k_res != BHARAT_IPC_STATUS_OK || k_space.space_id == 0) {
         // Rollback
         g_kernel_ops.reap_process(g_kernel_ops.ctx, &k_proc);
         bh_user_handle_revoke(&g_pm_handle_table, proc_handle);
         local_memset(proc, 0, sizeof(bh_pm_process_v1_t));
-        resp->status = k_res;
-        return k_res;
+        resp->status = k_res != BHARAT_IPC_STATUS_OK ? k_res : BHARAT_IPC_STATUS_ERR_INTERNAL;
+        return resp->status;
     }
 
     proc->vm_space_handle = k_space.space_id;
@@ -425,15 +437,16 @@ int32_t bh_pm_handle_spawn_v1(const bh_pm_spawn_request_v1_t *req, bh_pm_spawn_r
     }
 
     // Phase 5: Realize image PT_LOAD segments & stack
-    bh_pm_kernel_image_result_t k_img_res;
+    bh_pm_kernel_image_result_t k_img_res = {0};
     k_res = g_kernel_ops.realize_image(g_kernel_ops.ctx, &k_proc, &k_space, &load_plan, &k_img_res);
-    if (k_res != 0) {
+    if (k_res != BHARAT_IPC_STATUS_OK || k_img_res.main_thread_id == 0 ||
+        k_img_res.entry_point != load_plan.entry_point) {
         // Rollback
         g_kernel_ops.reap_process(g_kernel_ops.ctx, &k_proc);
         bh_user_handle_revoke(&g_pm_handle_table, proc_handle);
         local_memset(proc, 0, sizeof(bh_pm_process_v1_t));
-        resp->status = k_res;
-        return k_res;
+        resp->status = k_res != BHARAT_IPC_STATUS_OK ? k_res : BHARAT_IPC_STATUS_ERR_INTERNAL;
+        return resp->status;
     }
 
     proc->main_thread_id = k_img_res.main_thread_id;
@@ -482,6 +495,11 @@ int32_t bh_pm_handle_query_v1(const bh_pm_query_request_v1_t *req, bh_pm_query_r
     resp->abi_version = BH_PM_INTERFACE_VERSION_V1;
     resp->struct_size = sizeof(bh_pm_query_response_v1_t);
 
+    if (!valid_v1_request(req->abi_version, req->struct_size, sizeof(*req))) {
+        resp->status = BHARAT_IPC_STATUS_ERR_INVALID;
+        return resp->status;
+    }
+
     bh_pm_process_v1_t *proc = NULL;
     int h_res = bh_user_handle_lookup(&g_pm_handle_table, req->process_handle, BHARAT_CAP_OBJ_PROCESS, (void **)&proc, NULL);
     if (h_res != BH_HANDLE_TABLE_SUCCESS || !proc) {
@@ -508,6 +526,11 @@ int32_t bh_pm_handle_terminate_v1(const bh_pm_terminate_request_v1_t *req, bh_pm
     resp->abi_version = BH_PM_INTERFACE_VERSION_V1;
     resp->struct_size = sizeof(bh_pm_terminate_response_v1_t);
 
+    if (!valid_v1_request(req->abi_version, req->struct_size, sizeof(*req))) {
+        resp->status = BHARAT_IPC_STATUS_ERR_INVALID;
+        return resp->status;
+    }
+
     bh_pm_process_v1_t *proc = NULL;
     int h_res = bh_user_handle_lookup(&g_pm_handle_table, req->process_handle, BHARAT_CAP_OBJ_PROCESS, (void **)&proc, NULL);
     if (h_res != BH_HANDLE_TABLE_SUCCESS || !proc) {
@@ -515,10 +538,15 @@ int32_t bh_pm_handle_terminate_v1(const bh_pm_terminate_request_v1_t *req, bh_pm
         return BHARAT_IPC_STATUS_ERR_NOT_FOUND;
     }
 
-    // Idempotent terminate
-    if (proc->state == BH_PM_STATE_EXITED_V1 || proc->state == BH_PM_STATE_REAPED_V1) {
+    // Retried termination requests must not repeat the authority operation.
+    if (proc->state == BH_PM_STATE_TERMINATE_REQUESTED_V1 ||
+        proc->state == BH_PM_STATE_EXITED_V1) {
         resp->status = BHARAT_IPC_STATUS_OK;
         return BHARAT_IPC_STATUS_OK;
+    }
+    if (proc->state != BH_PM_STATE_RUNNING_V1) {
+        resp->status = BHARAT_IPC_STATUS_ERR_PERM;
+        return resp->status;
     }
 
     bh_pm_kernel_process_t k_proc = { .pid = proc->kernel_process_id };
@@ -542,6 +570,14 @@ int32_t bh_pm_handle_wait_v1(const bh_pm_wait_request_v1_t *req, bh_pm_wait_resp
     resp->abi_version = BH_PM_INTERFACE_VERSION_V1;
     resp->struct_size = sizeof(bh_pm_wait_response_v1_t);
 
+    if (!valid_v1_request(req->abi_version, req->struct_size, sizeof(*req)) ||
+        (req->wait_flags & ~(BH_PM_WAIT_NONBLOCK | BH_PM_WAIT_UNTIL_DEADLINE)) != 0 ||
+        ((req->wait_flags & BH_PM_WAIT_NONBLOCK) != 0 &&
+         (req->wait_flags & BH_PM_WAIT_UNTIL_DEADLINE) != 0)) {
+        resp->status = BHARAT_IPC_STATUS_ERR_INVALID;
+        return resp->status;
+    }
+
     bh_pm_process_v1_t *proc = NULL;
     int h_res = bh_user_handle_lookup(&g_pm_handle_table, req->process_handle, BHARAT_CAP_OBJ_PROCESS, (void **)&proc, NULL);
     if (h_res != BH_HANDLE_TABLE_SUCCESS || !proc) {
@@ -561,13 +597,9 @@ int32_t bh_pm_handle_wait_v1(const bh_pm_wait_request_v1_t *req, bh_pm_wait_resp
         return BHARAT_IPC_STATUS_ERR_BUSY;
     }
 
-    // Register a waiter
-    proc->has_waiter = true;
-    proc->waiter_flags = req->wait_flags;
-    proc->waiter_timeout_ms = req->timeout_ms;
-
-    resp->status = BHARAT_IPC_STATUS_ERR_BUSY; // Busy because it's still running/waiting
-    return BHARAT_IPC_STATUS_ERR_BUSY;
+    /* A real blocking wait requires timer and reply-continuation primitives. */
+    resp->status = BHARAT_IPC_STATUS_ERR_UNSUPPORTED;
+    return resp->status;
 }
 
 int32_t bh_pm_handle_reap_v1(const bh_pm_reap_request_v1_t *req, bh_pm_reap_response_v1_t *resp) {
@@ -579,6 +611,11 @@ int32_t bh_pm_handle_reap_v1(const bh_pm_reap_request_v1_t *req, bh_pm_reap_resp
     resp->abi_version = BH_PM_INTERFACE_VERSION_V1;
     resp->struct_size = sizeof(bh_pm_reap_response_v1_t);
 
+    if (!valid_v1_request(req->abi_version, req->struct_size, sizeof(*req))) {
+        resp->status = BHARAT_IPC_STATUS_ERR_INVALID;
+        return resp->status;
+    }
+
     bh_pm_process_v1_t *proc = NULL;
     int h_res = bh_user_handle_lookup(&g_pm_handle_table, req->process_handle, BHARAT_CAP_OBJ_PROCESS, (void **)&proc, NULL);
     if (h_res != BH_HANDLE_TABLE_SUCCESS || !proc) {
@@ -587,7 +624,7 @@ int32_t bh_pm_handle_reap_v1(const bh_pm_reap_request_v1_t *req, bh_pm_reap_resp
     }
 
     // Must be in zombie EXITED or FAILED state to reap
-    if (proc->state != BH_PM_STATE_EXITED_V1 && proc->state != BH_PM_STATE_FAILED_V1 && proc->state != BH_PM_STATE_THREAD_CREATED_V1) {
+    if (proc->state != BH_PM_STATE_EXITED_V1 && proc->state != BH_PM_STATE_FAILED_V1) {
         resp->status = BHARAT_IPC_STATUS_ERR_PERM;
         return BHARAT_IPC_STATUS_ERR_PERM;
     }
@@ -612,12 +649,16 @@ int32_t bh_pm_handle_reap_v1(const bh_pm_reap_request_v1_t *req, bh_pm_reap_resp
 }
 
 void bh_pm_notify_exit_v1(uint64_t kernel_process_id, int32_t exit_code, uint32_t exit_reason) {
+    if (kernel_process_id == 0) {
+        return;
+    }
     for (int i = 0; i < MAX_PROCESSES; i++) {
-        if (g_pm_processes[i].state != BH_PM_STATE_FREE_V1 && g_pm_processes[i].kernel_process_id == kernel_process_id) {
+        if ((g_pm_processes[i].state == BH_PM_STATE_RUNNING_V1 ||
+             g_pm_processes[i].state == BH_PM_STATE_TERMINATE_REQUESTED_V1) &&
+            g_pm_processes[i].kernel_process_id == kernel_process_id) {
             g_pm_processes[i].state = BH_PM_STATE_EXITED_V1;
             g_pm_processes[i].exit_code = exit_code;
             g_pm_processes[i].exit_reason = exit_reason;
-            g_pm_processes[i].has_waiter = false;
             break;
         }
     }
@@ -634,6 +675,10 @@ void process_manager_loop(bharat_ipc_endpoint_t endpoint) {
     uint8_t resp_payload_buf[512];
 
     while (true) {
+        local_memset(&req_header, 0, sizeof(req_header));
+        local_memset(&resp_header, 0, sizeof(resp_header));
+        local_memset(payload_buf, 0, sizeof(payload_buf));
+        local_memset(resp_payload_buf, 0, sizeof(resp_payload_buf));
         int32_t recv_status = bharat_ipc_recv(endpoint, &req_header, payload_buf, sizeof(payload_buf));
         if (recv_status < 0) {
             continue;
@@ -656,7 +701,7 @@ void process_manager_loop(bharat_ipc_endpoint_t endpoint) {
         if (req_header.interface_version == BH_PM_INTERFACE_VERSION_V1) {
             switch (req_header.opcode) {
                 case BH_PM_OP_SPAWN_V1: {
-                    if (req_header.payload_size >= sizeof(bh_pm_spawn_request_v1_t)) {
+                    if (req_header.payload_size == sizeof(bh_pm_spawn_request_v1_t)) {
                         const bh_pm_spawn_request_v1_t *req = (const bh_pm_spawn_request_v1_t *)payload_buf;
                         bh_pm_spawn_response_v1_t *resp = (bh_pm_spawn_response_v1_t *)resp_payload_buf;
                         dispatch_status = bh_pm_handle_spawn_v1(req, resp);
@@ -667,7 +712,7 @@ void process_manager_loop(bharat_ipc_endpoint_t endpoint) {
                     break;
                 }
                 case BH_PM_OP_QUERY_V1: {
-                    if (req_header.payload_size >= sizeof(bh_pm_query_request_v1_t)) {
+                    if (req_header.payload_size == sizeof(bh_pm_query_request_v1_t)) {
                         const bh_pm_query_request_v1_t *req = (const bh_pm_query_request_v1_t *)payload_buf;
                         bh_pm_query_response_v1_t *resp = (bh_pm_query_response_v1_t *)resp_payload_buf;
                         dispatch_status = bh_pm_handle_query_v1(req, resp);
@@ -678,7 +723,7 @@ void process_manager_loop(bharat_ipc_endpoint_t endpoint) {
                     break;
                 }
                 case BH_PM_OP_REQUEST_TERMINATE_V1: {
-                    if (req_header.payload_size >= sizeof(bh_pm_terminate_request_v1_t)) {
+                    if (req_header.payload_size == sizeof(bh_pm_terminate_request_v1_t)) {
                         const bh_pm_terminate_request_v1_t *req = (const bh_pm_terminate_request_v1_t *)payload_buf;
                         bh_pm_terminate_response_v1_t *resp = (bh_pm_terminate_response_v1_t *)resp_payload_buf;
                         dispatch_status = bh_pm_handle_terminate_v1(req, resp);
@@ -689,7 +734,7 @@ void process_manager_loop(bharat_ipc_endpoint_t endpoint) {
                     break;
                 }
                 case BH_PM_OP_WAIT_V1: {
-                    if (req_header.payload_size >= sizeof(bh_pm_wait_request_v1_t)) {
+                    if (req_header.payload_size == sizeof(bh_pm_wait_request_v1_t)) {
                         const bh_pm_wait_request_v1_t *req = (const bh_pm_wait_request_v1_t *)payload_buf;
                         bh_pm_wait_response_v1_t *resp = (bh_pm_wait_response_v1_t *)resp_payload_buf;
                         dispatch_status = bh_pm_handle_wait_v1(req, resp);
@@ -700,7 +745,7 @@ void process_manager_loop(bharat_ipc_endpoint_t endpoint) {
                     break;
                 }
                 case BH_PM_OP_REAP_V1: {
-                    if (req_header.payload_size >= sizeof(bh_pm_reap_request_v1_t)) {
+                    if (req_header.payload_size == sizeof(bh_pm_reap_request_v1_t)) {
                         const bh_pm_reap_request_v1_t *req = (const bh_pm_reap_request_v1_t *)payload_buf;
                         bh_pm_reap_response_v1_t *resp = (bh_pm_reap_response_v1_t *)resp_payload_buf;
                         dispatch_status = bh_pm_handle_reap_v1(req, resp);

--- a/core/services/process_manager/process_manager.h
+++ b/core/services/process_manager/process_manager.h
@@ -79,10 +79,6 @@ typedef struct {
     uint32_t affinity_mask;
     uint32_t memory_profile;
 
-    // Waiter tracking for WAIT
-    bool has_waiter;
-    uint32_t waiter_flags;
-    uint32_t waiter_timeout_ms;
 } bh_pm_process_v1_t;
 
 // Executable image registration

--- a/docs/architecture/services/process_manager.md
+++ b/docs/architecture/services/process_manager.md
@@ -1,8 +1,8 @@
 ---
 title: Process Manager Service Architecture
-status: Proposed
+status: Transitional
 owner: Documentation Working Group
-last_updated: 2026-04-25
+last_updated: 2026-08-13
 tags:
   - docs
   - architecture
@@ -12,9 +12,9 @@ see_also:
 ---
 # Process Manager Service Architecture
 
-**Version:** v1.0 (Proposed)
+**Version:** v1.0 (Transitional)
 **Scope:** Services
-**Status:** Draft → Implementation Ready
+**Status:** Transitional; not production-ready
 
 ---
 
@@ -87,6 +87,58 @@ When a process terminates, the orchestration ensures clean teardown:
 
 ---
 
-## 6. Implementation Notes
+## 6. Current implementation contract
 
-Currently, `core/services/process_manager/main.c` is a TODO shell. The next step is to formalize this orchestrator contract using BIDL (Bharat Interface Definition Language) so other services and runtimes can depend on its interfaces for spawn, exec, kill, wait, and reap operations.
+The v1 implementation is a bounded, single-owner service-local process table. The
+service loop is the only supported mutator; the asynchronous exit notifier must be
+serialized onto that same execution context. The kernel adapter is installed only
+during single-threaded startup and defaults to fail closed. Spawn publishes a handle
+only after process, address-space, image, and initial-thread creation have succeeded.
+Failures revoke the provisional handle and request kernel reaping.
+
+Every v1 operation validates its exact ABI version and structure size. Spawn also
+requires zeroed reserved fields, non-zero executable authority, and non-zero object
+identifiers returned by the kernel adapter. Query, terminate, wait, and reap reject
+stale handles through generation-checked handle lookup. Termination is idempotent and
+reaping is legal only for `EXITED` or explicitly `FAILED` objects. Blocking waits fail
+closed as unsupported; the service does not pretend that storing waiter metadata is a
+working wait implementation.
+
+## 7. Primitive maturity and production blockers
+
+The following mechanisms are required before this service can be described as
+production-ready:
+
+1. **Capability-authenticated v1 dispatch.** The legacy interface authorizes every
+   operation, but the v1 dispatcher does not yet bind caller capabilities, parent
+   scope, executable rights, or per-operation process rights to each request.
+2. **Real kernel authority adapter.** Production delivery must bind capability-based
+   process, address-space, loader, thread, start, terminate, and reap operations. The
+   default adapter intentionally returns `ERR_UNSUPPORTED`.
+3. **Serialized exit delivery.** Kernel exit events need a bounded IPC queue with
+   generation/incarnation identity, replay protection, backpressure, and ordering
+   relative to terminate and reap. Direct concurrent calls to the notifier are not
+   safe.
+4. **Deadline-aware wait continuations.** Blocking wait needs retained reply
+   continuations, monotonic HAL deadlines, cancellation on caller death, bounded
+   waiter storage, and wakeup race tests. Until then only non-blocking polling is
+   supported.
+5. **Rollback quarantine.** Adapter cleanup currently has no durable transaction
+   journal. A failed reap during spawn rollback requires a quarantined lifecycle
+   record and supervised retry rather than an unreachable leaked kernel object.
+6. **Executable ownership.** Registered image bytes are borrowed pointers. A loader
+   service must validate an executable capability and pin or copy immutable image
+   data for the whole transaction; registration must also support revocation.
+7. **Restart recovery and durable identity.** The in-memory table, incarnation value,
+   request IDs, and PID allocation do not survive service restart. Exactly-once spawn
+   replay and reconciliation with kernel-owned processes remain unimplemented.
+8. **Policy orchestration.** Namespace setup, capability seeding, personality binding,
+   parent/child relationships, quotas, audit records, and crash policy remain service
+   work rather than kernel mechanisms.
+9. **Backend evidence.** The authority adapter needs lifecycle and rollback coverage
+   on MMU, MMU-Lite, and MPU targets, including exhaustion, stale generation, timeout,
+   duplicate event, and partial-failure cases.
+
+These blockers are deliberately explicit: input hardening and deterministic local
+state transitions improve the current boundary, but they do not make missing kernel,
+IPC, timer, loader, or recovery primitives appear implemented.

--- a/quality/tests/host/process_vm/test_pm_spawn_transaction.c
+++ b/quality/tests/host/process_vm/test_pm_spawn_transaction.c
@@ -120,6 +120,9 @@ void test_spawn_rollback_failures(void) {
     setup_test_elf(elf_buf, sizeof(elf_buf));
     int reg_res = bh_pm_register_executable(990011, elf_buf, sizeof(elf_buf));
     assert(reg_res == 0);
+    assert(bh_pm_register_executable(990011, elf_buf, sizeof(elf_buf)) == -1);
+    assert(bh_pm_register_executable(0, elf_buf, sizeof(elf_buf)) == -1);
+    assert(bh_pm_register_executable(990012, NULL, sizeof(elf_buf)) == -1);
 
     bh_pm_spawn_request_v1_t req;
     memset(&req, 0, sizeof(req));
@@ -128,9 +131,16 @@ void test_spawn_rollback_failures(void) {
     req.executable_handle = 990011;
     strcpy(req.process_name, "test_prog");
 
+    bh_pm_spawn_response_v1_t invalid_resp;
+    req.reserved = 1;
+    int status = bh_pm_handle_spawn_v1(&req, &invalid_resp);
+    assert(status == BHARAT_IPC_STATUS_ERR_INVALID);
+    assert(bh_pm_get_active_count() == 0);
+    req.reserved = 0;
+
     /* An uninstalled adapter must not manufacture process identifiers. */
     bh_pm_spawn_response_v1_t unsupported_resp;
-    int status = bh_pm_handle_spawn_v1(&req, &unsupported_resp);
+    status = bh_pm_handle_spawn_v1(&req, &unsupported_resp);
     assert(status == BHARAT_IPC_STATUS_ERR_UNSUPPORTED);
     assert(unsupported_resp.status == BHARAT_IPC_STATUS_ERR_UNSUPPORTED);
     assert(unsupported_resp.kernel_process_id == 0);
@@ -173,6 +183,29 @@ void test_spawn_rollback_failures(void) {
     assert(resp.status == BHARAT_IPC_STATUS_OK);
     assert(resp.process_handle != 0);
     assert(bh_pm_get_active_count() == 1);
+
+    bh_pm_query_request_v1_t bad_query = {
+        .abi_version = BH_PM_INTERFACE_VERSION_V1 + 1,
+        .struct_size = sizeof(bad_query),
+        .process_handle = resp.process_handle,
+    };
+    bh_pm_query_response_v1_t query_resp;
+    assert(bh_pm_handle_query_v1(&bad_query, &query_resp) ==
+           BHARAT_IPC_STATUS_ERR_INVALID);
+
+    bh_pm_wait_request_v1_t bad_wait = {
+        .abi_version = BH_PM_INTERFACE_VERSION_V1,
+        .struct_size = sizeof(bad_wait),
+        .process_handle = resp.process_handle,
+        .wait_flags = UINT32_MAX,
+    };
+    bh_pm_wait_response_v1_t wait_resp;
+    assert(bh_pm_handle_wait_v1(&bad_wait, &wait_resp) ==
+           BHARAT_IPC_STATUS_ERR_INVALID);
+
+    bad_wait.wait_flags = 0;
+    assert(bh_pm_handle_wait_v1(&bad_wait, &wait_resp) ==
+           BHARAT_IPC_STATUS_ERR_UNSUPPORTED);
 
     printf("test_spawn_rollback_failures passed!\n");
 }


### PR DESCRIPTION
### Motivation

- Improve robustness and fail-closed behavior of the process manager spawn/query/terminate/wait/reap paths by closing several input, lifecycle and authority gaps discovered during testing and review.
- Make the v1 UAPI safer by validating ABI version/struct sizes, rejecting malformed requests, and preventing publication of provisional handles until the full spawn transaction succeeds.

### Description

- Validate inputs and harden registration: `bh_pm_register_executable` now rejects zero handles, null/empty image data, and duplicate registrations; legacy handlers check for null requests and fail closed. (changed `core/services/process_manager/process_manager.c` and header.)
- Strict v1 ABI checking and reserved-field validation: added `valid_v1_request()` and require exact `abi_version` and `struct_size`, non-zero executable handle, and zeroed reserved fields before processing. (v1 handlers hardened in `process_manager.c`.)
- Transaction safety and kernel-adapter checks: zero-initialize adapter outputs and reject adapter successes that return invalid identifiers (pid/space/thread/entry), and only publish a process handle after all phases succeed; rollbacks revoke provisional handles. (spawn phases in `process_manager.c`.)
- Lifecycle semantics tightened: make termination idempotent and only allowed from `RUNNING`, restrict reaping to `EXITED`/`FAILED`, ignore zero/stale exit notifications, and make blocking waits return `ERR_UNSUPPORTED` (explicitly documented as a missing primitive). (lifecycle logic in `process_manager.c` and `process_manager.h`.)
- IPC dispatch and buffer hygiene: clear per-message buffers between receives and require exact payload sizes for v1 opcodes to avoid ambiguous/trailing payload handling. (dispatch loop in `process_manager.c`.)
- Tests and docs: added focused assertions for invalid registration/ABI/reserved fields/unsupported blocking waits and updated architecture doc to mark the implementation as transitional and list remaining production blockers. (updated `quality/tests/host/process_vm/test_pm_spawn_transaction.c` and `docs/architecture/services/process_manager.md`.)

### Testing

- Ran the focused host unit transaction test by compiling and executing the test binary: `cc -std=c11 ... test_pm_spawn_transaction.c ... -o /tmp/bharat-pm-tests/test_pm_spawn_transaction && /tmp/bharat-pm-tests/test_pm_spawn_transaction` and the test passed (`test_spawn_rollback_failures passed!`).
- Ran linters and ABI checks: `python3 tools/lint/check_layer_references.py` (PASS), `python3 tools/lint/check_cmake_dependencies.py` (PASS), and `python3 tools/abi/syscall_abi.py --check` (PASS).
- Built and smoke-ran the five-target QEMU matrix: `./tools/build.sh all --target-yaml delivery/targets/qemu/<target>.yaml --smoke` for x86_64, arm64, riscv64, arm32_mmu_lite, riscv32_mmu_lite all returned PASS, and `python3 tools/run_qemu_matrix.py --headless --smoke --all-arch` observed PASS for all five required targets.
- Note on host CMake: an initial attempt to use `-DBHARAT_BUILD_HOST_TESTS=ON` to drive CMake-hosted tests was blocked by absent/legacy source paths in `quality/tests/host/CMakeLists.txt`; to get focused coverage the host test was compiled/run directly as above (focused host test compilation succeeded under strict warnings and passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7d5b810fc48320afdb11be3a91f1ed)