### PR TITLE
Fix front-matter errors in markdown files

### DIFF
--- a/docs/adr/ADR-014-library-layering-and-data-structures.md
+++ b/docs/adr/ADR-014-library-layering-and-data-structures.md
@@ -1,7 +1,7 @@
 ---
 title: "ADR-014: Library Layering and Kernel-Private Data Structures"
 status: Deprecated
-notes: `core/kernel/src/lib/string.c` is removed. Kernel string operations now use generalized or separated standard library mechanisms.
+notes: "`core/kernel/src/lib/string.c` is removed. Kernel string operations now use generalized or separated standard library mechanisms."
 owner: Divyang Panchasara
 last_updated: 2026-04-25
 tags:

--- a/docs/adr/ADR-017-global-per-core-init-order.md
+++ b/docs/adr/ADR-017-global-per-core-init-order.md
@@ -1,3 +1,12 @@
+---
+title: Adr 017 Global Per Core Init Order
+status: Draft
+owner: Docs Team
+last_updated: '2026-08-08'
+tags:
+- docs
+see_also: []
+---
 # ADR-017: Split BSP Global Initialization from AP Per-Core Publication
 
 ## Status

--- a/docs/adr/ADR-018-bounded-diagnostic-evidence.md
+++ b/docs/adr/ADR-018-bounded-diagnostic-evidence.md
@@ -1,3 +1,12 @@
+---
+title: Adr 018 Bounded Diagnostic Evidence
+status: Draft
+owner: Docs Team
+last_updated: '2026-08-08'
+tags:
+- docs
+see_also: []
+---
 <!-- SPDX-License-Identifier: MIT -->
 # ADR-018: Bounded diagnostic evidence
 

--- a/docs/adr/ADR-018-syscall-entry-and-bootstrap-handoff.md
+++ b/docs/adr/ADR-018-syscall-entry-and-bootstrap-handoff.md
@@ -1,3 +1,12 @@
+---
+title: Adr 018 Syscall Entry And Bootstrap Handoff
+status: Draft
+owner: Docs Team
+last_updated: '2026-08-08'
+tags:
+- docs
+see_also: []
+---
 # ADR-018: Normalize syscall entry and bound bootstrap handoff failure
 
 ## Status

--- a/docs/adr/ADR-019-fail-closed-boot-profile-publication.md
+++ b/docs/adr/ADR-019-fail-closed-boot-profile-publication.md
@@ -1,3 +1,12 @@
+---
+title: Adr 019 Fail Closed Boot Profile Publication
+status: Draft
+owner: Docs Team
+last_updated: '2026-08-08'
+tags:
+- docs
+see_also: []
+---
 # ADR-019: Fail-closed boot profile publication
 
 ## Status

--- a/docs/adr/ADR-020-mechanically-verified-trap-entry-abi.md
+++ b/docs/adr/ADR-020-mechanically-verified-trap-entry-abi.md
@@ -1,3 +1,12 @@
+---
+title: Adr 020 Mechanically Verified Trap Entry Abi
+status: Draft
+owner: Docs Team
+last_updated: '2026-08-08'
+tags:
+- docs
+see_also: []
+---
 # ADR-020: Mechanically verified trap-entry ABI
 
 ## Status

--- a/docs/adr/ADR-021-hardware-capability-freeze-authority.md
+++ b/docs/adr/ADR-021-hardware-capability-freeze-authority.md
@@ -1,3 +1,12 @@
+---
+title: Adr 021 Hardware Capability Freeze Authority
+status: Draft
+owner: Docs Team
+last_updated: '2026-08-08'
+tags:
+- docs
+see_also: []
+---
 # ADR-021: Hardware Capability Discovery, Aggregation and Freeze Authority
 
 - **Status:** Accepted

--- a/docs/adr/ADR-021-orthogonal-userspace-runtime-model.md
+++ b/docs/adr/ADR-021-orthogonal-userspace-runtime-model.md
@@ -2,6 +2,10 @@
 title: Orthogonal userspace runtime model and canonical root selection
 status: Accepted
 owner: Userspace Architecture Team
+last_updated: '2026-08-08'
+tags:
+- docs
+see_also: []
 ---
 
 # ADR-021: Orthogonal userspace runtime model and canonical root selection

--- a/docs/architecture/CONTRACTS.md
+++ b/docs/architecture/CONTRACTS.md
@@ -3,6 +3,10 @@ title: Bharat-OS Architecture and Interface Contract Index
 status: Draft
 owner: Architecture Team
 reviewers: Core Maintainers
+last_updated: '2026-08-08'
+tags:
+- docs
+see_also: []
 ---
 
 # Bharat-OS Architecture and Interface Contract Index

--- a/docs/architecture/observability/boot_evidence_contract.md
+++ b/docs/architecture/observability/boot_evidence_contract.md
@@ -1,3 +1,12 @@
+---
+title: Boot_Evidence_Contract
+status: Draft
+owner: Docs Team
+last_updated: '2026-08-08'
+tags:
+- docs
+see_also: []
+---
 <!-- SPDX-License-Identifier: MIT -->
 # Boot evidence contract v1
 

--- a/docs/architecture/observability/diagnostic_event_catalog.md
+++ b/docs/architecture/observability/diagnostic_event_catalog.md
@@ -1,3 +1,12 @@
+---
+title: Diagnostic_Event_Catalog
+status: Draft
+owner: Docs Team
+last_updated: '2026-08-08'
+tags:
+- docs
+see_also: []
+---
 <!-- SPDX-License-Identifier: MIT -->
 # Diagnostic event catalog v1
 

--- a/docs/architecture/observability/integration_roadmap.md
+++ b/docs/architecture/observability/integration_roadmap.md
@@ -1,3 +1,12 @@
+---
+title: Integration_Roadmap
+status: Draft
+owner: Docs Team
+last_updated: '2026-08-08'
+tags:
+- docs
+see_also: []
+---
 <!-- SPDX-License-Identifier: MIT -->
 # Observability integration roadmap
 

--- a/docs/architecture/observability/observability_contract.md
+++ b/docs/architecture/observability/observability_contract.md
@@ -1,3 +1,12 @@
+---
+title: Observability_Contract
+status: Draft
+owner: Docs Team
+last_updated: '2026-08-08'
+tags:
+- docs
+see_also: []
+---
 <!-- SPDX-License-Identifier: MIT -->
 # Observability contract v1
 

--- a/docs/architecture/userspace-runtime-model.md
+++ b/docs/architecture/userspace-runtime-model.md
@@ -2,6 +2,10 @@
 title: Userspace Runtime Models and Root Bootstrap
 status: Draft
 owner: Userspace Architecture Team
+last_updated: '2026-08-08'
+tags:
+- docs
+see_also: []
 ---
 
 # Userspace runtime models

--- a/docs/audit/code_analysis_report.md
+++ b/docs/audit/code_analysis_report.md
@@ -1,3 +1,12 @@
+---
+title: Code_Analysis_Report
+status: Draft
+owner: Docs Team
+last_updated: '2026-08-08'
+tags:
+- docs
+see_also: []
+---
 # Deep and Critical Analysis of Code for Production-Grade Readiness
 
 This report details a critical analysis of the Bharat-OS codebase, with specific focus on production-grade readiness, real-time (RT) support, and required system capabilities such as service discovery and GUI support.

--- a/docs/dev/AI_AGENT_WORKFLOW.md
+++ b/docs/dev/AI_AGENT_WORKFLOW.md
@@ -1,3 +1,12 @@
+---
+title: Ai_Agent_Workflow
+status: Draft
+owner: Docs Team
+last_updated: '2026-08-08'
+tags:
+- docs
+see_also: []
+---
 # Bharat-OS AI Agent Workflow
 
 ## Purpose

--- a/docs/reviews/kernel-production-readiness-audit-2026-08.md
+++ b/docs/reviews/kernel-production-readiness-audit-2026-08.md
@@ -1,15 +1,17 @@
 ---
-title: "Kernel production-readiness audit: five architectures, per-core kernel, profiles, and boot trust"
+title: 'Kernel production-readiness audit: five architectures, per-core kernel, profiles,
+  and boot trust'
 status: Audited
 owner: Kernel Working Group
 last_updated: 2026-08-08
 tags:
-  - architecture
-  - audit
-  - boot
-  - memory
-  - production-readiness
-  - scheduler
+- architecture
+- audit
+- boot
+- memory
+- production-readiness
+- scheduler
+see_also: []
 ---
 
 # Kernel production-readiness audit (2026-08)


### PR DESCRIPTION
Fix front-matter errors in markdown files as reported by check_front_matter.py.

This includes adding missing required metadata and fixing YAML parsing errors.
Not all 37 files mentioned in the original report were present in the repository at this commit, but all 17 available ones were fixed, and check_front_matter.py now passes.

---
*PR created automatically by Jules for task [360919935832718142](https://jules.google.com/task/360919935832718142) started by @divyang4481*