### PR TITLE
fix: Refactor mid-file includes in core/hal and core/kernel

### DIFF
--- a/core/arch/hal/arm/arm64/hal_cpu.c
+++ b/core/arch/hal/arm/arm64/hal_cpu.c
@@ -1,3 +1,4 @@
+#include "trap.h"
 #include "hal/hal.h"
 #include "hal/hal_timer.h"
 #include "secure_boot.h"
@@ -34,8 +35,6 @@ void hal_cpu_reboot(void) {
   }
 }
 
-// TODO: Needs refactor: #include directive placed mid-file for dependency/order compatibility.
-#include "trap.h"
 
 bool hal_cpu_is_syscall(const void *trap_frame) {
     if (!trap_frame) return false;

--- a/core/arch/hal/mpu/arm32/mpu_backend.c
+++ b/core/arch/hal/mpu/arm32/mpu_backend.c
@@ -6,6 +6,7 @@
 
 #define MAX_MPU_REGIONS 16
 #define ERR_NOT_SUPPORTED -1
+#include <slab.h>
 
 typedef struct {
     uintptr_t base;
@@ -19,8 +20,6 @@ typedef struct {
     int region_count;
 } mpu_backend_state_t;
 
-// TODO: Needs refactor: #include directive placed mid-file for dependency/order compatibility.
-#include <slab.h>
 
 static prot_domain_ops_t mpu_only_ops_arm32;
 

--- a/core/arch/hal/riscv/riscv64/hal_cpu.c
+++ b/core/arch/hal/riscv/riscv64/hal_cpu.c
@@ -1,3 +1,4 @@
+#include "trap.h"
 #include "sched/ai_sched.h"
 #include "hal/hal.h"
 #include "hal/hal_timer.h"
@@ -69,8 +70,6 @@ void hal_cpu_reboot(void) {
   }
 }
 
-// TODO: Needs refactor: #include directive placed mid-file for dependency/order compatibility.
-#include "trap.h"
 
 bool hal_cpu_is_syscall(const void *trap_frame) {
     if (!trap_frame) return false;

--- a/core/arch/hal/x86/x86_64/hal_cpu.c
+++ b/core/arch/hal/x86/x86_64/hal_cpu.c
@@ -1,3 +1,4 @@
+#include "trap.h"
 #include "hal/hal_timer.h"
 #include "sched/ai_sched.h"
 #include "hal/hal.h"
@@ -73,8 +74,6 @@ void hal_cpu_reboot(void) {
   }
 }
 
-// TODO: Needs refactor: #include directive placed mid-file for dependency/order compatibility.
-#include "trap.h"
 
 bool hal_cpu_is_syscall(const void *trap_frame) {
     if (!trap_frame) return false;
@@ -604,6 +603,7 @@ uint32_t hal_cpu_get_id(void) {
 #define MSR_IA32_PERFEVTSEL1 0x187
 #define MSR_IA32_PERF_GLOBAL_CTRL 0x38F
 #define ARCH_EVENT_INST_RETIRED 0xC0
+
 
 static void hal_cpu_pmc_init(void) {
   uint32_t eax, ebx, ecx, edx;

--- a/core/hal/common/hal_dma_coherency.c
+++ b/core/hal/common/hal_dma_coherency.c
@@ -1,4 +1,5 @@
 #include "hal/hal_dma.h"
+#include "arch/arch_caps.h"
 
 static const hal_dma_ops_t *g_hal_dma_ops;
 
@@ -59,8 +60,6 @@ void hal_dma_sync_for_cpu(hal_dma_buffer_t *buf) {
     }
 }
 
-// TODO: Needs refactor: #include directive placed mid-file for dependency/order compatibility.
-#include "arch/arch_caps.h"
 
 int hal_dma_is_coherent(void) {
     if (arch_has_cap(ARCH_CAP_DMA_COHERENT)) {

--- a/core/kernel/include/arch/arch_cpu_caps.h
+++ b/core/kernel/include/arch/arch_cpu_caps.h
@@ -24,17 +24,13 @@ typedef enum {
 
 // Include arch-specific feature header
 #if defined(__x86_64__)
-// TODO: Needs refactor: #include directive placed mid-file for dependency/order compatibility.
 #include "arch/x86_64/cpu_features.h"
 #elif defined(__aarch64__)
-// TODO: Needs refactor: #include directive placed mid-file for dependency/order compatibility.
 #include "arch/arm64/cpu_features.h"
 #elif defined(__riscv) && defined(BHARAT_ARCH_SHAKTI)
 // Distinguish generic riscv from shakti if needed, otherwise fall through
-// TODO: Needs refactor: #include directive placed mid-file for dependency/order compatibility.
 #include "arch/shakti/cpu_features.h"
 #elif defined(__riscv)
-// TODO: Needs refactor: #include directive placed mid-file for dependency/order compatibility.
 #include "arch/riscv64/cpu_features.h"
 #else
 // Fallback for unknown/stub

--- a/core/kernel/include/bharat/cpu_local.h
+++ b/core/kernel/include/bharat/cpu_local.h
@@ -4,6 +4,9 @@
 #include <stdint.h>
 #include <stddef.h>
 
+#include "capability.h"
+#include "sched/sched.h"
+
 /* Forward declarations */
 struct sched_rq;
 struct capability_table;
@@ -19,10 +22,6 @@ struct bh_thread;
 
 // We will use existing structs but forward declare or include them here.
 // In Bharat-OS sched.c uses core_runqueue_t as the per core queue
-// TODO: Needs refactor: #include directive placed mid-file for dependency/order compatibility.
-#include "capability.h"
-// TODO: Needs refactor: #include directive placed mid-file for dependency/order compatibility.
-#include "sched/sched.h"
 // #include <bharat/pmm.h>
 // #include <bharat/urpc.h>
 

--- a/core/kernel/include/core/multikernel.h
+++ b/core/kernel/include/core/multikernel.h
@@ -7,6 +7,7 @@
 
 #include "sched/sched.h"
 #include <stdint.h>
+#include <stdatomic.h>
 
 // Fallback alignment macro if not defined by config system
 #ifndef BHARAT_ALIGNED_CACHE
@@ -44,8 +45,6 @@ typedef enum {
   URPC_ERR_INVAL = -5, // To match the review suggestion
 } urpc_status_t;
 
-// TODO: Needs refactor: #include directive placed mid-file for dependency/order compatibility.
-#include <stdatomic.h>
 
 // Single-Producer / Single-Consumer (SPSC) lockless ring buffer.
 // Queue ownership rules:

--- a/core/kernel/include/device.h
+++ b/core/kernel/include/device.h
@@ -4,6 +4,7 @@
 #include <stdint.h>
 
 #include "mm.h"
+#include "hal/hal_iommu.h"
 
 typedef enum {
   DEVICE_CLASS_UART = 0,
@@ -155,8 +156,6 @@ int pci_discover_nic(device_mmio_window_t *rx_window,
 
 
 // --- DMA and IOMMU Device Capability Registration ---
-// TODO: Needs refactor: #include directive placed mid-file for dependency/order compatibility.
-#include "hal/hal_iommu.h"
 
 // Forward declare safely
 struct dma_caps;

--- a/core/kernel/include/hal/hal.h
+++ b/core/kernel/include/hal/hal.h
@@ -2,6 +2,7 @@
 #define BHARAT_HAL_H
 
 #include <stdint.h>
+#include <stdbool.h>
 
 
 /* Hardware Abstraction Layer Base Definitions */
@@ -19,8 +20,6 @@ void hal_init(void);
 uint64_t hal_cpu_get_fault_address(const void *trap_frame);
 
 // Exception classification
-// TODO: Needs refactor: #include directive placed mid-file for dependency/order compatibility.
-#include <stdbool.h>
 bool hal_cpu_is_syscall(const void *trap_frame);
 bool hal_cpu_is_page_fault(const void *trap_frame);
 bool hal_cpu_is_access_fault(const void *trap_frame);

--- a/core/kernel/include/hal/hal_discovery.h
+++ b/core/kernel/include/hal/hal_discovery.h
@@ -172,6 +172,7 @@ typedef struct {
 } accel_discovery_t;
 
 #include "bharat/display/boot_video.h"
+#include "boot/boot_info.h"
 
 // --- Global System Discovery State ---
 
@@ -202,8 +203,6 @@ typedef struct {
     uint32_t psci_version; // Standard PSCI version
 } system_discovery_t;
 
-// TODO: Needs refactor: #include directive placed mid-file for dependency/order compatibility.
-#include "boot/boot_info.h"
 
 // Retrieve the global discovery structure
 system_discovery_t* hal_get_system_discovery(void);

--- a/core/kernel/include/hal/hal_iommu.h
+++ b/core/kernel/include/hal/hal_iommu.h
@@ -4,6 +4,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdbool.h>
+#include "hal/iommu.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -57,8 +58,6 @@ void hal_iommu_set_ops(const hal_iommu_ops_t *ops);
 const hal_iommu_ops_t *hal_iommu_get_ops(void);
 
 // Include the old file for backward compat.
-// TODO: Needs refactor: #include directive placed mid-file for dependency/order compatibility.
-#include "hal/iommu.h"
 
 #ifdef __cplusplus
 }

--- a/core/kernel/include/io_subsys.h
+++ b/core/kernel/include/io_subsys.h
@@ -2,6 +2,7 @@
 #define BHARAT_IO_H
 
 #include <stdint.h>
+#include "../staging/formal/formal_verif.h"
 
 /*
  * Bharat-OS High-Throughput Asynchronous I/O Architecture
@@ -51,8 +52,6 @@ int io_setup_ring(uint32_t entries, io_ring_t* out_ring);
 int io_submit_sqes(io_ring_t* ring);
 
 // Zero-Copy Direct Device Access for OpenRAN UP (User Plane)
-// TODO: Needs refactor: #include directive placed mid-file for dependency/order compatibility.
-#include "../staging/formal/formal_verif.h"
 
 // Defines a shared memory region mapping a NIC's hardware queues directly to user-space
 typedef struct {

--- a/core/kernel/include/mm.h
+++ b/core/kernel/include/mm.h
@@ -15,12 +15,14 @@
 typedef uint64_t phys_addr_t;
 typedef uint64_t virt_addr_t;
 
-// TODO: Needs refactor: #include directive placed mid-file for dependency/order compatibility.
 #include "list.h"
-// TODO: Needs refactor: #include directive placed mid-file for dependency/order compatibility.
 #include "mm_coloring.h"
-// TODO: Needs refactor: #include directive placed mid-file for dependency/order compatibility.
 #include "mm/pmm.h"
+#include "spinlock.h"
+#include "mm/aspace.h"
+#include "../staging/formal/formal_verif.h"
+#include "mm/address_token.h"
+
 #include "bharat/kernel/ds/bh_refcount.h"
 
 // Page metadata structure for Buddy Allocator
@@ -98,12 +100,8 @@ int mm_zero_phys_range(phys_addr_t phys, size_t size);
 void mm_inc_page_ref(phys_addr_t page);
 
 // Virtual Memory Management (Architecture agnostic paging)
-// TODO: Needs refactor: #include directive placed mid-file for dependency/order compatibility.
-#include "spinlock.h"
 
 typedef struct vm_address_space address_space_t;
-// TODO: Needs refactor: #include directive placed mid-file for dependency/order compatibility.
-#include "mm/aspace.h"
 
 int vmm_init(void);
 int mm_global_init(void);
@@ -121,13 +119,9 @@ int mm_vmm_unmap_page(address_space_t *as, virt_addr_t vaddr);
 // Forward declaration for capability_token_t is not straightforward because
 // it's a typedef of an anonymous struct in formal_verif.h. So we include it
 // directly.
-// TODO: Needs refactor: #include directive placed mid-file for dependency/order compatibility.
-#include "../staging/formal/formal_verif.h"
 int vmm_map_device_mmio(virt_addr_t vaddr, phys_addr_t paddr, capability_t *cap,
                         int is_npu);
 
-// TODO: Needs refactor: #include directive placed mid-file for dependency/order compatibility.
-#include "mm/address_token.h"
 int vmm_map_device_mmio_token(virt_addr_t vaddr, phys_addr_t paddr,
                               uint64_t size, const bharat_addr_token_t *token,
                               int is_npu);
@@ -137,7 +131,7 @@ address_space_t *mm_create_address_space(void);
 
 void vmm_process_local_urpc_messages(uint32_t core_id);
 
-#endif // BHARAT_MM_H
-
 void tlb_shootdown(address_space_t *as, virt_addr_t vaddr);
 #define PAGE_EXEC 0x400
+
+#endif // BHARAT_MM_H

--- a/core/kernel/include/mm/aspace.h
+++ b/core/kernel/include/mm/aspace.h
@@ -16,6 +16,7 @@ extern "C" {
 
 #define VM_REGION_FLAG_STACK (1 << 0)
 #define VM_REGION_FLAG_COW   (1 << 1)
+#include "prot_domain.h"
 
 typedef enum {
     ASPACE_STATE_CREATED = 0,
@@ -49,8 +50,6 @@ typedef struct vm_region {
     struct vm_region *prev;
 } vm_region_t;
 
-// TODO: Needs refactor: #include directive placed mid-file for dependency/order compatibility.
-#include "prot_domain.h"
 
 typedef struct vm_address_space {
     uint64_t object_id;      // Unique ID compatible with legacy object_id tracking

--- a/core/kernel/include/mm/dma.h
+++ b/core/kernel/include/mm/dma.h
@@ -4,6 +4,8 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdbool.h>
+#include "mm/iommu.h"
+#include "../../include/spinlock.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -22,10 +24,6 @@ typedef enum {
     DMA_ALLOC_ZERO      = 1u << 2,
 } dma_alloc_flags_t;
 
-// TODO: Needs refactor: #include directive placed mid-file for dependency/order compatibility.
-#include "../../include/spinlock.h"
-// TODO: Needs refactor: #include directive placed mid-file for dependency/order compatibility.
-#include "mm/iommu.h"
 
 // Forward declaration of IOMMU backend ops
 typedef struct iommu_ops iommu_ops_t;

--- a/core/kernel/include/mm/iommu.h
+++ b/core/kernel/include/mm/iommu.h
@@ -5,6 +5,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include "kernel/status.h"
+#include "hal/hal_iommu.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -81,8 +82,6 @@ int iommu_invalidate_range(iommu_domain_t *dom, uintptr_t iova, size_t len);
 int iommu_get_dma_mode(iommu_device_t *dev, dma_translation_mode_t *mode_out);
 
 // Backend registration for hal implementations
-// TODO: Needs refactor: #include directive placed mid-file for dependency/order compatibility.
-#include "hal/hal_iommu.h"
 
 #ifdef __cplusplus
 }

--- a/core/kernel/include/mm/mm_remote.h
+++ b/core/kernel/include/mm/mm_remote.h
@@ -5,6 +5,7 @@
 #include <stddef.h>
 #include "../../include/mm.h"
 #include "mm_local.h"
+#include "../../include/spinlock.h"
 
 // Operations that cross core boundaries via URPC (may be async)
 
@@ -24,8 +25,6 @@ typedef struct {
     uint64_t seq; // Request sequence
 } mm_urpc_tlb_msg_t;
 
-// TODO: Needs refactor: #include directive placed mid-file for dependency/order compatibility.
-#include "../../include/spinlock.h"
 
 typedef struct {
     spinlock_t lock;

--- a/core/kernel/include/mm/pmm.h
+++ b/core/kernel/include/mm/pmm.h
@@ -50,6 +50,7 @@ typedef enum {
 } pmm_alloc_flags_t;
 
 #include "bharat/mem_class.h"
+#include <stdbool.h>
 
 typedef struct {
     uint64_t phys_addr;
@@ -99,8 +100,6 @@ int pmm_ref_put(uint64_t phys_addr);
 int pmm_pin(uint64_t phys_addr);
 int pmm_unpin(uint64_t phys_addr);
 
-// TODO: Needs refactor: #include directive placed mid-file for dependency/order compatibility.
-#include <stdbool.h>
 
 // Helper wrappers
 void *pmm_alloc_page_ex(alloc_class_t cls, uint32_t flags);

--- a/core/kernel/include/mm/vm_object.h
+++ b/core/kernel/include/mm/vm_object.h
@@ -48,6 +48,8 @@ typedef struct {
 
 #define VM_OBJECT_MAGIC_ALIVE 0x564D4F42 // "VMOB"
 #define VM_OBJECT_MAGIC_DEAD  0xDEADDEAD
+#include "../../include/spinlock.h"
+#include "../../include/mm.h"
 
 typedef struct vm_object_ops {
     int (*fault)(struct vm_object *obj,
@@ -60,10 +62,6 @@ typedef struct vm_object_ops {
     void (*release)(struct vm_object *obj);
 } vm_object_ops_t;
 
-// TODO: Needs refactor: #include directive placed mid-file for dependency/order compatibility.
-#include "../../include/spinlock.h"
-// TODO: Needs refactor: #include directive placed mid-file for dependency/order compatibility.
-#include "../../include/mm.h"
 struct vm_object {
     vm_object_kind_t kind;
     uint32_t flags;

--- a/core/kernel/include/personality_ops.h
+++ b/core/kernel/include/personality_ops.h
@@ -1,10 +1,9 @@
 #pragma once
+#include "trap_types.h"
 
 struct bh_thread;
 typedef struct bh_thread bh_thread_t;
 
-// TODO: Needs refactor: #include directive placed mid-file for dependency/order compatibility.
-#include "trap_types.h"
 
 // Forward declaration of trap_frame_t without typedef redefinition issues.
 struct trap_frame;

--- a/core/kernel/include/profile/profile.h
+++ b/core/kernel/include/profile/profile.h
@@ -1,6 +1,8 @@
 #ifndef BHARAT_PROFILE_H
 #define BHARAT_PROFILE_H
 
+#include <stdbool.h>
+
 /*
  * Bharat-OS profile selection and lightweight feature switches.
  *
@@ -39,8 +41,6 @@ void profile_init(void);
 #define FEATURE_QOS_HOOKS 1
 #endif
 
-// TODO: Needs refactor: #include directive placed mid-file for dependency/order compatibility.
-#include <stdbool.h>
 // Include the new canonical memory model contract
 #include "mm/mem_model.h"
 

--- a/core/kernel/include/security/isolation.h
+++ b/core/kernel/include/security/isolation.h
@@ -38,6 +38,7 @@ typedef struct {
 #define BHARAT_SANDBOX_FLAG_NO_KERNEL_SYMBOLS  (1u << 7)
 #define BHARAT_SANDBOX_FLAG_SIGNED_DRIVER_ONLY (1u << 8)
 #define BHARAT_SANDBOX_FLAG_USERSPACE_DRIVER   (1u << 9)
+#include <stddef.h>
 
 typedef enum {
     BHARAT_DRIVER_TRUST_CORE = 0,
@@ -86,8 +87,6 @@ int bharat_iommu_group_attach(bharat_iommu_group_t* group,
                               bharat_iommu_domain_t* domain);
 int bharat_iommu_group_detach(bharat_iommu_group_t* group);
 
-// TODO: Needs refactor: #include directive placed mid-file for dependency/order compatibility.
-#include <stddef.h>
 int bharat_iommu_map(bharat_iommu_domain_t* domain,
                      uint64_t iova,
                      uint64_t phys,

--- a/core/kernel/include/tests/ktest.h
+++ b/core/kernel/include/tests/ktest.h
@@ -4,6 +4,7 @@
 #include "hal/hal.h"
 #include <stdbool.h>
 #include <stdint.h>
+#include "boot/boot_selftest.h"
 
 
 #define KTEST_PRINT(s) hal_serial_write(s)
@@ -13,8 +14,6 @@ typedef struct {
   bool (*test_fn)(void);
 } ktest_case_t;
 
-// TODO: Needs refactor: #include directive placed mid-file for dependency/order compatibility.
-#include "boot/boot_selftest.h"
 
 typedef struct {
   const char *name;

--- a/core/kernel/src/tests/ktest_capability.c
+++ b/core/kernel/src/tests/ktest_capability.c
@@ -16,10 +16,9 @@
         } \
     } while(0)
 
-// TODO: Needs refactor: #include directive placed mid-file for dependency/order compatibility.
-#include "tests/ktest.h"
 
 #include "cap_policy.h"
+#include "tests/ktest.h"
 
 // Helper to check if a capability exists
 static bool cap_exists(capability_table_t* table, uint32_t cap_id) {

--- a/core/kernel/src/tests/test_vm_space.c
+++ b/core/kernel/src/tests/test_vm_space.c
@@ -1,20 +1,15 @@
 #include "../../include/tests/test_framework.h"
 #include "../../include/mm/vm_space.h"
 #include <stdlib.h>
+#include "../../include/mm/vm_mapping.h"
+#include "../../include/mm/arch_vm.h"
+#include <stddef.h>
+#include <stdint.h>
+#include <stdbool.h>
 
 uint32_t hal_get_core_id_mock(void) {
     return 0;
 }
-// TODO: Needs refactor: #include directive placed mid-file for dependency/order compatibility.
-#include "../../include/mm/vm_mapping.h"
-// TODO: Needs refactor: #include directive placed mid-file for dependency/order compatibility.
-#include "../../include/mm/arch_vm.h"
-// TODO: Needs refactor: #include directive placed mid-file for dependency/order compatibility.
-#include <stddef.h>
-// TODO: Needs refactor: #include directive placed mid-file for dependency/order compatibility.
-#include <stdint.h>
-// TODO: Needs refactor: #include directive placed mid-file for dependency/order compatibility.
-#include <stdbool.h>
 
 // Mock monitor operations
 int mon_vm_send_map(vm_space_t *space, const vm_map_req_t *req, bool strict) { return 0; }


### PR DESCRIPTION
This PR refactors all instances of `TODO: Needs refactor: #include directive placed mid-file` in the `core/hal` and `core/kernel/include` directories.

In many places, includes were placed in the middle of files to dodge circular dependencies, but this breaks standard C conventions and static analysis tools.

These includes were correctly relocated either to the top of the file, safely inside `#ifndef` include guards, and the `TODO` comments were purged.

Tested against all 5 supported headless configurations (x86_64, arm64, arm32, riscv64, riscv32) to ensure no regressions in build or boot behavior.

---
*PR created automatically by Jules for task [12741767234772407505](https://jules.google.com/task/12741767234772407505) started by @divyang4481*