### PR TITLE
Preserve IRQ state (save/restore), add irq-safe spinlocks, and fix EDF dequeue symmetry

### DIFF
--- a/core/arch/hal/arm/arm32/hal_cpu.c
+++ b/core/arch/hal/arm/arm32/hal_cpu.c
@@ -80,6 +80,14 @@ void hal_cpu_halt(void) { while(1); }
 void hal_interrupt_end_of_interrupt(uint32_t irq) { (void)irq; }
 void hal_cpu_enable_interrupts(void) {}
 void hal_cpu_disable_interrupts(void) {}
+hal_irq_state_t hal_irq_save_disable(void) {
+    hal_irq_state_t state;
+    __asm__ volatile("mrs %0, cpsr\n\tcpsid if" : "=r"(state) :: "memory");
+    return state;
+}
+void hal_irq_restore(hal_irq_state_t state) {
+    __asm__ volatile("msr cpsr_c, %0" :: "r"(state) : "memory");
+}
 void hal_ipi_send(uint32_t target_cpu, uint32_t vector) { (void)target_cpu; (void)vector; }
 uint32_t hal_cpu_get_id(void) { return 0; }
 void hal_core_poll_event(void) {}

--- a/core/arch/hal/arm/arm64/hal_cpu.c
+++ b/core/arch/hal/arm/arm64/hal_cpu.c
@@ -191,6 +191,15 @@ void hal_cpu_disable_interrupts(void) {
   __asm__ volatile("msr daifset, #3");
 }
 
+hal_irq_state_t hal_irq_save_disable(void) {
+  hal_irq_state_t state;
+  __asm__ volatile("mrs %0, daif\n\tmsr daifset, #3" : "=r"(state) :: "memory");
+  return state;
+}
+void hal_irq_restore(hal_irq_state_t state) {
+  __asm__ volatile("msr daif, %0" :: "r"(state) : "memory");
+}
+
 void hal_send_ipi_payload(uint32_t target_core, uint64_t payload) {
   (void)target_core;
   (void)payload;

--- a/core/arch/hal/riscv/riscv32/hal_cpu.c
+++ b/core/arch/hal/riscv/riscv32/hal_cpu.c
@@ -143,6 +143,15 @@ void hal_cpu_enable_interrupts(void) {
 void hal_cpu_disable_interrupts(void) {
   __asm__ volatile("csrci sstatus, 2" ::: "memory");
 }
+hal_irq_state_t hal_irq_save_disable(void) {
+  hal_irq_state_t state;
+  __asm__ volatile("csrrc %0, sstatus, %1" : "=r"(state) : "r"((hal_irq_state_t)2) : "memory");
+  return state;
+}
+void hal_irq_restore(hal_irq_state_t state) {
+  if ((state & 2U) != 0U) __asm__ volatile("csrsi sstatus, 2" ::: "memory");
+  else __asm__ volatile("csrci sstatus, 2" ::: "memory");
+}
 
 extern void trap_entry(void);
 extern void arch_discover_hw_caps(void);

--- a/core/arch/hal/riscv/riscv64/hal_cpu.c
+++ b/core/arch/hal/riscv/riscv64/hal_cpu.c
@@ -231,6 +231,24 @@ void hal_cpu_disable_interrupts(void) {
   __asm__ volatile("csrci sstatus, 2");
 #endif
 }
+hal_irq_state_t hal_irq_save_disable(void) {
+  hal_irq_state_t state;
+#ifdef CONFIG_RISCV_M_MODE
+  __asm__ volatile("csrrc %0, mstatus, %1" : "=r"(state) : "r"((hal_irq_state_t)8) : "memory");
+#else
+  __asm__ volatile("csrrc %0, sstatus, %1" : "=r"(state) : "r"((hal_irq_state_t)2) : "memory");
+#endif
+  return state;
+}
+void hal_irq_restore(hal_irq_state_t state) {
+#ifdef CONFIG_RISCV_M_MODE
+  if ((state & 8U) != 0U) __asm__ volatile("csrsi mstatus, 8" ::: "memory");
+  else __asm__ volatile("csrci mstatus, 8" ::: "memory");
+#else
+  if ((state & 2U) != 0U) __asm__ volatile("csrsi sstatus, 2" ::: "memory");
+  else __asm__ volatile("csrci sstatus, 2" ::: "memory");
+#endif
+}
 
 // --- Trap / Interrupt Handling ---
 

--- a/core/arch/hal/x86/x86_64/hal_cpu.c
+++ b/core/arch/hal/x86/x86_64/hal_cpu.c
@@ -224,6 +224,16 @@ void hal_cpu_enable_interrupts(void) { __asm__ volatile("sti"); }
 
 void hal_cpu_disable_interrupts(void) { __asm__ volatile("cli"); }
 
+hal_irq_state_t hal_irq_save_disable(void) {
+  hal_irq_state_t state;
+  __asm__ volatile("pushfq; popq %0; cli" : "=r"(state) :: "memory");
+  return state;
+}
+void hal_irq_restore(hal_irq_state_t state) {
+  if ((state & (1UL << 9)) != 0U) __asm__ volatile("sti" ::: "memory");
+  else __asm__ volatile("cli" ::: "memory");
+}
+
 // --- IDT / TSS Definitions ---
 
 struct tss_entry_struct {

--- a/core/hal/include/hal/hal_cpu.h
+++ b/core/hal/include/hal/hal_cpu.h
@@ -2,6 +2,9 @@
 
 #include <stdint.h>
 
+/* Opaque architecture interrupt mask snapshot, restored only on this CPU. */
+typedef uintptr_t hal_irq_state_t;
+
 struct hal_cpu_info {
     uint32_t logical_id;
     uint32_t cluster_id;
@@ -10,3 +13,7 @@ struct hal_cpu_info {
 
 int hal_cpu_current(void);
 const struct hal_cpu_info *hal_cpu_info(uint32_t cpu_id);
+
+/* Save the local mask and disable interrupts; paired restores preserve nesting. */
+hal_irq_state_t hal_irq_save_disable(void);
+void hal_irq_restore(hal_irq_state_t state);

--- a/core/kernel/CMakeLists.txt
+++ b/core/kernel/CMakeLists.txt
@@ -30,6 +30,9 @@ set(BHARAT_KERNEL_INCLUDE_DIR "${CMAKE_SOURCE_DIR}/core/kernel/include")
 if(NOT EXISTS "${BHARAT_KERNEL_INCLUDE_DIR}/bharat_config.h.in")
     message(FATAL_ERROR "Missing canonical kernel include root: ${BHARAT_KERNEL_INCLUDE_DIR}")
 endif()
+target_include_directories(bharat_kernel_buildopts INTERFACE
+    ${CMAKE_SOURCE_DIR}/core/hal/include
+)
 
 # Define and create the generated include directory in the build tree
 set(BHARAT_GENERATED_INCLUDE_DIR "${CMAKE_BINARY_DIR}/generated/include")
@@ -41,6 +44,7 @@ target_include_directories(bharat_kernel_includes INTERFACE
     ${CMAKE_BINARY_DIR}/generated
     ${CMAKE_SOURCE_DIR}/core/personalities/runtime/include
     ${BHARAT_HAL_ROOT}/include
+    ${CMAKE_SOURCE_DIR}/core/hal/include
     ${CMAKE_SOURCE_DIR}/interface/include
     ${CMAKE_SOURCE_DIR}/interface/uapi
     ${BHARAT_LIB_ROOT}/include

--- a/core/kernel/include/hal/hal.h
+++ b/core/kernel/include/hal/hal.h
@@ -2,6 +2,7 @@
 #define BHARAT_HAL_H
 
 #include <stdint.h>
+#include "hal/hal_cpu.h"
 
 
 /* Hardware Abstraction Layer Base Definitions */

--- a/core/kernel/include/hal/hal_cpu.h
+++ b/core/kernel/include/hal/hal_cpu.h
@@ -1,0 +1,7 @@
+#pragma once
+
+/*
+ * Compatibility forwarding path for kernel-header consumers that do not yet
+ * receive the canonical HAL include root. Do not add contracts here.
+ */
+#include "../../../hal/include/hal/hal_cpu.h"

--- a/core/kernel/include/spinlock.h
+++ b/core/kernel/include/spinlock.h
@@ -3,6 +3,7 @@
 
 #include "atomic.h"
 #include "arch/cpu_relax.h"
+#include "hal/hal_cpu.h"
 
 typedef struct {
     atomic_t locked;
@@ -21,6 +22,16 @@ static inline void spin_lock(spinlock_t* lock) {
 
 static inline void spin_unlock(spinlock_t* lock) {
     __atomic_clear(&lock->locked.value, __ATOMIC_RELEASE);
+}
+
+static inline void spin_lock_irqsave(spinlock_t* lock, hal_irq_state_t* state) {
+    *state = hal_irq_save_disable();
+    spin_lock(lock);
+}
+
+static inline void spin_unlock_irqrestore(spinlock_t* lock, hal_irq_state_t state) {
+    spin_unlock(lock);
+    hal_irq_restore(state);
 }
 
 #endif // BHARAT_SPINLOCK_H

--- a/core/kernel/src/ipc/mk_dispatch.c
+++ b/core/kernel/src/ipc/mk_dispatch.c
@@ -148,10 +148,10 @@ static void mk_handle_thread_handoff_req(mk_channel_t *channel, urpc_msg_t *msg)
     }
 
     // Spinlock/IRQ disable to protect thread state mutation
-    hal_cpu_disable_interrupts();
+    hal_irq_state_t irq_state = hal_irq_save_disable();
 
     if (thread->state != THREAD_STATE_REMOTE_HANDOFF_PENDING) {
-        hal_cpu_enable_interrupts();
+        hal_irq_restore(irq_state);
         urpc_msg_t nack = {
             .type = MK_MSG_THREAD_HANDOFF_NACK,
             .payload_size = 0,
@@ -173,7 +173,7 @@ static void mk_handle_thread_handoff_req(mk_channel_t *channel, urpc_msg_t *msg)
     // and hold no rq locks yet, we can just call sched_enqueue.
     sched_enqueue(thread, local_core);
 
-    hal_cpu_enable_interrupts();
+    hal_irq_restore(irq_state);
 
     // Send ACK
     urpc_msg_t ack = {

--- a/core/kernel/src/mm/pmm/pmm.c
+++ b/core/kernel/src/mm/pmm/pmm.c
@@ -187,12 +187,12 @@ static void *pmm_alloc_pages_order_colored(int order, uint32_t numa_node,
   }
 
   if (order == 0 && core_state && core_state->active && numa_node < 4) {
-      hal_cpu_disable_interrupts();
+      hal_irq_state_t irq_state = hal_irq_save_disable();
       pmm_pcache_t *pcache = &core_state->node_caches[numa_node];
       if (pcache->count > 0) {
           phys_addr_t phys = pcache->pages[--pcache->count];
           pcache->alloc_hits++;
-          hal_cpu_enable_interrupts();
+          hal_irq_restore(irq_state);
 
           page_t *page = phys_to_page(phys);
           if (page) {
@@ -205,18 +205,18 @@ static void *pmm_alloc_pages_order_colored(int order, uint32_t numa_node,
           return (void *)(uintptr_t)phys;
       } else {
           pcache->alloc_misses++;
-          hal_cpu_enable_interrupts();
+          hal_irq_restore(irq_state);
       }
   }
 
   pmm_drain_remote_frees(current_core);  // Retry cache after potentially draining inbox
   if (order == 0 && core_state && core_state->active && numa_node < 4) {
-      hal_cpu_disable_interrupts();
+      hal_irq_state_t irq_state = hal_irq_save_disable();
       pmm_pcache_t *pcache = &core_state->node_caches[numa_node];
       if (pcache->count > 0) {
           phys_addr_t phys = pcache->pages[--pcache->count];
           pcache->alloc_hits++;
-          hal_cpu_enable_interrupts();
+          hal_irq_restore(irq_state);
 
           page_t *page = phys_to_page(phys);
           if (page) {
@@ -228,7 +228,7 @@ static void *pmm_alloc_pages_order_colored(int order, uint32_t numa_node,
           }
           return (void *)(uintptr_t)phys;
       }
-      hal_cpu_enable_interrupts();
+      hal_irq_restore(irq_state);
   }
 
   zone_t *zone = &numa_zones[numa_node];
@@ -237,7 +237,7 @@ static void *pmm_alloc_pages_order_colored(int order, uint32_t numa_node,
 
   // If we missed in cache, attempt to refill a batch for order-0
   if (order == 0 && core_state && core_state->active && numa_node < 4) {
-      hal_cpu_disable_interrupts();
+      hal_irq_state_t irq_state = hal_irq_save_disable();
       pmm_pcache_t *pcache = &core_state->node_caches[numa_node];
       uint32_t refilled = 0;
       int start_color = 0;
@@ -265,7 +265,7 @@ static void *pmm_alloc_pages_order_colored(int order, uint32_t numa_node,
           atomic64_fetch_and_sub_ptr(&numa_nodes[numa_node].free_pages, refilled);
 
           phys_addr_t phys = pcache->pages[--pcache->count];
-          hal_cpu_enable_interrupts();
+          hal_irq_restore(irq_state);
 
           page_t *page = phys_to_page(phys);
           if (page) {
@@ -278,7 +278,7 @@ static void *pmm_alloc_pages_order_colored(int order, uint32_t numa_node,
           spin_unlock(&zone->lock);
           return (void *)(uintptr_t)phys;
       }
-      hal_cpu_enable_interrupts();
+      hal_irq_restore(irq_state);
   }
 
   int start_color = 0;
@@ -1052,7 +1052,7 @@ void mm_free_page(phys_addr_t page_addr) {
   // Local Magazine fast path for order-0 pages
   if (order == 0 && core_state && core_state->active && pmm_numa_node_valid(node_id) && pmm_page_can_enter_pcache(page)) {
       if (pmm_page_owned_by_core(page, current_core)) {
-          hal_cpu_disable_interrupts();
+          hal_irq_state_t irq_state = hal_irq_save_disable();
           pmm_pcache_t *pcache = &core_state->node_caches[node_id];
 
           if (pcache->count < PMM_PCACHE_HIGH) {
@@ -1063,7 +1063,7 @@ void mm_free_page(phys_addr_t page_addr) {
               page->flags = 0;
               page->pin_count = 0;
               page->order = 0;
-              hal_cpu_enable_interrupts();
+              hal_irq_restore(irq_state);
               return;
           } else {
               // Drain batch to zone slow path
@@ -1088,7 +1088,7 @@ void mm_free_page(phys_addr_t page_addr) {
               page->flags = 0;
               page->pin_count = 0;
               page->order = 0;
-              hal_cpu_enable_interrupts();
+              hal_irq_restore(irq_state);
               return;
           }
       } else if (pmm_core_id_valid(page->owner_core_id) && g_pmm_cores[page->owner_core_id].active) {

--- a/core/kernel/src/sched/sched.c
+++ b/core/kernel/src/sched/sched.c
@@ -211,7 +211,7 @@ void sched_detach_thread_from_queues(thread_slot_t *slot) {
   sched_rq_t *rq = sched_local_rq();
   sched_assert_local_rq(rq);
 
-  hal_cpu_disable_interrupts();
+  hal_irq_state_t irq_state = hal_irq_save_disable();
 
   if (slot->is_on_runqueue != 0U) {
     if (rq->policy == SCHED_POLICY_CLOUD_FAIR) {
@@ -236,7 +236,7 @@ void sched_detach_thread_from_queues(thread_slot_t *slot) {
     sched_block_dequeue(slot);
   }
 
-  hal_cpu_enable_interrupts();
+  hal_irq_restore(irq_state);
 }
 
 int sched_enqueue_reap(thread_slot_t *slot) {
@@ -910,15 +910,15 @@ bh_thread_t *sched_pick_next_ready_l1(uint32_t core_id) {
   return sched_pick_next_ready(core_id);
 }
 
-void sched_switch_to(bh_thread_t *next, uint32_t core_id) {
+void sched_switch_to(bh_thread_t *next, uint32_t core_id, hal_irq_state_t irq_state) {
   if (!next) {
-    hal_cpu_enable_interrupts();
+    hal_irq_restore(irq_state);
     return;
   }
 
   bh_thread_t *current = g_cpu_locals[core_id].runqueue.current_thread;
   if (current == next) {
-    hal_cpu_enable_interrupts();
+    hal_irq_restore(irq_state);
     return;
   }
 
@@ -986,6 +986,7 @@ void sched_switch_to(bh_thread_t *next, uint32_t core_id) {
   }
 
   arch_ext_state_restore(next);
+  hal_irq_restore(irq_state);
 }
 
 

--- a/core/kernel/src/sched/sched_core.c
+++ b/core/kernel/src/sched/sched_core.c
@@ -159,6 +159,8 @@ static kstatus_t sched_handle_migrate_activate(uint32_t current_cpu, sched_rq_t 
                 sched_invariant_on_enqueue(thread, current_cpu);
                 if (rq->policy == SCHED_POLICY_CLOUD_FAIR) {
                     sched_cfs_enqueue(rq, thread);
+                } else if (rq->policy == SCHED_POLICY_EDF) {
+                    sched_edf_enqueue(rq, thread);
                 } else {
                     list_add(&entity->run_node, &rq->ready_queue[entity->priority]);
                     sched_ready_bitmap_set(rq, entity->priority);
@@ -237,6 +239,8 @@ static kstatus_t sched_handle_remote_wake(uint32_t current_cpu, sched_rq_t *rq, 
         sched_invariant_on_enqueue(thread, current_cpu);
         if (rq->policy == SCHED_POLICY_CLOUD_FAIR) {
             sched_cfs_enqueue(rq, thread);
+        } else if (rq->policy == SCHED_POLICY_EDF) {
+            sched_edf_enqueue(rq, thread);
         } else {
             list_add(&entity->run_node, &rq->ready_queue[entity->priority]);
             sched_ready_bitmap_set(rq, entity->priority);
@@ -376,7 +380,7 @@ void sched_reschedule(void) {
   sched_reap_terminated_threads();
   sched_process_pending_ai_suggestions();
 
-  hal_cpu_disable_interrupts(); // Fast path local lockless
+  hal_irq_state_t irq_state = hal_irq_save_disable(); // Fast path local lockless
 
   sched_rq_t *rq = &g_cpu_locals[core].runqueue;
 
@@ -442,6 +446,8 @@ void sched_reschedule(void) {
                       sched_invariant_on_dequeue(victim);
                       if (rq->policy == SCHED_POLICY_CLOUD_FAIR) {
                           sched_cfs_dequeue(rq, victim);
+                      } else if (rq->policy == SCHED_POLICY_EDF) {
+                          sched_edf_dequeue(rq, victim);
                       } else {
                           list_del(&v_entity->run_node);
                           list_init(&v_entity->run_node);
@@ -469,13 +475,13 @@ void sched_reschedule(void) {
 
   if (g_cpu_locals[core].runqueue.throttled != 0U && g_cpu_locals[core].runqueue.idle_thread) {
     sched_publish_load(rq);
-    sched_switch_to(g_cpu_locals[core].runqueue.idle_thread, core);
+    sched_switch_to(g_cpu_locals[core].runqueue.idle_thread, core, irq_state);
     return;
   }
 
   bh_thread_t *next = sched_pick_next_ready(core);
   sched_publish_load(rq);
-  sched_switch_to(next, core);
+  sched_switch_to(next, core, irq_state);
 }
 
 

--- a/core/kernel/src/sched/sched_internal.h
+++ b/core/kernel/src/sched/sched_internal.h
@@ -119,7 +119,7 @@ bh_thread_t *sched_validate_picked_candidate(bh_thread_t *candidate,
                                              bh_thread_t *idle,
                                              uint32_t core_id);
 void sched_account_context_switch(sched_rq_t *rq, bh_thread_t *next);
-void sched_switch_to(bh_thread_t *next, uint32_t core_id);
+void sched_switch_to(bh_thread_t *next, uint32_t core_id, hal_irq_state_t irq_state);
 void sched_update_telemetry(bh_thread_t *thread);
 void sched_validate_rq(sched_rq_t *rq);
 

--- a/core/kernel/src/sched/sched_migrate.c
+++ b/core/kernel/src/sched/sched_migrate.c
@@ -247,9 +247,11 @@ int sched_quarantine_thread(bh_thread_t *thread, uint32_t reason) {
       sched_rq_t *rq = sched_local_rq();
       thread_slot_t *slot = sched_find_thread_slot_by_tid_local(rq, thread->thread_id);
       if (slot && slot->is_on_runqueue) {
-          hal_cpu_disable_interrupts();
+          hal_irq_state_t irq_state = hal_irq_save_disable();
           if (rq->policy == SCHED_POLICY_CLOUD_FAIR) {
             sched_cfs_dequeue(rq, thread);
+          } else if (rq->policy == SCHED_POLICY_EDF) {
+            sched_edf_dequeue(rq, thread);
           } else {
             list_del(&slot->run_node);
             list_init(&slot->run_node);
@@ -259,7 +261,7 @@ int sched_quarantine_thread(bh_thread_t *thread, uint32_t reason) {
           if (rq->runnable_count > 0U) {
             rq->runnable_count--;
           }
-          hal_cpu_enable_interrupts();
+          hal_irq_restore(irq_state);
       }
   }
 
@@ -332,10 +334,10 @@ int sched_request_handoff_tid(uint64_t tid, uint32_t target_cpu, uint32_t auth_t
     return -1;
   }
 
-  hal_cpu_disable_interrupts();
+  hal_irq_state_t irq_state = hal_irq_save_disable();
 
   if (thread->state != THREAD_STATE_READY) {
-    hal_cpu_enable_interrupts();
+    hal_irq_restore(irq_state);
     return -2;
   }
 
@@ -344,6 +346,8 @@ int sched_request_handoff_tid(uint64_t tid, uint32_t target_cpu, uint32_t auth_t
   if (slot->is_on_runqueue != 0U) {
     if (rq->policy == SCHED_POLICY_CLOUD_FAIR) {
       sched_cfs_dequeue(rq, thread);
+    } else if (rq->policy == SCHED_POLICY_EDF) {
+      sched_edf_dequeue(rq, thread);
     } else {
       list_del(&slot->run_node);
       list_init(&slot->run_node);
@@ -357,21 +361,23 @@ int sched_request_handoff_tid(uint64_t tid, uint32_t target_cpu, uint32_t auth_t
 
   thread->state = THREAD_STATE_REMOTE_HANDOFF_PENDING;
 
-  hal_cpu_enable_interrupts();
+  hal_irq_restore(irq_state);
 
   mk_channel_t channel;
   if (mk_get_channel(current_core, target_cpu, &channel) != 0) {
-    hal_cpu_disable_interrupts();
+    hal_irq_state_t irq_state = hal_irq_save_disable();
     thread->state = THREAD_STATE_READY;
     if (rq->policy == SCHED_POLICY_CLOUD_FAIR) {
       sched_cfs_enqueue(rq, thread);
+    } else if (rq->policy == SCHED_POLICY_EDF) {
+      sched_edf_enqueue(rq, thread);
     } else {
       list_add(&slot->run_node, &rq->ready_queue[thread->priority]);
       sched_ready_bitmap_set(rq, thread->priority);
     }
     slot->is_on_runqueue = 1U;
     rq->runnable_count++;
-    hal_cpu_enable_interrupts();
+    hal_irq_restore(irq_state);
     return -3;
   }
 
@@ -394,17 +400,19 @@ int sched_request_handoff_tid(uint64_t tid, uint32_t target_cpu, uint32_t auth_t
 
   int ret = mk_send_message(&channel, msg.type, msg.payload_data, msg.payload_size);
   if (ret != 0) {
-      hal_cpu_disable_interrupts();
+      hal_irq_state_t irq_state = hal_irq_save_disable();
       thread->state = THREAD_STATE_READY;
       if (rq->policy == SCHED_POLICY_CLOUD_FAIR) {
         sched_cfs_enqueue(rq, thread);
+      } else if (rq->policy == SCHED_POLICY_EDF) {
+        sched_edf_enqueue(rq, thread);
       } else {
         list_add(&slot->run_node, &rq->ready_queue[thread->priority]);
         sched_ready_bitmap_set(rq, thread->priority);
       }
       slot->is_on_runqueue = 1U;
       rq->runnable_count++;
-      hal_cpu_enable_interrupts();
+      hal_irq_restore(irq_state);
       return -4;
   }
 

--- a/core/kernel/src/sched/sched_pi.c
+++ b/core/kernel/src/sched/sched_pi.c
@@ -66,7 +66,7 @@ int sched_adjust_priority_local(bh_thread_t *thread, uint32_t new_priority) {
   thread_slot_t *slot = sched_find_thread_slot_by_tid(thread->thread_id);
 
   if (slot && slot->is_on_runqueue != 0U) {
-    hal_cpu_disable_interrupts();
+    hal_irq_state_t irq_state = hal_irq_save_disable();
 
     if (rq->policy == SCHED_POLICY_CLOUD_FAIR) {
       sched_cfs_dequeue(rq, thread);
@@ -81,7 +81,7 @@ int sched_adjust_priority_local(bh_thread_t *thread, uint32_t new_priority) {
       rq->runnable_count--;
     }
 
-    hal_cpu_enable_interrupts();
+    hal_irq_restore(irq_state);
   }
 
   thread->priority = new_priority;

--- a/core/kernel/src/sched/sched_runqueue.c
+++ b/core/kernel/src/sched/sched_runqueue.c
@@ -45,13 +45,13 @@ int sched_enqueue(bh_thread_t *thread, uint32_t core_id) {
 
   sched_rq_t *rq = sched_local_rq();
 
-  hal_cpu_disable_interrupts();
+  hal_irq_state_t irq_state = hal_irq_save_disable();
 
   sched_entity_t *entity = sched_find_entity_by_thread(thread);
   if (!entity) {
     entity = sched_allocate_entity(current_core);
     if (!entity) {
-      hal_cpu_enable_interrupts();
+      hal_irq_restore(irq_state);
       return -1;
     }
     entity->tid = thread->thread_id;
@@ -121,7 +121,7 @@ int sched_enqueue(bh_thread_t *thread, uint32_t core_id) {
 
   sched_validate_rq(rq);
 
-  hal_cpu_enable_interrupts();
+  hal_irq_restore(irq_state);
   return 0;
 }
 
@@ -170,6 +170,8 @@ static void sched_dequeue_task_l0(bh_thread_t *thread, uint32_t core_id) {
     sched_invariant_on_dequeue(thread);
     if (rq->policy == SCHED_POLICY_CLOUD_FAIR) {
       sched_cfs_dequeue(rq, thread);
+    } else if (rq->policy == SCHED_POLICY_EDF) {
+      sched_edf_dequeue(rq, thread);
     } else {
       list_del(&entity->run_node);
       list_init(&entity->run_node);

--- a/core/kernel/src/sched/sched_thread.c
+++ b/core/kernel/src/sched/sched_thread.c
@@ -65,14 +65,14 @@ kstatus_t thread_destroy(bh_thread_t *thread) {
   }
 
   // Prevent race with background reaper or other cores
-  hal_cpu_disable_interrupts();
+  hal_irq_state_t irq_state = hal_irq_save_disable();
   
   spin_lock(&rq->lock);
   
   if (slot->reap_pending != 0U) {
       // Thread is already being reaped, let the reaper finish it
       spin_unlock(&rq->lock);
-      hal_cpu_enable_interrupts();
+      hal_irq_restore(irq_state);
       return K_OK;
   }
   
@@ -112,7 +112,7 @@ kstatus_t thread_destroy(bh_thread_t *thread) {
   }
   spin_unlock(&rq->lock);
 
-  hal_cpu_enable_interrupts();
+  hal_irq_restore(irq_state);
   return K_OK;
 }
 

--- a/core/kernel/src/tests/ktest_rt_sched.c
+++ b/core/kernel/src/tests/ktest_rt_sched.c
@@ -9,6 +9,7 @@ extern void sched_test_reset(void);
 extern void sched_set_test_core_count(uint32_t core_count);
 #endif
 extern bh_thread_t *sched_pick_next_ready_l0(uint32_t core_id);
+extern void sched_dequeue_task_l1(bh_thread_t *thread, uint32_t core_id);
 
 static void dummy_thread_entry(void) {
     while (1) {
@@ -94,6 +95,14 @@ static bool test_edf_admission_and_queue(void) {
     t2->absolute_deadline_ms = 50;
 
     // Enqueue T1 and T2
+    sched_enqueue(t1, 0);
+    sched_enqueue(t2, 0);
+
+    /* Generic lifecycle dequeue must erase the EDF tree node. */
+    sched_dequeue_task_l1(t2, 0);
+    bh_thread_t *after_dequeue = sched_pick_next_ready_l0(0);
+    KTEST_ASSERT(after_dequeue == t1,
+                 "EDF lifecycle dequeue must remove the earliest deadline task");
     sched_enqueue(t1, 0);
     sched_enqueue(t2, 0);
 

--- a/docs/adr/ADR-033-interrupt-state-preserving-locking.md
+++ b/docs/adr/ADR-033-interrupt-state-preserving-locking.md
@@ -1,0 +1,44 @@
+# ADR-033: Interrupt-state-preserving kernel locking
+
+## Status
+
+Accepted (2026-08-13)
+
+## Decision
+
+Architecture HAL CPU backends expose `hal_irq_save_disable()` and
+`hal_irq_restore()`. The saved value is opaque outside the implementing
+architecture, is CPU-local, and must be restored on the same CPU before the
+protected operation returns. Nested callers therefore preserve the interrupt
+mask present at entry instead of unconditionally enabling interrupts.
+
+Kernel code that disables interrupts temporarily must use this paired contract.
+Code that also takes a spinlock may use `spin_lock_irqsave()` and
+`spin_unlock_irqrestore()`. Lock order is interrupt masking before spinlock
+acquisition, then spinlock release before interrupt-state restoration. Saved
+state must never be placed in an IPC message, retained across migration, or
+restored by another CPU.
+
+Explicit `hal_cpu_enable_interrupts()` remains valid only for lifecycle
+transitions whose contract intentionally establishes an interrupt-enabled
+execution context, such as boot handoff and scheduler dispatch. It is not a
+valid critical-section exit operation.
+
+## Invariant and failure behavior
+
+The invariant is: a function must never make interrupts more enabled than they
+were on entry. Restore uses the architecture snapshot rather than inferred
+software state. Invalid cross-CPU or unmatched restoration is a caller contract
+violation; the snapshot is deliberately not a transferable kernel object.
+
+## Architecture mapping
+
+- x86_64 snapshots RFLAGS and restores the interrupt-enable bit.
+- AArch64 snapshots DAIF and restores its interrupt mask.
+- ARM32 snapshots CPSR and restores its interrupt mask bits.
+- RISC-V snapshots the active privilege status CSR and restores its global
+  interrupt-enable bit.
+
+Host tests prove nested save/restore and IRQ-safe spinlock behavior. The five
+architecture build-and-smoke matrix provides compile and runtime integration
+evidence for each backend.

--- a/docs/architecture/interrupt/interrupt-architecture.md
+++ b/docs/architecture/interrupt/interrupt-architecture.md
@@ -16,6 +16,10 @@ see_also:
 
 Bharat-OS employs a **three-layer interrupt architecture** to provide a robust, hardware-agnostic, and feature-rich interrupt handling system. This design decouples the generic OS-level interrupt handling from the specific hardware controller details, allowing for extensibility, clean porting, and support for advanced features like MSI/MSI-X, virtualization, and accelerator profiles.
 
+Local critical sections use the state-preserving HAL contract described by
+ADR-033. Temporary interrupt masking restores the entry state. Saved state is
+CPU-local and cannot cross migration or wire boundaries.
+
 The architecture strictly separates intent and routing from the hardware mechanisms.
 
 ## Three-Layer Architecture

--- a/docs/architecture/kernel/scheduler/README.md
+++ b/docs/architecture/kernel/scheduler/README.md
@@ -2,7 +2,7 @@
 title: Kernel Scheduler Documentation
 status: Proposed
 owner: Documentation Working Group
-last_updated: 2026-04-25
+last_updated: 2026-08-13
 tags:
   - docs
   - architecture
@@ -33,6 +33,21 @@ The scheduler implementation lives primarily in:
 - RT admissions (`sched_admission_edf`, `sched_admission_rms`) with utilization budgets.
 - AI suggestion ingestion and bounded application path (`sched_enqueue_ai_suggestion`, `sched_process_pending_ai_suggestions`).
 - Cross-core migration and balancing primitives (`sched_migrate_task`, periodic `sched_balance_once`).
+
+## Policy lifecycle symmetry
+
+Every runnable transition uses the owner core policy's backing runqueue. RR,
+priority, and RMS use priority lists; cloud-fair uses the CFS tree; EDF uses the
+EDF tree. This applies to enqueue/dequeue, block/wake, termination, quarantine,
+migration/rollback, priority changes, PI, and work stealing. EDF removal must
+call `sched_edf_dequeue()` and never apply `list_del()` to its priority-list node.
+
+| Transition | RR | Priority | CFS | EDF | RMS |
+| --- | --- | --- | --- | --- | --- |
+| enqueue / wake | list | list | CFS tree | EDF tree | list |
+| dequeue / block / terminate | list | list | CFS tree | EDF tree | list |
+| migration / rollback | list | list | CFS tree | EDF tree | list |
+| priority / PI | list | list | CFS tree | EDF tree | list |
 
 ## Documents in this folder
 

--- a/quality/tests/host/CMakeLists.txt
+++ b/quality/tests/host/CMakeLists.txt
@@ -132,6 +132,10 @@ add_executable(test_pmm_pcache test_pmm_pcache.c ../../kernel/src/mm/pmm/pmm.c .
 target_include_directories(test_pmm_pcache PRIVATE ${CMAKE_SOURCE_DIR}/core/kernel/include ${CMAKE_SOURCE_DIR}/core/kernel/src ${CMAKE_SOURCE_DIR}/interface/include ${CMAKE_SOURCE_DIR}/core/lib/include ${CMAKE_SOURCE_DIR}/core/boot/include)
 add_test(NAME host_test_pmm_pcache COMMAND test_pmm_pcache)
 set_tests_properties(host_test_pmm_pcache PROPERTIES LABELS "pmm")
+
+add_executable(test_irq_state test_irq_state.c)
+target_include_directories(test_irq_state PRIVATE ${CMAKE_SOURCE_DIR}/core/kernel/include ${CMAKE_SOURCE_DIR}/core/hal/include)
+add_test(NAME host_test_irq_state COMMAND test_irq_state)
 add_executable(test_netmgr_interface_table services/test_netmgr_interface_table.c ../../core/services/netmgr/src/interface_table.c ../../core/lib/runtime/src/freestanding_string.c)
 target_include_directories(test_netmgr_interface_table PRIVATE ../../core/services/netmgr/src ../../core/services/netmgr/include ../../core/services/core/subsysmgr/include ../../core/lib/net/include ../../core/lib/runtime/include)
 add_test(NAME host_test_netmgr_interface_table COMMAND test_netmgr_interface_table)

--- a/quality/tests/host/test_irq_state.c
+++ b/quality/tests/host/test_irq_state.c
@@ -1,0 +1,58 @@
+#include "spinlock.h"
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdio.h>
+
+static bool interrupts_enabled;
+
+void arch_cpu_relax(void) {}
+
+hal_irq_state_t hal_irq_save_disable(void) {
+  hal_irq_state_t state = interrupts_enabled ? 1U : 0U;
+  interrupts_enabled = false;
+  return state;
+}
+
+void hal_irq_restore(hal_irq_state_t state) {
+  interrupts_enabled = state != 0U;
+}
+
+static void test_nested_save_restore(void) {
+  interrupts_enabled = true;
+  hal_irq_state_t outer = hal_irq_save_disable();
+  hal_irq_state_t inner = hal_irq_save_disable();
+
+  assert(!interrupts_enabled);
+  hal_irq_restore(inner);
+  assert(!interrupts_enabled);
+  hal_irq_restore(outer);
+  assert(interrupts_enabled);
+}
+
+static void test_disabled_entry_remains_disabled(void) {
+  interrupts_enabled = false;
+  hal_irq_state_t state = hal_irq_save_disable();
+  hal_irq_restore(state);
+  assert(!interrupts_enabled);
+}
+
+static void test_spin_lock_irqsave_nesting(void) {
+  spinlock_t lock;
+  spin_lock_init(&lock);
+  interrupts_enabled = false;
+
+  hal_irq_state_t state;
+  spin_lock_irqsave(&lock, &state);
+  assert(!interrupts_enabled);
+  spin_unlock_irqrestore(&lock, state);
+  assert(!interrupts_enabled);
+}
+
+int main(void) {
+  test_nested_save_restore();
+  test_disabled_entry_remains_disabled();
+  test_spin_lock_irqsave_nesting();
+  puts("IRQ state nesting tests passed");
+  return 0;
+}


### PR DESCRIPTION
### Motivation

- Prevent unsafe interrupt re-enables and nested-IRQ bugs by providing a save/restore HAL contract instead of unconditional `enable` calls.  
- Provide irq-safe spinlock primitives so critical sections can atomically combine locking and IRQ masking without breaking caller nesting invariants.  
- Fix a correctness hole where EDF tasks were sometimes dequeued via the priority-list path, violating policy symmetry and risking scheduler corruption.

### Description

- Introduce `hal_irq_state_t` and the paired HAL contract `hal_irq_save_disable()` / `hal_irq_restore()` in the canonical HAL include and implement it for x86_64, AArch64, ARM32, RISC-V64 and RISC-V32.  
- Add `spin_lock_irqsave()` / `spin_unlock_irqrestore()` to `spinlock.h` and migrate temporary IRQ-masking call sites in PMM, scheduler, IPC, migration, thread lifecycle, and related paths from `hal_cpu_disable_interrupts()`/`hal_cpu_enable_interrupts()` to save/restore semantics.  
- Fix scheduler policy symmetry by routing EDF lifecycle transitions to `sched_edf_enqueue()`/`sched_edf_dequeue()` across enqueue/dequeue/migration/wake/quarantine/steal paths, and thread the saved IRQ snapshot through `sched_switch_to()` so the IRQ state is restored after context switch.  
- Add ADR-033 documenting the invariant and mapping rules, a host unit test `quality/tests/host/test_irq_state.c` exercising nested save/restore and `spin_lock_irqsave()` semantics, and update scheduler docs and CMake targets to include the new test and HAL headers.

### Testing

- Built and ran the host unit `test_irq_state` via `cc` and the binary executed successfully (`IRQ state nesting tests passed`).  
- Ran repository linters and contract checks with `python3 tools/lint/check_layer_references.py`, `python3 tools/lint/check_cmake_dependencies.py` and `python3 tools/abi/syscall_abi.py --check`, all of which passed.  
- Performed focused kernel builds including `k_sched` and full-target smoke builds using `./tools/build.sh all --target-yaml delivery/targets/qemu/<arch>_desktop_headless.yaml --smoke` for all five required targets, and each target completed its smoke run (PASS).  
- Executed the QEMU matrix runner `python3 tools/run_qemu_matrix.py --headless --smoke --all-arch` and observed the multi-arch smoke gate pass for the required architectures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7dc8cb91a88320b8bc1c010425b088)