### PR TITLE
Require kernel authority adapters for process and VM services

### DIFF
--- a/core/services/process_manager/main.c
+++ b/core/services/process_manager/main.c
@@ -7,6 +7,11 @@ int main(int argc, char** argv) {
 
     process_manager_init();
 
+    /* Refuse to advertise a process service without real kernel authority. */
+    if (!bh_pm_kernel_ops_installed()) {
+        return BHARAT_IPC_STATUS_ERR_UNSUPPORTED;
+    }
+
     bharat_ipc_endpoint_t endpoint = 0x1000; // Fake endpoint for now
 
     process_manager_loop(endpoint);

--- a/core/services/process_manager/process_manager.c
+++ b/core/services/process_manager/process_manager.c
@@ -82,19 +82,27 @@ static const bh_pm_kernel_ops_t g_default_kernel_ops = {
 
 /* Service-local adapter selection; configured during single-threaded startup. */
 static bh_pm_kernel_ops_t g_kernel_ops;
+static bool g_kernel_ops_installed;
 
 int32_t bh_pm_set_kernel_ops(const bh_pm_kernel_ops_t *ops) {
     if (!ops) {
         g_kernel_ops = g_default_kernel_ops;
-        return BHARAT_IPC_STATUS_OK;
+        g_kernel_ops_installed = false;
+        return BHARAT_IPC_STATUS_ERR_UNSUPPORTED;
     }
     if (!ops->create_process || !ops->create_vm_space || !ops->realize_image ||
         !ops->start_process || !ops->request_terminate || !ops->reap_process) {
         g_kernel_ops = g_default_kernel_ops;
+        g_kernel_ops_installed = false;
         return BHARAT_IPC_STATUS_ERR_UNSUPPORTED;
     }
     g_kernel_ops = *ops;
+    g_kernel_ops_installed = true;
     return BHARAT_IPC_STATUS_OK;
+}
+
+bool bh_pm_kernel_ops_installed(void) {
+    return g_kernel_ops_installed;
 }
 
 void bh_pm_set_failure_injection(int fail_stage) {
@@ -202,6 +210,7 @@ void process_manager_init(void) {
 
     bh_user_handle_table_init(&g_pm_handle_table, g_pm_handle_slots, MAX_PROCESSES);
     g_kernel_ops = g_default_kernel_ops;
+    g_kernel_ops_installed = false;
     g_fail_stage = 0;
 }
 

--- a/core/services/process_manager/process_manager.h
+++ b/core/services/process_manager/process_manager.h
@@ -99,8 +99,9 @@ int32_t process_manager_handle_query(const pm_req_query_t *req, pm_resp_query_t 
 int32_t process_manager_authorize(uint32_t opcode, const void *req, bharat_cap_handle_t caller_cap);
 
 // v1 Process Manager Interfaces
-/* Installs one complete authority adapter. NULL restores the fail-closed adapter. */
+/* Installs one complete adapter. NULL restores fail-closed and returns unsupported. */
 int32_t bh_pm_set_kernel_ops(const bh_pm_kernel_ops_t *ops);
+bool bh_pm_kernel_ops_installed(void);
 void bh_pm_set_failure_injection(int fail_stage); // 0 = none, 1-5 represent spawn phases
 int bh_pm_register_executable(uint64_t handle, const uint8_t *bytes, size_t size);
 int bh_pm_get_active_count(void);

--- a/core/services/vm_manager/main.c
+++ b/core/services/vm_manager/main.c
@@ -7,6 +7,11 @@ int main(int argc, char** argv) {
 
     vm_manager_init();
 
+    /* Do not expose a VM service backed only by the fail-closed adapter. */
+    if (!bh_vm_authority_ops_installed()) {
+        return BHARAT_IPC_STATUS_ERR_UNSUPPORTED;
+    }
+
     bharat_ipc_endpoint_t endpoint = 0x2000; // Fake endpoint for now
 
     vm_manager_loop(endpoint);

--- a/core/services/vm_manager/vm_manager.c
+++ b/core/services/vm_manager/vm_manager.c
@@ -81,19 +81,27 @@ static const bh_vm_authority_ops_t g_default_authority_ops = {
 
 /* Service-local adapter selection; configured during single-threaded startup. */
 static bh_vm_authority_ops_t g_authority_ops;
+static bool g_authority_ops_installed;
 
 int32_t bh_vm_set_authority_ops(const bh_vm_authority_ops_t *ops) {
     if (!ops) {
         g_authority_ops = g_default_authority_ops;
-        return BHARAT_IPC_STATUS_OK;
+        g_authority_ops_installed = false;
+        return BHARAT_IPC_STATUS_ERR_UNSUPPORTED;
     }
     if (!ops->space_create || !ops->space_destroy || !ops->map ||
         !ops->unmap || !ops->protect || !ops->query) {
         g_authority_ops = g_default_authority_ops;
+        g_authority_ops_installed = false;
         return BHARAT_IPC_STATUS_ERR_UNSUPPORTED;
     }
     g_authority_ops = *ops;
+    g_authority_ops_installed = true;
     return BHARAT_IPC_STATUS_OK;
+}
+
+bool bh_vm_authority_ops_installed(void) {
+    return g_authority_ops_installed;
 }
 
 int bh_vm_get_active_spaces_count(void) {
@@ -205,6 +213,7 @@ void vm_manager_init(void) {
     bh_user_handle_table_init(&g_vm_space_handle_table, g_vm_space_slots, MAX_SPACES);
     bh_user_handle_table_init(&g_vm_region_handle_table, g_vm_region_slots, MAX_REGIONS);
     g_authority_ops = g_default_authority_ops;
+    g_authority_ops_installed = false;
 }
 
 int32_t vm_manager_handle_map(const vm_req_map_t *req, vm_resp_map_t *resp) {

--- a/core/services/vm_manager/vm_manager.h
+++ b/core/services/vm_manager/vm_manager.h
@@ -90,8 +90,9 @@ int32_t vm_manager_handle_fault(const vm_req_fault_t *req, vm_resp_fault_t *resp
 int32_t vm_manager_authorize(uint32_t opcode, const void *req, bharat_cap_handle_t caller_cap);
 
 // v1 global interfaces
-/* Installs one complete authority adapter. NULL restores the fail-closed adapter. */
+/* Installs one complete adapter. NULL restores fail-closed and returns unsupported. */
 int32_t bh_vm_set_authority_ops(const bh_vm_authority_ops_t *ops);
+bool bh_vm_authority_ops_installed(void);
 int bh_vm_get_active_spaces_count(void);
 int bh_vm_get_active_regions_count(void);
 

--- a/docs/architecture/services/process_manager.md
+++ b/docs/architecture/services/process_manager.md
@@ -96,6 +96,15 @@ during single-threaded startup and defaults to fail closed. Spawn publishes a ha
 only after process, address-space, image, and initial-thread creation have succeeded.
 Failures revoke the provisional handle and request kernel reaping.
 
+The standalone service refuses to enter its IPC loop unless a complete kernel
+authority adapter was installed during startup. Restoring the default adapter,
+including by passing `NULL`, returns `ERR_UNSUPPORTED`; it is not a successful
+configuration operation. Current delivery images therefore cannot claim that
+`bench_hmem_tensor` was spawned through `process_manager`: the native ABI does not
+yet provide the capability-mediated process/address-space/image authority transport
+needed to install that adapter. The SDK benchmark remains host-side evidence and the
+QEMU HMEM benchmark remains kernel-side evidence until that transport exists.
+
 Every v1 operation validates its exact ABI version and structure size. Spawn also
 requires zeroed reserved fields, non-zero executable authority, and non-zero object
 identifiers returned by the kernel adapter. Query, terminate, wait, and reap reject

--- a/quality/tests/host/process_vm/test_pm_spawn_transaction.c
+++ b/quality/tests/host/process_vm/test_pm_spawn_transaction.c
@@ -115,6 +115,8 @@ static int32_t track_reap_process(void *ctx, bh_pm_kernel_process_t *proc) {
 
 void test_spawn_rollback_failures(void) {
     process_manager_init();
+    assert(!bh_pm_kernel_ops_installed());
+    assert(bh_pm_set_kernel_ops(NULL) == BHARAT_IPC_STATUS_ERR_UNSUPPORTED);
 
     uint8_t elf_buf[1024];
     setup_test_elf(elf_buf, sizeof(elf_buf));
@@ -156,6 +158,7 @@ void test_spawn_rollback_failures(void) {
         .reap_process = track_reap_process
     };
     assert(bh_pm_set_kernel_ops(&ops) == BHARAT_IPC_STATUS_OK);
+    assert(bh_pm_kernel_ops_installed());
 
     // Test failure injection at each stage
     for (int fail_stage = 1; fail_stage <= 5; fail_stage++) {

--- a/quality/tests/host/process_vm/test_vm_authority_integration.c
+++ b/quality/tests/host/process_vm/test_vm_authority_integration.c
@@ -49,6 +49,8 @@ static int32_t auth_query(void *ctx, bh_vm_kernel_space_ref_t ref, uint64_t vadd
 
 void test_vm_authority_integration_v1(void) {
     vm_manager_init();
+    assert(!bh_vm_authority_ops_installed());
+    assert(bh_vm_set_authority_ops(NULL) == BHARAT_IPC_STATUS_ERR_UNSUPPORTED);
 
     bh_vm_create_space_request_v1_t unsupported_req;
     memset(&unsupported_req, 0, sizeof(unsupported_req));
@@ -71,6 +73,7 @@ void test_vm_authority_integration_v1(void) {
         .query = auth_query
     };
     assert(bh_vm_set_authority_ops(&ops) == BHARAT_IPC_STATUS_OK);
+    assert(bh_vm_authority_ops_installed());
 
     g_mapped_count = 0;
     g_unmapped_count = 0;


### PR DESCRIPTION
### Motivation

- Prevent user-visible services from fabricating kernel objects or identifiers when no real kernel authority adapter is installed, and ensure the HMEM/tensor benchmark cannot be claimed as a spawned userspace process by a synthetic backend.
- Harden the fail-closed contract for uninstalled adapters so that a reset-to-default is not treated as a successful production configuration.

### Description

- Track explicit "installed" state for the process-manager and vm-manager authority adapters and make `bh_pm_set_kernel_ops` and `bh_vm_set_authority_ops` return `BHARAT_IPC_STATUS_ERR_UNSUPPORTED` when the adapter is unset or invalid.
- Add `bh_pm_kernel_ops_installed()` and `bh_vm_authority_ops_installed()` query helpers and initialize those flags to false on service init.
- Prevent the standalone service mains from entering their IPC loops when no real authority adapter is installed by returning `ERR_UNSUPPORTED` early in `process_manager/main.c` and `vm_manager/main.c`.
- Update unit/host regression tests to assert the new fail-closed semantics and to validate that uninstalled adapters do not produce synthetic PIDs/space IDs; update documentation to note that delivery images cannot claim real-process spawn until the capability-mediated ABI/transport exists.

### Testing

- `python3 tools/lint/check_layer_references.py` — PASS: no new layer violations observed.
- `python3 tools/lint/check_cmake_dependencies.py` — PASS: no dependency violations.
- `python3 tools/abi/syscall_abi.py --check` — PASS: syscall ABI remained clean.
- `python3 tools/run_qemu_matrix.py --help` — PASS: confirmed matrix runner supports `--all-arch`.
- Built and smoke-ran the five required QEMU targets with the repository runner: `./tools/build.sh all --target-yaml delivery/targets/qemu/<arch>_desktop_headless.yaml --smoke` for x86_64, arm64, riscv64, arm32_mmu_lite, riscv32_mmu_lite — PASS for all five targets and `python3 tools/run_qemu_matrix.py --headless --smoke --all-arch` — PASS: all required targets reported PASS.
- `cmake --preset host-test && cmake --build --preset host-test -j2` — BLOCKED: host-test CMake configuration indicated missing source paths in `quality/tests/host/CMakeLists.txt`, preventing focused host-test generation (pre-existing project configuration issue, not caused by these changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7d608961988320b11f980f4fd61703)