### PR TITLE
Fix native-width atomics for 32-bit targets (RV32/ARM32): MPSC rings, scheduler, diag, and atomic64 fallback

### DIFF
--- a/core/kernel/CMakeLists.txt
+++ b/core/kernel/CMakeLists.txt
@@ -694,6 +694,12 @@ set_target_properties(kernel.elf PROPERTIES
     OUTPUT_NAME "kernel.elf"
     SUFFIX ""
 )
+# Atomic width is an architecture contract for every kernel object library,
+# not only the final kernel.elf sources.
+target_compile_options(bharat_kernel_buildopts INTERFACE
+    $<$<COMPILE_LANGUAGE:C>:-Werror=atomic-alignment>
+)
+
 # Extra warnings for C sources only
 target_compile_options(kernel.elf PRIVATE
     $<$<COMPILE_LANGUAGE:C>:-ffreestanding>

--- a/core/kernel/include/atomic.h
+++ b/core/kernel/include/atomic.h
@@ -87,6 +87,10 @@ static inline uint64_t atomic64_fetch_and_add_ptr(volatile uint64_t *ptr, uint64
 static inline uint64_t atomic64_fetch_and_sub_ptr(volatile uint64_t *ptr, uint64_t val) {
     return __atomic_fetch_sub(ptr, val, __ATOMIC_SEQ_CST);
 }
+
+static inline uint64_t atomic64_load_ptr(const volatile uint64_t *ptr) {
+    return __atomic_load_n(ptr, __ATOMIC_ACQUIRE);
+}
 #else
 // 32-bit fallback for 64-bit atomics.
 // On 32-bit platforms, 64-bit atomic operations might not be lock-free and
@@ -153,6 +157,13 @@ static inline uint64_t atomic64_fetch_and_sub_ptr(volatile uint64_t *ptr, uint64
     *ptr -= val;
     arch_atomic64_unlock();
     return old;
+}
+
+static inline uint64_t atomic64_load_ptr(const volatile uint64_t *ptr) {
+    arch_atomic64_lock();
+    uint64_t value = *ptr;
+    arch_atomic64_unlock();
+    return value;
 }
 #endif
 

--- a/core/kernel/include/ipc/mk_proto.h
+++ b/core/kernel/include/ipc/mk_proto.h
@@ -126,13 +126,16 @@ typedef struct {
 } bh_mk_wire_message_t;
 
 typedef struct __attribute__((aligned(64))) {
-    _Atomic uint64_t sequence;
+    _Atomic uint32_t sequence;
     bh_mk_wire_message_t message;
 } bh_mk_ring_slot_t;
 
+/* Producers share the native-width head and slot sequences.  The sole
+ * consumer owns consumer_tail.  Capacities remain below half the uint32_t
+ * sequence space so signed modulo comparisons are unambiguous at rollover. */
 typedef struct {
-    _Atomic uint64_t producer_head;
-    uint64_t consumer_tail;
+    _Atomic uint32_t producer_head;
+    uint32_t consumer_tail;
 
     _Atomic uint32_t available_credits;
     uint32_t capacity;
@@ -243,6 +246,9 @@ typedef struct {
     bh_mk_endpoint_table_t endpoints;
     bh_mk_diag_t diagnostics;
 
+    /* Owner-core sequence allocator.  It is atomic because send can be
+     * entered by multiple local execution contexts; it is never remote-mutated. */
+    _Atomic uint32_t tx_sequence;
     _Atomic uint32_t ready;
     _Atomic uint32_t generation;
 } bh_mk_core_fabric_t;

--- a/core/kernel/include/sched/sched.h
+++ b/core/kernel/include/sched/sched.h
@@ -110,16 +110,18 @@ typedef struct {
 } sched_remote_cmd_envelope_t;
 
 typedef struct {
-    volatile uint64_t seq;
+    volatile uint32_t seq;
     sched_remote_cmd_envelope_t value;
 } sched_cmd_slot_t;
 
+/* Native-width MPSC synchronization counters.  Ring capacity is bounded well
+ * below 2^31 so modulo subtraction remains ordered across uint32_t rollover. */
 typedef struct {
     sched_cmd_slot_t *slots;
     uint32_t capacity;
     uint32_t mask;
-    volatile uint64_t head;
-    uint64_t tail;
+    volatile uint32_t head;
+    uint32_t tail;
 } sched_cmd_ring_t;
 
 typedef enum {
@@ -136,7 +138,7 @@ typedef struct {
 } sched_remote_completion_t;
 
 typedef struct {
-    volatile uint64_t seq;
+    volatile uint32_t seq;
     sched_remote_completion_t value;
 } sched_completion_slot_t;
 
@@ -144,8 +146,8 @@ typedef struct {
     sched_completion_slot_t *slots;
     uint32_t capacity;
     uint32_t mask;
-    volatile uint64_t head;
-    uint64_t tail;
+    volatile uint32_t head;
+    uint32_t tail;
 } sched_completion_ring_t;
 
 typedef struct {
@@ -157,11 +159,11 @@ typedef struct {
 
     volatile uint32_t resched_pending;
 
-    uint64_t submitted;
-    uint64_t consumed;
-    uint64_t full;
-    uint64_t ipi_sent;
-    uint64_t ipi_coalesced;
+    uint32_t submitted;
+    uint32_t consumed;
+    uint32_t full;
+    uint32_t ipi_sent;
+    uint32_t ipi_coalesced;
 } sched_remote_inbox_t;
 
 /*

--- a/core/kernel/src/atomic64_fallback.c
+++ b/core/kernel/src/atomic64_fallback.c
@@ -3,14 +3,12 @@
 #include <stdbool.h>
 
 #if ARCH_WORD_BITS == 32
-static spinlock_t g_atomic64_lock;
-static bool g_atomic64_lock_init = false;
+/* Temporary shared compatibility backend for genuinely required atomic64
+ * operations on 32-bit SMP targets.  Static zero initialization is valid for
+ * spinlock_t and makes the lock usable before secondary CPUs start. */
+static spinlock_t g_atomic64_lock = { .locked = { .value = 0 } };
 
 void arch_atomic64_lock(void) {
-    if (!g_atomic64_lock_init) {
-        spin_lock_init(&g_atomic64_lock);
-        g_atomic64_lock_init = true;
-    }
     spin_lock(&g_atomic64_lock);
 }
 
@@ -121,4 +119,3 @@ uint64_t __atomic_add_fetch_8(volatile void *ptr, uint64_t val, int memorder) {
     return newval;
 }
 #endif
-

--- a/core/kernel/src/ipc/fabric/mk_fabric.c
+++ b/core/kernel/src/ipc/fabric/mk_fabric.c
@@ -89,6 +89,7 @@ kstatus_t bh_mk_fabric_init(uint32_t discovered_core_count) {
         }
 
         atomic_store_explicit(&f->generation, 1, memory_order_relaxed);
+        atomic_store_explicit(&f->tx_sequence, 1U, memory_order_relaxed);
         atomic_store_explicit(&f->ready, 1, memory_order_release);
     }
 
@@ -239,8 +240,9 @@ kstatus_t bh_mk_send(
         wire_msg.header.txn_generation = 0xFFFFFFFFU;
     }
 
-    static _Atomic uint64_t g_sequence_counter = 1;
-    wire_msg.header.sequence = atomic_fetch_add_explicit(&g_sequence_counter, 1, memory_order_relaxed);
+    uint32_t local_sequence = atomic_fetch_add_explicit(
+        &src_fab->tx_sequence, 1U, memory_order_relaxed);
+    wire_msg.header.sequence = ((uint64_t)src_core << 32) | local_sequence;
     wire_msg.header.deadline_ticks = hal_timer_monotonic_ticks() + 1000;
     wire_msg.header.payload_size = payload_size;
 

--- a/core/kernel/src/ipc/fabric/mk_mpsc_ring.c
+++ b/core/kernel/src/ipc/fabric/mk_mpsc_ring.c
@@ -1,8 +1,15 @@
 #include "ipc/mk_proto.h"
 #include <stdbool.h>
 
+#define BH_MK_MPSC_MAX_CAPACITY (1U << 31)
+
+_Static_assert(BH_MK_LANE_CONTROL_CAP < BH_MK_MPSC_MAX_CAPACITY, "control lane must preserve modulo ordering");
+_Static_assert(BH_MK_LANE_NORMAL_CAP < BH_MK_MPSC_MAX_CAPACITY, "normal lane must preserve modulo ordering");
+_Static_assert(BH_MK_LANE_BULK_CAP < BH_MK_MPSC_MAX_CAPACITY, "bulk lane must preserve modulo ordering");
+
 kstatus_t bh_mk_mpsc_ring_init(bh_mk_mpsc_ring_t *ring, bh_mk_ring_slot_t *slots, uint32_t capacity) {
-    if (!ring || !slots || capacity == 0 || (capacity & (capacity - 1)) != 0) {
+    if (!ring || !slots || capacity == 0 || capacity >= BH_MK_MPSC_MAX_CAPACITY ||
+        (capacity & (capacity - 1U)) != 0U) {
         return K_ERR_INVALID_ARG;
     }
 
@@ -14,7 +21,7 @@ kstatus_t bh_mk_mpsc_ring_init(bh_mk_mpsc_ring_t *ring, bh_mk_ring_slot_t *slots
     atomic_store_explicit(&ring->available_credits, capacity, memory_order_relaxed);
 
     for (uint32_t i = 0; i < capacity; i++) {
-        atomic_store_explicit(&slots[i].sequence, (uint64_t)i, memory_order_relaxed);
+        atomic_store_explicit(&slots[i].sequence, i, memory_order_relaxed);
         __builtin_memset(&slots[i].message, 0, sizeof(bh_mk_wire_message_t));
     }
 
@@ -38,17 +45,17 @@ kstatus_t bh_mk_mpsc_ring_enqueue(bh_mk_mpsc_ring_t *ring, const bh_mk_wire_mess
     }
 
     // 2. Reserve ticket (producer_head)
-    uint64_t pos = atomic_load_explicit(&ring->producer_head, memory_order_relaxed);
+    uint32_t pos = atomic_load_explicit(&ring->producer_head, memory_order_relaxed);
     uint32_t attempts = 0;
     for (;;) {
         bh_mk_ring_slot_t *slot = &ring->slots[pos & ring->mask];
-        uint64_t seq = atomic_load_explicit(&slot->sequence, memory_order_acquire);
-        intptr_t diff = (intptr_t)seq - (intptr_t)pos;
+        uint32_t seq = atomic_load_explicit(&slot->sequence, memory_order_acquire);
+        int32_t diff = (int32_t)(seq - pos);
         if (diff == 0) {
-            if (atomic_compare_exchange_weak_explicit(&ring->producer_head, &pos, pos + 1, memory_order_relaxed, memory_order_relaxed)) {
+            if (atomic_compare_exchange_weak_explicit(&ring->producer_head, &pos, pos + 1U, memory_order_relaxed, memory_order_relaxed)) {
                 // Success! We reserved slot at pos.
                 slot->message = *msg;
-                atomic_store_explicit(&slot->sequence, pos + 1, memory_order_release);
+                atomic_store_explicit(&slot->sequence, pos + 1U, memory_order_release);
                 return K_OK;
             }
         } else if (diff < 0) {
@@ -70,16 +77,16 @@ kstatus_t bh_mk_mpsc_ring_dequeue(bh_mk_mpsc_ring_t *ring, bh_mk_wire_message_t 
         return K_ERR_INVALID_ARG;
     }
 
-    uint64_t pos = ring->consumer_tail;
+    uint32_t pos = ring->consumer_tail;
     bh_mk_ring_slot_t *slot = &ring->slots[pos & ring->mask];
-    uint64_t seq = atomic_load_explicit(&slot->sequence, memory_order_acquire);
-    intptr_t diff = (intptr_t)seq - (intptr_t)(pos + 1);
+    uint32_t seq = atomic_load_explicit(&slot->sequence, memory_order_acquire);
+    int32_t diff = (int32_t)(seq - (pos + 1U));
 
     if (diff == 0) {
         *out_msg = slot->message;
         // Mark slot ready for the next producer cycle
         atomic_store_explicit(&slot->sequence, pos + ring->capacity, memory_order_release);
-        ring->consumer_tail = pos + 1;
+        ring->consumer_tail = pos + 1U;
 
         // Replenish credit
         atomic_fetch_add_explicit(&ring->available_credits, 1, memory_order_release);

--- a/core/kernel/src/mm/mem_class.c
+++ b/core/kernel/src/mm/mem_class.c
@@ -47,7 +47,7 @@ int sys_mem_alloc_class(size_t size, uint32_t mem_class, uint32_t flags, uint64_
     }
 
     if (mem_class < MEM_CLASS_MAX) {
-        __atomic_fetch_add(&class_allocations[mem_class], size, __ATOMIC_RELAXED);
+        atomic64_fetch_and_add_ptr(&class_allocations[mem_class], size);
     } else {
         return K_ERR_INVALID_ARG;
     }

--- a/core/kernel/src/mm/tlb/tlb_pending.c
+++ b/core/kernel/src/mm/tlb/tlb_pending.c
@@ -1,6 +1,7 @@
 #include "tlb_pending.h"
 #include "../../../include/hal/hal.h"
 #include "../../../include/bharat/cpu_local.h"
+#include "../../../include/atomic.h"
 
 extern uint32_t g_active_core_count;
 
@@ -86,7 +87,7 @@ void tlb_pending_ack(uint32_t reqid, uint32_t acking_core) {
         __atomic_load_n(&entry->request_id, __ATOMIC_ACQUIRE) == reqid) {
 
         uint64_t mask = (1ULL << acking_core);
-        uint64_t prev = __atomic_fetch_or(&entry->ack_mask, mask, __ATOMIC_RELEASE);
+        uint64_t prev = atomic64_fetch_and_or(&entry->ack_mask, mask);
         if (!(prev & mask)) {
             __atomic_add_fetch(&g_tlb_stats[core_id].acks_received, 1, __ATOMIC_RELAXED);
         } else {
@@ -99,7 +100,7 @@ void tlb_pending_ack(uint32_t reqid, uint32_t acking_core) {
 
 bool tlb_pending_is_complete(uint32_t current_core, int slot) {
     tlb_pending_entry_t* entry = &g_tlb_pending[current_core][slot];
-    uint64_t ack = __atomic_load_n(&entry->ack_mask, __ATOMIC_ACQUIRE);
+    uint64_t ack = atomic64_load_ptr(&entry->ack_mask);
     return (ack & entry->target_mask) == entry->target_mask;
 }
 
@@ -117,6 +118,6 @@ uint64_t tlb_pending_get_missing_mask(uint32_t core_id, int slot) {
     if (core_id >= g_active_core_count || slot >= BHARAT_TLB_MAX_PENDING_PER_CORE) return 0;
     tlb_pending_entry_t* entry = &g_tlb_pending[core_id][slot];
     if (!__atomic_load_n(&entry->in_use, __ATOMIC_ACQUIRE)) return 0;
-    uint64_t ack = __atomic_load_n(&entry->ack_mask, __ATOMIC_ACQUIRE);
+    uint64_t ack = atomic64_load_ptr(&entry->ack_mask);
     return entry->target_mask & ~ack;
 }

--- a/core/kernel/src/mm/tlb/tlb_pending.h
+++ b/core/kernel/src/mm/tlb/tlb_pending.h
@@ -15,18 +15,18 @@ typedef struct {
 } tlb_pending_entry_t;
 
 typedef struct {
-    uint64_t requests_issued;
-    uint64_t targets_total;
-    uint64_t acks_received;
-    uint64_t stale_acks;
-    uint64_t allocation_failures;
-    uint64_t fallback_count;
-    uint64_t duplicate_acks;
-    uint64_t retries;
-    uint64_t timeouts;
-    uint64_t send_failures;
-    uint64_t partial_completions;
-    uint64_t legacy_fallback_usage;
+    uint32_t requests_issued;
+    uint32_t targets_total;
+    uint32_t acks_received;
+    uint32_t stale_acks;
+    uint32_t allocation_failures;
+    uint32_t fallback_count;
+    uint32_t duplicate_acks;
+    uint32_t retries;
+    uint32_t timeouts;
+    uint32_t send_failures;
+    uint32_t partial_completions;
+    uint32_t legacy_fallback_usage;
 } tlb_pending_stats_t;
 
 // Encodes request ID from component pieces.

--- a/core/kernel/src/mm/vm/aspace/aspace.c
+++ b/core/kernel/src/mm/vm/aspace/aspace.c
@@ -137,7 +137,7 @@ int aspace_create(address_space_t **out_aspace, uint32_t flags) {
         }
     }
 
-    as->object_id = __atomic_fetch_add(&next_as_id, 1, __ATOMIC_SEQ_CST);
+    as->object_id = atomic64_fetch_and_add_ptr(&next_as_id, 1);
     spin_lock_init(&as->lock);
     as->tlb_gen = 1;
     as->active_mask = 0;
@@ -513,7 +513,7 @@ kstatus_t aspace_activate_on_cpu(address_space_t *aspace, uint32_t cpu_id) {
     }
 
     aspace->state = ASPACE_STATE_ACTIVE;
-    __atomic_or_fetch(&aspace->active_mask, (1ULL << cpu_id), __ATOMIC_SEQ_CST);
+    atomic64_fetch_and_or(&aspace->active_mask, (1ULL << cpu_id));
     spin_unlock(&aspace->lock);
     return K_OK;
 }
@@ -524,7 +524,7 @@ kstatus_t aspace_deactivate_on_cpu(address_space_t *aspace, uint32_t cpu_id) {
 
     // We don't necessarily lock here if we want it to be fast during switch,
     // but the requirement said to use named APIs.
-    __atomic_and_fetch(&aspace->active_mask, ~(1ULL << cpu_id), __ATOMIC_SEQ_CST);
+    atomic64_fetch_and_and(&aspace->active_mask, ~(1ULL << cpu_id));
 
     // If mask is empty and state was active, we could potentially move it back to created,
     // but typically it stays ACTIVE once it has been used.
@@ -541,12 +541,12 @@ void aspace_mark_poisoned(address_space_t *aspace) {
 
 uint64_t aspace_get_active_mask(address_space_t *aspace) {
     if (!aspace) return 0;
-    return __atomic_load_n(&aspace->active_mask, __ATOMIC_ACQUIRE);
+    return atomic64_load_ptr(&aspace->active_mask);
 }
 
 uint64_t aspace_next_tlb_generation(address_space_t *aspace) {
     if (!aspace) return 0;
-    return __atomic_add_fetch(&aspace->tlb_gen, 1, __ATOMIC_SEQ_CST);
+    return atomic64_fetch_and_add_ptr(&aspace->tlb_gen, 1) + 1U;
 }
 
 bool aspace_is_valid_for_tlb(address_space_t *aspace) {

--- a/core/kernel/src/mm/vm/aspace/aspace_switch.c
+++ b/core/kernel/src/mm/vm/aspace/aspace_switch.c
@@ -47,7 +47,7 @@ void vm_debug_validate_active_tracking(void) {
     for (uint32_t i = 0; i < MAX_CPUS; i++) {
         address_space_t *as = g_cpu_locals[i].current_as;
         if (as) {
-            uint64_t mask = __atomic_load_n(&as->active_mask, __ATOMIC_ACQUIRE);
+            uint64_t mask = aspace_get_active_mask(as);
             if (!(mask & (1ULL << i))) {
                 kernel_panic("vm_debug_validate_active_tracking: active_mask out of sync\n");
             }

--- a/core/kernel/src/sched/sched_core.c
+++ b/core/kernel/src/sched/sched_core.c
@@ -1009,7 +1009,8 @@ void sched_remote_cmd_poll_timeouts(void) {
 }
 
 kstatus_t sched_cmd_ring_init(sched_cmd_ring_t *q, sched_cmd_slot_t *slots, uint32_t capacity) {
-    if (!q || !slots || capacity < 2 || (capacity & (capacity - 1)) != 0) {
+    if (!q || !slots || capacity < 2 || capacity >= (1U << 31) ||
+        (capacity & (capacity - 1U)) != 0U) {
         return K_ERR_INVALID_ARG;
     }
     q->slots = slots;
@@ -1028,12 +1029,12 @@ kstatus_t sched_cmd_ring_init(sched_cmd_ring_t *q, sched_cmd_slot_t *slots, uint
 kstatus_t sched_cmd_ring_push(sched_cmd_ring_t *q, const sched_remote_cmd_envelope_t *value) {
     if (!q || !value) return K_ERR_INVALID_ARG;
     sched_cmd_slot_t *slot;
-    uint64_t pos = q->head;
+    uint32_t pos = q->head;
 
     while (true) {
         slot = &q->slots[pos & q->mask];
-        uint64_t seq = __atomic_load_n(&slot->seq, __ATOMIC_ACQUIRE);
-        int64_t diff = (int64_t)seq - (int64_t)pos;
+        uint32_t seq = __atomic_load_n(&slot->seq, __ATOMIC_ACQUIRE);
+        int32_t diff = (int32_t)(seq - pos);
 
         if (diff == 0) {
             if (__atomic_compare_exchange_n(&q->head, &pos, pos + 1, false, __ATOMIC_RELAXED, __ATOMIC_RELAXED)) {
@@ -1054,11 +1055,11 @@ kstatus_t sched_cmd_ring_push(sched_cmd_ring_t *q, const sched_remote_cmd_envelo
 kstatus_t sched_cmd_ring_pop(sched_cmd_ring_t *q, sched_remote_cmd_envelope_t *out_value) {
     if (!q) return K_ERR_INVALID_ARG;
     sched_cmd_slot_t *slot;
-    uint64_t pos = q->tail;
+    uint32_t pos = q->tail;
 
     slot = &q->slots[pos & q->mask];
-    uint64_t seq = __atomic_load_n(&slot->seq, __ATOMIC_ACQUIRE);
-    int64_t diff = (int64_t)seq - (int64_t)(pos + 1);
+    uint32_t seq = __atomic_load_n(&slot->seq, __ATOMIC_ACQUIRE);
+    int32_t diff = (int32_t)(seq - (pos + 1U));
 
     if (diff == 0) {
         q->tail = pos + 1;
@@ -1073,12 +1074,13 @@ kstatus_t sched_cmd_ring_pop(sched_cmd_ring_t *q, sched_remote_cmd_envelope_t *o
 
 bool sched_cmd_ring_empty(const sched_cmd_ring_t *q) {
     if (!q) return true;
-    uint64_t head = __atomic_load_n(&q->head, __ATOMIC_RELAXED);
+    uint32_t head = __atomic_load_n(&q->head, __ATOMIC_RELAXED);
     return q->tail == head;
 }
 
 kstatus_t sched_completion_ring_init(sched_completion_ring_t *q, sched_completion_slot_t *slots, uint32_t capacity) {
-    if (!q || !slots || capacity < 2 || (capacity & (capacity - 1)) != 0) {
+    if (!q || !slots || capacity < 2 || capacity >= (1U << 31) ||
+        (capacity & (capacity - 1U)) != 0U) {
         return K_ERR_INVALID_ARG;
     }
     q->slots = slots;
@@ -1097,12 +1099,12 @@ kstatus_t sched_completion_ring_init(sched_completion_ring_t *q, sched_completio
 kstatus_t sched_completion_ring_push(sched_completion_ring_t *q, const sched_remote_completion_t *value) {
     if (!q || !value) return K_ERR_INVALID_ARG;
     sched_completion_slot_t *slot;
-    uint64_t pos = q->head;
+    uint32_t pos = q->head;
 
     while (true) {
         slot = &q->slots[pos & q->mask];
-        uint64_t seq = __atomic_load_n(&slot->seq, __ATOMIC_ACQUIRE);
-        int64_t diff = (int64_t)seq - (int64_t)pos;
+        uint32_t seq = __atomic_load_n(&slot->seq, __ATOMIC_ACQUIRE);
+        int32_t diff = (int32_t)(seq - pos);
 
         if (diff == 0) {
             if (__atomic_compare_exchange_n(&q->head, &pos, pos + 1, false, __ATOMIC_RELAXED, __ATOMIC_RELAXED)) {
@@ -1123,11 +1125,11 @@ kstatus_t sched_completion_ring_push(sched_completion_ring_t *q, const sched_rem
 kstatus_t sched_completion_ring_pop(sched_completion_ring_t *q, sched_remote_completion_t *out_value) {
     if (!q) return K_ERR_INVALID_ARG;
     sched_completion_slot_t *slot;
-    uint64_t pos = q->tail;
+    uint32_t pos = q->tail;
 
     slot = &q->slots[pos & q->mask];
-    uint64_t seq = __atomic_load_n(&slot->seq, __ATOMIC_ACQUIRE);
-    int64_t diff = (int64_t)seq - (int64_t)(pos + 1);
+    uint32_t seq = __atomic_load_n(&slot->seq, __ATOMIC_ACQUIRE);
+    int32_t diff = (int32_t)(seq - (pos + 1U));
 
     if (diff == 0) {
         q->tail = pos + 1;
@@ -1142,6 +1144,6 @@ kstatus_t sched_completion_ring_pop(sched_completion_ring_t *q, sched_remote_com
 
 bool sched_completion_ring_empty(const sched_completion_ring_t *q) {
     if (!q) return true;
-    uint64_t head = __atomic_load_n(&q->head, __ATOMIC_RELAXED);
+    uint32_t head = __atomic_load_n(&q->head, __ATOMIC_RELAXED);
     return q->tail == head;
 }

--- a/core/kernel/src/sched/sched_diag.c
+++ b/core/kernel/src/sched/sched_diag.c
@@ -6,7 +6,7 @@
 typedef struct sched_diag_core_state {
   uint32_t runtime_level;
   uint32_t last_event;
-  uint64_t event_count[BH_SCHED_DIAG_EVENT_COUNT];
+  uint32_t event_count[BH_SCHED_DIAG_EVENT_COUNT];
 } sched_diag_core_state_t;
 
 /* Owner-local mutable state: slot N is written only by CPU N. */

--- a/core/lib/diag/include/bharat/diag/diag_ring.h
+++ b/core/lib/diag/include/bharat/diag/diag_ring.h
@@ -12,7 +12,7 @@
 #endif
 
 typedef struct bh_diag_record { bh_diag_event_header_t header; uint8_t payload[BHARAT_DIAG_MAX_PAYLOAD]; } bh_diag_record_t;
-typedef struct bh_diag_ring_slot { _Atomic uint64_t committed_sequence; bh_diag_record_t record; } bh_diag_ring_slot_t;
+typedef struct bh_diag_ring_slot { _Atomic uint32_t committed_sequence; bh_diag_record_t record; } bh_diag_ring_slot_t;
 typedef struct bh_diag_ring_stats { uint64_t accepted, consumed, dropped, corrupt, high_watermark; } bh_diag_ring_stats_t;
 
 /* Single writer and single reader own their respective indices.  The writer
@@ -22,9 +22,9 @@ typedef struct bh_diag_ring {
     bh_diag_ring_slot_t *slots;
     uint32_t capacity;
     uint32_t max_payload;
-    _Atomic uint64_t write_position;
-    _Atomic uint64_t read_position;
-    _Atomic uint64_t accepted, consumed, dropped, corrupt, high_watermark;
+    _Atomic uint32_t write_position;
+    _Atomic uint32_t read_position;
+    _Atomic uint32_t accepted, consumed, dropped, corrupt, high_watermark;
 } bh_diag_ring_t;
 
 bh_status_t bh_diag_ring_init(bh_diag_ring_t *ring, bh_diag_ring_slot_t *slots, uint32_t capacity, uint32_t max_payload);

--- a/core/lib/diag/src/diag_ring.c
+++ b/core/lib/diag/src/diag_ring.c
@@ -11,8 +11,8 @@ static void bytes_copy(void *destination, const void *source, size_t size) {
 }
 
 static int ring_valid(const bh_diag_ring_t *ring) { return ring && ring->slots && ring->capacity && ring->max_payload <= BHARAT_DIAG_MAX_PAYLOAD; }
-static void update_high_watermark(bh_diag_ring_t *ring, uint64_t value) {
-    uint64_t old = atomic_load_explicit(&ring->high_watermark, memory_order_relaxed);
+static void update_high_watermark(bh_diag_ring_t *ring, uint32_t value) {
+    uint32_t old = atomic_load_explicit(&ring->high_watermark, memory_order_relaxed);
     while (old < value && !atomic_compare_exchange_weak_explicit(&ring->high_watermark, &old, value, memory_order_relaxed, memory_order_relaxed)) {}
 }
 bh_status_t bh_diag_ring_init(bh_diag_ring_t *ring, bh_diag_ring_slot_t *slots, uint32_t capacity, uint32_t max_payload) {
@@ -24,8 +24,8 @@ bh_status_t bh_diag_ring_init(bh_diag_ring_t *ring, bh_diag_ring_slot_t *slots, 
 bh_status_t bh_diag_ring_try_write(bh_diag_ring_t *ring, const bh_diag_event_header_t *header, const void *payload) {
     if (!ring_valid(ring) || !header || (header->payload_size && !payload)) return BH_ERR_INVALID_ARGUMENT;
     if (header->abi_version != BH_DIAG_ABI_VERSION || header->header_size != sizeof(*header) || header->payload_size > ring->max_payload || header->severity >= BH_DIAG_SEVERITY_COUNT || header->source_kind >= BH_DIAG_SOURCE_KIND_COUNT) return BH_ERR_INVALID_ARGUMENT;
-    uint64_t write = atomic_load_explicit(&ring->write_position, memory_order_relaxed);
-    uint64_t read = atomic_load_explicit(&ring->read_position, memory_order_acquire);
+    uint32_t write = atomic_load_explicit(&ring->write_position, memory_order_relaxed);
+    uint32_t read = atomic_load_explicit(&ring->read_position, memory_order_acquire);
     if (write - read >= ring->capacity) { atomic_fetch_add_explicit(&ring->dropped, 1, memory_order_relaxed); return BH_ERR_BUFFER_FULL; }
     bh_diag_ring_slot_t *slot = &ring->slots[write % ring->capacity];
     slot->record.header = *header; slot->record.header.sequence = write + 1;
@@ -37,11 +37,11 @@ bh_status_t bh_diag_ring_try_write(bh_diag_ring_t *ring, const bh_diag_event_hea
 }
 static bh_status_t copy_next(bh_diag_ring_t *ring, bh_diag_record_t *record, int consume) {
     if (!ring_valid(ring) || !record) return BH_ERR_INVALID_ARGUMENT;
-    uint64_t read = atomic_load_explicit(&ring->read_position, memory_order_relaxed);
-    uint64_t write = atomic_load_explicit(&ring->write_position, memory_order_acquire);
+    uint32_t read = atomic_load_explicit(&ring->read_position, memory_order_relaxed);
+    uint32_t write = atomic_load_explicit(&ring->write_position, memory_order_acquire);
     if (read == write) return BH_ERR_NOT_FOUND;
     bh_diag_ring_slot_t *slot = &ring->slots[read % ring->capacity];
-    uint64_t expected = read + 1;
+    uint32_t expected = read + 1U;
     if (atomic_load_explicit(&slot->committed_sequence, memory_order_acquire) != expected || slot->record.header.sequence != expected || slot->record.header.header_size != sizeof(bh_diag_event_header_t) || slot->record.header.payload_size > ring->max_payload) { atomic_fetch_add_explicit(&ring->corrupt, 1, memory_order_relaxed); return BH_ERR_FAULT; }
     *record = slot->record;
     if (consume) { atomic_store_explicit(&slot->committed_sequence, 0, memory_order_release); atomic_store_explicit(&ring->read_position, read + 1, memory_order_release); atomic_fetch_add_explicit(&ring->consumed, 1, memory_order_relaxed); }

--- a/delivery/cmake/toolchains/arm32-elf.cmake
+++ b/delivery/cmake/toolchains/arm32-elf.cmake
@@ -9,7 +9,6 @@ set(CMAKE_LINKER ld)
 set(CMAKE_EXE_LINKER_FLAGS_INIT "-fuse-ld=bfd -nostdlib -fno-pie -Wl,-no-pie ")
 
 set(CMAKE_C_COMPILER_TARGET arm-none-eabi)
-set(CMAKE_ASM_COMPILER_TARGET arm-none-eabi)
 set(CMAKE_ASM_COMPILER_TARGET armv7a-unknown-none-eabi)
 
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)

--- a/docs/architecture/edge32-portability-audit.md
+++ b/docs/architecture/edge32-portability-audit.md
@@ -44,3 +44,16 @@ This document summarizes the current status of pointer-width inference and porta
 - **Status**: Needs Refactor
 - **Details**: DMA coherent checks and caching instructions are highly specific to ARM64 and X86_64. Tier 2 devices might lack hardware-coherent DMA, meaning cache maintenance must be explicitly handled. Replace hardware DMA assumptions with checks for `ARCH_CAP_DMA_COHERENT`.
 - **Action**: Must fix before arm32 bring-up.
+
+## Native-width atomic synchronization
+- **Status**: Implemented for bounded IPC, scheduler, and diagnostic rings
+- **Details**: Ring tickets, slot publication sequences, positions, and hot-path
+  telemetry use 32-bit atomics on every ISA. Capacities are bounded below
+  `2^31`, and comparisons use defined `uint32_t` modulo subtraction so rollover
+  does not require 64-bit atomic instructions. The multikernel wire sequence
+  remains 64-bit, but is composed from the source core and an owner-local
+  32-bit allocator. Genuine 64-bit masks and generations use Bharat-OS's
+  explicit atomic64 compatibility backend on 32-bit targets.
+- **Validation**: Kernel targets compile with `-Werror=atomic-alignment`;
+  warning suppression and a freestanding `libatomic` dependency are
+  intentionally prohibited.

--- a/quality/tests/host/ipc/fabric/test_mk_mpsc_ring.c
+++ b/quality/tests/host/ipc/fabric/test_mk_mpsc_ring.c
@@ -1,5 +1,6 @@
 #include <assert.h>
 #include <stdio.h>
+#include <stdint.h>
 #include "ipc/mk_proto.h"
 #include "fake_hal.h"
 
@@ -52,6 +53,27 @@ int main(void) {
     bh_mk_wire_message_t empty_msg;
     st = bh_mk_mpsc_ring_dequeue(&ring, &empty_msg);
     assert(st == K_ERR_AGAIN);
+
+    // Seed an empty ring immediately before uint32_t rollover.  Each slot's
+    // free sequence must match its next producer ticket modulo 2^32.
+    const uint32_t near_wrap = UINT32_MAX - 2U;
+    atomic_store(&ring.producer_head, near_wrap);
+    ring.consumer_tail = near_wrap;
+    atomic_store(&ring.available_credits, ring.capacity);
+    for (uint32_t i = 0; i < ring.capacity; ++i) {
+        uint32_t ticket = near_wrap + i;
+        atomic_store(&slots[ticket & ring.mask].sequence, ticket);
+    }
+    for (uint32_t i = 0; i < 5U; ++i) {
+        bh_mk_wire_message_t msg = {0};
+        msg.header.sequence = 200U + i;
+        assert(bh_mk_mpsc_ring_enqueue(&ring, &msg) == K_OK);
+        bh_mk_wire_message_t out_msg;
+        assert(bh_mk_mpsc_ring_dequeue(&ring, &out_msg) == K_OK);
+        assert(out_msg.header.sequence == 200U + i);
+    }
+    assert(atomic_load(&ring.producer_head) == 2U);
+    assert(ring.consumer_tail == 2U);
 
     printf("test_mk_mpsc_ring PASSED\n");
     return 0;


### PR DESCRIPTION
### Motivation

- Clang `-Watomic-alignment` warnings revealed real correctness/portability issues where hot-path synchronization used 64-bit atomics on 32-bit ISAs; this must be fixed rather than suppressed.
- The IPC MPSC rings, scheduler rings, and diagnostic rings used 64-bit synchronization counters even though capacities are bounded, causing software 64-bit atomics and performance/correctness risk on ARM32/RV32.
- The global 64-bit sequence and a racy lazy-init atomic64 fallback violated the per-core ownership model and had races on init and IRQ/SMP semantics.

### Description

- Converted IPC MPSC ring synchronization to native 32-bit atomics for slot `sequence`, `producer_head`, and `consumer_tail`, added capacity bounds and modulo-safe signed arithmetic, and updated `mk_mpsc_ring` logic accordingly (`core/kernel/include/ipc/mk_proto.h`, `core/kernel/src/ipc/fabric/mk_mpsc_ring.c`).
- Replaced the global shared 64-bit wire sequence with an owner-local per-core 32-bit `tx_sequence` stored in `bh_mk_core_fabric_t` and compose the 64-bit wire sequence as `(src_core<<32) | local_seq` in `mk_fabric.c` (`core/kernel/src/ipc/fabric/mk_fabric.c`).
- Converted scheduler command/completion ring `seq/head/tail` and related hot counters to 32-bit native-width atomics and added capacity validation (`core/kernel/include/sched/sched.h`, `core/kernel/src/sched/sched_core.c`, `core/kernel/src/sched/sched_diag.c`).
- Converted diagnostic ring slot sequence, positions, and statistics to 32-bit atomics and updated implementation to use 32-bit arithmetic (`core/lib/diag/include/bharat/diag/diag_ring.h`, `core/lib/diag/src/diag_ring.c`).
- Hardened 32-bit atomic64 fallback: changed lazy init to static-initialized `spinlock_t` to avoid a race and made explicit IRQ/SMP-safe locking usage (`core/kernel/src/atomic64_fallback.c`).
- Added small atomic helpers and routed loads for genuine 64-bit masks through the explicit `atomic64_*` API and a safe `atomic64_load_ptr` wrapper used by mm/TLB code (`core/kernel/include/atomic.h`, `core/kernel/src/mm/vm/aspace/aspace.c`, `core/kernel/src/mm/tlb/tlb_pending.c`).
- Updated memory/TLB/stat code to use the explicit atomic64 helpers where 64-bit semantics are required (`core/kernel/src/mm/mem_class.c`, `core/kernel/src/mm/tlb/tlb_pending.[ch]`, `core/kernel/src/mm/vm/aspace/*`).
- Enforced the atomic-width contract by adding `-Werror=atomic-alignment` to the kernel build options interface so all kernel object libraries enforce it (`core/kernel/CMakeLists.txt`) and removed redundant ASM target setting in ARM32 toolchain file (`delivery/cmake/toolchains/arm32-elf.cmake`).
- Added a regression test to exercise wraparound across `UINT32_MAX` for the MPSC ring (`quality/tests/host/ipc/fabric/test_mk_mpsc_ring.c`).
- Documented the design/contract in `docs/architecture/edge32-portability-audit.md` and preserved the 64-bit wire ABI while ensuring owner-local sequence allocation.

### Testing

- Ran static checks: `python3 tools/lint/check_layer_references.py` (ran, reported existing baseline debt), and `python3 tools/lint/check_cmake_dependencies.py` (passed).
- Syscall ABI checks and tests: `python3 tools/abi/syscall_abi.py --check` and `python3 -m unittest tools.abi.test_syscall_abi` (passed); some existing ABI-generated-lock mismatches in workspace were reported by the tool (not caused by this change).
- Unit/host tests compiled and ran locally: `quality/tests/host/test_diag_ring` and `quality/tests/host/ipc/fabric/test_mk_mpsc_ring` (both passed locally after modifications).
- Per-target builds and smoke runs:
  - RV32/RV64/ARM32 headless and many desktop targets: built and the mandatory five-architecture smoke matrix ran; the matrix run showed all five required smoke targets PASS for the headless presets.
  - RV32/ARM32 GUI desktop builds reached unrelated third-party LVGL preprocessor issues (existing in the tree: `third_party/lvgl` checks involving `UINTPTR_MAX`) and thus those GUI builds failed on that unrelated preprocessing error; importantly, no atomic-alignment warnings were emitted during the builds.
- Ensured no unresolved external `__atomic_*_8` references exist in RV32 kernel ELF (checked `llvm-nm` on `build/.../kernel.elf`), and inspected final tree for only intended diffs.
- Committed changes as: "fix native-width atomics on 32-bit targets" (local commit `c4afe3ab`).

Notes: PR creation was attempted with GitHub CLI but the environment lacked authentication; the patch and commit are present in the working tree and can be pushed/PRed by an authenticated user or CI job.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7d9d8a0a488320932e35871372f816)