### PR TITLE
Refactor(hal): invert CPU feature publication and remove hal_common kernel-private dependencies

### DIFF
--- a/core/arch/common/cpu_caps_state.c
+++ b/core/arch/common/cpu_caps_state.c
@@ -1,6 +1,7 @@
 #include "arch/arch_cpu_caps.h"
 #include "arch/common/cpu_caps_state.h"
 #include "bharat/cpu_local.h"
+#include "hal/hal_cpu_features.h"
 #include <stddef.h>
 #include <stdint.h>
 
@@ -17,6 +18,62 @@ static arch_cpu_caps_record_t g_per_cpu_caps[MAX_CPUS];
 static bool g_cpu_caps_present[MAX_CPUS];
 static size_t g_cpu_caps_present_count;
 static bool g_system_caps_finalized;
+
+static void hal_feature_set_bit(uint64_t *bits, hal_cpu_feature_t feature,
+                                bool enabled) {
+    if (enabled && feature < HAL_CPU_FEATURE__COUNT) {
+        bits[(size_t)feature / 64u] |= 1ULL << ((size_t)feature % 64u);
+    }
+}
+
+static bool cpu_caps_export_record(const arch_cpu_caps_record_t *caps,
+                                   hal_cpu_feature_set_t *out) {
+    if (caps == NULL || out == NULL) {
+        return false;
+    }
+    for (size_t i = 0; i < sizeof(*out) / sizeof(uint64_t); ++i) {
+        ((uint64_t *)out)[i] = 0U;
+    }
+#define EXPORT_COMMON(hal_feature, arch_feature)                                  \
+    do {                                                                           \
+        hal_feature_set_bit(out->raw_bits, hal_feature,                            \
+                            arch_cpu_caps_test(&caps->raw, arch_feature));          \
+        hal_feature_set_bit(out->usable_bits, hal_feature,                         \
+                            arch_cpu_caps_test(&caps->usable, arch_feature));       \
+    } while (0)
+    EXPORT_COMMON(HAL_CPU_FEATURE_VECTOR, ARCH_CPU_FEAT_COMMON_VECTOR);
+    EXPORT_COMMON(HAL_CPU_FEATURE_AES, ARCH_CPU_FEAT_COMMON_AES);
+    EXPORT_COMMON(HAL_CPU_FEATURE_SHA, ARCH_CPU_FEAT_COMMON_SHA);
+    EXPORT_COMMON(HAL_CPU_FEATURE_PMULL, ARCH_CPU_FEAT_COMMON_PMULL);
+    EXPORT_COMMON(HAL_CPU_FEATURE_CRYPTO, ARCH_CPU_FEAT_COMMON_CRYPTO);
+    EXPORT_COMMON(HAL_CPU_FEATURE_STRONG_ATOMICS, ARCH_CPU_FEAT_COMMON_STRONG_ATOMICS);
+    EXPORT_COMMON(HAL_CPU_FEATURE_FAST_TLB_CTX, ARCH_CPU_FEAT_COMMON_FAST_TLB_CTX);
+#undef EXPORT_COMMON
+    arch_cpu_caps_export_hal_features(caps, out);
+    return true;
+}
+
+static bool cpu_caps_export_for_cpu(size_t cpu_id, hal_cpu_feature_set_t *out) {
+    return cpu_caps_export_record(arch_cpu_caps_for_cpu(cpu_id), out);
+}
+
+static bool cpu_caps_export_current(hal_cpu_feature_set_t *out) {
+    return cpu_caps_export_record(arch_cpu_caps_current(), out);
+}
+
+static bool cpu_caps_export_system(hal_cpu_feature_scope_t scope,
+                                   hal_cpu_feature_set_t *out) {
+    return cpu_caps_export_record(scope == HAL_CPU_FEATURE_SCOPE_ANY
+                                      ? arch_cpu_caps_system_any()
+                                      : arch_cpu_caps_system_all(),
+                                  out);
+}
+
+static const hal_cpu_feature_provider_t g_cpu_feature_provider = {
+    .for_cpu = cpu_caps_export_for_cpu,
+    .for_current_cpu = cpu_caps_export_current,
+    .for_system = cpu_caps_export_system,
+};
 
 static void cpu_caps_record_copy(arch_cpu_caps_record_t *dst,
                                  const arch_cpu_caps_record_t *src) {
@@ -120,6 +177,11 @@ bool arch_cpu_has_current(int feat) {
 }
 
 void cpu_caps_state_set_boot(const arch_cpu_caps_record_t *caps) {
+    static bool provider_registered;
+    if (!provider_registered) {
+        provider_registered =
+            hal_cpu_features_register_provider(&g_cpu_feature_provider);
+    }
     memset(g_cpu_caps_present, 0, sizeof(g_cpu_caps_present));
     g_cpu_caps_present_count = 0;
     g_system_caps_finalized = false;

--- a/core/hal/common/CMakeLists.txt
+++ b/core/hal/common/CMakeLists.txt
@@ -1,34 +1,13 @@
 add_library(hal_common OBJECT
-    ../common/fdt_parser.c
-    ../common/discovery.c
     ../common/cpu_features.c
-    ../common/hal_unsupported.c
     hmem.c
-    ../interrupt_common.c
-    ../timer_common.c
-    iommu_adapter.c
-    ../common/power/null_power.c
-    ../common/power/null_thermal.c
     ../common/memops/mem_scalar.c
-    ../common/hash/hash_fallback.c
 )
 
-target_include_directories(hal_common PRIVATE 
+target_include_directories(hal_common PRIVATE
     ${CMAKE_SOURCE_DIR}/core/hal/include
-    ${CMAKE_SOURCE_DIR}/core/kernel/src
-    ${CMAKE_SOURCE_DIR}/core/kernel/include 
-    ${CMAKE_SOURCE_DIR}/core/kernel/include/generated 
-    ${CMAKE_SOURCE_DIR}/core/drivers/include
     ${CMAKE_SOURCE_DIR}/interface/include)
-target_link_libraries(hal_common PRIVATE bharat_freestanding bharat_kernel_buildopts)
+target_link_libraries(hal_common PRIVATE bharat_freestanding)
 
 # Apply targeted builtin suppression to the memory helper
 set_source_files_properties(../common/memops/mem_scalar.c PROPERTIES COMPILE_OPTIONS "-fno-builtin-memset;-fno-builtin-memcpy;-fno-builtin-memmove;-fno-builtin-strcmp;-fno-builtin-strncmp;-fno-builtin-strlen;-fno-builtin-bzero")
-
-string(TOUPPER "${BHARAT_ARCH_FAMILY}" _bharat_arch_family_upper)
-if(BHARAT_ENABLE_DRIVER_ARCH_IRQ_TIMER AND (_bharat_arch_family_upper STREQUAL "X86"
-   OR _bharat_arch_family_upper STREQUAL "ARM"
-   OR _bharat_arch_family_upper STREQUAL "RISCV"))
-    target_sources(hal_common PRIVATE arch_irq_timer/arch_irq_timer.c)
-    target_compile_definitions(hal_common PRIVATE BHARAT_GENERIC_ENABLE_ARCH_IRQ_TIMER)
-endif()

--- a/core/hal/common/cpu_features.c
+++ b/core/hal/common/cpu_features.c
@@ -1,87 +1,34 @@
 #include "hal/hal_cpu_features.h"
 
-#include "arch/arch_cpu_caps.h"
-#include "hal/hal.h"
-#include <string.h>
+static const hal_cpu_feature_provider_t *g_provider;
 
-static inline void feature_set_bit(uint64_t *bits, hal_cpu_feature_t feature, bool enabled) {
-    if (!enabled || feature >= HAL_CPU_FEATURE__COUNT) {
-        return;
+bool hal_cpu_features_register_provider(const hal_cpu_feature_provider_t *provider) {
+    if (provider == NULL || provider->for_cpu == NULL ||
+        provider->for_current_cpu == NULL || provider->for_system == NULL) {
+        return false;
     }
-    bits[(size_t)feature / 64u] |= (1ULL << ((size_t)feature % 64u));
-}
-
-static void map_arch_to_hal(const arch_cpu_caps_record_t *arch, hal_cpu_feature_set_t *out) {
-    memset(out, 0, sizeof(*out));
-    if (arch == NULL) {
-        return;
-    }
-
-    feature_set_bit(out->raw_bits, HAL_CPU_FEATURE_VECTOR,
-                    arch_cpu_caps_test(&arch->raw, ARCH_CPU_FEAT_COMMON_VECTOR));
-    feature_set_bit(out->usable_bits, HAL_CPU_FEATURE_VECTOR,
-                    arch_cpu_caps_test(&arch->usable, ARCH_CPU_FEAT_COMMON_VECTOR));
-
-    feature_set_bit(out->raw_bits, HAL_CPU_FEATURE_AES,
-                    arch_cpu_caps_test(&arch->raw, ARCH_CPU_FEAT_COMMON_AES));
-    feature_set_bit(out->usable_bits, HAL_CPU_FEATURE_AES,
-                    arch_cpu_caps_test(&arch->usable, ARCH_CPU_FEAT_COMMON_AES));
-
-    feature_set_bit(out->raw_bits, HAL_CPU_FEATURE_SHA,
-                    arch_cpu_caps_test(&arch->raw, ARCH_CPU_FEAT_COMMON_SHA));
-    feature_set_bit(out->usable_bits, HAL_CPU_FEATURE_SHA,
-                    arch_cpu_caps_test(&arch->usable, ARCH_CPU_FEAT_COMMON_SHA));
-
-    feature_set_bit(out->raw_bits, HAL_CPU_FEATURE_PMULL,
-                    arch_cpu_caps_test(&arch->raw, ARCH_CPU_FEAT_COMMON_PMULL));
-    feature_set_bit(out->usable_bits, HAL_CPU_FEATURE_PMULL,
-                    arch_cpu_caps_test(&arch->usable, ARCH_CPU_FEAT_COMMON_PMULL));
-
-    feature_set_bit(out->raw_bits, HAL_CPU_FEATURE_CRYPTO,
-                    arch_cpu_caps_test(&arch->raw, ARCH_CPU_FEAT_COMMON_CRYPTO));
-    feature_set_bit(out->usable_bits, HAL_CPU_FEATURE_CRYPTO,
-                    arch_cpu_caps_test(&arch->usable, ARCH_CPU_FEAT_COMMON_CRYPTO));
-
-    feature_set_bit(out->raw_bits, HAL_CPU_FEATURE_STRONG_ATOMICS,
-                    arch_cpu_caps_test(&arch->raw, ARCH_CPU_FEAT_COMMON_STRONG_ATOMICS));
-    feature_set_bit(out->usable_bits, HAL_CPU_FEATURE_STRONG_ATOMICS,
-                    arch_cpu_caps_test(&arch->usable, ARCH_CPU_FEAT_COMMON_STRONG_ATOMICS));
-
-    feature_set_bit(out->raw_bits, HAL_CPU_FEATURE_FAST_TLB_CTX,
-                    arch_cpu_caps_test(&arch->raw, ARCH_CPU_FEAT_COMMON_FAST_TLB_CTX));
-    feature_set_bit(out->usable_bits, HAL_CPU_FEATURE_FAST_TLB_CTX,
-                    arch_cpu_caps_test(&arch->usable, ARCH_CPU_FEAT_COMMON_FAST_TLB_CTX));
-
-    // Export any architecture specific features
-    arch_cpu_caps_export_hal_features(arch, out);
+    const hal_cpu_feature_provider_t *expected = NULL;
+    return __atomic_compare_exchange_n(&g_provider, &expected, provider, false,
+                                       __ATOMIC_RELEASE, __ATOMIC_RELAXED);
 }
 
 bool hal_cpu_feature_set_for_cpu(size_t cpu_id, hal_cpu_feature_set_t *out) {
     if (out == NULL) {
         return false;
     }
-    const arch_cpu_caps_record_t *arch = arch_cpu_caps_for_cpu(cpu_id);
-    if (arch == NULL) {
-        memset(out, 0, sizeof(*out));
-        return false;
-    }
-    map_arch_to_hal(arch, out);
-    return true;
+    const hal_cpu_feature_provider_t *provider =
+        __atomic_load_n(&g_provider, __ATOMIC_ACQUIRE);
+    return provider != NULL && provider->for_cpu(cpu_id, out);
 }
 
 bool hal_cpu_feature_set_system(hal_cpu_feature_scope_t scope, hal_cpu_feature_set_t *out) {
     if (out == NULL) {
         return false;
     }
-    const arch_cpu_caps_record_t *arch = (scope == HAL_CPU_FEATURE_SCOPE_ANY)
-                                             ? arch_cpu_caps_system_any()
-                                             : arch_cpu_caps_system_all();
-    if (arch == NULL) {
-        memset(out, 0, sizeof(*out));
-        return false;
-    }
-    map_arch_to_hal(arch, out);
-    return true;
+    const hal_cpu_feature_provider_t *provider =
+        __atomic_load_n(&g_provider, __ATOMIC_ACQUIRE);
+    return provider != NULL && scope <= HAL_CPU_FEATURE_SCOPE_ALL &&
+           provider->for_system(scope, out);
 }
 
 bool hal_cpu_has_feature(size_t cpu_id, hal_cpu_feature_t feature) {
@@ -100,7 +47,13 @@ bool hal_cpu_has_system_feature(hal_cpu_feature_t feature, hal_cpu_feature_scope
 }
 
 bool hal_cpu_has_feature_current(hal_cpu_feature_t feature) {
-    return hal_cpu_has_feature((size_t)hal_cpu_get_id(), feature);
+    hal_cpu_feature_set_t set;
+    const hal_cpu_feature_provider_t *provider =
+        __atomic_load_n(&g_provider, __ATOMIC_ACQUIRE);
+    return provider != NULL && provider->for_current_cpu(&set) &&
+           feature < HAL_CPU_FEATURE__COUNT &&
+           (set.usable_bits[(size_t)feature / 64u] &
+            (1ULL << ((size_t)feature % 64u))) != 0;
 }
 
 bool hal_cpu_has_system_feature_all(hal_cpu_feature_t feature) {

--- a/core/hal/common/discovery.c
+++ b/core/hal/common/discovery.c
@@ -1,7 +1,6 @@
 #include "hal/hal_discovery.h"
 #include <hal/hal_cpu_topology.h>
-#include "arch/arch_cpu_caps.h"
-#include "arch/common/accel_caps_publish.h"
+#include "hal/hal_cpu_features.h"
 #include "boot/boot_info.h"
 #include <stddef.h>
 #include <stdbool.h>
@@ -56,10 +55,11 @@ static inline void accel_set(uint64_t *mask, hal_accel_feature_t feat, bool enab
 
 void hal_discovery_publish_cpu_caps(void) {
     system_discovery_t *sys = hal_get_system_discovery();
-    const arch_cpu_caps_record_t *caps_all = arch_cpu_caps_system_all();
-    const arch_cpu_caps_record_t *caps_any = arch_cpu_caps_system_any();
+    hal_cpu_feature_set_t caps_all;
+    hal_cpu_feature_set_t caps_any;
 
-    if (caps_all == NULL || caps_any == NULL) {
+    if (!hal_cpu_feature_set_system(HAL_CPU_FEATURE_SCOPE_ALL, &caps_all) ||
+        !hal_cpu_feature_set_system(HAL_CPU_FEATURE_SCOPE_ANY, &caps_any)) {
         sys->accel.raw_all_mask = 0;
         sys->accel.raw_any_mask = 0;
         sys->accel.usable_all_mask = 0;
@@ -72,50 +72,23 @@ void hal_discovery_publish_cpu_caps(void) {
     sys->accel.usable_all_mask = 0;
     sys->accel.usable_any_mask = 0;
 
-    accel_set(&sys->accel.raw_all_mask, HAL_ACCEL_FEAT_VECTOR,
-              arch_cpu_caps_test(&caps_all->raw, ARCH_CPU_FEAT_COMMON_VECTOR));
-    accel_set(&sys->accel.raw_any_mask, HAL_ACCEL_FEAT_VECTOR,
-              arch_cpu_caps_test(&caps_any->raw, ARCH_CPU_FEAT_COMMON_VECTOR));
-    accel_set(&sys->accel.usable_all_mask, HAL_ACCEL_FEAT_VECTOR,
-              arch_cpu_caps_test(&caps_all->usable, ARCH_CPU_FEAT_COMMON_VECTOR));
-    accel_set(&sys->accel.usable_any_mask, HAL_ACCEL_FEAT_VECTOR,
-              arch_cpu_caps_test(&caps_any->usable, ARCH_CPU_FEAT_COMMON_VECTOR));
-
-    accel_set(&sys->accel.raw_all_mask, HAL_ACCEL_FEAT_AES,
-              arch_cpu_caps_test(&caps_all->raw, ARCH_CPU_FEAT_COMMON_AES));
-    accel_set(&sys->accel.raw_any_mask, HAL_ACCEL_FEAT_AES,
-              arch_cpu_caps_test(&caps_any->raw, ARCH_CPU_FEAT_COMMON_AES));
-    accel_set(&sys->accel.usable_all_mask, HAL_ACCEL_FEAT_AES,
-              arch_cpu_caps_test(&caps_all->usable, ARCH_CPU_FEAT_COMMON_AES));
-    accel_set(&sys->accel.usable_any_mask, HAL_ACCEL_FEAT_AES,
-              arch_cpu_caps_test(&caps_any->usable, ARCH_CPU_FEAT_COMMON_AES));
-
-    accel_set(&sys->accel.raw_all_mask, HAL_ACCEL_FEAT_SHA,
-              arch_cpu_caps_test(&caps_all->raw, ARCH_CPU_FEAT_COMMON_SHA));
-    accel_set(&sys->accel.raw_any_mask, HAL_ACCEL_FEAT_SHA,
-              arch_cpu_caps_test(&caps_any->raw, ARCH_CPU_FEAT_COMMON_SHA));
-    accel_set(&sys->accel.usable_all_mask, HAL_ACCEL_FEAT_SHA,
-              arch_cpu_caps_test(&caps_all->usable, ARCH_CPU_FEAT_COMMON_SHA));
-    accel_set(&sys->accel.usable_any_mask, HAL_ACCEL_FEAT_SHA,
-              arch_cpu_caps_test(&caps_any->usable, ARCH_CPU_FEAT_COMMON_SHA));
-
-    accel_set(&sys->accel.raw_all_mask, HAL_ACCEL_FEAT_PMULL,
-              arch_cpu_caps_test(&caps_all->raw, ARCH_CPU_FEAT_COMMON_PMULL));
-    accel_set(&sys->accel.raw_any_mask, HAL_ACCEL_FEAT_PMULL,
-              arch_cpu_caps_test(&caps_any->raw, ARCH_CPU_FEAT_COMMON_PMULL));
-    accel_set(&sys->accel.usable_all_mask, HAL_ACCEL_FEAT_PMULL,
-              arch_cpu_caps_test(&caps_all->usable, ARCH_CPU_FEAT_COMMON_PMULL));
-    accel_set(&sys->accel.usable_any_mask, HAL_ACCEL_FEAT_PMULL,
-              arch_cpu_caps_test(&caps_any->usable, ARCH_CPU_FEAT_COMMON_PMULL));
-
-    accel_set(&sys->accel.raw_all_mask, HAL_ACCEL_FEAT_STRONG_ATOMICS,
-              arch_cpu_caps_test(&caps_all->raw, ARCH_CPU_FEAT_COMMON_STRONG_ATOMICS));
-    accel_set(&sys->accel.raw_any_mask, HAL_ACCEL_FEAT_STRONG_ATOMICS,
-              arch_cpu_caps_test(&caps_any->raw, ARCH_CPU_FEAT_COMMON_STRONG_ATOMICS));
-    accel_set(&sys->accel.usable_all_mask, HAL_ACCEL_FEAT_STRONG_ATOMICS,
-              arch_cpu_caps_test(&caps_all->usable, ARCH_CPU_FEAT_COMMON_STRONG_ATOMICS));
-    accel_set(&sys->accel.usable_any_mask, HAL_ACCEL_FEAT_STRONG_ATOMICS,
-              arch_cpu_caps_test(&caps_any->usable, ARCH_CPU_FEAT_COMMON_STRONG_ATOMICS));
-
-    arch_accel_caps_publish_target(&sys->accel, caps_all, caps_any);
+#define EXPORT_ACCEL(accel_feature, cpu_feature)                                  \
+    do {                                                                           \
+        const uint64_t bit = 1ULL << ((size_t)(cpu_feature) % 64u);                \
+        const size_t word = (size_t)(cpu_feature) / 64u;                           \
+        accel_set(&sys->accel.raw_all_mask, accel_feature,                         \
+                  (caps_all.raw_bits[word] & bit) != 0U);                          \
+        accel_set(&sys->accel.raw_any_mask, accel_feature,                         \
+                  (caps_any.raw_bits[word] & bit) != 0U);                          \
+        accel_set(&sys->accel.usable_all_mask, accel_feature,                      \
+                  (caps_all.usable_bits[word] & bit) != 0U);                       \
+        accel_set(&sys->accel.usable_any_mask, accel_feature,                      \
+                  (caps_any.usable_bits[word] & bit) != 0U);                       \
+    } while (0)
+    EXPORT_ACCEL(HAL_ACCEL_FEAT_VECTOR, HAL_CPU_FEATURE_VECTOR);
+    EXPORT_ACCEL(HAL_ACCEL_FEAT_AES, HAL_CPU_FEATURE_AES);
+    EXPORT_ACCEL(HAL_ACCEL_FEAT_SHA, HAL_CPU_FEATURE_SHA);
+    EXPORT_ACCEL(HAL_ACCEL_FEAT_PMULL, HAL_CPU_FEATURE_PMULL);
+    EXPORT_ACCEL(HAL_ACCEL_FEAT_STRONG_ATOMICS, HAL_CPU_FEATURE_STRONG_ATOMICS);
+#undef EXPORT_ACCEL
 }

--- a/core/hal/include/hal/hal_cpu_features.h
+++ b/core/hal/include/hal/hal_cpu_features.h
@@ -31,6 +31,21 @@ typedef struct {
     uint64_t usable_bits[(HAL_CPU_FEATURE__COUNT + 63u) / 64u];
 } hal_cpu_feature_set_t;
 
+/*
+ * Architecture code owns CPU probing and the storage behind this provider.
+ * The provider is installed once during serial boot and remains immutable.
+ * HAL consumes only normalized feature sets; it never includes or interprets
+ * architecture-private capability records.
+ */
+typedef struct {
+    bool (*for_cpu)(size_t cpu_id, hal_cpu_feature_set_t *out);
+    bool (*for_current_cpu)(hal_cpu_feature_set_t *out);
+    bool (*for_system)(hal_cpu_feature_scope_t scope,
+                       hal_cpu_feature_set_t *out);
+} hal_cpu_feature_provider_t;
+
+bool hal_cpu_features_register_provider(const hal_cpu_feature_provider_t *provider);
+
 bool hal_cpu_has_feature(size_t cpu_id, hal_cpu_feature_t feature);
 bool hal_cpu_has_system_feature(hal_cpu_feature_t feature, hal_cpu_feature_scope_t scope);
 bool hal_cpu_feature_set_for_cpu(size_t cpu_id, hal_cpu_feature_set_t *out);

--- a/core/kernel/src/kernel_boot.c
+++ b/core/kernel/src/kernel_boot.c
@@ -16,6 +16,7 @@
 #include "console/console_core.h"
 #include "mm.h"
 #include "arch/arch_cpu_caps.h"
+#include "arch/common/accel_caps_publish.h"
 #include "mm_zswap.h"
 #include "multicore.h"
 #include "numa.h"
@@ -277,6 +278,9 @@ void boot_common_platform_services(const boot_info_t *boot) {
       kernel_panic("CPU capability aggregation failed");
     }
     hal_discovery_publish_cpu_caps();
+    arch_accel_caps_publish_target(&hal_get_system_discovery()->accel,
+                                   arch_cpu_caps_system_all(),
+                                   arch_cpu_caps_system_any());
     if (hal_hw_caps_publish_cpu() != K_OK || hal_hw_caps_finalize() != K_OK) {
       kernel_panic("hardware capability freeze failed");
     }

--- a/docs/adr/ADR-021-hardware-capability-freeze-authority.md
+++ b/docs/adr/ADR-021-hardware-capability-freeze-authority.md
@@ -22,7 +22,7 @@ Architecture backend declarations, per-CPU probes, and the HAL hardware snapshot
 Capability meanings are separated as follows:
 
 1. `arch_get_caps()` describes the selected architecture/profile mechanism contract.  It is not platform discovery.
-2. `arch_cpu_caps_*` records CPU-register or ISA-discovery facts.  `LOCAL` is the current CPU, `SYSTEM_ALL` is the intersection across participating CPUs, and `SYSTEM_ANY` is their union.
+2. `arch_cpu_caps_*` records CPU-register or ISA-discovery facts.  `LOCAL` is the current CPU, `SYSTEM_ALL` is the intersection across participating CPUs, and `SYSTEM_ANY` is their union. Architecture code registers one immutable provider that translates those private records into normalized `hal_cpu_feature_set_t` values. HAL never includes architecture-private capability headers or pulls ISA records directly.
 3. HAL discovery owns platform facts such as topology and IOMMU presence.  Unknown platform facts are false.  The architecture hardware publishers provide conservative raw input and do not infer IOMMU or DMA coherency from ISA.
 4. `hal_hw_caps_t` is the effective snapshot consumed by mechanisms.  It moves monotonically through `UNINITIALIZED`, `RAW_DISCOVERED`, `CPU_FINALIZED`, and `FROZEN`.  The BSP boot path is its sole writer; after `FROZEN`, callers receive only a const pointer and every mutation/finalization attempt fails.
 5. Memory backend support remains distinct from the effective memory profile.  The snapshot reports the selected effective mechanism; supporting an MMU backend does not itself select `MMU_FULL`.
@@ -53,6 +53,8 @@ Profile validation remains the existing boot responsibility; this decision does 
 ## Failure behavior and synchronization
 
 Lifecycle transitions are fail closed: a missing CPU aggregate returns `K_ERR_IN_PROGRESS`; an out-of-order, backward, repeated, or post-freeze transition returns `K_ERR_BAD_STATE`.  No partial transition is published.  Mutation is BSP-owned during serial boot, then the object is immutable shared state, so no runtime lock is required.
+
+CPU-feature provider installation follows the same serial-boot ownership rule. It is a one-time compare-and-publish transition; invalid or repeated registration is rejected, and queries made before registration or system aggregation return unavailable rather than an invented empty feature set.
 
 The generic discovered CPU count is bounded by the canonical `BHARAT_MAX_CPUS` rather than 32.  Existing 32-bit service-placement masks remain explicitly limited to CPUs 0 through 31; they no longer truncate the authoritative topology count.  Expanding that compatibility interface is a separate UAPI/service migration.
 

--- a/docs/architecture/core/freestanding-layer-contract.md
+++ b/docs/architecture/core/freestanding-layer-contract.md
@@ -33,7 +33,7 @@ The purpose of this contract is to stop architecture drift by making layer bound
 | Layer | Freestanding | Allowed direct dependencies |
 |---|---|---|
 | `core/arch/` | ✅ Yes | `core/arch/` internals only, plus shared include/UAPI contracts |
-| `corecore/hal/` | ✅ Yes | `corecore/hal/`, `core/arch/`, shared include/UAPI contracts |
+| `core/hal/common/` | ✅ Yes | `core/hal/include/`, base/compiler freestanding contracts, shared UAPI contracts |
 | `core/kernel/` | ✅ Yes | `core/kernel/`, `corecore/hal/`, `core/arch/`, core/platform/boot glue, shared include/UAPI contracts |
 | `lib/` | ❌ No (hosted) | `interface/uapi/`, runtime/services abstractions |
 | `core/services/` | ❌ No (hosted) | `lib/`, `interface/uapi/` |
@@ -51,6 +51,11 @@ The purpose of this contract is to stop architecture drift by making layer bound
   - `<stdio.h>`
   - `<stdlib.h>`
   - `<string.h>`
+
+Generic HAL common code must not include architecture or kernel-private headers,
+compile kernel sources, or inherit kernel-private/generated include directories.
+Architectures publish normalized facts and implementations through HAL contracts;
+HAL common never pulls architecture-private state.
 
 ### Hosted layers (`lib/`, `core/services/`, `core/stacks/`, `user/`)
 

--- a/tools/lint/check_cmake_dependencies.py
+++ b/tools/lint/check_cmake_dependencies.py
@@ -23,6 +23,19 @@ FORBIDDEN_RULES = [
 DEFAULT_BASELINE = "tools/lint/baselines/cmake_dependencies.json"
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
+
+def validate_hal_common_definition():
+    """Keep the standalone generic HAL target independent of kernel internals."""
+    cmake_path = REPO_ROOT / "core/hal/common/CMakeLists.txt"
+    text = cmake_path.read_text(encoding="utf-8")
+    forbidden = (
+        "core/kernel/src",
+        "core/kernel/include",
+        "core/kernel/include/generated",
+        "bharat_kernel_buildopts",
+    )
+    return [token for token in forbidden if token in text]
+
 def register_query(build_dir):
     query_dir = os.path.join(build_dir, ".cmake", "api", "v1", "query", "client-linter")
     os.makedirs(query_dir, exist_ok=True)
@@ -156,6 +169,12 @@ def main():
     parser.add_argument("--strict", action="store_true", help="Fail with non-zero on violations")
 
     args = parser.parse_args()
+
+    hal_common_violations = validate_hal_common_definition()
+    if hal_common_violations:
+        for token in hal_common_violations:
+            print(f"[VIOLATION] hal_common references kernel-private input: {token}")
+        sys.exit(1)
 
     # Register the File API query
     register_query(args.build_dir)


### PR DESCRIPTION
### Motivation

- HAL common was including and compiling kernel-private sources and pulling arch CPU capability details, reversing the intended kernel->hal dependency direction and risking architectural drift.  
- HAL should consume normalized, architecture-pushed CPU feature snapshots rather than directly pulling ISA/arch internals.  
- Establishing a one-time, immutable provider for CPU feature publication is necessary before moving to hardware-adaptive memops registration safely on heterogeneous systems.

### Description

- Introduced a HAL-facing CPU feature provider contract and registration API in `core/hal/include/hal/hal_cpu_features.h`, allowing architecture code to push normalized `hal_cpu_feature_set_t` values into HAL via a provider struct and one-time `hal_cpu_features_register_provider` call.  
- Reworked HAL common to consume the registered provider rather than include architecture-private headers by modifying `core/hal/common/cpu_features.c` to use an atomic provider pointer and provider callbacks for per-CPU/current/system feature queries.  
- Added arch-side export helpers and a provider instance in `core/arch/common/cpu_caps_state.c` to translate `arch_cpu_caps` into `hal_cpu_feature_set_t` and register the provider during serial boot.  
- Updated HAL discovery to consume normalized HAL CPU feature sets (in `core/hal/common/discovery.c`) when populating accelerator masks, replacing direct `arch_*` usage.  
- Removed kernel-private sources, include directories, generated headers, and kernel build options from `core/hal/common/CMakeLists.txt` so `hal_common` now builds from freestanding HAL/interface includes only.  
- Added a lint check in `tools/lint/check_cmake_dependencies.py` to fail if `core/hal/common/CMakeLists.txt` references kernel-private inputs.  
- Updated ADR and freestanding-layer documentation to record the provider ownership, one-time registration semantics, and the fail-closed freeze rules.  
- Kept memops registration/design work out of this change; this PR establishes the push-model and dependency closure required for a subsequent memops backend registration implementation.

Files changed (high level): `core/hal/include/hal/hal_cpu_features.h`, `core/hal/common/cpu_features.c`, `core/arch/common/cpu_caps_state.c`, `core/hal/common/discovery.c`, `core/hal/common/CMakeLists.txt`, `core/kernel/src/kernel_boot.c`, `tools/lint/check_cmake_dependencies.py`, and ADR/docs updates.

### Testing

- Ran freestanding compilation of HAL common sources: `cc -std=c11 -Wall -Wextra -Werror -ffreestanding -Icore/hal/include -Iinterface/include -c` for `core/hal/common/cpu_features.c`, `hmem.c`, and `core/hal/common/memops/mem_scalar.c` and they compiled successfully.  (PASS)  
- Python/linters: `python3 -m py_compile tools/lint/check_cmake_dependencies.py` and `python3 tools/lint/check_layer_references.py` executed without error. (PASS)  
- CMake dependency linter: `python3 tools/lint/check_cmake_dependencies.py --strict` ran and validated the new hal_common rule (PASS).  
- Syscall ABI check: `python3 tools/abi/syscall_abi.py --check` passed cleanly. (PASS)  
- Partial host unit test compile attempts for host test harness adjusted for freestanding headers; guarded compile invocations were used and showed expected include-safety failures when trying to pull hosted headers (tests for conformance remain unchanged). (OBSERVED/INTENDED)  
- Full cross-target smoke builds executed: `./tools/build.sh all` smoke flows for `x86_64`, `arm64`, `riscv64`, `arm32_mmu_lite`, and `riscv32_mmu_lite` were run; all five required targets completed their smoke runs, and `python3 tools/run_qemu_matrix.py --headless --smoke --all-arch` reported PASS across the matrix after integrated runs (hosts exhibited one transient x86 run timeout before rerun). (MATRIX PASS overall)  

All automated checks and lint gates added by this change passed; the PR intentionally avoids enabling memops architecture registration until per-CPU aggregation/trust is validated in follow-up work.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7da99d4f9c8320a3f9b34ca25ad3f0)