### PR TITLE
hal/memops: per-core architecture backends + userspace memops resolver

### DIFF
--- a/core/arch/arm/arm32/memops.c
+++ b/core/arch/arm/arm32/memops.c
@@ -2,6 +2,20 @@
 #include "hal/hal_memops.h"
 
 void arch_memops_register(size_t cpu_id, const arch_cpu_caps_record_t *caps) {
-    (void)cpu_id;
     (void)caps;
+    extern void *hal_memcpy_arm32_gpr(void *, const void *, size_t);
+    extern void *hal_memset_arm32_gpr(void *, int, size_t);
+    extern void *hal_memmove_arm32_gpr(void *, const void *, size_t);
+    extern int hal_memcmp_arm32_gpr(const void *, const void *, size_t);
+    const hal_memops_backend_t backend = {
+        .copy = hal_memcpy_arm32_gpr,
+        .set = hal_memset_arm32_gpr,
+        .move = hal_memmove_arm32_gpr,
+        .compare = hal_memcmp_arm32_gpr,
+        .context_flags = BH_MEMCTX_F_DEFAULT | BH_MEMCTX_F_MAY_SLEEP |
+                         BH_MEMCTX_F_NO_SIMD | BH_MEMCTX_F_NO_DMA |
+                         BH_MEMCTX_F_NO_FAULT,
+        .implementation_flags = HAL_MEMOPS_IMPL_F_GPR_ONLY,
+    };
+    (void)hal_memops_register(cpu_id, &backend);
 }

--- a/core/arch/arm/arm32/memops_gpr.c
+++ b/core/arch/arm/arm32/memops_gpr.c
@@ -1,0 +1,5 @@
+#include <stddef.h>
+#include <stdint.h>
+
+#define PREFIX arm32
+#include "../../common/memops_gpr32.inc"

--- a/core/arch/arm/arm64/memops.c
+++ b/core/arch/arm/arm64/memops.c
@@ -3,13 +3,20 @@
 
 void *hal_memcpy_gpr_bulk(void *, const void *, size_t);
 void *hal_memset_gpr_bulk(void *, int, size_t);
+void *hal_memmove_gpr_bulk(void *, const void *, size_t);
+int hal_memcmp_gpr_bulk(const void *, const void *, size_t);
 
 void arch_memops_register(size_t cpu_id, const arch_cpu_caps_record_t *caps) {
     (void)caps;
     const hal_memops_backend_t backend = {
         .copy = hal_memcpy_gpr_bulk,
         .set = hal_memset_gpr_bulk,
-        .move = hal_memmove_scalar,
+        .move = hal_memmove_gpr_bulk,
+        .compare = hal_memcmp_gpr_bulk,
+        .context_flags = BH_MEMCTX_F_DEFAULT | BH_MEMCTX_F_MAY_SLEEP |
+                         BH_MEMCTX_F_NO_SIMD | BH_MEMCTX_F_NO_DMA |
+                         BH_MEMCTX_F_NO_FAULT,
+        .implementation_flags = HAL_MEMOPS_IMPL_F_GPR_ONLY,
     };
     (void)hal_memops_register(cpu_id, &backend);
 }

--- a/core/arch/arm/arm64/memops_gpr_bulk.c
+++ b/core/arch/arm/arm64/memops_gpr_bulk.c
@@ -137,3 +137,26 @@ void *hal_memset_gpr_bulk(void *dst, int c, size_t n) {
 
     return dst;
 }
+
+void *hal_memmove_gpr_bulk(void *dst, const void *src, size_t n) {
+    const uintptr_t da = (uintptr_t)dst;
+    const uintptr_t sa = (uintptr_t)src;
+    if (n == 0u || da == sa) return dst;
+    if (da < sa || da - sa >= n) return hal_memcpy_gpr_bulk(dst, src, n);
+
+    uint8_t *d = (uint8_t *)dst + n;
+    const uint8_t *s = (const uint8_t *)src + n;
+    while (n-- != 0u) *--d = *--s;
+    return dst;
+}
+
+int hal_memcmp_gpr_bulk(const void *lhs, const void *rhs, size_t n) {
+    const uint8_t *a = lhs;
+    const uint8_t *b = rhs;
+    while (n-- != 0u) {
+        const unsigned av = *a++;
+        const unsigned bv = *b++;
+        if (av != bv) return (int)av - (int)bv;
+    }
+    return 0;
+}

--- a/core/arch/common/memops_gpr32.inc
+++ b/core/arch/common/memops_gpr32.inc
@@ -1,0 +1,52 @@
+#define BH_JOIN_INNER(a, b) a##b
+#define BH_JOIN(a, b) BH_JOIN_INNER(a, b)
+#define BH_MEMOP(name) BH_JOIN(BH_JOIN(hal_##name##_, PREFIX), _gpr)
+
+void *BH_MEMOP(memcpy)(void *dst, const void *src, size_t n) {
+    uint8_t *d = dst;
+    const uint8_t *s = src;
+    while (n >= 4u) {
+        d[0] = s[0]; d[1] = s[1]; d[2] = s[2]; d[3] = s[3];
+        d += 4; s += 4; n -= 4u;
+    }
+    while (n-- != 0u) *d++ = *s++;
+    return dst;
+}
+
+void *BH_MEMOP(memset)(void *dst, int c, size_t n) {
+    uint8_t *d = dst;
+    const uint8_t v = (uint8_t)c;
+    while (n >= 4u) {
+        d[0] = v; d[1] = v; d[2] = v; d[3] = v;
+        d += 4; n -= 4u;
+    }
+    while (n-- != 0u) *d++ = v;
+    return dst;
+}
+
+void *BH_MEMOP(memmove)(void *dst, const void *src, size_t n) {
+    const uintptr_t da = (uintptr_t)dst;
+    const uintptr_t sa = (uintptr_t)src;
+    if (n == 0u || da == sa) return dst;
+    if (da < sa || da - sa >= n) return BH_MEMOP(memcpy)(dst, src, n);
+    uint8_t *d = (uint8_t *)dst + n;
+    const uint8_t *s = (const uint8_t *)src + n;
+    while (n-- != 0u) *--d = *--s;
+    return dst;
+}
+
+int BH_MEMOP(memcmp)(const void *lhs, const void *rhs, size_t n) {
+    const uint8_t *a = lhs;
+    const uint8_t *b = rhs;
+    while (n-- != 0u) {
+        const unsigned av = *a++;
+        const unsigned bv = *b++;
+        if (av != bv) return (int)av - (int)bv;
+    }
+    return 0;
+}
+
+#undef BH_MEMOP
+#undef BH_JOIN
+#undef BH_JOIN_INNER
+#undef PREFIX

--- a/core/arch/riscv/riscv32/memops.c
+++ b/core/arch/riscv/riscv32/memops.c
@@ -2,6 +2,20 @@
 #include "hal/hal_memops.h"
 
 void arch_memops_register(size_t cpu_id, const arch_cpu_caps_record_t *caps) {
-    (void)cpu_id;
     (void)caps;
+    extern void *hal_memcpy_rv32_gpr(void *, const void *, size_t);
+    extern void *hal_memset_rv32_gpr(void *, int, size_t);
+    extern void *hal_memmove_rv32_gpr(void *, const void *, size_t);
+    extern int hal_memcmp_rv32_gpr(const void *, const void *, size_t);
+    const hal_memops_backend_t backend = {
+        .copy = hal_memcpy_rv32_gpr,
+        .set = hal_memset_rv32_gpr,
+        .move = hal_memmove_rv32_gpr,
+        .compare = hal_memcmp_rv32_gpr,
+        .context_flags = BH_MEMCTX_F_DEFAULT | BH_MEMCTX_F_MAY_SLEEP |
+                         BH_MEMCTX_F_NO_SIMD | BH_MEMCTX_F_NO_DMA |
+                         BH_MEMCTX_F_NO_FAULT,
+        .implementation_flags = HAL_MEMOPS_IMPL_F_GPR_ONLY,
+    };
+    (void)hal_memops_register(cpu_id, &backend);
 }

--- a/core/arch/riscv/riscv32/memops_gpr.c
+++ b/core/arch/riscv/riscv32/memops_gpr.c
@@ -1,0 +1,5 @@
+#include <stddef.h>
+#include <stdint.h>
+
+#define PREFIX rv32
+#include "../../common/memops_gpr32.inc"

--- a/core/arch/riscv/riscv64/memops.c
+++ b/core/arch/riscv/riscv64/memops.c
@@ -3,13 +3,20 @@
 
 void *hal_memcpy_gpr_bulk(void *, const void *, size_t);
 void *hal_memset_gpr_bulk(void *, int, size_t);
+void *hal_memmove_gpr_bulk(void *, const void *, size_t);
+int hal_memcmp_gpr_bulk(const void *, const void *, size_t);
 
 void arch_memops_register(size_t cpu_id, const arch_cpu_caps_record_t *caps) {
     (void)caps;
     const hal_memops_backend_t backend = {
         .copy = hal_memcpy_gpr_bulk,
         .set = hal_memset_gpr_bulk,
-        .move = hal_memmove_scalar,
+        .move = hal_memmove_gpr_bulk,
+        .compare = hal_memcmp_gpr_bulk,
+        .context_flags = BH_MEMCTX_F_DEFAULT | BH_MEMCTX_F_MAY_SLEEP |
+                         BH_MEMCTX_F_NO_SIMD | BH_MEMCTX_F_NO_DMA |
+                         BH_MEMCTX_F_NO_FAULT,
+        .implementation_flags = HAL_MEMOPS_IMPL_F_GPR_ONLY,
     };
     (void)hal_memops_register(cpu_id, &backend);
 }

--- a/core/arch/riscv/riscv64/memops_gpr_bulk.c
+++ b/core/arch/riscv/riscv64/memops_gpr_bulk.c
@@ -110,3 +110,26 @@ void *hal_memset_gpr_bulk(void *dst, int c, size_t n) {
 
     return dst;
 }
+
+void *hal_memmove_gpr_bulk(void *dst, const void *src, size_t n) {
+    const uintptr_t da = (uintptr_t)dst;
+    const uintptr_t sa = (uintptr_t)src;
+    if (n == 0u || da == sa) return dst;
+    if (da < sa || da - sa >= n) return hal_memcpy_gpr_bulk(dst, src, n);
+
+    uint8_t *d = (uint8_t *)dst + n;
+    const uint8_t *s = (const uint8_t *)src + n;
+    while (n-- != 0u) *--d = *--s;
+    return dst;
+}
+
+int hal_memcmp_gpr_bulk(const void *lhs, const void *rhs, size_t n) {
+    const uint8_t *a = lhs;
+    const uint8_t *b = rhs;
+    while (n-- != 0u) {
+        const unsigned av = *a++;
+        const unsigned bv = *b++;
+        if (av != bv) return (int)av - (int)bv;
+    }
+    return 0;
+}

--- a/core/arch/x86/x86_64/memops.c
+++ b/core/arch/x86/x86_64/memops.c
@@ -3,13 +3,23 @@
 
 void *hal_memcpy_fast_string(void *, const void *, size_t);
 void *hal_memset_fast_string(void *, int, size_t);
+void *hal_memmove_fast_string(void *, const void *, size_t);
+int hal_memcmp_x86_gpr(const void *, const void *, size_t);
+void *hal_memcpy_x86_gpr(void *, const void *, size_t);
+void *hal_memset_x86_gpr(void *, int, size_t);
 
 void arch_memops_register(size_t cpu_id, const arch_cpu_caps_record_t *caps) {
-    if (!arch_cpu_caps_test(&caps->usable, ARCH_CPU_FEAT_X86_ERMS)) return;
+    const bool erms = arch_cpu_caps_test(&caps->usable, ARCH_CPU_FEAT_X86_ERMS);
     const hal_memops_backend_t backend = {
-        .copy = hal_memcpy_fast_string,
-        .set = hal_memset_fast_string,
-        .move = hal_memmove_scalar,
+        .copy = erms ? hal_memcpy_fast_string : hal_memcpy_x86_gpr,
+        .set = erms ? hal_memset_fast_string : hal_memset_x86_gpr,
+        .move = hal_memmove_fast_string,
+        .compare = hal_memcmp_x86_gpr,
+        .context_flags = BH_MEMCTX_F_DEFAULT | BH_MEMCTX_F_MAY_SLEEP |
+                         BH_MEMCTX_F_NO_SIMD | BH_MEMCTX_F_NO_DMA |
+                         BH_MEMCTX_F_NO_FAULT,
+        .implementation_flags = HAL_MEMOPS_IMPL_F_GPR_ONLY |
+                                (erms ? HAL_MEMOPS_IMPL_F_FAST_STRING : 0u),
     };
     (void)hal_memops_register(cpu_id, &backend);
 }

--- a/core/arch/x86/x86_64/memops_fast_string.c
+++ b/core/arch/x86/x86_64/memops_fast_string.c
@@ -8,6 +8,19 @@
 
 #include "hal/hal_memops.h"
 
+void *hal_memcpy_x86_gpr(void *dst, const void *src, size_t n) {
+    unsigned char *d = dst;
+    const unsigned char *s = src;
+    while (n-- != 0u) *d++ = *s++;
+    return dst;
+}
+
+void *hal_memset_x86_gpr(void *dst, int c, size_t n) {
+    unsigned char *d = dst;
+    while (n-- != 0u) *d++ = (unsigned char)c;
+    return dst;
+}
+
 void *hal_memcpy_fast_string(void *dst, const void *src, size_t n) {
     void *ret = dst;
     __asm__ __volatile__(
@@ -28,4 +41,30 @@ void *hal_memset_fast_string(void *dst, int c, size_t n) {
         : "memory"
     );
     return ret;
+}
+
+void *hal_memmove_fast_string(void *dst, const void *src, size_t n) {
+    void *ret = dst;
+    const uintptr_t da = (uintptr_t)dst;
+    const uintptr_t sa = (uintptr_t)src;
+
+    if (n == 0u || da == sa) return ret;
+    if (da < sa || da - sa >= n) return hal_memcpy_fast_string(dst, src, n);
+
+    unsigned char *d = (unsigned char *)dst + n;
+    const unsigned char *s = (const unsigned char *)src + n;
+    /* Never expose DF=1 to an interrupt or exception handler. */
+    while (n-- != 0u) *--d = *--s;
+    return ret;
+}
+
+int hal_memcmp_x86_gpr(const void *lhs, const void *rhs, size_t n) {
+    const unsigned char *a = lhs;
+    const unsigned char *b = rhs;
+    while (n-- != 0u) {
+        const unsigned av = *a++;
+        const unsigned bv = *b++;
+        if (av != bv) return (int)av - (int)bv;
+    }
+    return 0;
 }

--- a/core/hal/common/memops/mem_dispatch.c
+++ b/core/hal/common/memops/mem_dispatch.c
@@ -16,7 +16,12 @@ bool hal_memops_begin(hal_memops_current_cpu_fn_t current_cpu) {
 
 bool hal_memops_register(size_t cpu_id, const hal_memops_backend_t *backend) {
     if (g_frozen || backend == NULL || cpu_id >= HAL_MEMOPS_MAX_CPUS ||
-        backend->copy == NULL || backend->set == NULL || backend->move == NULL) return false;
+        backend->copy == NULL || backend->set == NULL || backend->move == NULL ||
+        backend->compare == NULL ||
+        (backend->context_flags & (BH_MEMCTX_F_EARLY_BOOT | BH_MEMCTX_F_IRQ_SAFE)) != 0u ||
+        (backend->context_flags & ~BH_MEMCTX_F_ALL) != 0u ||
+        (backend->implementation_flags & ~HAL_MEMOPS_IMPL_F_ALL) != 0u)
+        return false;
     g_backends[cpu_id] = *backend;
     g_present[cpu_id] = true;
     return true;
@@ -34,7 +39,15 @@ static const hal_memops_backend_t *selected(uint32_t flags) {
     if ((flags & (BH_MEMCTX_F_EARLY_BOOT | BH_MEMCTX_F_IRQ_SAFE)) != 0u ||
         !hal_memops_is_frozen() || g_current_cpu == NULL) return NULL;
     const size_t cpu = g_current_cpu();
-    return cpu < HAL_MEMOPS_MAX_CPUS && g_present[cpu] ? &g_backends[cpu] : NULL;
+    if (cpu >= HAL_MEMOPS_MAX_CPUS || !g_present[cpu]) return NULL;
+    const hal_memops_backend_t *backend = &g_backends[cpu];
+    return (flags & ~backend->context_flags) == 0u ? backend : NULL;
+}
+
+int hal_memcmp(const void *lhs, const void *rhs, size_t n, uint32_t flags) {
+    const hal_memops_backend_t *backend = selected(flags);
+    return backend == NULL ? hal_memcmp_scalar(lhs, rhs, n)
+                           : backend->compare(lhs, rhs, n);
 }
 
 void *hal_memcpy(void *dst, const void *src, size_t n, uint32_t flags) {

--- a/core/hal/common/memops/mem_scalar.c
+++ b/core/hal/common/memops/mem_scalar.c
@@ -55,6 +55,18 @@ void *hal_memmove_scalar(void *dst, const void *src, size_t n) {
     return dst;
 }
 
+int hal_memcmp_scalar(const void *lhs, const void *rhs, size_t n) {
+    const volatile unsigned char *a = (const volatile unsigned char *)lhs;
+    const volatile unsigned char *b = (const volatile unsigned char *)rhs;
+
+    while (n-- != 0u) {
+        const unsigned char av = *a++;
+        const unsigned char bv = *b++;
+        if (av != bv) return (int)av - (int)bv;
+    }
+    return 0;
+}
+
 void hal_memset_raw(void *dst, int val, size_t len) {
     volatile unsigned char *d = (volatile unsigned char *)dst;
 

--- a/core/hal/include/hal/hal_memops.h
+++ b/core/hal/include/hal/hal_memops.h
@@ -17,11 +17,22 @@
 typedef void *(*hal_memcpy_backend_fn_t)(void *, const void *, size_t);
 typedef void *(*hal_memset_backend_fn_t)(void *, int, size_t);
 typedef void *(*hal_memmove_backend_fn_t)(void *, const void *, size_t);
+typedef int (*hal_memcmp_backend_fn_t)(const void *, const void *, size_t);
+
+#define HAL_MEMOPS_IMPL_F_GPR_ONLY    (1u << 0)
+#define HAL_MEMOPS_IMPL_F_FAST_STRING (1u << 1)
+#define HAL_MEMOPS_IMPL_F_ALL (HAL_MEMOPS_IMPL_F_GPR_ONLY | HAL_MEMOPS_IMPL_F_FAST_STRING)
+#define BH_MEMCTX_F_ALL (BH_MEMCTX_F_MAY_SLEEP | BH_MEMCTX_F_IRQ_SAFE | \
+                         BH_MEMCTX_F_EARLY_BOOT | BH_MEMCTX_F_NO_SIMD | \
+                         BH_MEMCTX_F_NO_DMA | BH_MEMCTX_F_NO_FAULT)
 
 typedef struct {
     hal_memcpy_backend_fn_t copy;
     hal_memset_backend_fn_t set;
     hal_memmove_backend_fn_t move;
+    hal_memcmp_backend_fn_t compare;
+    uint32_t context_flags;
+    uint32_t implementation_flags;
 } hal_memops_backend_t;
 
 typedef size_t (*hal_memops_current_cpu_fn_t)(void);
@@ -38,11 +49,13 @@ bool hal_memops_is_frozen(void);
 void *hal_memcpy(void *dst, const void *src, size_t n, uint32_t flags);
 void *hal_memset(void *dst, int c, size_t n, uint32_t flags);
 void *hal_memmove(void *dst, const void *src, size_t n, uint32_t flags);
+int hal_memcmp(const void *lhs, const void *rhs, size_t n, uint32_t flags);
 
 /* Canonical byte-only Tier-0 fallbacks (implemented by HAL common). */
 void *hal_memcpy_scalar(void *dst, const void *src, size_t n);
 void *hal_memset_scalar(void *dst, int c, size_t n);
 void *hal_memmove_scalar(void *dst, const void *src, size_t n);
+int hal_memcmp_scalar(const void *lhs, const void *rhs, size_t n);
 
 /* Tier-0 primitives: Guaranteed non-recursive raw memory operations */
 void hal_memset_raw(void *dst, int val, size_t len);

--- a/core/kernel/src/core/CMakeLists.txt
+++ b/core/kernel/src/core/CMakeLists.txt
@@ -19,11 +19,13 @@ add_library(k_core OBJECT
     $<$<STREQUAL:${ARCH},x86_64>:${BHARAT_ARCH_ROOT}/x86/x86_64/memops.c>
     $<$<STREQUAL:${ARCH},x86_64>:${BHARAT_ARCH_ROOT}/x86/x86_64/memops_fast_string.c>
     $<$<STREQUAL:${ARCH},arm32>:${BHARAT_ARCH_ROOT}/arm/arm32/memops.c>
+    $<$<STREQUAL:${ARCH},arm32>:${BHARAT_ARCH_ROOT}/arm/arm32/memops_gpr.c>
     $<$<STREQUAL:${ARCH},arm64>:${BHARAT_ARCH_ROOT}/arm/arm64/memops.c>
     $<$<STREQUAL:${ARCH},arm64>:${BHARAT_ARCH_ROOT}/arm/arm64/memops_gpr_bulk.c>
     $<$<STREQUAL:${ARCH},riscv64>:${BHARAT_ARCH_ROOT}/riscv/riscv64/memops.c>
     $<$<STREQUAL:${ARCH},riscv64>:${BHARAT_ARCH_ROOT}/riscv/riscv64/memops_gpr_bulk.c>
     $<$<STREQUAL:${ARCH},riscv32>:${BHARAT_ARCH_ROOT}/riscv/riscv32/memops.c>
+    $<$<STREQUAL:${ARCH},riscv32>:${BHARAT_ARCH_ROOT}/riscv/riscv32/memops_gpr.c>
     ${BHARAT_KERNEL_SRC_ROOT}/stack_protector.c
     ${BHARAT_KERNEL_SRC_ROOT}/crypto/secure_mem.c
     ${BHARAT_KERNEL_SRC_ROOT}/power/power_core.c

--- a/core/lib/bharatlibc/CMakeLists.txt
+++ b/core/lib/bharatlibc/CMakeLists.txt
@@ -137,6 +137,7 @@ endif()
 # 1. bharatlibc_core
 add_library(bharatlibc_core STATIC
     src/core/memory/memory.c
+    src/arch/memory.c
     src/core/string/string.c
     src/core/errno/errno.c
     src/core/assert/assert.c

--- a/core/lib/bharatlibc/docs/architecture.md
+++ b/core/lib/bharatlibc/docs/architecture.md
@@ -9,6 +9,16 @@ BharatLibC is a next-generation, profile-driven, isolated standard library desig
 3. **Backend Abstraction**: Platform-specific system calls and environment operations are accessed via a well-defined backend dispatch layer (`bh_bsys_backend_ops_t`).
 4. **No Hidden State**: Avoids lazy global state, unsafe fallbacks, and non-deterministic locks, making it suitable for RT/MPU and safety-critical profiles.
 
+## Memory operation selection
+
+The standard copy, move, set, and compare functions start on a byte-only local
+implementation. During CRT startup, `bh_libc_memops_init()` may publish exactly
+one validated CPU-feature descriptor containing the feature intersection for
+every CPU on which the process can run. The resolver then freezes a lib-local
+GPR or x86 ERMS table. It never calls HAL and performs no feature test in the
+steady-state implementations. Invalid and repeated initialization leaves the
+previous safe selection unchanged.
+
 ## POSIX Is a Portability Layer
 
 POSIX support is a source-level API and semantics layer in BharatLibC/libposix. It

--- a/core/lib/bharatlibc/include/bharat/libc/memops.h
+++ b/core/lib/bharatlibc/include/bharat/libc/memops.h
@@ -1,0 +1,28 @@
+#ifndef BHARAT_LIBC_MEMOPS_H
+#define BHARAT_LIBC_MEMOPS_H
+
+#include <standard/stddef.h>
+#include <standard/stdint.h>
+#include <stdbool.h>
+
+#ifndef BHARAT_CPU_FEATURES_V1_H
+#define BHARAT_CPU_FEATURES_V1_H
+#define BHARAT_CPU_FEATURES_ABI_V1 1u
+#define BHARAT_CPU_FEATURE_WORDS 4u
+#define BHARAT_CPU_FEATURE_FAST_STRING 0u
+
+/* Safe-on-all-schedulable-CPUs descriptor supplied by the Bharat CRT. */
+typedef struct {
+    uint16_t abi_version;
+    uint16_t size;
+    uint32_t reserved;
+    uint64_t feature_words[BHARAT_CPU_FEATURE_WORDS];
+    uint32_t cache_line_size;
+    uint32_t preferred_copy_alignment;
+} bharat_cpu_features_v1_t;
+#endif
+
+/* One-way initialization; invalid or repeated publication fails closed. */
+bool bh_libc_memops_init(const bharat_cpu_features_v1_t *features);
+
+#endif

--- a/core/lib/bharatlibc/src/arch/memory.c
+++ b/core/lib/bharatlibc/src/arch/memory.c
@@ -1,0 +1,80 @@
+#include <bharat/libc/config.h>
+#include "../core/memory/memory_backend.h"
+
+static void *gpr_copy(void *dst, const void *src, size_t n) {
+    unsigned char *d = dst;
+    const unsigned char *s = src;
+    while (n >= 8u) {
+        d[0]=s[0]; d[1]=s[1]; d[2]=s[2]; d[3]=s[3];
+        d[4]=s[4]; d[5]=s[5]; d[6]=s[6]; d[7]=s[7];
+        d += 8; s += 8; n -= 8u;
+    }
+    while (n-- != 0u) *d++ = *s++;
+    return dst;
+}
+
+static void *gpr_move(void *dst, const void *src, size_t n) {
+    const uintptr_t da = (uintptr_t)dst;
+    const uintptr_t sa = (uintptr_t)src;
+    if (n == 0u || da == sa) return dst;
+    if (da < sa || da - sa >= n) return gpr_copy(dst, src, n);
+    unsigned char *d = (unsigned char *)dst + n;
+    const unsigned char *s = (const unsigned char *)src + n;
+    while (n-- != 0u) *--d = *--s;
+    return dst;
+}
+
+static void *gpr_set(void *dst, int c, size_t n) {
+    unsigned char *d = dst;
+    const unsigned char v = (unsigned char)c;
+    while (n >= 8u) {
+        d[0]=v; d[1]=v; d[2]=v; d[3]=v; d[4]=v; d[5]=v; d[6]=v; d[7]=v;
+        d += 8; n -= 8u;
+    }
+    while (n-- != 0u) *d++ = v;
+    return dst;
+}
+
+static int gpr_compare(const void *lhs, const void *rhs, size_t n) {
+    const unsigned char *a = lhs;
+    const unsigned char *b = rhs;
+    while (n-- != 0u) {
+        const unsigned av = *a++;
+        const unsigned bv = *b++;
+        if (av != bv) return (int)av - (int)bv;
+    }
+    return 0;
+}
+
+static const bh_libc_memops_backend_t gpr_backend = {
+    gpr_copy, gpr_move, gpr_set, gpr_compare
+};
+
+#if defined(BH_LIBC_ARCH_X86_64)
+static void *erms_copy(void *dst, const void *src, size_t n) {
+    void *ret = dst;
+    __asm__ __volatile__("rep movsb" : "+D"(dst), "+S"(src), "+c"(n) : : "memory");
+    return ret;
+}
+static void *erms_set(void *dst, int c, size_t n) {
+    void *ret = dst;
+    __asm__ __volatile__("rep stosb" : "+D"(dst), "+c"(n) : "a"(c) : "memory");
+    return ret;
+}
+static const bh_libc_memops_backend_t erms_backend = {
+    erms_copy, gpr_move, erms_set, gpr_compare
+};
+#endif
+
+const bh_libc_memops_backend_t *
+bh_libc_arch_memops_select(const bharat_cpu_features_v1_t *features) {
+#if defined(BH_LIBC_ARCH_X86_64)
+    if ((features->feature_words[0] &
+         (1ULL << BHARAT_CPU_FEATURE_FAST_STRING)) != 0u) {
+        return &erms_backend;
+    }
+#else
+    (void)features;
+#endif
+    return &gpr_backend;
+}

--- a/core/lib/bharatlibc/src/core/memory/memory.c
+++ b/core/lib/bharatlibc/src/core/memory/memory.c
@@ -1,45 +1,72 @@
+#include <bharat/libc/memops.h>
 #include <standard/string.h>
 
-void *memcpy(void *restrict dest, const void *restrict src, size_t n) {
-    char *d = (char *)dest;
-    const char *s = (const char *)src;
-    for (size_t i = 0; i < n; i++) {
-        d[i] = s[i];
-    }
+#include "memory_backend.h"
+
+static void *generic_copy(void *dest, const void *src, size_t n) {
+    unsigned char *d = dest;
+    const unsigned char *s = src;
+    while (n-- != 0u) *d++ = *s++;
     return dest;
 }
 
-void *memmove(void *dest, const void *src, size_t n) {
-    char *d = (char *)dest;
-    const char *s = (const char *)src;
-    if (d < s) {
-        for (size_t i = 0; i < n; i++) {
-            d[i] = s[i];
-        }
-    } else if (d > s) {
-        for (size_t i = n; i > 0; i--) {
-            d[i - 1] = s[i - 1];
-        }
-    }
+static void *generic_move(void *dest, const void *src, size_t n) {
+    unsigned char *d = dest;
+    const unsigned char *s = src;
+    const uintptr_t da = (uintptr_t)dest;
+    const uintptr_t sa = (uintptr_t)src;
+    if (n == 0u || da == sa) return dest;
+    if (da < sa || da - sa >= n) return generic_copy(dest, src, n);
+    d += n; s += n;
+    while (n-- != 0u) *--d = *--s;
     return dest;
 }
 
-void *memset(void *s, int c, size_t n) {
-    unsigned char *p = (unsigned char *)s;
-    unsigned char val = (unsigned char)c;
-    for (size_t i = 0; i < n; i++) {
-        p[i] = val;
-    }
-    return s;
+static void *generic_set(void *dest, int c, size_t n) {
+    unsigned char *d = dest;
+    while (n-- != 0u) *d++ = (unsigned char)c;
+    return dest;
 }
 
-int memcmp(const void *s1, const void *s2, size_t n) {
-    const unsigned char *p1 = (const unsigned char *)s1;
-    const unsigned char *p2 = (const unsigned char *)s2;
-    for (size_t i = 0; i < n; i++) {
-        if (p1[i] != p2[i]) {
-            return p1[i] - p2[i];
-        }
+static int generic_compare(const void *lhs, const void *rhs, size_t n) {
+    const unsigned char *a = lhs;
+    const unsigned char *b = rhs;
+    while (n-- != 0u) {
+        const unsigned av = *a++;
+        const unsigned bv = *b++;
+        if (av != bv) return (int)av - (int)bv;
     }
     return 0;
+}
+
+static const bh_libc_memops_backend_t generic_backend = {
+    generic_copy, generic_move, generic_set, generic_compare
+};
+static const bh_libc_memops_backend_t *selected_backend = &generic_backend;
+/* CRT owns 0 -> 1 -> 2 publication; readers acquire the immutable pointer. */
+static int resolver_state;
+
+bool bh_libc_memops_init(const bharat_cpu_features_v1_t *features) {
+    if (features == NULL || features->abi_version != BHARAT_CPU_FEATURES_ABI_V1 ||
+        features->size < sizeof(*features)) return false;
+    int expected = 0;
+    if (!__atomic_compare_exchange_n(&resolver_state, &expected, 1, false,
+                                     __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE)) return false;
+    const bh_libc_memops_backend_t *candidate = bh_libc_arch_memops_select(features);
+    if (candidate != NULL) __atomic_store_n(&selected_backend, candidate, __ATOMIC_RELEASE);
+    __atomic_store_n(&resolver_state, 2, __ATOMIC_RELEASE);
+    return true;
+}
+
+void *memcpy(void *restrict dest, const void *restrict src, size_t n) {
+    return __atomic_load_n(&selected_backend, __ATOMIC_ACQUIRE)->copy(dest, src, n);
+}
+void *memmove(void *dest, const void *src, size_t n) {
+    return __atomic_load_n(&selected_backend, __ATOMIC_ACQUIRE)->move(dest, src, n);
+}
+void *memset(void *dest, int c, size_t n) {
+    return __atomic_load_n(&selected_backend, __ATOMIC_ACQUIRE)->set(dest, c, n);
+}
+int memcmp(const void *lhs, const void *rhs, size_t n) {
+    return __atomic_load_n(&selected_backend, __ATOMIC_ACQUIRE)->compare(lhs, rhs, n);
 }

--- a/core/lib/bharatlibc/src/core/memory/memory_backend.h
+++ b/core/lib/bharatlibc/src/core/memory/memory_backend.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <bharat/libc/memops.h>
+
+typedef struct {
+    void *(*copy)(void *, const void *, size_t);
+    void *(*move)(void *, const void *, size_t);
+    void *(*set)(void *, int, size_t);
+    int (*compare)(const void *, const void *, size_t);
+} bh_libc_memops_backend_t;
+
+const bh_libc_memops_backend_t *
+bh_libc_arch_memops_select(const bharat_cpu_features_v1_t *features);

--- a/core/lib/bharatlibc/tests/host/test_string_memory.c
+++ b/core/lib/bharatlibc/tests/host/test_string_memory.c
@@ -1,5 +1,6 @@
 #include <standard/string.h>
 #include <standard/assert.h>
+#include <bharat/libc/memops.h>
 
 int main(void) {
     char buf1[32];
@@ -26,6 +27,17 @@ int main(void) {
     char move_buf[16] = "abcdefgh";
     memmove(move_buf + 2, move_buf, 5); /* abcde -> offset 2, overlaps */
     assert(memcmp(move_buf, "ababcdeh", 8) == 0);
+
+    /* The safe-on-all-CPUs descriptor is validated and published once. */
+    bharat_cpu_features_v1_t features = {
+        .abi_version = BHARAT_CPU_FEATURES_ABI_V1,
+        .size = sizeof(features),
+    };
+    assert(bh_libc_memops_init(&features));
+    assert(!bh_libc_memops_init(&features));
+    memset(buf1, 0x5a, sizeof(buf1));
+    memcpy(buf2, buf1, sizeof(buf1));
+    assert(memcmp(buf1, buf2, sizeof(buf1)) == 0);
 
     /* Test strlen */
     assert(strlen("hello") == 5);

--- a/docs/adr/ADR-032-hal-feature-and-memops-publication.md
+++ b/docs/adr/ADR-032-hal-feature-and-memops-publication.md
@@ -23,18 +23,28 @@ early boot, or IRQ-safe execution selects the scalar fallback. There is no
 unfreeze operation; frozen records and function tables are immutable and read
 lock-free.
 
-x86 registers REP only when CPUID reports ERMS usable on that CPU. Arm64 and
-RV64 register alignment-safe GPR implementations. Arm32 and RV32 remain scalar.
-SIMD/vector state is outside this contract.
+x86 registers REP only when CPUID reports ERMS usable on that CPU. Arm64,
+Arm32, RV64, and RV32 register integer-only implementations. Every backend
+provides copy, move, set, and compare; incomplete tables are rejected. Backend
+context flags are checked by HAL, while implementation flags are descriptive
+and contain no ISA-specific vocabulary. SIMD/vector state is outside this
+contract.
+
+BharatLibC does not call HAL. Its independent resolver starts on a byte-safe
+fallback, accepts the versioned `bharat_cpu_features_v1_t` system-intersection
+descriptor once, validates its size/version, and then publishes a lib-local
+ISA implementation. A scheduler may expose a larger descriptor only when it
+also constrains execution to CPUs that guarantee every exposed feature.
 
 ## Dependency and failure boundary
 
 `hal_common` builds against HAL contracts and public interface/base types only.
 `core/hal/common` must not import `arch/*` or `kernel/src/*`; libraries must not
 import HAL internals or kernel-private sources. CI enforces this direction.
-Invalid or late publication is rejected, feature queries fail closed until
+Invalid, incomplete, or late publication is rejected, feature queries fail closed until
 freeze, and unknown DMA coherency is treated as non-coherent. No userspace
-capability or trust boundary changes in this vertical slice.
+authority is conveyed by the CPU feature descriptor: the word "feature" is
+deliberately used instead of the security meaning of capability.
 
 ## Consequences
 

--- a/docs/architecture/CONTRACTS.md
+++ b/docs/architecture/CONTRACTS.md
@@ -42,6 +42,7 @@ When implementation differs from an authority, treat it as a defect or an explic
 | Scheduler/per-core ownership | Add exact architecture/ADR references | Scheduler and cross-core commands | SMP ownership/migration tests | Scheduler maintainers |
 | Service lifecycle | Add exact service contract/ADR references | Service manager and services | Event-loop/restart/watchdog tests | Service runtime maintainers |
 | Diagnostic event and evidence ABI | `interface/uapi/diag/` and `contracts/evidence/` | Per-core rings, diagnostic collector, host evidence tooling | Host ABI/ring/parser/schema tests | Observability maintainers |
+| Userspace CPU feature descriptor | `interface/uapi/runtime/cpu_features.h` | CRT publication and library-local ISA resolvers; system intersection unless affinity constrains execution | Header layout assertions and BharatLibC resolver tests | Runtime and architecture maintainers |
 
 ## Required entry contents
 

--- a/docs/architecture/kernel/hardware-adaptive/KMEM-ACCEL-001-hw-memops.md
+++ b/docs/architecture/kernel/hardware-adaptive/KMEM-ACCEL-001-hw-memops.md
@@ -55,15 +55,22 @@ to another memory primitive. HAL common owns the dispatched `hal_memcpy()`,
 `hal_memset()`, and `hal_memmove()` entry points. Architecture directories may
 only publish immutable per-core GPR backends during serial boot.
 
-IRQ-safe and early-boot dispatch must select Tier 0. RV32 remains scalar-only
-until an XLEN-neutral GPR implementation is independently qualified; RV64
-memops objects are not valid RV32 providers. Tier 0 `memmove` determines copy
+IRQ-safe and early-boot dispatch must select Tier 0. Arm32 and RV32 use their
+own integer-only providers; 64-bit objects are never reused as 32-bit
+providers. Tier 0 `memmove` determines copy
 direction using overflow-safe `uintptr_t` address differences and never forms
 an unchecked end pointer.
 
 The backend table and normalized CPU feature records have a one-way lifecycle:
 serial publication followed by freeze. Before freeze, for an unregistered core,
 or for early-boot/IRQ-safe calls, dispatch selects Tier 0.
+
+All providers implement the complete copy/move/set/compare table. HAL validates
+the table and context mask at serial registration and contains no ERMS, SIMD,
+NEON, SVE, or RVV selection logic. The architecture probe alone chooses a
+provider. BharatLibC has a parallel resolver and never imports HAL or kernel
+headers; it consumes only the versioned, safe-on-all-schedulable-CPUs feature
+descriptor from `interface/uapi/runtime/cpu_features.h`.
 
 ## Execution Plan
 1. **Define Neutral API**: Create the standard functions for zeroing and cache maintenance.

--- a/interface/uapi/runtime/cpu_features.h
+++ b/interface/uapi/runtime/cpu_features.h
@@ -1,0 +1,24 @@
+#ifndef BHARAT_CPU_FEATURES_V1_H
+#define BHARAT_CPU_FEATURES_V1_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#define BHARAT_CPU_FEATURES_ABI_V1 1u
+#define BHARAT_CPU_FEATURE_WORDS 4u
+#define BHARAT_CPU_FEATURE_FAST_STRING 0u
+
+typedef struct {
+    uint16_t abi_version;
+    uint16_t size;
+    uint32_t reserved;
+    uint64_t feature_words[BHARAT_CPU_FEATURE_WORDS];
+    uint32_t cache_line_size;
+    uint32_t preferred_copy_alignment;
+} bharat_cpu_features_v1_t;
+
+_Static_assert(sizeof(bharat_cpu_features_v1_t) == 48u,
+               "CPU feature UAPI layout changed");
+
+#endif

--- a/quality/tests/host/test_memops_conformance.c
+++ b/quality/tests/host/test_memops_conformance.c
@@ -24,6 +24,10 @@ static void *marked_move(void *d, const void *s, size_t n) {
     ++backend_calls;
     return hal_memmove_scalar(d, s, n);
 }
+static int marked_compare(const void *a, const void *b, size_t n) {
+    ++backend_calls;
+    return hal_memcmp_scalar(a, b, n);
+}
 
 static void model_move(uint8_t *dst, const uint8_t *src, size_t n) {
     const uintptr_t da = (uintptr_t)dst;
@@ -88,7 +92,14 @@ static int check_overlap(size_t n) {
 }
 
 int main(void) {
-    const hal_memops_backend_t backend = {marked_copy, marked_set, marked_move};
+    const hal_memops_backend_t backend = {
+        .copy = marked_copy,
+        .set = marked_set,
+        .move = marked_move,
+        .compare = marked_compare,
+        .context_flags = BH_MEMCTX_F_DEFAULT | BH_MEMCTX_F_NO_SIMD,
+        .implementation_flags = HAL_MEMOPS_IMPL_F_GPR_ONLY,
+    };
     uint8_t probe[8] = {0};
     if (!hal_memops_begin(current_cpu) || !hal_memops_register(1u, &backend)) return 10;
     fake_cpu = 1u;
@@ -97,12 +108,14 @@ int main(void) {
     if (!hal_memops_freeze() || hal_memops_register(0u, &backend)) return 12;
     (void)hal_memset(probe, 2, sizeof(probe), BH_MEMCTX_F_DEFAULT);
     if (backend_calls != 1u) return 13;
+    if (hal_memcmp(probe, probe, sizeof(probe), BH_MEMCTX_F_DEFAULT) != 0 ||
+        backend_calls != 2u) return 16;
     (void)hal_memset(probe, 3, sizeof(probe), BH_MEMCTX_F_IRQ_SAFE);
     (void)hal_memcpy(probe, probe, 0u, BH_MEMCTX_F_EARLY_BOOT);
-    if (backend_calls != 1u) return 14; /* emergency contexts are always scalar */
+    if (backend_calls != 2u) return 14; /* emergency contexts are always scalar */
     fake_cpu = 0u;
     (void)hal_memmove(probe, probe, 0u, BH_MEMCTX_F_DEFAULT);
-    if (backend_calls != 1u) return 15; /* unregistered core is scalar */
+    if (backend_calls != 2u) return 15; /* unregistered core is scalar */
     static const size_t edges[] = {511u, 512u, 513u, 1023u, 1024u, 1025u, 4095u, 4096u, 4097u};
     for (size_t n = 0; n <= 256u; ++n) {
         int rc = check_length(n);


### PR DESCRIPTION
### Motivation
- Make memory operations selectable per-core and per-CPU-feature without leaking ISA vocabulary into HAL, and provide a safe scalar fallback for early/IRQ contexts. 
- Support heterogeneous machines where different CPUs may expose different acceleration features and avoid a single global backend assumption. 
- Keep BharatLibC independent from HAL by providing a stable userspace CPU-feature descriptor and a one-time libc resolver that selects an ISA-local implementation without calling HAL.

### Description
- Expanded the HAL memops backend API to include `compare` and backend metadata (`context_flags`, `implementation_flags`) and added validation for complete tables and valid flags in `hal_memops_register`. (`core/hal/include/hal/hal_memops.h`, `core/hal/common/memops/mem_dispatch.c`).
- Implemented immutable per-core backend registration and freeze semantics with scalar Tier-0 fallbacks for early-boot/IRQ-safe/unknown-core contexts (`core/hal/common/memops/mem_dispatch.c`, `core/hal/common/memops/mem_scalar.c`).
- Added architecture-owned providers for x86_64, arm64, riscv64 and integer-only providers for arm32/riscv32, with ERMS-aware selection on x86 and GPR-only implementations for others; each provider publishes copy/move/set/compare during serial boot (`core/arch/*/memops*.c`, new `core/arch/common/memops_gpr32.inc`).
- Introduced a stable userspace CPU-feature UAPI (`interface/uapi/runtime/cpu_features.h`) and a BharatLibC one-time resolver that atomically publishes a lib-local memops backend based on the safe-on-all-schedulable-CPUs descriptor, keeping libc independent of HAL (`core/lib/bharatlibc/include/bharat/libc/memops.h`, `core/lib/bharatlibc/src/core/memory/memory.c`, `core/lib/bharatlibc/src/arch/memory.c`, `core/lib/bharatlibc/src/core/memory/memory_backend.h`).
- Added and updated tests and documentation: extended memops conformance test to include `memcmp`/dispatch/freeze checks, added libc resolver validation in libc tests, and updated ADRs and CONTRACTS to record ownership and failure semantics (`quality/tests/host/test_memops_conformance.c`, `core/lib/bharatlibc/tests/host/test_string_memory.c`, `docs/adr/ADR-032*`, `docs/architecture/*`).
- Build system updates: kernel and libc CMake wiring updated to include new arch providers and libc arch objects (`core/kernel/src/core/CMakeLists.txt`, `core/lib/bharatlibc/CMakeLists.txt`).

### Testing
- Ran the focused HAL conformance test: `cc ... test_memops_conformance && /tmp/test_memops` — PASS ("memops conformance passed").
- Built and ran the focused BharatLibC memory unit: compiled and executed the libc mem tests with the one-time resolver — PASS.
- Ran static/quasi-static checks and linters: `python3 tools/lint/check_layer_references.py` and `python3 tools/lint/check_cmake_dependencies.py` — PASS.
- Ran syscall ABI check: `python3 tools/abi/syscall_abi.py --check` — PASS.
- Performed targeted host builds and smoke-run matrix across all required QEMU targets using the repository runner: `./tools/build.sh ... --target-yaml <target> --smoke` for `x86_64`, `arm64`, `riscv64`, `arm32_mmu_lite`, and `riscv32` — each target PASS.
- Executed the matrix runner: `python3 tools/run_qemu_matrix.py --headless --smoke --all-arch` — PASS: all five architecture targets booted and observed required boot markers.
- Notes: `tools/check_no_recursive_memops.py` requires a kernel ELF argument; recursion checks were exercised indirectly via the builds and runtime self-tests. Pull-request creation from this environment is blocked because there is no configured remote/PR tool; changes have been committed locally for review.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7dba8ef6748320a5fe748b2c93af45)