### PR TITLE
Fix kernel link when framebuffer UI (FBUI) is disabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ include(BharatProfiles)
 include(BharatPersonality)
 include(BharatComponentPolicy)
 option(BHARAT_ENABLE_DMA_MAP "Enable DMA map APIs" ON)
+option(BHARAT_BOOT_GUI "Enable boot-time GUI handoff metadata" ON)
 include(BharatIOPolicy)
 include(${BHARAT_CMAKE_ROOT}/BharatConstraints.cmake)
 

--- a/core/kernel/CMakeLists.txt
+++ b/core/kernel/CMakeLists.txt
@@ -164,7 +164,6 @@ configure_file(
     "${BHARAT_GENERATED_INCLUDE_DIR}/bharat_config.h"
     @ONLY
 )
-option(BHARAT_BOOT_GUI "Enable boot-time GUI handoff metadata" ON)
 if(NOT DEFINED BHARAT_BOOT_HW_PROFILE OR "${BHARAT_BOOT_HW_PROFILE}" STREQUAL "")
     message(FATAL_ERROR "BHARAT_BOOT_HW_PROFILE must not be empty")
 endif()
@@ -655,6 +654,9 @@ add_executable(kernel.elf
     $<TARGET_OBJECTS:k_init>
     $<TARGET_OBJECTS:k_fs>
     $<TARGET_OBJECTS:k_monitor>
+)
+target_compile_definitions(kernel.elf PRIVATE
+    BHARAT_ENABLE_FBUI=$<BOOL:${BHARAT_ENABLE_FBUI}>
 )
 
 # Always enable kernel selftests for test builds

--- a/core/kernel/src/kernel_boot.c
+++ b/core/kernel/src/kernel_boot.c
@@ -385,7 +385,9 @@ extern void kernel_run_boot_tests(void);
 extern void hello_world_app(void);
 extern void kernel_tester_app(void);
 extern void bharat_demo_app_legacy(void);
+#if BHARAT_ENABLE_FBUI
 extern void bharat_demo_app(void);
+#endif
 
 extern int boot_video_map(const boot_info_t *boot);
 
@@ -466,8 +468,7 @@ static void runtime_enter_normal(const boot_info_t *boot) {
     KPRINT("  [BOOT] Runtime initialization complete\n");
     boot_gui_update_progress(100, "LAUNCHING USERSPACE");
 
-#if defined(BHARAT_BOOT_GUI) && BHARAT_BOOT_GUI
-    extern void bharat_demo_app(void);
+#if BHARAT_BOOT_GUI && BHARAT_ENABLE_FBUI
     KPRINT("  [BOOT] Transitioning to Graphical System Dashboard...\n");
     bharat_demo_app();
 #endif
@@ -587,7 +588,9 @@ static void runtime_enter_legacy_bringup(const boot_info_t *boot) {
     hello_world_app();
     kernel_tester_app();
     bharat_demo_app_legacy();
+#if BHARAT_ENABLE_FBUI
     bharat_demo_app();
+#endif
 
     while (1) {
       // Background AI


### PR DESCRIPTION
### Motivation

- Prevent a link-time failure caused by `bharat_demo_app` being referenced even when the framebuffer UI component is disabled by the component policy.  The build should not pull in a user-space demo symbol unless FBUI is enabled.  

### Description

- Move `BHARAT_BOOT_GUI` into the root `CMakeLists.txt` so the component policy resolves GUI/UI defaults during the initial configure pass.  (changed `CMakeLists.txt`).
- Expose the resolved `BHARAT_ENABLE_FBUI` to the kernel target with `target_compile_definitions(kernel.elf PRIVATE BHARAT_ENABLE_FBUI=...)` so kernel sources can conditionally depend on the demo symbol. (changed `core/kernel/CMakeLists.txt`).
- Guard the `bharat_demo_app` declaration and all call sites with `#if BHARAT_ENABLE_FBUI` to avoid referencing the symbol when FBUI is disabled. (changed `core/kernel/src/kernel_boot.c`).

### Testing

- Ran repository linters and ABI checks: `python3 tools/lint/check_layer_references.py` (PASS), `python3 tools/lint/check_cmake_dependencies.py` (PASS), and `python3 tools/abi/syscall_abi.py --check` (PASS).  
- Focused build and test commands: `cmake --build --preset=x86_64-dev -j2` (PASS: kernel link completed and `kernel/kernel.elf` produced); `ctest --preset=x86_64-dev -R 'test_shell_'` (BLOCKED/FAIL: no `x86_64-dev` test preset available in this configuration).  
- QEMU smoke builds: `./tools/build.sh all --target-yaml delivery/targets/qemu/x86_64_desktop_headless.yaml --smoke` (PASS); `./tools/build.sh all --target-yaml delivery/targets/qemu/arm64_desktop_headless.yaml --smoke` (FAIL/INTERRUPTED: run was interrupted while QEMU produced partial boot output and the evidence collector reported missing markers); remaining target smoke builds were not reached in this run (BLOCKED).  

Note: PR creation automation was not executed in this environment because the local `make_pr` helper is not available (`/opt/codex/mcp/make_pr.py` failed due to missing Python package `mcp`), so the change has been committed locally and is ready for a normal PR submission.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7d7942cc088320aa15691202a10d0b)