### PR TITLE
feat(shell): add diagnostic control-plane UAPI and route admin commands through backend

### DIFF
--- a/core/services/system/shell/include/shell_backend.h
+++ b/core/services/system/shell/include/shell_backend.h
@@ -3,6 +3,7 @@
 
 #include <stddef.h>
 #include "shell.h"
+#include <bharat/uapi/shell/diagnostic.h>
 
 typedef struct {
     int (*get_uptime_ms)(uint64_t* uptime_ms);
@@ -16,6 +17,7 @@ typedef struct {
     int (*mem_stat)(char* out, size_t out_len);
     int (*reboot)(void);
     int (*diag_run)(char* out, size_t out_len);
+    int (*diag_query)(const bh_shell_diag_request_v1_t* request, char* out, size_t out_len);
     void (*audit_event)(const char* event, const char* command, shell_status_code_t status);
 } shell_backend_api_t;
 

--- a/core/services/system/shell/src/commands/shell_commands.c
+++ b/core/services/system/shell/src/commands/shell_commands.c
@@ -2,6 +2,30 @@
 
 #include "shell_string.h"
 
+static shell_response_t mk(shell_status_code_t code, const char* msg, const char* payload);
+
+static shell_response_t cmd_diag_query(const shell_backend_api_t* backend, bh_shell_diag_query_t query,
+                                       const char* message, const shell_argv_t* argv, size_t argument_index) {
+    static char payload[SHELL_MAX_OUTPUT_LEN];
+    bh_shell_diag_request_v1_t request = {0};
+    size_t argument_len = 0u;
+    if (!backend || !backend->diag_query) return mk(SHELL_RC_BACKEND_UNAVAILABLE, "diagnostic service unavailable", NULL);
+    if ((query == BH_SHELL_DIAG_SERVICE_STATUS || query == BH_SHELL_DIAG_HMEM_ALLOC) && argument_index >= argv->count)
+        return mk(SHELL_RC_INVALID_ARG, "missing argument", NULL);
+    if (argument_index < argv->count) {
+        argument_len = shell_strlen(argv->tokens[argument_index]);
+        if (argument_len >= sizeof(request.argument)) return mk(SHELL_RC_INVALID_ARG, "argument too long", NULL);
+        shell_memcpy(request.argument, argv->tokens[argument_index], argument_len + 1u);
+    }
+    request.abi_version = BH_SHELL_DIAG_ABI_VERSION;
+    request.struct_size = (uint16_t)sizeof(request);
+    request.query = (uint32_t)query;
+    request.argument_length = (uint32_t)argument_len;
+    if (backend->diag_query(&request, payload, sizeof(payload)) != 0)
+        return mk(SHELL_RC_BACKEND_UNAVAILABLE, "diagnostic query unavailable", NULL);
+    return mk(SHELL_RC_OK, message, payload);
+}
+
 static void write_u64_dec(char* out, size_t out_len, uint64_t value) {
     char tmp[21];
     size_t n = 0;
@@ -31,7 +55,7 @@ static shell_response_t cmd_help(const shell_session_t* session,
     (void)session; (void)backend; (void)argv;
     return mk(SHELL_RC_OK,
               "commands",
-              "help version uptime echo status sys info svc list svc status log tail health summary dev list mem stat reboot");
+              "help version uptime cpuinfo hwcap ps service list service status meminfo vmstat hmem info hmem topology hmem stats hmem alloc hmem bench tensor info tensor bench timer info capstat device list io stat net status diag");
 }
 
 static shell_response_t cmd_version(const shell_session_t* s, const shell_backend_api_t* b, const shell_argv_t* a) {
@@ -179,6 +203,31 @@ static shell_response_t cmd_reboot(const shell_session_t* s, const shell_backend
     return mk(SHELL_RC_OK, "reboot", "accepted");
 }
 
+#define DIAG_HANDLER(name, query, label, arg_index) \
+static shell_response_t name(const shell_session_t* s, const shell_backend_api_t* b, const shell_argv_t* a) { \
+    (void)s; return cmd_diag_query(b, query, label, a, arg_index); \
+}
+DIAG_HANDLER(cmd_cpuinfo, BH_SHELL_DIAG_CPU_INFO, "cpuinfo", 1u)
+DIAG_HANDLER(cmd_hwcap, BH_SHELL_DIAG_HW_CAP, "hwcap", 1u)
+DIAG_HANDLER(cmd_ps, BH_SHELL_DIAG_PROCESS_LIST, "ps", 1u)
+DIAG_HANDLER(cmd_service_list, BH_SHELL_DIAG_SERVICE_LIST, "service list", 2u)
+DIAG_HANDLER(cmd_service_status, BH_SHELL_DIAG_SERVICE_STATUS, "service status", 2u)
+DIAG_HANDLER(cmd_meminfo, BH_SHELL_DIAG_MEMORY_INFO, "meminfo", 1u)
+DIAG_HANDLER(cmd_vmstat, BH_SHELL_DIAG_VM_STAT, "vmstat", 1u)
+DIAG_HANDLER(cmd_hmem_info, BH_SHELL_DIAG_HMEM_INFO, "hmem info", 2u)
+DIAG_HANDLER(cmd_hmem_topology, BH_SHELL_DIAG_HMEM_TOPOLOGY, "hmem topology", 2u)
+DIAG_HANDLER(cmd_hmem_stats, BH_SHELL_DIAG_HMEM_STATS, "hmem stats", 2u)
+DIAG_HANDLER(cmd_hmem_alloc, BH_SHELL_DIAG_HMEM_ALLOC, "hmem alloc", 2u)
+DIAG_HANDLER(cmd_hmem_bench, BH_SHELL_DIAG_HMEM_BENCH, "hmem bench", 2u)
+DIAG_HANDLER(cmd_tensor_info, BH_SHELL_DIAG_TENSOR_INFO, "tensor info", 2u)
+DIAG_HANDLER(cmd_tensor_bench, BH_SHELL_DIAG_TENSOR_BENCH, "tensor bench", 2u)
+DIAG_HANDLER(cmd_timer_info, BH_SHELL_DIAG_TIMER_INFO, "timer info", 2u)
+DIAG_HANDLER(cmd_capstat, BH_SHELL_DIAG_CAP_STAT, "capstat", 1u)
+DIAG_HANDLER(cmd_device_list, BH_SHELL_DIAG_DEVICE_LIST, "device list", 2u)
+DIAG_HANDLER(cmd_io_stat, BH_SHELL_DIAG_IO_STAT, "io stat", 2u)
+DIAG_HANDLER(cmd_net_status, BH_SHELL_DIAG_NET_STATUS, "net status", 2u)
+DIAG_HANDLER(cmd_diag, BH_SHELL_DIAG_RUN, "diag", 1u)
+
 const shell_command_entry_t* shell_registry_get(size_t* count) {
     static const shell_command_entry_t entries[] = {
         {.command = "help", .required_caps = SHELL_CAP_NONE, .allowed_in_prod = true, .timeout_ms = 10, .handler = cmd_help},
@@ -195,6 +244,26 @@ const shell_command_entry_t* shell_registry_get(size_t* count) {
         {.command = "mem stat", .required_caps = SHELL_CAP_NONE, .allowed_in_prod = true, .timeout_ms = 100, .handler = cmd_mem_stat},
         {.command = "diag run", .required_caps = SHELL_CAP_DIAG, .allowed_in_prod = false, .timeout_ms = 1, .handler = cmd_diag_run},
         {.command = "reboot", .required_caps = SHELL_CAP_REBOOT, .allowed_in_prod = false, .timeout_ms = 200, .handler = cmd_reboot},
+        {.command = "cpuinfo", .required_caps = SHELL_CAP_NONE, .allowed_in_prod = true, .timeout_ms = 100, .handler = cmd_cpuinfo},
+        {.command = "hwcap", .required_caps = SHELL_CAP_NONE, .allowed_in_prod = true, .timeout_ms = 100, .handler = cmd_hwcap},
+        {.command = "ps", .required_caps = SHELL_CAP_NONE, .allowed_in_prod = true, .timeout_ms = 100, .handler = cmd_ps},
+        {.command = "service list", .required_caps = SHELL_CAP_NONE, .allowed_in_prod = true, .timeout_ms = 100, .handler = cmd_service_list},
+        {.command = "service status", .required_caps = SHELL_CAP_NONE, .allowed_in_prod = true, .timeout_ms = 100, .handler = cmd_service_status},
+        {.command = "meminfo", .required_caps = SHELL_CAP_NONE, .allowed_in_prod = true, .timeout_ms = 100, .handler = cmd_meminfo},
+        {.command = "vmstat", .required_caps = SHELL_CAP_NONE, .allowed_in_prod = true, .timeout_ms = 100, .handler = cmd_vmstat},
+        {.command = "hmem info", .required_caps = SHELL_CAP_NONE, .allowed_in_prod = true, .timeout_ms = 100, .handler = cmd_hmem_info},
+        {.command = "hmem topology", .required_caps = SHELL_CAP_NONE, .allowed_in_prod = true, .timeout_ms = 100, .handler = cmd_hmem_topology},
+        {.command = "hmem stats", .required_caps = SHELL_CAP_NONE, .allowed_in_prod = true, .timeout_ms = 100, .handler = cmd_hmem_stats},
+        {.command = "hmem alloc", .required_caps = SHELL_CAP_DIAG, .allowed_in_prod = false, .timeout_ms = 200, .handler = cmd_hmem_alloc},
+        {.command = "hmem bench", .required_caps = SHELL_CAP_DIAG, .allowed_in_prod = false, .timeout_ms = 1000, .handler = cmd_hmem_bench},
+        {.command = "tensor info", .required_caps = SHELL_CAP_NONE, .allowed_in_prod = true, .timeout_ms = 100, .handler = cmd_tensor_info},
+        {.command = "tensor bench", .required_caps = SHELL_CAP_DIAG, .allowed_in_prod = false, .timeout_ms = 1000, .handler = cmd_tensor_bench},
+        {.command = "timer info", .required_caps = SHELL_CAP_NONE, .allowed_in_prod = true, .timeout_ms = 100, .handler = cmd_timer_info},
+        {.command = "capstat", .required_caps = SHELL_CAP_NONE, .allowed_in_prod = true, .timeout_ms = 100, .handler = cmd_capstat},
+        {.command = "device list", .required_caps = SHELL_CAP_NONE, .allowed_in_prod = true, .timeout_ms = 100, .handler = cmd_device_list},
+        {.command = "io stat", .required_caps = SHELL_CAP_NONE, .allowed_in_prod = true, .timeout_ms = 100, .handler = cmd_io_stat},
+        {.command = "net status", .required_caps = SHELL_CAP_NONE, .allowed_in_prod = true, .timeout_ms = 100, .handler = cmd_net_status},
+        {.command = "diag", .required_caps = SHELL_CAP_DIAG, .allowed_in_prod = false, .timeout_ms = 1000, .handler = cmd_diag},
     };
     if (count) {
         *count = sizeof(entries) / sizeof(entries[0]);

--- a/core/services/system/shell/src/shell_backend_runtime.c
+++ b/core/services/system/shell/src/shell_backend_runtime.c
@@ -16,15 +16,13 @@ static int backend_uptime(uint64_t* uptime_ms) {
 }
 
 static int backend_status(char* out, size_t out_len) {
-    if (!out || out_len < 32) return BHARAT_STATUS_ERR_LENGTH;
-    shell_memcpy(out, "state=running profile=runtime", 30);
-    return BHARAT_STATUS_OK;
+    (void)out; (void)out_len;
+    return BHARAT_STATUS_ERR_UNSUPPORTED;
 }
 
 static int backend_sys_info(char* out, size_t out_len) {
-    if (!out || out_len < 32) return BHARAT_STATUS_ERR_LENGTH;
-    shell_memcpy(out, "os=Bharat-OS mode=production", 29);
-    return BHARAT_STATUS_OK;
+    (void)out; (void)out_len;
+    return BHARAT_STATUS_ERR_UNSUPPORTED;
 }
 
 static int backend_svc_list(char* out, size_t out_len) {
@@ -67,6 +65,12 @@ static int backend_diag_run(char* out, size_t out_len) {
     return BHARAT_STATUS_ERR_UNSUPPORTED;
 }
 
+static int backend_diag_query(const bh_shell_diag_request_v1_t* request, char* out, size_t out_len) {
+    (void)request; (void)out; (void)out_len;
+    /* Fail closed until bootstrap supplies a capability-backed endpoint. */
+    return BHARAT_STATUS_ERR_UNSUPPORTED;
+}
+
 static void backend_audit(const char* event, const char* command, shell_status_code_t status) {
     (void)event; (void)command; (void)status;
 }
@@ -84,6 +88,7 @@ const shell_backend_api_t* shell_runtime_backend(void) {
         .mem_stat = backend_mem_stat,
         .reboot = backend_reboot,
         .diag_run = backend_diag_run,
+        .diag_query = backend_diag_query,
         .audit_event = backend_audit,
     };
     return &api;

--- a/core/services/system/shell/tests/CMakeLists.txt
+++ b/core/services/system/shell/tests/CMakeLists.txt
@@ -12,7 +12,7 @@ set(SHELL_TEST_SRCS
 
 function(add_shell_test name source)
     add_executable(${name} ${source} ${SHELL_TEST_SRCS})
-    target_include_directories(${name} PRIVATE ../include ../../../../lib)
+    target_include_directories(${name} PRIVATE ../include ../../../../lib ${CMAKE_SOURCE_DIR}/interface/include)
     target_compile_definitions(${name} PRIVATE SHELL_NO_MAIN=1)
     add_test(NAME ${name} COMMAND ${name})
 endfunction()
@@ -23,3 +23,4 @@ add_shell_test(test_shell_auth_and_denials test_shell_auth_and_denials.c)
 add_shell_test(test_shell_malformed_and_unknown test_shell_malformed_and_unknown.c)
 add_shell_test(test_shell_timeout_and_backend_failure test_shell_timeout_and_backend_failure.c)
 add_shell_test(test_shell_integration_session test_shell_integration_session.c)
+add_shell_test(test_shell_diagnostic_control_plane test_shell_diagnostic_control_plane.c)

--- a/core/services/system/shell/tests/test_shell_diagnostic_control_plane.c
+++ b/core/services/system/shell/tests/test_shell_diagnostic_control_plane.c
@@ -1,0 +1,44 @@
+#include "shell_dispatch.h"
+#include "shell_parser.h"
+#include "shell_session.h"
+
+#include <assert.h>
+#include <string.h>
+
+static bh_shell_diag_request_v1_t observed;
+
+static int diagnostic_service(const bh_shell_diag_request_v1_t *request,
+                              char *out, size_t out_len) {
+  assert(request != NULL);
+  assert(out_len >= sizeof("source=service"));
+  observed = *request;
+  memcpy(out, "source=service", sizeof("source=service"));
+  return 0;
+}
+
+int main(void) {
+  shell_session_t session;
+  shell_backend_api_t backend = {0};
+  shell_argv_t argv;
+  shell_response_t response;
+  char line[] = "service status console";
+  char unavailable_line[] = "cpuinfo";
+
+  shell_session_init(&session, SHELL_MODE_DEV, SHELL_CAP_NONE);
+  backend.diag_query = diagnostic_service;
+  assert(shell_parse_line(line, &argv) == 0);
+  response = shell_dispatch(&session, &backend, &argv);
+  assert(response.code == SHELL_RC_OK);
+  assert(strcmp(response.payload, "source=service") == 0);
+  assert(observed.abi_version == BH_SHELL_DIAG_ABI_VERSION);
+  assert(observed.struct_size == sizeof(observed));
+  assert(observed.query == BH_SHELL_DIAG_SERVICE_STATUS);
+  assert(observed.argument_length == strlen("console"));
+  assert(strcmp(observed.argument, "console") == 0);
+
+  backend.diag_query = NULL;
+  assert(shell_parse_line(unavailable_line, &argv) == 0);
+  response = shell_dispatch(&session, &backend, &argv);
+  assert(response.code == SHELL_RC_BACKEND_UNAVAILABLE);
+  return 0;
+}

--- a/docs/adr/ADR-023-shell-diagnostic-control-plane.md
+++ b/docs/adr/ADR-023-shell-diagnostic-control-plane.md
@@ -1,0 +1,17 @@
+# ADR-023: Bharat Shell diagnostic control plane
+
+## Status
+
+Accepted
+
+## Decision
+
+The native Bharat Shell is the console-first administration and debugging surface. Shell command handlers may format requests and responses, but they must obtain runtime state only through capability-backed service or kernel diagnostic endpoints. They must never read kernel or service globals directly.
+
+The first contract is `bh_shell_diag_request_v1_t`: a versioned, fixed-width, by-value request containing a bounded argument. Diagnostic services own discovery and mutable state. The shell owns no diagnostic cache. A missing endpoint, unsupported query, malformed request, or insufficient capability fails closed and produces an unavailable/forbidden shell result rather than fabricated data.
+
+Read-only observations may be enabled in production profiles. Allocation and benchmark operations require the diagnostic capability and are disabled in production by default. Providers remain responsible for narrower capability, object, rights, scope, and liveness checks before accessing their subsystem.
+
+## Consequences
+
+This establishes the command vocabulary without waiting for POSIX compatibility and makes service boundaries observable. Runtime bootstrap still needs to bind the backend to real endpoints per target; until then the production backend explicitly returns unsupported. The wire request contains no pointers, handles, architecture-sized integers, or mutable shared state.

--- a/docs/architecture/CONTRACTS.md
+++ b/docs/architecture/CONTRACTS.md
@@ -22,6 +22,7 @@ When implementation differs from an authority, treat it as a defect or an explic
 
 | Area | Authority | Generated outputs / consumers | Required validation | Owner |
 |---|---|---|---|---|
+| Shell diagnostic control plane | `interface/include/bharat/uapi/shell/diagnostic.h` and ADR-023 | Native shell and capability-backed diagnostic providers | Shell diagnostic control-plane host test plus target smoke builds | System services maintainers |
 | Processor trap-entry ABI | `docs/adr/ADR-020-mechanically-verified-trap-entry-abi.md` and `core/kernel/include/trap.h` | Build-generated `trap_offsets.inc`; five architecture entry stubs; normalized trap decoder | `python3 tools/abi/test_trap_frame_abi.py <generated>/trap_offsets.inc <five assembly files>` plus target smoke builds | Kernel architecture maintainers |
 | Native syscall ABI | `interface/contracts/abi/native_syscalls.json` and ADR-018 | Build-generated syscall numbers/table metadata; native `write` bootstrap authority is the implicit current process | `python3 tools/abi/syscall_abi.py --check` regenerates twice in temporary directories and verifies the locked output hashes | Kernel ABI maintainers |
 | Syscall compatibility lock | `interface/contracts/abi/native_syscalls.lock.json` | Locked syscall count, numbers, metadata, and generated-output SHA-256 values | ABI check and the intentional procedure in `docs/dev/native-syscall-abi-change.md` | Kernel ABI maintainers |

--- a/docs/architecture/system/shell-architecture.md
+++ b/docs/architecture/system/shell-architecture.md
@@ -31,6 +31,9 @@ This document defines the canonical Bharat-OS system shell architecture and alig
 - Deferred POSIX compatibility shell: `core/personalities/compat/`
 
 Shell handlers must use service contracts/backend APIs and must not access kernel internals directly.
+The diagnostic request contract is `interface/include/bharat/uapi/shell/diagnostic.h`:
+providers own discovery and state, while the shell only validates, dispatches, and
+formats bounded responses.
 
 ## Shell classes
 
@@ -48,6 +51,11 @@ Shell handlers must use service contracts/backend APIs and must not access kerne
 - Deny path + auth lockout behavior.
 - Text and `kv` output modes.
 - Host tests covering parser, registry, denials, malformed input, timeout/backend failure, integration session.
+- Console-first administration catalog (`cpuinfo`, `hwcap`, `ps`, service, memory,
+  heterogeneous-memory, tensor, timer, capability, device, I/O, network, and
+  diagnostic commands) routed through the versioned diagnostic-provider boundary.
+- Runtime `status` and `sys info` no longer fabricate static state; an unbound
+  diagnostic/service endpoint fails closed.
 
 ### Missing / partial
 

--- a/interface/include/bharat/uapi/shell/diagnostic.h
+++ b/interface/include/bharat/uapi/shell/diagnostic.h
@@ -1,0 +1,49 @@
+#ifndef BHARAT_UAPI_SHELL_DIAGNOSTIC_H
+#define BHARAT_UAPI_SHELL_DIAGNOSTIC_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define BH_SHELL_DIAG_ABI_VERSION 1u
+#define BH_SHELL_DIAG_MAX_ARGUMENT 96u
+
+typedef enum bh_shell_diag_query {
+  BH_SHELL_DIAG_CPU_INFO = 1,
+  BH_SHELL_DIAG_HW_CAP = 2,
+  BH_SHELL_DIAG_PROCESS_LIST = 3,
+  BH_SHELL_DIAG_SERVICE_LIST = 4,
+  BH_SHELL_DIAG_SERVICE_STATUS = 5,
+  BH_SHELL_DIAG_MEMORY_INFO = 6,
+  BH_SHELL_DIAG_VM_STAT = 7,
+  BH_SHELL_DIAG_HMEM_INFO = 8,
+  BH_SHELL_DIAG_HMEM_TOPOLOGY = 9,
+  BH_SHELL_DIAG_HMEM_STATS = 10,
+  BH_SHELL_DIAG_HMEM_ALLOC = 11,
+  BH_SHELL_DIAG_HMEM_BENCH = 12,
+  BH_SHELL_DIAG_TENSOR_INFO = 13,
+  BH_SHELL_DIAG_TENSOR_BENCH = 14,
+  BH_SHELL_DIAG_TIMER_INFO = 15,
+  BH_SHELL_DIAG_CAP_STAT = 16,
+  BH_SHELL_DIAG_DEVICE_LIST = 17,
+  BH_SHELL_DIAG_IO_STAT = 18,
+  BH_SHELL_DIAG_NET_STATUS = 19,
+  BH_SHELL_DIAG_RUN = 20
+} bh_shell_diag_query_t;
+
+/* Fixed-width, by-value request. The receiving service owns all discovered
+ * state. */
+typedef struct bh_shell_diag_request_v1 {
+  uint16_t abi_version;
+  uint16_t struct_size;
+  uint32_t query;
+  uint32_t argument_length;
+  uint32_t reserved;
+  char argument[BH_SHELL_DIAG_MAX_ARGUMENT];
+} bh_shell_diag_request_v1_t;
+
+_Static_assert(sizeof(bh_shell_diag_request_v1_t) == 112u,
+               "shell diagnostic request ABI size changed");
+_Static_assert(offsetof(bh_shell_diag_request_v1_t, argument) == 16u,
+               "shell diagnostic request ABI layout changed");
+
+#endif


### PR DESCRIPTION
### Motivation

- Provide a console-first admin/debug control plane by routing shell commands through a versioned diagnostic/provider boundary instead of reading kernel or service globals directly.
- Expose a stable, pointer-free diagnostic request ABI so the shell can ask services for real state (CPU, services, memory, hmem, tensor, devices, net, diag, etc.) while failing closed when a provider is not available.

### Description

- Add a versioned diagnostic UAPI `bh_shell_diag_request_v1_t` and query enum in `interface/include/bharat/uapi/shell/diagnostic.h` with compile-time layout assertions and a 96-byte bounded argument field.
- Extend the shell backend API with `diag_query` and implement a runtime backend stub `backend_diag_query` that fail-closes until bootstrap supplies a capability-backed diagnostic endpoint (`core/services/system/shell/include/shell_backend.h`, `core/services/system/shell/src/shell_backend_runtime.c`).
- Add a central `cmd_diag_query` helper and register a broad, console-first command catalog routed exclusively through the diagnostic query boundary (commands such as `cpuinfo`, `hwcap`, `ps`, `service list`, `service status <name>`, `meminfo`, `vmstat`, `hmem *`, `tensor *`, `timer info`, `capstat`, `device list`, `io stat`, `net status`, `diag`, etc.) with capability and production-mode gating for mutating/benchmark ops (`core/services/system/shell/src/commands/shell_commands.c`).
- Add a focused host regression test `test_shell_diagnostic_control_plane.c` that verifies a `service status console` invocation produces a well-formed `bh_shell_diag_request_v1_t`, and that requests fail closed when the backend is absent (`core/services/system/shell/tests/`).
- Add ADR documenting the diagnostic control-plane decision and update architecture contract/docs to record the new contract and the rule that the shell is a service-backed administration surface (`docs/adr/ADR-023-shell-diagnostic-control-plane.md`, `docs/architecture/CONTRACTS.md`, `docs/architecture/system/shell-architecture.md`).
- Update shell tests CMake to include the `interface/include` path so tests can build against the new UAPI header and add the new host test to the test list (`core/services/system/shell/tests/CMakeLists.txt`).

### Testing

- Ran focused host compile+run of the new diagnostic control-plane test using `cc -std=c11 ... -DSHELL_NO_MAIN=1 ...` and executed the test binary; the regression test passed (it verifies the request contents and fail-closed behavior). Warnings about signedness in `core/lib/urpc/urpc.c` remain but did not block the host test.
- Ran static/contract checks: `python3 tools/lint/check_layer_references.py` and `python3 tools/lint/check_cmake_dependencies.py` (both passed) and `python3 tools/abi/syscall_abi.py --check` (passed).
- Performed full-matrix smoke builds and runs using the repository gate scripts and QEMU matrix: `./tools/build.sh all --target-yaml delivery/targets/qemu/<target>.yaml --smoke` for all five required targets and `python3 tools/run_qemu_matrix.py --headless --smoke --all-arch`; the all-arch QEMU smoke matrix passed for the targets exercised in this environment.
- Performed a local build of the shell service and an overall project build; the shell executable and shell service tests built successfully; an unrelated kernel link failure was observed under one local preset during an earlier CTest run (missing demo symbol) and is external to the shell changes.
- Notes: `make_pr`/PR automation was attempted but is blocked in this environment because the `make_pr` helper is not available and no GitHub authentication/remote is configured; create the PR from the branch using the normal repository workflow when ready.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7d7351b6f88320b449db6421c0e3a5)