### PR TITLE
docs: ADR-025 portable-first crypto dispatch and update crypto docs

### DIFF
--- a/docs/adr/ADR-025-portable-crypto-dispatch-boundary.md
+++ b/docs/adr/ADR-025-portable-crypto-dispatch-boundary.md
@@ -1,0 +1,113 @@
+---
+title: Portable-First Crypto Dispatch and Kernel Boundary
+status: Accepted
+owner: Security Architecture Working Group
+last_updated: 2026-08-13
+tags:
+  - adr
+  - security
+  - crypto
+  - architecture
+see_also:
+  - ../architecture/security/crypto/overview.md
+  - ../architecture/security/crypto/hardware-backends.md
+  - ../architecture/security/crypto/roadmap.md
+  - ../architecture/crypto-boundary.md
+---
+# ADR-025: Portable-first crypto dispatch and kernel boundary
+
+## Context
+
+Bharat-OS already discovers CPU cryptographic capabilities instead of assuming
+that an instruction is safe to execute. That detection rule must scale beyond
+the initial x86 AES and polynomial-multiply hooks without scattering ISA tests
+through consumers or moving general-purpose cryptography into the kernel.
+
+Cryptographic implementations also need a mandatory portable path. Hardware
+features can be absent, disabled by platform policy, unavailable on a migrated
+thread, or heterogeneous across cores. A reported feature is therefore not, by
+itself, permission to issue the corresponding instruction.
+
+## Decision
+
+Audited user-space crypto libraries and services use one operation-aware
+dispatch contract:
+
+```text
+Portable implementation
+        |
+        +-- x86 AES-NI / PCLMUL / SHA
+        +-- ARM AES / PMULL / SHA
+        `-- future RISC-V crypto extensions
+```
+
+The portable implementation is mandatory and is the default until an
+architecture backend is both compiled in and selected from usable runtime
+capabilities. Architecture implementations stay in `core/arch/`; normalized
+feature discovery stays behind HAL/runtime contracts; crypto consumers do not
+perform direct ISA probing. Selection is per operation because AES, polynomial
+multiply, SHA, and entropy instructions are independent capabilities. A
+backend that cannot satisfy the complete requested operation is ineligible;
+dispatch falls back to the audited portable implementation rather than
+composing an unreviewed partial result.
+
+Accelerated and portable implementations must have identical results, error
+semantics, bounds checks, constant-time requirements, and key-zeroization
+behavior. Known-answer and differential tests are required before an
+accelerated backend is enabled. Capability discovery is read-only after its
+boot publication; dispatch tables contain no cross-core mutable policy.
+
+Kernel crypto is limited to security-critical kernel mechanisms that cannot be
+delegated, including entropy collection/conditioning needed by the kernel,
+verified boot or image verification before user space is trusted, and narrowly
+scoped integrity or secret-hygiene mechanisms. General-purpose algorithms,
+high-volume TLS or data-plane crypto, key policy, certificate parsing, and
+storage/OTA orchestration belong in an audited user-space library or service
+with the same ISA dispatch architecture. Access to hardware providers and
+kernel-held security objects remains capability-mediated.
+
+If neither a validated portable implementation nor an eligible accelerated
+implementation exists, the operation returns an explicit unsupported/error
+result and produces no output. Placeholders, reversible test transforms, and
+partially initialized outputs must never be exposed as cryptographic success.
+
+Implementation priority is:
+
+1. secure random generation;
+2. SHA-256 and SHA-384;
+3. AES-GCM;
+4. HMAC and HKDF;
+5. signature verification for boot and images;
+6. TLS cryptography; and
+7. disk and OTA integrity.
+
+## Consequences
+
+### Positive
+
+- Every supported ISA retains a safe, testable baseline.
+- x86, ARM, and future RISC-V acceleration share one consumer contract.
+- Operation-specific eligibility prevents one crypto feature from being
+  mistaken for support for a different primitive.
+- High-volume and policy-rich cryptography stays outside the kernel TCB.
+
+### Negative
+
+- Each accelerated implementation requires portable differential tests and
+  architecture-specific execution evidence.
+- Heterogeneous systems may use the portable backend unless scheduling or
+  system-wide capability guarantees make an accelerated backend safe.
+- Boot-time crypto may require a small separately audited implementation when
+  the user-space service is not yet available.
+
+### Follow-up requirements
+
+- Replace the current pilot transform hooks with typed operations that fail
+  closed until audited primitives are connected.
+- Add operation-specific capability queries for entropy, SHA-256/SHA-384,
+  AES, and polynomial multiply.
+- Add known-answer, portable-versus-accelerated differential, forced-fallback,
+  unsupported-operation, and output-on-failure tests.
+- Do not claim an algorithm or ISA backend as supported until those tests run
+  on the relevant target.
+

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -69,6 +69,7 @@ Use this minimum structure for all new ADRs:
 | ADR-013 | Multikernel Memory Protection Architecture | [`ADR-013-multikernel-memory-protection-architecture.md`](ADR-013-multikernel-memory-protection-architecture.md) |
 | ADR-014 | Library Layering and Data Structures | [`ADR-014-library-layering-and-data-structures.md`](ADR-014-library-layering-and-data-structures.md) |
 | ADR-015 | Documentation Information Architecture | [`ADR-015-documentation-information-architecture.md`](ADR-015-documentation-information-architecture.md) |
+| ADR-025 | Portable-First Crypto Dispatch and Kernel Boundary | [`ADR-025-portable-crypto-dispatch-boundary.md`](ADR-025-portable-crypto-dispatch-boundary.md) |
 
 ### Functional ADR Extensions
 

--- a/docs/architecture/security/crypto/hardware-backends.md
+++ b/docs/architecture/security/crypto/hardware-backends.md
@@ -2,7 +2,7 @@
 title: Cryptographic Hardware Backends
 status: Proposed
 owner: Divyang Panchasara
-last_updated: 2024-05-15
+last_updated: 2026-08-13
 tags:
   - security
   - crypto
@@ -15,6 +15,14 @@ version: 1.0
 # Cryptographic Hardware Backends
 
 Bharat-OS must support a diverse range of hardware security features across different architectures (x86_64, ARM64, RISC-V). To handle this complexity, the kernel defines three abstract backend classes that hardware drivers must implement. This ensures a stable internal API regardless of the underlying hardware.
+
+CPU instruction backends are implementations of an operation, not standalone
+algorithm APIs. The user-space runtime/service selects them through the
+portable-first dispatch contract in
+[`ADR-025`](../../../adr/ADR-025-portable-crypto-dispatch-boundary.md). A backend
+is eligible only when the exact operation's usable capability is present; the
+generic portable implementation remains the required fallback. Direct ISA
+feature tests in TLS, storage, OTA, or application consumers are prohibited.
 
 ## Backend Classes
 
@@ -47,3 +55,18 @@ The following outlines the specific hardware features and extensions that Bharat
 *   **SBI-Mediated Entropy / Security Hooks:** (`RNG_PROVIDER`, `SECURE_ELEMENT_OR_TPM` via SBI) Utilizing the Supervisor Binary Interface (SBI) to request entropy or perform security operations provided by the execution environment (e.g., firmware or a hypervisor).
 *   **External Secure Element / TPM Integration Path:** (`SECURE_ELEMENT_OR_TPM`) Support for standard discrete TPMs or secure elements attached via SPI/I2C.
 *   **Future Profile for DICE-like Measured Boot Flows:** Architectural support for Device Identifier Composition Engine (DICE) concepts, establishing a hardware root of trust and measured boot sequence specifically tailored for the RISC-V ecosystem.
+
+## Dispatch and validation requirements
+
+- Select independently for secure entropy, SHA-256/SHA-384, AES, and
+  polynomial multiply; never infer one from a generic crypto bit.
+- Use only capabilities marked usable after architecture detection and platform
+  policy. System-wide dispatch must use the all-core capability set unless
+  execution is pinned to a core with an equivalent owner-local guarantee.
+- Keep architecture instruction bodies in `core/arch/`. HAL and runtime expose
+  normalized contracts and selection; consumers remain architecture-neutral.
+- Require known-answer tests and byte-for-byte differential tests against the
+  portable implementation for every accelerated operation.
+- On backend rejection or failure, return an explicit error or restart the
+  complete operation with the portable backend before any output is published.
+  Never mix partial outputs from different backends.

--- a/docs/architecture/security/crypto/overview.md
+++ b/docs/architecture/security/crypto/overview.md
@@ -2,7 +2,7 @@
 title: Cryptography & Security Subsystem Overview
 status: Proposed
 owner: Divyang Panchasara
-last_updated: 2024-05-15
+last_updated: 2026-08-13
 tags:
   - security
   - crypto
@@ -16,6 +16,33 @@ version: 1.0
 Bharat-OS enforces a strict boundary between the kernel's **trust-enforcing mechanisms** and the user-space **policy/algorithm services**.
 
 The guiding rule is: **keep cryptography mechanisms in the kernel only where the kernel must enforce trust, isolation, boot integrity, or hardware binding; push algorithms, protocols, policy, and most key lifecycle work into core/services/stacks.** This aligns with the Bharat-OS direction of a small stable core kernel with profile-driven core/services/stacks layered on top.
+
+## Portable-first dispatch model
+
+The audited user-space crypto library/service presents one algorithm contract
+and selects an implementation by usable runtime capability:
+
+```text
+Portable implementation
+        |
+        +-- x86 AES-NI / PCLMUL / SHA
+        +-- ARM AES / PMULL / SHA
+        `-- future RISC-V crypto extensions
+```
+
+The portable implementation is mandatory. Dispatch is per operation rather
+than a single `has_crypto` decision: AES does not imply polynomial multiply,
+SHA, or a secure entropy source. ISA probing remains in `core/arch/`, normalized
+capability reporting remains behind HAL/runtime contracts, and consumers call
+the backend-neutral crypto API. Missing, disabled, or insufficient hardware
+support selects the portable implementation. If no validated implementation is
+available, the operation fails closed without producing output.
+
+Kernel-resident crypto is reserved for security-critical mechanisms that must
+run before or independently of trusted user space. TLS and other high-volume
+data cryptography belong in an audited user-space library or service using this
+same dispatch model. The binding decision is recorded in
+[`ADR-025`](../../../adr/ADR-025-portable-crypto-dispatch-boundary.md).
 
 ## 4-Layer Security Architecture
 

--- a/docs/architecture/security/crypto/roadmap.md
+++ b/docs/architecture/security/crypto/roadmap.md
@@ -2,7 +2,7 @@
 title: Cryptography & Security Roadmap
 status: Proposed
 owner: Divyang Panchasara
-last_updated: 2024-05-15
+last_updated: 2026-08-13
 tags:
   - security
   - crypto
@@ -14,6 +14,33 @@ version: 1.0
 # Cryptography & Security Roadmap
 
 This roadmap outlines the phased implementation plan for the Bharat-OS Cryptography and Security subsystem. It is designed to establish a solid foundation in the kernel first (mechanisms), followed by the user-space services (policies and algorithms), and finally integration with the rest of the operating system.
+
+## Delivery priority
+
+Work proceeds in security dependency order:
+
+1. **Secure random generation** — health-checked entropy providers and a
+   portable DRBG/conditioning path before key-generating consumers.
+2. **SHA-256 / SHA-384** — portable implementations first, followed by x86 SHA
+   and ARM SHA dispatch with known-answer and differential tests.
+3. **AES-GCM** — treat AES and polynomial multiply as independent eligibility
+   requirements; provide portable authenticated encryption when either is
+   unavailable.
+4. **HMAC / HKDF** — build on the validated hash contract without duplicating
+   ISA dispatch in the constructions.
+5. **Boot/image signature verification** — keep only the minimal pre-userspace
+   verification path in the trusted boot/kernel boundary; service-side image
+   policy remains in user space.
+6. **TLS cryptography** — integrate the audited user-space library/service; do
+   not introduce a kernel TLS crypto stack.
+7. **Disk/OTA integrity** — integrate through storage and update services after
+   the primitive and signature contracts are validated.
+
+Each stage must ship a portable implementation before optional ISA backends.
+An accelerated path is incomplete until forced-fallback, unsupported-feature,
+known-answer, and portable-versus-accelerated differential tests pass on its
+target architecture. See
+[`ADR-025`](../../../adr/ADR-025-portable-crypto-dispatch-boundary.md).
 
 ## Implementation snapshot (as of 2026-04-21)
 
@@ -50,7 +77,7 @@ This phase implements the core, low-level mechanisms within the kernel, strictly
 
 This phase implements the drivers for the three abstract hardware backend classes defined in the architecture.
 
-*   [ ] **CPU Accelerator Abstraction:** Implement detection and routing for CPU-level instruction extensions (e.g., AES-NI, ARMv8 Crypto Extensions, RISC-V Scalar Crypto).
+*   [ ] **CPU Accelerator Abstraction:** Implement operation-specific detection and portable-first routing for x86 AES-NI/PCLMUL/SHA, ARM AES/PMULL/SHA, and future RISC-V crypto extensions.
 *   [ ] **TPM / Secure Element Abstraction:** Implement the low-level communication drivers (e.g., over SPI or LPC) for discrete security chips, focusing on exposing the device endpoint to user-space rather than implementing the full TPM 2.0 command set.
 *   [ ] **Sealing Backend Abstraction:** Implement the specific mechanisms for tying cryptographic operations to the platform's trusted state (e.g., using TPM PCRs or TrustZone variables).
 


### PR DESCRIPTION
### Motivation

- Provide an explicit portable-first, operation-aware dispatch contract for crypto so consumers never probe ISA directly and a safe portable fallback always exists.
- Keep the kernel minimal and TCB-small by restricting kernel-resident crypto to security-critical mechanisms (entropy, boot/image verification, secret hygiene) and move high-volume/policy-rich crypto to audited user-space services.

### Description

- Add `docs/adr/ADR-025-portable-crypto-dispatch-boundary.md` defining the portable-first, per-operation dispatch model, fail-closed semantics, validation requirements, and implementation priority (secure RNG, SHA-256/384, AES-GCM, HMAC/HKDF, signatures, TLS, disk/OTA integrity). 
- Update crypto documentation to reference the ADR and enforce the contract: `docs/architecture/security/crypto/overview.md`, `docs/architecture/security/crypto/hardware-backends.md`, and `docs/architecture/security/crypto/roadmap.md` were updated to document per-operation eligibility, HAL/arch placement, and validation requirements. 
- Add ADR-025 to the ADR index: `docs/adr/README.md` updated. 
- Commit recorded as `6c48635d` with message `docs: define portable-first crypto dispatch` and no kernel/ABI/runtime code changes were made in this PR (documentation-only change).

### Testing

- Ran static/contract checks: `python3 tools/lint/check_layer_references.py`, `python3 tools/lint/check_cmake_dependencies.py`, and `python3 tools/abi/syscall_abi.py --check` — all PASS. 
- Validated documentation front-matter and ADR links for the changed files with the repo doc checks and a focused YAML validation script; the changed files validated cleanly while the repository-wide doc check reported pre-existing metadata/path warnings unrelated to these edits (informational). 
- Per-matrix builds: executed the five smoke builds via `./tools/build.sh all --target-yaml <target>` for x86_64, arm64, riscv64, arm32_mmu_lite, and riscv32_mmu_lite — all PASS. 
- QEMU matrix: ran `python3 tools/run_qemu_matrix.py --headless --smoke --all-arch` and observed PASS for all five required targets (boot markers and smoke criteria satisfied).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7d8c6c6ec0832093ab365b39724318)