### PR TITLE
core: fix unused variable warning for mpu_translate_ops

### DIFF
--- a/core/hal/common/hal_pt_mpu.c
+++ b/core/hal/common/hal_pt_mpu.c
@@ -13,7 +13,7 @@ static bool mpu_has_linear_physmap(void) { return true; }
 static phys_addr_t mpu_linear_physmap_base(void) { return 0; }
 static phys_addr_t mpu_linear_physmap_limit(void) { return ~0ULL; }
 
-static const hal_translate_ops_t mpu_translate_ops = {
+static const hal_translate_ops_t mpu_translate_ops __attribute__((unused)) = {
     .backend_type = mpu_backend_type,
     .exec_class = mpu_exec_class,
     .phys_to_virt = mpu_phys_to_virt,


### PR DESCRIPTION
Fixes a compiler warning in `core/hal/common/hal_pt_mpu.c` where `mpu_translate_ops` was declared but not used, causing build failures when warnings are treated as errors. Added `__attribute__((unused))` to explicitly mark it and suppress the warning.

---
*PR created automatically by Jules for task [3643960891955998675](https://jules.google.com/task/3643960891955998675) started by @divyang4481*