### PR TITLE
Harden native syscall ABI metadata validation

### DIFF
--- a/docs/dev/native-syscall-abi-change.md
+++ b/docs/dev/native-syscall-abi-change.md
@@ -31,6 +31,16 @@ in temporary directories, and compares their SHA-256 values with the committed
 lock. It therefore fails for a renumber, an unlocked addition, stale generated
 expectations, metadata count drift, or nondeterministic generation.
 
+Metadata validation is closed-world and fail-closed: unknown fields, argument
+kinds, directions, traits, classes, statuses, capability source kinds,
+validation phases, and scopes are rejected. Pointer `size_source` values must
+name an input scalar argument or use `sizeof(type_name)`. Register capability
+sources must name scalar arguments; structure-field sources must name a
+`user_struct` argument and use the `after_usercopy` phase. Other capability
+sources must use `before_handler`. These checks keep malformed metadata from
+silently degrading to generator defaults or moving capability inspection ahead
+of the fault-safe usercopy boundary.
+
 ## Intentional ABI-change procedure
 
 1. Obtain ABI compatibility review before editing the manifest. Existing Native

--- a/tools/abi/syscall_abi.py
+++ b/tools/abi/syscall_abi.py
@@ -33,6 +33,36 @@ KIND_MAPPING = {
     "implicit_current_thread": "BH_SYS_CAP_SOURCE_IMPLICIT_THREAD",
 }
 
+ALLOWED_TOP_LEVEL_KEYS = {"version", "syscalls"}
+ALLOWED_SYSCALL_KEYS = {
+    "number", "symbol", "name", "status", "class", "handler",
+    "arguments", "capability", "traits",
+}
+ALLOWED_ARGUMENT_KEYS = {"name", "kind", "type", "direction", "size_source"}
+ALLOWED_ARGUMENT_KINDS = {"scalar", "pointer", "user_struct"}
+ALLOWED_DIRECTIONS = {"in", "out", "in_out"}
+ALLOWED_STATUSES = {"stable", "experimental", "deprecated"}
+ALLOWED_CAPABILITY_KEYS = {
+    "source", "validation_phase", "object_type", "rights", "scope",
+}
+ALLOWED_CAPABILITY_SOURCE_KEYS = {"kind", "argument", "field"}
+ALLOWED_CAPABILITY_SCOPES = {"current_process", "current_thread", "system"}
+IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+TYPE_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_ ]*(?:\s*\*)?$")
+SIZEOF_RE = re.compile(r"^sizeof\([A-Za-z_][A-Za-z0-9_]*\)$")
+
+
+def schema_error(message):
+    print(f"Schema Error: {message}")
+    return False
+
+
+def exact_keys(value, allowed, context):
+    unknown = set(value) - allowed
+    if unknown:
+        return schema_error(f"{context} has unknown key(s): {', '.join(sorted(unknown))}")
+    return True
+
 VAL_PHASE_MAPPING = {
     "before_handler": "BH_SYS_CAP_VAL_BEFORE_HANDLER",
     "after_usercopy": "BH_SYS_CAP_VAL_AFTER_USERCOPY",
@@ -58,7 +88,8 @@ def save_json(path, data):
 
 def validate_schema(manifest):
     if not isinstance(manifest, dict) or "version" not in manifest or "syscalls" not in manifest:
-        print("Schema Error: Missing top-level fields 'version' or 'syscalls'")
+        return schema_error("Missing top-level fields 'version' or 'syscalls'")
+    if not exact_keys(manifest, ALLOWED_TOP_LEVEL_KEYS, "Manifest"):
         return False
     if not isinstance(manifest["version"], int) or not isinstance(manifest["syscalls"], list):
         print("Schema Error: 'version' must be an integer and 'syscalls' must be a list")
@@ -73,41 +104,83 @@ def validate_schema(manifest):
             if key not in sc:
                 print(f"Schema Error: Syscall {sc.get('symbol', 'unknown')} missing required key '{key}'")
                 return False
+        if not exact_keys(sc, ALLOWED_SYSCALL_KEYS, f"Syscall {sc['symbol']}"):
+            return False
+        if not isinstance(sc["arguments"], list) or not isinstance(sc["traits"], list):
+            return schema_error(f"Syscall {sc['symbol']} arguments and traits must be lists")
 
         # Validate arguments schema
         for arg in sc["arguments"]:
+            if not isinstance(arg, dict):
+                return schema_error(f"Argument in {sc['symbol']} must be an object")
             arg_keys = ["name", "kind", "type", "direction"]
             for ak in arg_keys:
                 if ak not in arg:
                     print(f"Schema Error: Argument in {sc['symbol']} missing key '{ak}'")
                     return False
+            if not exact_keys(arg, ALLOWED_ARGUMENT_KEYS,
+                              f"Argument '{arg['name']}' in {sc['symbol']}"):
+                return False
+            if arg["kind"] not in ALLOWED_ARGUMENT_KINDS:
+                return schema_error(
+                    f"Argument '{arg['name']}' in {sc['symbol']} has invalid kind '{arg['kind']}'")
+            if arg["direction"] not in ALLOWED_DIRECTIONS:
+                return schema_error(
+                    f"Argument '{arg['name']}' in {sc['symbol']} has invalid direction '{arg['direction']}'")
+            if not isinstance(arg["name"], str) or not IDENTIFIER_RE.fullmatch(arg["name"]):
+                return schema_error(f"Argument name in {sc['symbol']} is not a C identifier")
+            if not isinstance(arg["type"], str) or not TYPE_RE.fullmatch(arg["type"]):
+                return schema_error(f"Argument '{arg['name']}' in {sc['symbol']} has an invalid type")
             if arg["kind"] == "pointer":
                 if "size_source" not in arg:
                     print(f"Schema Error: Pointer argument '{arg['name']}' in {sc['symbol']} must define 'size_source'")
                     return False
+                if not isinstance(arg["size_source"], str) or not arg["size_source"]:
+                    return schema_error(
+                        f"Pointer argument '{arg['name']}' in {sc['symbol']} has an invalid size_source")
+            elif "size_source" in arg:
+                return schema_error(
+                    f"Non-pointer argument '{arg['name']}' in {sc['symbol']} cannot define size_source")
 
         # Validate traits and capability
         if sc["capability"] is not None:
             cap = sc["capability"]
-            cap_keys = ["source", "object_type", "rights", "scope"]
+            if not isinstance(cap, dict):
+                return schema_error(f"Capability for {sc['symbol']} must be an object or null")
+            cap_keys = ["source", "validation_phase", "object_type", "rights", "scope"]
             for ck in cap_keys:
                 if ck not in cap:
                     print(f"Schema Error: Capability for {sc['symbol']} missing key '{ck}'")
                     return False
+            if not exact_keys(cap, ALLOWED_CAPABILITY_KEYS, f"Capability for {sc['symbol']}"):
+                return False
 
             source = cap["source"]
-            if isinstance(source, dict):
-                if "kind" not in source:
-                    print(f"Schema Error: Capability source object in {sc['symbol']} must have 'kind'")
-                    return False
-                if source["kind"] in ["register", "struct_field"]:
-                    if "argument" not in source:
-                        print(f"Schema Error: Capability source object {source['kind']} in {sc['symbol']} must have 'argument'")
-                        return False
-                if source["kind"] == "struct_field":
-                    if "field" not in source:
-                        print(f"Schema Error: Capability source object struct_field in {sc['symbol']} must have 'field'")
-                        return False
+            if not isinstance(source, dict):
+                return schema_error(f"Capability source in {sc['symbol']} must be an object")
+            if "kind" not in source:
+                return schema_error(f"Capability source object in {sc['symbol']} must have 'kind'")
+            if not exact_keys(source, ALLOWED_CAPABILITY_SOURCE_KEYS,
+                              f"Capability source for {sc['symbol']}"):
+                return False
+            kind = source["kind"]
+            if kind not in KIND_MAPPING:
+                return schema_error(f"Capability source in {sc['symbol']} has invalid kind '{kind}'")
+            required_source_keys = {"kind"}
+            if kind in ["register", "struct_field"]:
+                required_source_keys.add("argument")
+            if kind == "struct_field":
+                required_source_keys.add("field")
+            if set(source) != required_source_keys:
+                return schema_error(
+                    f"Capability source {kind} in {sc['symbol']} must contain exactly "
+                    f"{', '.join(sorted(required_source_keys))}")
+            if cap["validation_phase"] not in VAL_PHASE_MAPPING:
+                return schema_error(f"Capability for {sc['symbol']} has invalid validation_phase")
+            if cap["scope"] not in ALLOWED_CAPABILITY_SCOPES:
+                return schema_error(f"Capability for {sc['symbol']} has invalid scope")
+            if not isinstance(cap["rights"], list) or not cap["rights"]:
+                return schema_error(f"Capability for {sc['symbol']} must require at least one right")
 
     return True
 
@@ -121,6 +194,16 @@ def validate_semantics(manifest):
         num = sc["number"]
         sym = sc["symbol"]
         name = sc["name"]
+
+        if not IDENTIFIER_RE.fullmatch(sym) or not IDENTIFIER_RE.fullmatch(name):
+            print(f"Semantic Error: Syscall {sym} symbol and name must be C identifiers")
+            return False
+        if sc["status"] not in ALLOWED_STATUSES or sc["class"] not in CLASS_MAPPING:
+            print(f"Semantic Error: Syscall {sym} has an unsupported status or class")
+            return False
+        if not IDENTIFIER_RE.fullmatch(sc["handler"]):
+            print(f"Semantic Error: Syscall {sym} handler must be a C identifier")
+            return False
 
         if num in numbers:
             print(f"Semantic Error: Duplicate syscall number {num}")
@@ -144,9 +227,29 @@ def validate_semantics(manifest):
 
         # Trait compatibility
         traits = sc["traits"]
+        if len(traits) != len(set(traits)) or any(t not in TRAIT_FLAGS for t in traits):
+            print(f"Semantic Error: Syscall {sym} has duplicate or unknown traits")
+            return False
         if "fast" in traits and "blocking" in traits:
             print(f"Semantic Error: Syscall {sym} cannot be both 'fast' and 'blocking'")
             return False
+
+        arg_names = [a["name"] for a in sc["arguments"]]
+        if len(arg_names) != len(set(arg_names)):
+            print(f"Semantic Error: Syscall {sym} has duplicate argument names")
+            return False
+        for arg in sc["arguments"]:
+            if arg["kind"] != "pointer":
+                continue
+            size_source = arg["size_source"]
+            if size_source not in arg_names and not SIZEOF_RE.fullmatch(size_source):
+                print(f"Semantic Error: Pointer {arg['name']} in {sym} has unresolved size_source '{size_source}'")
+                return False
+            if size_source in arg_names:
+                size_arg = sc["arguments"][arg_names.index(size_source)]
+                if size_arg["kind"] != "scalar" or size_arg["direction"] != "in":
+                    print(f"Semantic Error: Pointer {arg['name']} in {sym} size_source must be an input scalar")
+                    return False
         if "fast" in traits and ("user_read" in traits or "user_write" in traits):
             print(f"Semantic Error: Syscall {sym} cannot be 'fast' and use usercopy (user_read/user_write)")
             return False
@@ -165,10 +268,27 @@ def validate_semantics(manifest):
                 arg_name = source
 
             if arg_name is not None:
-                arg_names = [a["name"] for a in sc["arguments"]]
                 if arg_name not in arg_names:
                     print(f"Semantic Error: Syscall {sym} capability source '{arg_name}' not in arguments list")
                     return False
+                source_arg = sc["arguments"][arg_names.index(arg_name)]
+                if kind == "register" and source_arg["kind"] != "scalar":
+                    print(f"Semantic Error: Register capability source in {sym} must reference a scalar")
+                    return False
+                if kind == "struct_field" and source_arg["kind"] != "user_struct":
+                    print(f"Semantic Error: Struct-field capability source in {sym} must reference a user_struct")
+                    return False
+            phase = sc["capability"]["validation_phase"]
+            if kind == "struct_field" and phase != "after_usercopy":
+                print(f"Semantic Error: Struct-field capability source in {sym} must validate after_usercopy")
+                return False
+            if kind != "struct_field" and phase != "before_handler":
+                print(f"Semantic Error: Capability source in {sym} must validate before_handler")
+                return False
+            rights = sc["capability"]["rights"]
+            if len(rights) != len(set(rights)) or any(not IDENTIFIER_RE.fullmatch(r) for r in rights):
+                print(f"Semantic Error: Capability rights in {sym} must be unique C identifiers")
+                return False
 
     return True
 

--- a/tools/abi/test_syscall_abi.py
+++ b/tools/abi/test_syscall_abi.py
@@ -34,9 +34,49 @@ class SyscallAbiTest(unittest.TestCase):
         del manifest["syscalls"][0]["handler"]
         self.assertFalse(syscall_abi.validate_schema(manifest))
 
+    def test_schema_rejects_unknown_argument_metadata(self):
+        manifest = copy.deepcopy(self.manifest)
+        manifest["syscalls"][1]["arguments"][0]["unchecked"] = True
+        self.assertFalse(syscall_abi.validate_schema(manifest))
+
+    def test_schema_rejects_unknown_capability_source_kind(self):
+        manifest = copy.deepcopy(self.manifest)
+        manifest["syscalls"][2]["capability"]["source"]["kind"] = "ambient"
+        self.assertFalse(syscall_abi.validate_schema(manifest))
+
+    def test_schema_requires_explicit_capability_validation_phase(self):
+        manifest = copy.deepcopy(self.manifest)
+        del manifest["syscalls"][2]["capability"]["validation_phase"]
+        self.assertFalse(syscall_abi.validate_schema(manifest))
+
     def test_duplicate_number_is_rejected(self):
         manifest = copy.deepcopy(self.manifest)
         manifest["syscalls"][1]["number"] = manifest["syscalls"][0]["number"]
+        self.assertFalse(syscall_abi.validate_semantics(manifest))
+
+    def test_pointer_size_source_must_resolve(self):
+        manifest = copy.deepcopy(self.manifest)
+        manifest["syscalls"][20]["arguments"][1]["size_source"] = "missing_length"
+        self.assertFalse(syscall_abi.validate_semantics(manifest))
+
+    def test_pointer_size_source_must_be_input_scalar(self):
+        manifest = copy.deepcopy(self.manifest)
+        manifest["syscalls"][20]["arguments"][2]["direction"] = "out"
+        self.assertFalse(syscall_abi.validate_semantics(manifest))
+
+    def test_register_capability_source_must_be_scalar(self):
+        manifest = copy.deepcopy(self.manifest)
+        manifest["syscalls"][2]["arguments"][0]["kind"] = "user_struct"
+        self.assertFalse(syscall_abi.validate_semantics(manifest))
+
+    def test_struct_capability_source_must_validate_after_usercopy(self):
+        manifest = copy.deepcopy(self.manifest)
+        manifest["syscalls"][1]["capability"]["validation_phase"] = "before_handler"
+        self.assertFalse(syscall_abi.validate_semantics(manifest))
+
+    def test_unknown_trait_is_rejected(self):
+        manifest = copy.deepcopy(self.manifest)
+        manifest["syscalls"][0]["traits"].append("restartable")
         self.assertFalse(syscall_abi.validate_semantics(manifest))
 
     def test_locked_number_change_is_rejected(self):


### PR DESCRIPTION
### Motivation
- Prevent malformed or underspecified native syscall metadata from producing unsafe generated outputs or moving capability checks ahead of fault-safe usercopy. 
- Enforce a closed-world, fail-closed validator so the syscall manifest and generator remain the authoritative, auditable source for syscall semantics without changing the syscall dispatcher.

### Description
- Strengthen the ABI validator in `tools/abi/syscall_abi.py` with allowlists and regex checks for top-level keys, syscall fields, argument kinds/directions/types/names, pointer `size_source` expressions, capability source shapes, validation phases, scopes, and rights.
- Add cross-field semantic checks that require pointer length sources to resolve to input scalars or `sizeof(type)`, require register capability sources to reference scalar args, and require struct-field capability sources to reference `user_struct` args and validate `after_usercopy`.
- Add focused negative regression tests in `tools/abi/test_syscall_abi.py` covering unknown fields, invalid capability sources/phases, unresolved pointer size metadata, and trait validation.
- Update developer documentation in `docs/dev/native-syscall-abi-change.md` to describe the closed-world fail-closed contract and the generator/lock workflow for intentional ABI changes.
- No changes to kernel syscall routing (`bh_syscall_gate`) or generated ABI outputs committed; only validator, tests, and docs were modified.

### Testing
- `python3 -m unittest tools.abi.test_syscall_abi` — PASS: all focused ABI validator unit tests passed (host-side regression suite).
- `python3 tools/abi/syscall_abi.py --check` — PASS: schema+semantic checks, lock compare, reproducible generated-output hashes, and raw-number audit passed.
- `python3 -m py_compile tools/abi/syscall_abi.py tools/abi/test_syscall_abi.py` — PASS: syntax/compile check succeeded.
- `python3 tools/lint/check_layer_references.py` — PASS: scanned ~2,886 files, zero violations.
- `python3 tools/lint/check_cmake_dependencies.py` — PASS: zero dependency violations.
- `./tools/build.sh all --target-yaml delivery/targets/qemu/arm64_desktop_headless.yaml --smoke` — PASS: build completed and QEMU boot observed required boot markers.
- `./tools/build.sh all --target-yaml delivery/targets/qemu/x86_64_desktop_headless.yaml --smoke` — BLOCKED: build and QEMU boot executed but final qualification evidence was not retained in the session; not claimed as PASS.
- `./tools/build.sh ... --target-yaml delivery/targets/qemu/{riscv64_desktop_headless,arm32_mmu_lite_headless,riscv32_mmu_lite_headless}.yaml --smoke` — BLOCKED: builds started and reached ABI/build checks but full QEMU qualification evidence was not observed before reporting.
- `python3 tools/run_qemu_matrix.py --headless --smoke --all-arch` — BLOCKED: full-matrix run was not executed to completion within this change window and is not claimed as passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7d85eebfd0832088b95e6153835993)