### PR TITLE
Add HMEM-driven POSIX Phase A to BharatLibC

### DIFF
--- a/core/lib/bharatlibc/CMakeLists.txt
+++ b/core/lib/bharatlibc/CMakeLists.txt
@@ -185,7 +185,7 @@ add_library(bharatlibc_alloc STATIC
     src/alloc/bounded_freelist.c
 )
 target_include_directories(bharatlibc_alloc PUBLIC ${BUILD_INCLUDES})
-target_link_libraries(bharatlibc_alloc PUBLIC bharatlibc_core)
+target_link_libraries(bharatlibc_alloc PUBLIC bharatlibc_core bharatlibc_bsys)
 set_target_properties(bharatlibc_alloc PROPERTIES EXPORT_NAME Alloc)
 
 # 4. bharatlibc_stdio_min
@@ -196,7 +196,14 @@ target_include_directories(bharatlibc_stdio_min PUBLIC ${BUILD_INCLUDES})
 target_link_libraries(bharatlibc_stdio_min PUBLIC bharatlibc_core bharatlibc_bsys)
 set_target_properties(bharatlibc_stdio_min PROPERTIES EXPORT_NAME StdioMin)
 
-# 5. bharatlibc_crt (freestanding CRT initialization stub)
+# 5. bharatlibc_posix_phase_a: the HMEM-demo portability surface. It adapts
+# POSIX source APIs to libbsys and does not define a raw syscall namespace.
+add_library(bharatlibc_posix_phase_a STATIC src/posix/phase_a.c)
+target_include_directories(bharatlibc_posix_phase_a PUBLIC ${BUILD_INCLUDES})
+target_link_libraries(bharatlibc_posix_phase_a PUBLIC bharatlibc_bsys bharatlibc_alloc)
+set_target_properties(bharatlibc_posix_phase_a PROPERTIES EXPORT_NAME PosixPhaseA)
+
+# 6. bharatlibc_crt (freestanding CRT initialization stub)
 add_library(bharatlibc_crt STATIC src/crt/common/crt_stub.c)
 target_include_directories(bharatlibc_crt PUBLIC ${BUILD_INCLUDES})
 set_target_properties(bharatlibc_crt PROPERTIES EXPORT_NAME CRT)
@@ -211,6 +218,7 @@ add_library(BharatLibC::Core ALIAS bharatlibc_core)
 add_library(BharatLibC::BSys ALIAS bharatlibc_bsys)
 add_library(BharatLibC::Alloc ALIAS bharatlibc_alloc)
 add_library(BharatLibC::StdioMin ALIAS bharatlibc_stdio_min)
+add_library(BharatLibC::PosixPhaseA ALIAS bharatlibc_posix_phase_a)
 add_library(BharatLibC::CRT ALIAS bharatlibc_crt)
 
 # ---------------------------------------------------------

--- a/core/lib/bharatlibc/contracts/bharat_libc_abi_v1.yaml
+++ b/core/lib/bharatlibc/contracts/bharat_libc_abi_v1.yaml
@@ -5,3 +5,9 @@ definitions:
     return: void*
   - name: memset
     return: void*
+  - name: memmove
+    return: void*
+  - name: malloc
+    return: void*
+  - name: free
+    return: void

--- a/core/lib/bharatlibc/contracts/posix_subset_v1.yaml
+++ b/core/lib/bharatlibc/contracts/posix_subset_v1.yaml
@@ -7,17 +7,36 @@ posix_subset:
     - Bharat native API
     - native syscall or service IPC
   implemented:
-    - write
     - read
+    - write
     - close
+    - clock_gettime
+    - nanosleep
+    - getpid
+    - isatty
+    - malloc
+    - free
+    - memcpy
+    - memset
+    - memmove
   functions:
     - read
     - write
     - close
+    - malloc
+    - free
+    - memcpy
+    - memset
+    - memmove
     - open
     - openat
     - lseek
     - fstat
+    - readdir
+    - mkdir
+    - unlink
+    - dup
+    - pipe
     - isatty
     - clock_gettime
     - nanosleep
@@ -26,7 +45,6 @@ posix_subset:
     - munmap
     - mprotect
     - brk
-    - sbrk
     - _exit
     - pthread_create
     - pthread_join
@@ -35,31 +53,40 @@ posix_subset:
     - TLS
   stages:
     - stage: 1
-      name: libc_foundation
+      name: hmem_demo
       functions:
         - read
         - write
         - close
-        - open
-        - openat
-        - lseek
-        - fstat
         - isatty
         - clock_gettime
         - nanosleep
         - getpid
+        - malloc
+        - free
+        - memcpy
+        - memset
+        - memmove
     - stage: 2
-      name: memory_process
+      name: after_ramfs
+      functions:
+        - open
+        - openat
+        - lseek
+        - fstat
+        - readdir
+        - mkdir
+        - unlink
+        - dup
+        - pipe
+    - stage: 3
+      name: process_thread_workloads
       functions:
         - mmap
         - munmap
         - mprotect
         - brk
-        - sbrk
         - _exit
-    - stage: 3
-      name: threading
-      functions:
         - pthread_create
         - pthread_join
         - pthread_mutex

--- a/core/lib/bharatlibc/include/bharat/bsys/backend.h
+++ b/core/lib/bharatlibc/include/bharat/bsys/backend.h
@@ -40,6 +40,15 @@ typedef struct {
 
     void (*process_exit)(
         int32_t status);
+
+    /* Append-only ABI v1 extensions. Keep the original fields above stable. */
+    int32_t (*nanosleep)(
+        const bh_bsys_timespec_t *request,
+        bh_bsys_timespec_t *remaining);
+
+    int32_t (*process_id)(uint32_t *out_process_id);
+
+    int32_t (*isatty)(uint32_t handle, uint32_t *out_is_tty);
 } bh_bsys_backend_ops_t;
 
 /* Backend registration and query */

--- a/core/lib/bharatlibc/include/standard/errno.h
+++ b/core/lib/bharatlibc/include/standard/errno.h
@@ -29,6 +29,7 @@ extern int *__bh_libc_errno_location(void);
 #define ENOSPC          28
 #define EROFS           30
 #define EPIPE           32
+#define EOVERFLOW       75
 #define ENOSYS          38
 #define EADDRNOTAVAIL   99
 #define ENETDOWN        100

--- a/core/lib/bharatlibc/include/standard/stdlib.h
+++ b/core/lib/bharatlibc/include/standard/stdlib.h
@@ -3,6 +3,8 @@
 
 #include <standard/stddef.h>
 
+void *malloc(size_t size);
+void free(void *pointer);
 void exit(int status);
 
 #endif /* BHARATLIBC_STDLIB_H */

--- a/core/lib/bharatlibc/include/standard/sys/types.h
+++ b/core/lib/bharatlibc/include/standard/sys/types.h
@@ -1,0 +1,9 @@
+#ifndef BHARATLIBC_SYS_TYPES_H
+#define BHARATLIBC_SYS_TYPES_H
+
+#include <standard/stdint.h>
+
+typedef intptr_t ssize_t;
+typedef int32_t pid_t;
+
+#endif /* BHARATLIBC_SYS_TYPES_H */

--- a/core/lib/bharatlibc/include/standard/time.h
+++ b/core/lib/bharatlibc/include/standard/time.h
@@ -1,0 +1,20 @@
+#ifndef BHARATLIBC_TIME_H
+#define BHARATLIBC_TIME_H
+
+#include <standard/stdint.h>
+
+typedef int32_t clockid_t;
+typedef int64_t time_t;
+
+struct timespec {
+  time_t tv_sec;
+  int64_t tv_nsec;
+};
+
+#define CLOCK_REALTIME 0
+#define CLOCK_MONOTONIC 1
+
+int clock_gettime(clockid_t clock_id, struct timespec *time_value);
+int nanosleep(const struct timespec *request, struct timespec *remaining);
+
+#endif /* BHARATLIBC_TIME_H */

--- a/core/lib/bharatlibc/include/standard/unistd.h
+++ b/core/lib/bharatlibc/include/standard/unistd.h
@@ -1,0 +1,13 @@
+#ifndef BHARATLIBC_UNISTD_H
+#define BHARATLIBC_UNISTD_H
+
+#include <standard/stddef.h>
+#include <standard/sys/types.h>
+
+ssize_t read(int descriptor, void *buffer, size_t capacity);
+ssize_t write(int descriptor, const void *buffer, size_t length);
+int close(int descriptor);
+pid_t getpid(void);
+int isatty(int descriptor);
+
+#endif /* BHARATLIBC_UNISTD_H */

--- a/core/lib/bharatlibc/src/alloc/allocator_dispatch.c
+++ b/core/lib/bharatlibc/src/alloc/allocator_dispatch.c
@@ -1,30 +1,53 @@
+#include <bharat/bsys/backend.h>
 #include <bharat/libc/alloc.h>
+#include <standard/stdint.h>
 
 static bh_fixed_arena_t *g_fixed_arena = NULL;
 static bh_bounded_freelist_t *g_bounded_freelist = NULL;
+static bh_bounded_freelist_t g_backend_freelist;
+static int g_backend_heap_initialized = 0;
 
 void bh_allocator_set_fixed_arena(bh_fixed_arena_t *arena) {
-    g_fixed_arena = arena;
-    g_bounded_freelist = NULL;
+  g_fixed_arena = arena;
+  g_bounded_freelist = NULL;
 }
 
 void bh_allocator_set_bounded_freelist(bh_bounded_freelist_t *fl) {
-    g_bounded_freelist = fl;
-    g_fixed_arena = NULL;
+  g_bounded_freelist = fl;
+  g_fixed_arena = NULL;
 }
 
 void *bh_malloc(size_t size) {
-    if (g_bounded_freelist) {
-        return bh_bounded_freelist_alloc(g_bounded_freelist, size);
+  if (!g_bounded_freelist && !g_fixed_arena && !g_backend_heap_initialized) {
+    const bh_bsys_backend_ops_t *backend = bh_bsys_get_backend();
+    uintptr_t base = 0;
+    uint32_t capacity = 0;
+
+    /* Phase A is single-threaded. This process-local lazy initialization
+     * must become synchronized before the pthread phase is enabled. */
+    g_backend_heap_initialized = 1;
+    if (backend && backend->heap_region &&
+        backend->heap_region(&base, &capacity) == 0 && base != 0 &&
+        (base & (sizeof(uint64_t) - 1U)) == 0U) {
+      bh_bounded_freelist_init(&g_backend_freelist, (void *)base, capacity);
+      g_bounded_freelist = &g_backend_freelist;
     }
-    if (g_fixed_arena) {
-        return bh_fixed_arena_alloc(g_fixed_arena, size, 8);
-    }
-    return NULL;
+  }
+  if (g_bounded_freelist) {
+    return bh_bounded_freelist_alloc(g_bounded_freelist, size);
+  }
+  if (g_fixed_arena) {
+    return bh_fixed_arena_alloc(g_fixed_arena, size, 8);
+  }
+  return NULL;
 }
 
+void *malloc(size_t size) { return bh_malloc(size); }
+
+void free(void *pointer) { bh_free(pointer); }
+
 void bh_free(void *ptr) {
-    if (g_bounded_freelist && ptr) {
-        bh_bounded_freelist_free(g_bounded_freelist, ptr);
-    }
+  if (g_bounded_freelist && ptr) {
+    bh_bounded_freelist_free(g_bounded_freelist, ptr);
+  }
 }

--- a/core/lib/bharatlibc/src/backends/bharat/bharat_backend.c
+++ b/core/lib/bharatlibc/src/backends/bharat/bharat_backend.c
@@ -5,49 +5,70 @@
  * registered and tested on host, or utilized as a default target skeleton.
  */
 
-static int32_t bharat_write(uint32_t handle, const void *buffer, uint32_t length, uint32_t *written) {
-    (void)handle;
-    (void)buffer;
-    (void)length;
-    (void)written;
-    return -38; /* -SYS_ENOSYS */
+static int32_t bharat_write(uint32_t handle, const void *buffer,
+                            uint32_t length, uint32_t *written) {
+  (void)handle;
+  (void)buffer;
+  (void)length;
+  (void)written;
+  return -38; /* -SYS_ENOSYS */
 }
 
-static int32_t bharat_read(uint32_t handle, void *buffer, uint32_t capacity, uint32_t *received) {
-    (void)handle;
-    (void)buffer;
-    (void)capacity;
-    (void)received;
-    return -38; /* -SYS_ENOSYS */
+static int32_t bharat_read(uint32_t handle, void *buffer, uint32_t capacity,
+                           uint32_t *received) {
+  (void)handle;
+  (void)buffer;
+  (void)capacity;
+  (void)received;
+  return -38; /* -SYS_ENOSYS */
 }
 
 static int32_t bharat_close(uint32_t handle) {
-    (void)handle;
-    return -38; /* -SYS_ENOSYS */
+  (void)handle;
+  return -38; /* -SYS_ENOSYS */
 }
 
-static int32_t bharat_clock_gettime(uint32_t clock_id, bh_bsys_timespec_t *out_time) {
-    (void)clock_id;
-    (void)out_time;
-    return -38; /* -SYS_ENOSYS */
+static int32_t bharat_clock_gettime(uint32_t clock_id,
+                                    bh_bsys_timespec_t *out_time) {
+  (void)clock_id;
+  (void)out_time;
+  return -38; /* -SYS_ENOSYS */
+}
+
+static int32_t bharat_nanosleep(const bh_bsys_timespec_t *request,
+                                bh_bsys_timespec_t *remaining) {
+  (void)request;
+  (void)remaining;
+  return -38; /* -SYS_ENOSYS */
 }
 
 static int32_t bharat_sleep_until(uint64_t deadline_ticks) {
-    (void)deadline_ticks;
-    return -38; /* -SYS_ENOSYS */
+  (void)deadline_ticks;
+  return -38; /* -SYS_ENOSYS */
+}
+
+static int32_t bharat_process_id(uint32_t *out_process_id) {
+  (void)out_process_id;
+  return -38; /* -SYS_ENOSYS */
+}
+
+static int32_t bharat_isatty(uint32_t handle, uint32_t *out_is_tty) {
+  (void)handle;
+  (void)out_is_tty;
+  return -38; /* -SYS_ENOSYS */
 }
 
 static int32_t bharat_heap_region(uintptr_t *out_base, uint32_t *out_size) {
-    (void)out_base;
-    (void)out_size;
-    return -38; /* -SYS_ENOSYS */
+  (void)out_base;
+  (void)out_size;
+  return -38; /* -SYS_ENOSYS */
 }
 
 static void bharat_process_exit(int32_t status) {
-    (void)status;
-    while (1) {
-        __asm__ __volatile__("");
-    }
+  (void)status;
+  while (1) {
+    __asm__ __volatile__("");
+  }
 }
 
 static const bh_bsys_backend_ops_t g_bharat_ops = {
@@ -59,9 +80,11 @@ static const bh_bsys_backend_ops_t g_bharat_ops = {
     .clock_gettime = bharat_clock_gettime,
     .sleep_until = bharat_sleep_until,
     .heap_region = bharat_heap_region,
-    .process_exit = bharat_process_exit
-};
+    .process_exit = bharat_process_exit,
+    .nanosleep = bharat_nanosleep,
+    .process_id = bharat_process_id,
+    .isatty = bharat_isatty};
 
 void bh_bsys_init_bharat_backend(void) {
-    bh_bsys_register_backend(&g_bharat_ops);
+  bh_bsys_register_backend(&g_bharat_ops);
 }

--- a/core/lib/bharatlibc/src/backends/host/host_backend.c
+++ b/core/lib/bharatlibc/src/backends/host/host_backend.c
@@ -1,59 +1,109 @@
+#define _POSIX_C_SOURCE 200809L
 #include <bharat/bsys/backend.h>
 #include <standard/stddef.h>
 
 #ifdef BHARATLIBC_HOST_MODE
 
-#include <unistd.h>
-#include <time.h>
+#include <errno.h>
 #include <stdlib.h>
+#include <time.h>
+#include <unistd.h>
 
-static int32_t host_write(uint32_t handle, const void *buffer, uint32_t length, uint32_t *written) {
-    ssize_t rc = write((int)handle, buffer, (size_t)length);
-    if (rc < 0) return -1;
-    if (written) *written = (uint32_t)rc;
-    return 0;
+static int32_t host_write(uint32_t handle, const void *buffer, uint32_t length,
+                          uint32_t *written) {
+  ssize_t rc = write((int)handle, buffer, (size_t)length);
+  if (rc < 0)
+    return -errno;
+  if (written)
+    *written = (uint32_t)rc;
+  return 0;
 }
 
-static int32_t host_read(uint32_t handle, void *buffer, uint32_t capacity, uint32_t *received) {
-    ssize_t rc = read((int)handle, buffer, (size_t)capacity);
-    if (rc < 0) return -1;
-    if (received) *received = (uint32_t)rc;
-    return 0;
+static int32_t host_read(uint32_t handle, void *buffer, uint32_t capacity,
+                         uint32_t *received) {
+  ssize_t rc = read((int)handle, buffer, (size_t)capacity);
+  if (rc < 0)
+    return -errno;
+  if (received)
+    *received = (uint32_t)rc;
+  return 0;
 }
 
 static int32_t host_close(uint32_t handle) {
-    int rc = close((int)handle);
-    return (rc == 0) ? 0 : -1;
+  int rc = close((int)handle);
+  return (rc == 0) ? 0 : -errno;
 }
 
-static int32_t host_clock_gettime(uint32_t clock_id, bh_bsys_timespec_t *out_time) {
-    struct timespec ts;
-    int rc = clock_gettime((clockid_t)clock_id, &ts);
-    if (rc == 0 && out_time) {
-        out_time->tv_sec = ts.tv_sec;
-        out_time->tv_nsec = ts.tv_nsec;
-        return 0;
-    }
-    return -1;
+static int32_t host_clock_gettime(uint32_t clock_id,
+                                  bh_bsys_timespec_t *out_time) {
+  struct timespec ts;
+  int rc = clock_gettime((clockid_t)clock_id, &ts);
+  if (rc == 0 && out_time) {
+    out_time->tv_sec = ts.tv_sec;
+    out_time->tv_nsec = ts.tv_nsec;
+    return 0;
+  }
+  return -errno;
+}
+
+static int32_t host_nanosleep(const bh_bsys_timespec_t *request,
+                              bh_bsys_timespec_t *remaining) {
+  struct timespec req = {(time_t)request->tv_sec, (long)request->tv_nsec};
+  struct timespec rem = {0, 0};
+  if (nanosleep(&req, &rem) == 0)
+    return 0;
+  if (remaining) {
+    remaining->tv_sec = (uint64_t)rem.tv_sec;
+    remaining->tv_nsec = (uint64_t)rem.tv_nsec;
+  }
+  return -errno;
 }
 
 static int32_t host_sleep_until(uint64_t deadline_ticks) {
-    struct timespec req = {0, 1000000}; /* sleep for 1ms */
-    nanosleep(&req, NULL);
+  struct timespec now;
+  bh_bsys_timespec_t delay;
+
+  if (clock_gettime(CLOCK_MONOTONIC, &now) != 0)
+    return -errno;
+  const uint64_t nsec_per_sec = (uint64_t)1000000000U;
+  uint64_t now_ns = (uint64_t)now.tv_sec * nsec_per_sec + (uint64_t)now.tv_nsec;
+  if (deadline_ticks <= now_ns)
     return 0;
+  delay.tv_sec = (deadline_ticks - now_ns) / nsec_per_sec;
+  delay.tv_nsec = (deadline_ticks - now_ns) % nsec_per_sec;
+  return host_nanosleep(&delay, NULL);
 }
 
-static uint8_t host_heap[1024 * 1024]; /* 1MB static host heap */
+static int32_t host_process_id(uint32_t *out_process_id) {
+  pid_t pid = getpid();
+  if (pid < 0)
+    return -errno;
+  *out_process_id = (uint32_t)pid;
+  return 0;
+}
+
+static int32_t host_isatty(uint32_t handle, uint32_t *out_is_tty) {
+  int rc = isatty((int)handle);
+  if (rc == 0 && errno != 0)
+    return -errno;
+  *out_is_tty = rc != 0;
+  return 0;
+}
+
+static union {
+  uint64_t alignment;
+  uint8_t bytes[1024 * 1024];
+} host_heap; /* Process-local 1 MiB test heap. */
 
 static int32_t host_heap_region(uintptr_t *out_base, uint32_t *out_size) {
-    if (out_base) *out_base = (uintptr_t)host_heap;
-    if (out_size) *out_size = sizeof(host_heap);
-    return 0;
+  if (out_base)
+    *out_base = (uintptr_t)host_heap.bytes;
+  if (out_size)
+    *out_size = sizeof(host_heap.bytes);
+  return 0;
 }
 
-static void host_process_exit(int32_t status) {
-    exit(status);
-}
+static void host_process_exit(int32_t status) { exit(status); }
 
 static const bh_bsys_backend_ops_t g_host_ops = {
     .abi_version = 1,
@@ -64,12 +114,12 @@ static const bh_bsys_backend_ops_t g_host_ops = {
     .clock_gettime = host_clock_gettime,
     .sleep_until = host_sleep_until,
     .heap_region = host_heap_region,
-    .process_exit = host_process_exit
-};
+    .process_exit = host_process_exit,
+    .nanosleep = host_nanosleep,
+    .process_id = host_process_id,
+    .isatty = host_isatty};
 
-void bh_bsys_init_host_backend(void) {
-    bh_bsys_register_backend(&g_host_ops);
-}
+void bh_bsys_init_host_backend(void) { bh_bsys_register_backend(&g_host_ops); }
 
 #else
 

--- a/core/lib/bharatlibc/src/posix/phase_a.c
+++ b/core/lib/bharatlibc/src/posix/phase_a.c
@@ -1,0 +1,153 @@
+#include <bharat/bsys/backend.h>
+#include <bharat/libc/status.h>
+#include <standard/errno.h>
+#include <standard/stdint.h>
+#include <standard/sys/types.h>
+#include <standard/time.h>
+#include <standard/unistd.h>
+
+#define BH_POSIX_BACKEND_MAX_IO UINT32_MAX
+#define BH_POSIX_NSEC_PER_SEC ((uint64_t)1000000000U)
+
+static int fail_status(int32_t status) {
+  errno = bh_status_to_errno(status);
+  return -1;
+}
+
+static const bh_bsys_backend_ops_t *backend_or_fail(void) {
+  const bh_bsys_backend_ops_t *backend = bh_bsys_get_backend();
+  if (!backend)
+    errno = ENOSYS;
+  return backend;
+}
+
+ssize_t read(int descriptor, void *buffer, size_t capacity) {
+  const bh_bsys_backend_ops_t *backend = backend_or_fail();
+  uint32_t received = 0;
+  int32_t status;
+
+  if (!backend || !backend->read)
+    return -1;
+  if (descriptor < 0 || (!buffer && capacity != 0U) ||
+      capacity > BH_POSIX_BACKEND_MAX_IO) {
+    errno = EINVAL;
+    return -1;
+  }
+  status = backend->read((uint32_t)descriptor, buffer, (uint32_t)capacity,
+                         &received);
+  return status == 0 ? (ssize_t)received : (ssize_t)fail_status(status);
+}
+
+ssize_t write(int descriptor, const void *buffer, size_t length) {
+  const bh_bsys_backend_ops_t *backend = backend_or_fail();
+  uint32_t written = 0;
+  int32_t status;
+
+  if (!backend || !backend->write)
+    return -1;
+  if (descriptor < 0 || (!buffer && length != 0U) ||
+      length > BH_POSIX_BACKEND_MAX_IO) {
+    errno = EINVAL;
+    return -1;
+  }
+  status =
+      backend->write((uint32_t)descriptor, buffer, (uint32_t)length, &written);
+  return status == 0 ? (ssize_t)written : (ssize_t)fail_status(status);
+}
+
+int close(int descriptor) {
+  const bh_bsys_backend_ops_t *backend = backend_or_fail();
+  int32_t status;
+
+  if (!backend || !backend->close)
+    return -1;
+  if (descriptor < 0) {
+    errno = EBADF;
+    return -1;
+  }
+  status = backend->close((uint32_t)descriptor);
+  return status == 0 ? 0 : fail_status(status);
+}
+
+int clock_gettime(clockid_t clock_id, struct timespec *time_value) {
+  const bh_bsys_backend_ops_t *backend = backend_or_fail();
+  bh_bsys_timespec_t value = {0, 0};
+  int32_t status;
+
+  if (!backend || !backend->clock_gettime)
+    return -1;
+  if (!time_value ||
+      (clock_id != CLOCK_REALTIME && clock_id != CLOCK_MONOTONIC)) {
+    errno = EINVAL;
+    return -1;
+  }
+  status = backend->clock_gettime((uint32_t)clock_id, &value);
+  if (status != 0)
+    return fail_status(status);
+  if (value.tv_sec > INT64_MAX || value.tv_nsec >= BH_POSIX_NSEC_PER_SEC) {
+    errno = EIO;
+    return -1;
+  }
+  time_value->tv_sec = (time_t)value.tv_sec;
+  time_value->tv_nsec = (int64_t)value.tv_nsec;
+  return 0;
+}
+
+int nanosleep(const struct timespec *request, struct timespec *remaining) {
+  const bh_bsys_backend_ops_t *backend = backend_or_fail();
+  bh_bsys_timespec_t requested;
+  bh_bsys_timespec_t remainder = {0, 0};
+  int32_t status;
+
+  if (!backend || !backend->nanosleep)
+    return -1;
+  if (!request || request->tv_sec < 0 || request->tv_nsec < 0 ||
+      (uint64_t)request->tv_nsec >= BH_POSIX_NSEC_PER_SEC) {
+    errno = EINVAL;
+    return -1;
+  }
+  requested.tv_sec = (uint64_t)request->tv_sec;
+  requested.tv_nsec = (uint64_t)request->tv_nsec;
+  status = backend->nanosleep(&requested, remaining ? &remainder : 0);
+  if (remaining) {
+    remaining->tv_sec = (time_t)remainder.tv_sec;
+    remaining->tv_nsec = (int64_t)remainder.tv_nsec;
+  }
+  return status == 0 ? 0 : fail_status(status);
+}
+
+pid_t getpid(void) {
+  const bh_bsys_backend_ops_t *backend = backend_or_fail();
+  uint32_t process_id = 0;
+  int32_t status;
+
+  if (!backend || !backend->process_id)
+    return -1;
+  status = backend->process_id(&process_id);
+  if (status != 0)
+    return (pid_t)fail_status(status);
+  if (process_id > INT32_MAX) {
+    errno = EOVERFLOW;
+    return -1;
+  }
+  return (pid_t)process_id;
+}
+
+int isatty(int descriptor) {
+  const bh_bsys_backend_ops_t *backend = backend_or_fail();
+  uint32_t is_tty = 0;
+  int32_t status;
+
+  if (!backend || !backend->isatty)
+    return 0;
+  if (descriptor < 0) {
+    errno = EBADF;
+    return 0;
+  }
+  status = backend->isatty((uint32_t)descriptor, &is_tty);
+  if (status != 0) {
+    fail_status(status);
+    return 0;
+  }
+  return is_tty != 0U;
+}

--- a/core/lib/bharatlibc/tests/CMakeLists.txt
+++ b/core/lib/bharatlibc/tests/CMakeLists.txt
@@ -68,3 +68,8 @@ add_bh_test(test_bsys_unsupported host/test_bsys_unsupported.c)
 add_bh_test(test_runtime_capability_match host/test_runtime_capability_match.c)
 add_bh_test(test_runtime_capability_rejection host/test_runtime_capability_rejection.c)
 add_bh_test(test_build_info host/test_build_info.c)
+
+add_executable(test_posix_phase_a host/test_posix_phase_a.c)
+target_link_libraries(test_posix_phase_a PRIVATE BharatLibC::PosixPhaseA)
+add_test(NAME test_posix_phase_a COMMAND test_posix_phase_a)
+set_tests_properties(test_posix_phase_a PROPERTIES TIMEOUT 10 LABELS "unit;fast;posix")

--- a/core/lib/bharatlibc/tests/contracts/test_posix_subset_contract.py
+++ b/core/lib/bharatlibc/tests/contracts/test_posix_subset_contract.py
@@ -9,14 +9,20 @@ import yaml
 CONTRACT = Path(__file__).parents[2] / "contracts" / "posix_subset_v1.yaml"
 PROJECT_ROOT = CONTRACT.parent.parent
 
-EXPECTED_IMPLEMENTED = {"read", "write", "close"}
+EXPECTED_IMPLEMENTED = {
+    "read", "write", "close", "clock_gettime", "nanosleep", "getpid",
+    "isatty", "malloc", "free", "memcpy", "memset", "memmove",
+}
 EXPECTED_STAGES = {
     1: {
-        "read", "write", "close", "open", "openat", "lseek", "fstat",
-        "isatty", "clock_gettime", "nanosleep", "getpid",
+        "read", "write", "close", "isatty", "clock_gettime", "nanosleep",
+        "getpid", "malloc", "free", "memcpy", "memset", "memmove",
     },
-    2: {"mmap", "munmap", "mprotect", "brk", "sbrk", "_exit"},
-    3: {
+    2: {
+        "open", "openat", "lseek", "fstat", "readdir", "mkdir", "unlink",
+        "dup", "pipe",
+    },
+    3: {"mmap", "munmap", "mprotect", "brk", "_exit",
         "pthread_create", "pthread_join", "pthread_mutex", "pthread_cond", "TLS",
     },
     4: set(),
@@ -35,6 +41,9 @@ def main() -> None:
     assert stages == EXPECTED_STAGES
     assert set(contract["functions"]) == set().union(*EXPECTED_STAGES.values())
     assert EXPECTED_IMPLEMENTED <= stages[1]
+    assert [entry["name"] for entry in contract["stages"][:3]] == [
+        "hmem_demo", "after_ramfs", "process_thread_workloads",
+    ]
 
     socket_stage = next(entry for entry in contract["stages"] if entry["stage"] == 4)
     assert socket_stage["prerequisite"] == "stable_network_service_abi"

--- a/core/lib/bharatlibc/tests/host/test_posix_phase_a.c
+++ b/core/lib/bharatlibc/tests/host/test_posix_phase_a.c
@@ -1,0 +1,112 @@
+#include <bharat/bsys/backend.h>
+#include <standard/assert.h>
+#include <standard/errno.h>
+#include <standard/stdint.h>
+#include <standard/stdlib.h>
+#include <standard/string.h>
+#include <standard/time.h>
+#include <standard/unistd.h>
+
+static union {
+  uint64_t alignment;
+  uint8_t bytes[4096];
+} heap;
+static uint32_t last_handle;
+
+static int32_t mock_write(uint32_t handle, const void *buffer, uint32_t length,
+                          uint32_t *written) {
+  last_handle = handle;
+  assert(buffer != NULL);
+  *written = length;
+  return 0;
+}
+
+static int32_t mock_read(uint32_t handle, void *buffer, uint32_t capacity,
+                         uint32_t *received) {
+  last_handle = handle;
+  if (capacity != 0U)
+    ((uint8_t *)buffer)[0] = 0x5aU;
+  *received = capacity != 0U;
+  return 0;
+}
+
+static int32_t mock_close(uint32_t handle) {
+  last_handle = handle;
+  return handle == 9U ? 0 : -9;
+}
+
+static int32_t mock_clock(uint32_t clock_id, bh_bsys_timespec_t *out_time) {
+  assert(clock_id == CLOCK_MONOTONIC);
+  out_time->tv_sec = 12U;
+  out_time->tv_nsec = 34U;
+  return 0;
+}
+
+static int32_t mock_sleep(const bh_bsys_timespec_t *request,
+                          bh_bsys_timespec_t *remaining) {
+  assert(request->tv_sec == 0U && request->tv_nsec == 50U);
+  if (remaining)
+    *remaining = (bh_bsys_timespec_t){0, 0};
+  return 0;
+}
+
+static int32_t mock_pid(uint32_t *out_process_id) {
+  *out_process_id = 42U;
+  return 0;
+}
+
+static int32_t mock_isatty(uint32_t handle, uint32_t *out_is_tty) {
+  *out_is_tty = handle == 1U;
+  return 0;
+}
+
+static int32_t mock_heap(uintptr_t *out_base, uint32_t *out_size) {
+  *out_base = (uintptr_t)heap.bytes;
+  *out_size = sizeof(heap.bytes);
+  return 0;
+}
+
+int main(void) {
+  const bh_bsys_backend_ops_t backend = {
+      .abi_version = 1,
+      .structure_size = sizeof(backend),
+      .write = mock_write,
+      .read = mock_read,
+      .close = mock_close,
+      .clock_gettime = mock_clock,
+      .nanosleep = mock_sleep,
+      .process_id = mock_pid,
+      .isatty = mock_isatty,
+      .heap_region = mock_heap,
+  };
+  uint8_t byte = 0;
+  struct timespec time_value;
+  struct timespec delay = {0, 50};
+
+  bh_bsys_register_backend(&backend);
+  assert(write(1, "x", 1) == 1 && last_handle == 1U);
+  assert(read(0, &byte, 1) == 1 && byte == 0x5aU && last_handle == 0U);
+  assert(close(9) == 0 && close(8) == -1 && errno == EBADF);
+  assert(clock_gettime(CLOCK_MONOTONIC, &time_value) == 0);
+  assert(time_value.tv_sec == 12 && time_value.tv_nsec == 34);
+  assert(nanosleep(&delay, NULL) == 0);
+  assert(getpid() == 42);
+  assert(isatty(1) == 1 && isatty(2) == 0);
+
+  void *first = malloc(64U);
+  void *second = malloc(64U);
+  assert(first != NULL && second != NULL && first != second);
+  memset(first, 0xa5, 64U);
+  memcpy(second, first, 64U);
+  assert(memcmp(first, second, 64U) == 0);
+  memmove((uint8_t *)second + 1, second, 63U);
+  assert(((uint8_t *)second)[1] == 0xa5U);
+  free(first);
+  free(second);
+
+  assert(clock_gettime(99, &time_value) == -1 && errno == EINVAL);
+  delay.tv_nsec = 1000000000;
+  assert(nanosleep(&delay, NULL) == -1 && errno == EINVAL);
+  assert(read(-1, &byte, 1) == -1 && errno == EINVAL);
+  return 0;
+}

--- a/docs/adr/009-sdk-libc-strategy.md
+++ b/docs/adr/009-sdk-libc-strategy.md
@@ -2,7 +2,7 @@
 title: "ADR 009: SDK & Libc Strategy for Bharat-OS"
 status: Accepted
 owner: Documentation Working Group
-last_updated: 2026-04-25
+last_updated: 2026-08-13
 tags:
   - docs
   - adr
@@ -32,6 +32,15 @@ We will adopt a **tiered, mechanism-first SDK/libc approach**, rather than a mon
 3. **Personality layers third.** Behavioral compatibilities (e.g., Linux, RT/Embedded, Appliance, Drone) will live above the kernel and libc, mapping API behaviors, `errno` values, and subsystem expectations as independent runtime profiles.
 
 Architecturally, the kernel will remain focused on capabilities, address spaces, endpoint IPC, and threads. The libc will communicate with the kernel strictly via a stable **Bharat UAPI** (e.g., a `libbsys` layer), ensuring that POSIX remains a translation/adaptation layer.
+
+The first selective-POSIX increment is explicitly bounded by the HMEM/tensor
+demo. It consists of console I/O (`read`, `write`, `close`, `isatty`), time
+(`clock_gettime`, `nanosleep`), process identity (`getpid`), allocation
+(`malloc`, `free`), and memory primitives (`memcpy`, `memset`, `memmove`). File
+and directory APIs wait for RAMFS; VM and pthread APIs wait for the later
+process/thread phase. This ordering is part of the decision: implemented API
+inventory must be evidence-driven and must not be expanded merely to improve a
+POSIX-compliance score.
 
 ### Source Strategy: Hybrid Two-Step Approach
 

--- a/docs/architecture/posix-compat-matrix.md
+++ b/docs/architecture/posix-compat-matrix.md
@@ -2,7 +2,7 @@
 title: POSIX Compatibility Matrix
 status: Proposed
 owner: Documentation Working Group
-last_updated: 2026-04-25
+last_updated: 2026-08-13
 tags:
   - docs
   - architecture
@@ -10,6 +10,34 @@ see_also:
   - README.md
 ---
 # POSIX Compatibility Matrix
+
+## HMEM-driven delivery phases
+
+Near-term POSIX maturity is driven by runnable demonstrations rather than a
+broad compliance claim. The source-compatibility path remains:
+
+```text
+BharatLibC/libposix
+       ↓
+Bharat native API
+       ↓
+native syscall or service IPC
+```
+
+There is no second raw kernel syscall namespace. Phase A now provides the
+HMEM/tensor benchmark foundation: `read`, `write`, `close`, `clock_gettime`,
+`nanosleep`, `getpid`, and `isatty`, plus `malloc`/`free` and the
+`memcpy`/`memset`/`memmove` memory primitives. The APIs dispatch through the
+selected `libbsys` backend. A backend that has no native binding must return
+`ENOSYS`; wrapper availability does not imply that every target backend has
+implemented the mechanism.
+
+Phase B starts only after RAMFS is usable and adds `open`, `openat`, `lseek`,
+`fstat`, `readdir`, `mkdir`, `unlink`, `dup`, and `pipe`. Phase C adds the VM,
+process-exit, pthread, condition-variable, and TLS surface needed for process
+and thread workloads. A small BharatLibC-linked command interpreter is the
+first shell portability target; Bash and static Linux/musl binaries remain
+later compatibility milestones.
 
 POSIX compatibility is a profile, not an all-or-nothing guarantee. In Bharat-OS, POSIX is implemented via a multi-tiered compatibility strategy aimed at fast bring-up, deterministic edge deployment, and minimal monolithic assumptions in the core kernel.
 


### PR DESCRIPTION
### Motivation

- Provide the minimal, evidence-driven POSIX subset required to run the HMEM/tensor benchmark and a small shell without exposing a second raw kernel syscall namespace. 
- Keep the kernel minimal and push POSIX translation into `BharatLibC/libposix` atop the `libbsys` UAPI so unsupported targets fail closed. 
- Bootstrap a small userspace allocator and memory primitives so benchmark and demo code can run before RAMFS and full process/thread work are implemented. 

### Description

- Add a new Posix Phase A adapter library that implements `read`, `write`, `close`, `clock_gettime`, `nanosleep`, `getpid`, `isatty`, `malloc`, `free`, and memory primitives (`memcpy`, `memset`, `memmove`) over the `libbsys` backend; new file: `core/lib/bharatlibc/src/posix/phase_a.c`. 
- Extend `libbsys` backend ABI (append-only) with optional v1 extensions for `nanosleep`, `process_id`, `isatty`, and a `heap_region` backing used by a process-local allocator; header updated: `core/lib/bharatlibc/include/bharat/bsys/backend.h`. 
- Add small standard headers needed by the Phase A surface: `time.h`, `unistd.h`, and `sys/types.h` under `core/lib/bharatlibc/include/standard/`. 
- Provide a process-local lazy-backed bounded freelist allocator and expose `malloc`/`free` that will initialize from `libbsys` `heap_region` when available; changed: `core/lib/bharatlibc/src/alloc/allocator_dispatch.c` and CMake updates to link the alloc/bsys pieces. 
- Extend host backend with errno-preserving returns, `nanosleep`, `process_id`, `isatty`, and a process-local aligned test heap; keep Bharat backend fail-closed (returns `ENOSYS`) until native bindings are implemented; changed files: `core/lib/bharatlibc/src/backends/host/host_backend.c`, `core/lib/bharatlibc/src/backends/bharat/bharat_backend.c`. 
- Add focused unit coverage and a host-driven positive/negative test for Phase A (mock backend): `core/lib/bharatlibc/tests/host/test_posix_phase_a.c` and wiring in `core/lib/bharatlibc/tests/CMakeLists.txt`. 
- Update POSIX-phase contract and docs to make the HMEM-driven Phase A scope explicit and to stage Phase B (RAMFS) and Phase C (VM/thread workloads): `core/lib/bharatlibc/contracts/posix_subset_v1.yaml`, `docs/architecture/posix-compat-matrix.md`, and `docs/adr/009-sdk-libc-strategy.md`.

### Testing

- Focused host compilation and unit run: compiled Phase A sources and ran the Phase A test with `cc -std=c11 -Wall -Wextra -Werror ...` and the test executable; result: PASS. 
- Backend compile checks: built host and bharat backend objects with `-DBHARATLIBC_HOST_MODE=1` and compilation succeeded; result: PASS. 
- Contract and meta-tests: ran `python3 core/lib/bharatlibc/tests/contracts/test_posix_subset_contract.py`, `python3 tools/lint/check_layer_references.py`, and `python3 tools/lint/check_cmake_dependencies.py`; results: PASS (no new violations). 
- Syscall ABI check: ran `python3 tools/abi/syscall_abi.py --check`; result: PASS. 
- Five-target smoke builds: executed the repository smoke builds for the required QEMU targets; all five targets built and booted smoke markers successfully; results: PASS for each target. 
- QEMU matrix: ran `python3 tools/run_qemu_matrix.py --headless --smoke --all-arch` and observed PASS across the matrix. 
- Known limitation: the top-level BharatLibC CMake preset (`host-test`) remains blocked by pre-existing missing helper modules in this repo's CMake (e.g. `BharatOSProfileBridge`, `BharatLibCOptions` etc.), so the full `cmake --preset host-test` end-to-end of the standalone BharatLibC build is BLOCKED; focused compilation and tests were used instead.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7d7b1e0d088320be61aa2e485ce5b5)