### PR TITLE
Fix SDK build header dependencies

### DIFF
--- a/interface/sdk/CMakeLists.txt
+++ b/interface/sdk/CMakeLists.txt
@@ -32,6 +32,8 @@ foreach(component process ipc device cap)
     target_compile_features(bharat_${component} PUBLIC c_std_11)
     target_include_directories(bharat_${component} PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../uapi>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
     target_include_directories(bharat_${component} PRIVATE lib/internal)
     target_link_libraries(bharat_${component} PUBLIC bharat_core)

--- a/interface/sdk/examples/accelerator_relu/main.c
+++ b/interface/sdk/examples/accelerator_relu/main.c
@@ -1,3 +1,4 @@
 #include <bharat/accel.h>
 #include <bharat/os.h>
+#include <bharat/device.h>
 int main(void) { bh_device_info_t info = {.struct_size = sizeof(info)}; bh_status_t status = bh_device_find(BH_DEVICE_CLASS_ACCELERATOR, 0, &info); if (status == BH_ERR_UNSUPPORTED) return bh_log("accelerator: unavailable on hosted v0.1 backend\n") != BH_OK; return status != BH_OK; }

--- a/interface/sdk/examples/sensor_reader/main.c
+++ b/interface/sdk/examples/sensor_reader/main.c
@@ -1,3 +1,4 @@
 #include <bharat/os.h>
 #include <bharat/sensor.h>
+#include <bharat/device.h>
 int main(void) { bh_device_info_t info = {.struct_size = sizeof(info)}; bh_status_t status = bh_device_find(BH_DEVICE_CLASS_SENSOR, 0, &info); if (status == BH_ERR_UNSUPPORTED) return bh_log("sensor: unavailable on hosted v0.1 backend\n") != BH_OK; return status != BH_OK; }

--- a/interface/sdk/lib/memory/hmem.c
+++ b/interface/sdk/lib/memory/hmem.c
@@ -2,6 +2,7 @@
 #include <bharat/hmem.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdint.h>
 
 #define HOST_HMEM_SLOTS 64U
 typedef struct {


### PR DESCRIPTION
Fixes the SDK aggregate build failure caused by missing header includes and paths.

---
*PR created automatically by Jules for task [286773055143500290](https://jules.google.com/task/286773055143500290) started by @divyang4481*