### PR TITLE
test(gui): add QMP visual smoke harness

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -400,6 +400,26 @@ userspace boot markers before passing:
 ./tools/build.sh all --target-yaml delivery/targets/qemu/x86_64_showcase_gui.yaml --headless --smoke
 ```
 
+For pixel-level evidence, use the GUI visual smoke harness. Unlike the serial
+smoke command, this command builds and packages from the target YAML, starts a
+windowless QEMU display with private serial and QMP channels, waits for the
+display and first-present markers, and validates a QMP `screendump` against the
+mode reported by the guest:
+
+```bash
+python3 tools/test/qemu_gui_smoke.py \
+  --target delivery/targets/qemu/x86_64_showcase_gui.yaml
+```
+
+The test rejects malformed captures, dimension mismatches, fewer than eight
+distinct RGB colors, or a frame where less than one percent of pixels differ
+from the dominant color. These thresholds may be made stricter with
+`--minimum-colors` and `--minimum-non-dominant-ratio`; lowering them is intended
+only for focused diagnosis, not for CI. The default evidence directory is
+`build/<preset>/artifacts/gui-smoke/` and contains `first-frame.ppm`,
+`serial.log`, and `qemu.log`. These are generated evidence and must not be
+committed.
+
 ## 5.1 Canonical headless smoke-test commands (all 5 architectures)
 
 All commands verified with `[Run] PASS` on QEMU. Build + package + run in one shot.

--- a/docs/demo/gui-showcase.md
+++ b/docs/demo/gui-showcase.md
@@ -53,13 +53,26 @@ Build, package, and run the dedicated 512 MiB x86_64 graphical target:
 python3 tools/build.py run --target-yaml delivery/targets/qemu/x86_64_showcase_gui.yaml
 ```
 
-Expected serial milestones include `UI_NATIVE: SPLASH_VISIBLE` followed by
-`UI_NATIVE: HOME_VISIBLE`. The latter means the desktop launcher is visible.
+Expected serial milestones include `[gui] display-ready width=<w> height=<h>`
+and `[gui] first-frame-presented`. To prove pixels rather than only control-flow
+progress, run the visual gate:
+
+```bash
+python3 tools/test/qemu_gui_smoke.py \
+  --target delivery/targets/qemu/x86_64_showcase_gui.yaml
+```
+
+The harness retains the QMP screenshot and serial/QEMU logs under
+`build/x86_64-dev/artifacts/gui-smoke/`. It fails when the captured dimensions
+disagree with the broker-queried mode or when scanout is blank/uniform.
 
 ## Boundaries and limitations
 
-- The native showcase still uses simulated display-broker IPC and an off-screen
-  buffer; this target does not yet prove virtio-gpu scanout.
+- The native showcase now exercises display-broker v2 session, lease, surface,
+  buffer, and present operations. Its client mapping is still process-local
+  until kernel-mediated shared-buffer mapping and the x86_64 scanout backend are
+  complete; consequently the visual smoke gate is expected to expose, rather
+  than conceal, a uniform or stale QEMU scanout.
 - Input-manager event draining is wired, but the showcase stub returns no physical
   events until it is replaced by the QEMU input service connection.
 - Runtime data is intentionally injected through a provider. The UI never reads

--- a/docs/gui/GUI_PRODUCT_P0_PLAN.md
+++ b/docs/gui/GUI_PRODUCT_P0_PLAN.md
@@ -38,10 +38,12 @@ proof that QEMU received pixels. GUI-002 must therefore reject a uniform
 screenshot even when the marker is present. The architecture must not be bypassed
 with a raw framebuffer pointer.
 
-## GUI-002 — QEMU visual smoke harness (next P0)
+## GUI-002 — QEMU visual smoke harness (implemented; visual gate pending)
 
-Add `tools/test/qemu_gui_smoke.py` with the canonical target
-`delivery/targets/qemu/x86_64_showcase_gui.yaml` as its default.
+`tools/test/qemu_gui_smoke.py` uses the canonical target
+`delivery/targets/qemu/x86_64_showcase_gui.yaml` as its default. The host unit
+suite covers command construction, marker timeout and parsing, malformed PPM,
+dimension mismatch, uniform and successful frames, and forced termination.
 
 1. Validate and build exclusively from the target YAML.
 2. Start QEMU with a serial log and a private QMP socket.

--- a/tools/test/__init__.py
+++ b/tools/test/__init__.py
@@ -1,0 +1,1 @@
+"""Host-side integration test tools."""

--- a/tools/test/qemu_gui_smoke.py
+++ b/tools/test/qemu_gui_smoke.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+"""Build a GUI target and prove that QEMU scanout contains a real frame."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import socket
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import BinaryIO
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools.build.paths import get_manifest_dir, get_output_root
+from tools.build.target_resolver import resolve_yaml_target
+from tools.run.runner_qemu import build_qemu_command, load_run_manifest
+
+DEFAULT_TARGET = REPO_ROOT / "delivery/targets/qemu/x86_64_showcase_gui.yaml"
+DISPLAY_MARKER = "[gui] display-ready"
+FRAME_MARKER = "[gui] first-frame-presented"
+MODE_PATTERN = re.compile(r"\[gui\] display-ready width=(\d+) height=(\d+)")
+FORBIDDEN_MARKERS = ("PANIC", "ASSERT", "FAULT", "Unhandled exception")
+
+
+class GuiSmokeError(RuntimeError):
+    """A stable, user-facing visual smoke failure."""
+
+
+@dataclass(frozen=True)
+class PpmImage:
+    width: int
+    height: int
+    pixels: bytes
+
+
+def _ppm_token(stream: BinaryIO) -> bytes:
+    token = bytearray()
+    while True:
+        byte = stream.read(1)
+        if not byte:
+            raise GuiSmokeError("malformed PPM: unexpected end of header")
+        if byte == b"#":
+            stream.readline()
+            continue
+        if not byte.isspace():
+            token.extend(byte)
+            break
+    while True:
+        byte = stream.read(1)
+        if not byte or byte.isspace():
+            return bytes(token)
+        token.extend(byte)
+
+
+def read_ppm(path: Path) -> PpmImage:
+    """Read the binary P6 subset emitted by QEMU's screendump command."""
+    try:
+        with path.open("rb") as stream:
+            magic = _ppm_token(stream)
+            width_raw = _ppm_token(stream)
+            height_raw = _ppm_token(stream)
+            max_value_raw = _ppm_token(stream)
+            if magic != b"P6":
+                raise GuiSmokeError("malformed PPM: expected P6 magic")
+            try:
+                width = int(width_raw)
+                height = int(height_raw)
+                max_value = int(max_value_raw)
+            except ValueError as exc:
+                raise GuiSmokeError("malformed PPM: non-numeric dimensions") from exc
+            if width <= 0 or height <= 0 or max_value != 255:
+                raise GuiSmokeError("malformed PPM: invalid dimensions or max value")
+            expected_size = width * height * 3
+            pixels = stream.read()
+    except OSError as exc:
+        raise GuiSmokeError(f"cannot read screenshot: {exc}") from exc
+    if len(pixels) != expected_size:
+        raise GuiSmokeError(
+            f"malformed PPM: expected {expected_size} pixel bytes, got {len(pixels)}"
+        )
+    return PpmImage(width, height, pixels)
+
+
+def validate_frame(
+    image: PpmImage,
+    expected_width: int,
+    expected_height: int,
+    *,
+    minimum_colors: int = 8,
+    minimum_non_dominant_ratio: float = 0.01,
+) -> tuple[int, float]:
+    """Reject dimensions that disagree with the guest and blank/uniform scanout."""
+    if (image.width, image.height) != (expected_width, expected_height):
+        raise GuiSmokeError(
+            "screenshot dimensions "
+            f"{image.width}x{image.height} do not match guest mode "
+            f"{expected_width}x{expected_height}"
+        )
+    counts: dict[bytes, int] = {}
+    for offset in range(0, len(image.pixels), 3):
+        pixel = image.pixels[offset : offset + 3]
+        counts[pixel] = counts.get(pixel, 0) + 1
+    pixel_count = image.width * image.height
+    dominant = max(counts.values())
+    non_dominant_ratio = (pixel_count - dominant) / pixel_count
+    if len(counts) < minimum_colors or non_dominant_ratio < minimum_non_dominant_ratio:
+        raise GuiSmokeError(
+            "scanout is blank or uniform: "
+            f"colors={len(counts)} non_dominant_ratio={non_dominant_ratio:.6f}; "
+            f"required colors>={minimum_colors} ratio>={minimum_non_dominant_ratio:.6f}"
+        )
+    return len(counts), non_dominant_ratio
+
+
+def make_qemu_command(manifest: dict, serial_log: Path, qmp_socket: Path) -> list[str]:
+    """Construct a windowless QEMU command while retaining the emulated display."""
+    base = build_qemu_command(manifest, display_override="headless")
+    command: list[str] = []
+    index = 0
+    while index < len(base):
+        argument = base[index]
+        if argument == "-nographic":
+            index += 1
+            continue
+        if argument in ("-serial", "-display"):
+            index += 2
+            continue
+        command.append(argument)
+        index += 1
+    command.extend(
+        [
+            "-display",
+            "none",
+            "-serial",
+            f"file:{serial_log}",
+            "-qmp",
+            f"unix:{qmp_socket},server=on,wait=off",
+        ]
+    )
+    return command
+
+
+class QmpClient:
+    def __init__(self, path: Path, deadline: float):
+        self._socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        while True:
+            try:
+                self._socket.connect(str(path))
+                break
+            except (FileNotFoundError, ConnectionRefusedError):
+                if time.monotonic() >= deadline:
+                    self._socket.close()
+                    raise GuiSmokeError("timed out connecting to QMP")
+                time.sleep(0.05)
+        remaining = max(0.1, deadline - time.monotonic())
+        self._socket.settimeout(remaining)
+        self._stream = self._socket.makefile("rwb", buffering=0)
+        greeting = self._read_response()
+        if "QMP" not in greeting:
+            self.close()
+            raise GuiSmokeError("QMP greeting was missing")
+        self.execute("qmp_capabilities")
+
+    def _read_response(self) -> dict:
+        while True:
+            line = self._stream.readline()
+            if not line:
+                raise GuiSmokeError("QMP connection closed unexpectedly")
+            try:
+                response = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise GuiSmokeError("QMP returned malformed JSON") from exc
+            if "event" not in response:
+                return response
+
+    def execute(self, name: str, arguments: dict | None = None) -> dict:
+        request: dict[str, object] = {"execute": name}
+        if arguments:
+            request["arguments"] = arguments
+        self._stream.write(json.dumps(request).encode("utf-8") + b"\r\n")
+        response = self._read_response()
+        if "error" in response:
+            description = response["error"].get("desc", "unknown QMP error")
+            raise GuiSmokeError(f"QMP {name} failed: {description}")
+        return response
+
+    def close(self) -> None:
+        try:
+            self._stream.close()
+        finally:
+            self._socket.close()
+
+
+def wait_for_markers(serial_log: Path, process: subprocess.Popen, deadline: float) -> tuple[int, int]:
+    observed_display = False
+    observed_frame = False
+    width = 0
+    height = 0
+    consumed = 0
+    while time.monotonic() < deadline:
+        if serial_log.exists():
+            content = serial_log.read_text(encoding="utf-8", errors="replace")
+            new_content = content[consumed:]
+            consumed = len(content)
+            for forbidden in FORBIDDEN_MARKERS:
+                if forbidden in new_content:
+                    raise GuiSmokeError(f"forbidden serial marker observed: {forbidden}")
+            match = MODE_PATTERN.search(content)
+            if match:
+                width, height = int(match.group(1)), int(match.group(2))
+                observed_display = True
+            observed_frame = FRAME_MARKER in content
+            if observed_display and observed_frame:
+                return width, height
+        return_code = process.poll()
+        if return_code is not None:
+            raise GuiSmokeError(
+                f"QEMU exited with status {return_code} before the first-frame markers"
+            )
+        time.sleep(0.05)
+    missing = []
+    if not observed_display:
+        missing.append(DISPLAY_MARKER)
+    if not observed_frame:
+        missing.append(FRAME_MARKER)
+    raise GuiSmokeError(f"timed out waiting for serial markers: {', '.join(missing)}")
+
+
+def stop_qemu(process: subprocess.Popen, qmp: QmpClient | None) -> bool:
+    """Request a clean QMP shutdown, falling back to bounded termination."""
+    forced = False
+    if process.poll() is not None:
+        return forced
+    if qmp is not None:
+        try:
+            qmp.execute("quit")
+        except (GuiSmokeError, OSError):
+            forced = True
+    try:
+        process.wait(timeout=3)
+    except subprocess.TimeoutExpired:
+        forced = True
+        process.terminate()
+        try:
+            process.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=2)
+    return forced
+
+
+def run_checked(command: list[str]) -> None:
+    print(f"[gui-smoke] command: {' '.join(command)}", flush=True)
+    result = subprocess.run(command, cwd=REPO_ROOT, check=False)
+    if result.returncode != 0:
+        raise GuiSmokeError(
+            f"command failed with status {result.returncode}: {' '.join(command)}"
+        )
+
+
+def run_smoke(args: argparse.Namespace) -> None:
+    target_path = args.target.resolve()
+    target = resolve_yaml_target(target_path)
+    if target.arch != "x86_64" or target.run is None or target.run.nographic:
+        raise GuiSmokeError("GUI-002 currently requires an x86_64 graphical QEMU target")
+
+    run_checked([sys.executable, "tools/build.py", "build", "--target-yaml", str(target_path)])
+    run_checked([sys.executable, "tools/build.py", "package", "--target-yaml", str(target_path)])
+
+    manifest_path = get_manifest_dir(target, REPO_ROOT) / "run-manifest.json"
+    manifest = load_run_manifest(manifest_path)
+    artifact_dir = args.artifact_dir or get_output_root(target, REPO_ROOT) / "artifacts/gui-smoke"
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    serial_log = artifact_dir / "serial.log"
+    qemu_log = artifact_dir / "qemu.log"
+    screenshot = artifact_dir / "first-frame.ppm"
+    qmp_socket = artifact_dir / "qmp.sock"
+    for path in (serial_log, qemu_log, screenshot, qmp_socket):
+        path.unlink(missing_ok=True)
+
+    command = make_qemu_command(manifest, serial_log, qmp_socket)
+    print(f"[gui-smoke] target: {target_path}")
+    print(f"[gui-smoke] qemu: {' '.join(command)}", flush=True)
+    deadline = time.monotonic() + args.timeout
+    process: subprocess.Popen | None = None
+    qmp: QmpClient | None = None
+    forced = False
+    try:
+        with qemu_log.open("wb") as diagnostics:
+            process = subprocess.Popen(
+                command,
+                cwd=REPO_ROOT,
+                stdin=subprocess.DEVNULL,
+                stdout=diagnostics,
+                stderr=subprocess.STDOUT,
+            )
+            qmp = QmpClient(qmp_socket, deadline)
+            width, height = wait_for_markers(serial_log, process, deadline)
+            qmp.execute("screendump", {"filename": str(screenshot), "format": "ppm"})
+            image = read_ppm(screenshot)
+            color_count, ratio = validate_frame(
+                image,
+                width,
+                height,
+                minimum_colors=args.minimum_colors,
+                minimum_non_dominant_ratio=args.minimum_non_dominant_ratio,
+            )
+            print(
+                f"[gui-smoke] PASS target={target.name} mode={width}x{height} "
+                f"colors={color_count} non_dominant_ratio={ratio:.6f} "
+                f"screenshot={screenshot} serial={serial_log}"
+            )
+    finally:
+        if process is not None:
+            forced = stop_qemu(process, qmp)
+        if qmp is not None:
+            qmp.close()
+        qmp_socket.unlink(missing_ok=True)
+        if forced:
+            print("[gui-smoke] warning: QEMU required forced termination", file=sys.stderr)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Build a GUI target, capture QEMU scanout through QMP, and reject uniform frames."
+    )
+    parser.add_argument("--target", type=Path, default=DEFAULT_TARGET, help=f"target YAML (default: {DEFAULT_TARGET.relative_to(REPO_ROOT)})")
+    parser.add_argument("--artifact-dir", type=Path, help="artifact output directory (default: target build directory)")
+    parser.add_argument("--timeout", type=float, default=60.0, help="bounded boot/QMP timeout in seconds (default: 60)")
+    parser.add_argument("--minimum-colors", type=int, default=8, help="minimum distinct RGB colors (default: 8)")
+    parser.add_argument("--minimum-non-dominant-ratio", type=float, default=0.01, help="minimum pixels differing from the dominant color (default: 0.01)")
+    args = parser.parse_args(argv)
+    if args.timeout <= 0 or args.minimum_colors < 2 or not 0 < args.minimum_non_dominant_ratio <= 1:
+        parser.error("timeout must be positive, colors >= 2, and ratio in (0, 1]")
+    return args
+
+
+def main(argv: list[str] | None = None) -> int:
+    try:
+        run_smoke(parse_args(argv))
+    except (GuiSmokeError, OSError, ValueError) as exc:
+        print(f"[gui-smoke] FAIL: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/test/test_qemu_gui_smoke.py
+++ b/tools/test/test_qemu_gui_smoke.py
@@ -1,0 +1,98 @@
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from tools.test.qemu_gui_smoke import (
+    GuiSmokeError,
+    PpmImage,
+    make_qemu_command,
+    read_ppm,
+    stop_qemu,
+    validate_frame,
+    wait_for_markers,
+)
+
+
+class PpmTests(unittest.TestCase):
+    def test_reads_commented_ppm(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "frame.ppm"
+            path.write_bytes(b"P6\n# qemu\n2 1\n255\n" + bytes((0, 1, 2, 3, 4, 5)))
+            image = read_ppm(path)
+        self.assertEqual((image.width, image.height), (2, 1))
+        self.assertEqual(image.pixels, bytes((0, 1, 2, 3, 4, 5)))
+
+    def test_rejects_malformed_ppm(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "frame.ppm"
+            path.write_bytes(b"P3\n1 1\n255\n0 0 0")
+            with self.assertRaisesRegex(GuiSmokeError, "expected P6"):
+                read_ppm(path)
+
+    def test_rejects_wrong_dimensions(self):
+        image = PpmImage(2, 2, bytes(12))
+        with self.assertRaisesRegex(GuiSmokeError, "do not match guest mode"):
+            validate_frame(image, 3, 2)
+
+    def test_rejects_uniform_frame(self):
+        image = PpmImage(10, 10, bytes((12, 34, 56)) * 100)
+        with self.assertRaisesRegex(GuiSmokeError, "blank or uniform"):
+            validate_frame(image, 10, 10)
+
+    def test_accepts_diverse_frame(self):
+        pixels = b"".join(bytes((index, index, index)) for index in range(100))
+        colors, ratio = validate_frame(PpmImage(10, 10, pixels), 10, 10)
+        self.assertEqual(colors, 100)
+        self.assertGreater(ratio, 0.9)
+
+
+class HarnessTests(unittest.TestCase):
+    @mock.patch("tools.test.qemu_gui_smoke.build_qemu_command")
+    def test_command_keeps_display_device_and_adds_private_channels(self, build_command):
+        build_command.return_value = [
+            "qemu-system-x86_64",
+            "-device",
+            "virtio-gpu-pci",
+            "-nographic",
+            "-serial",
+            "stdio",
+        ]
+        command = make_qemu_command({}, Path("serial.log"), Path("qmp.sock"))
+        self.assertIn("virtio-gpu-pci", command)
+        self.assertNotIn("-nographic", command)
+        self.assertIn("file:serial.log", command)
+        self.assertIn("unix:qmp.sock,server=on,wait=off", command)
+
+    def test_marker_timeout_is_bounded(self):
+        process = mock.Mock()
+        process.poll.return_value = None
+        with tempfile.TemporaryDirectory() as directory:
+            log = Path(directory) / "serial.log"
+            with self.assertRaisesRegex(GuiSmokeError, "timed out"):
+                wait_for_markers(log, process, 0.0)
+
+    def test_marker_parser_returns_queried_mode(self):
+        process = mock.Mock()
+        process.poll.return_value = None
+        with tempfile.TemporaryDirectory() as directory:
+            log = Path(directory) / "serial.log"
+            log.write_text(
+                "[gui] display-ready width=1024 height=768 refresh=60\n"
+                "[gui] first-frame-presented frame=1\n"
+            )
+            self.assertEqual(wait_for_markers(log, process, 1e20), (1024, 768))
+
+    def test_forced_termination_after_qmp_failure(self):
+        process = mock.Mock()
+        process.poll.return_value = None
+        process.wait.side_effect = [subprocess.TimeoutExpired("qemu", 3), None]
+        qmp = mock.Mock()
+        qmp.execute.side_effect = GuiSmokeError("closed")
+        self.assertTrue(stop_qemu(process, qmp))
+        process.terminate.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation

- Prove real scanout pixels for the GUI showcase instead of relying on serial markers alone by adding a QMP-driven visual gate. 
- Start with an x86_64, target-YAML-driven vertical slice so tests validate `QEMU framebuffer → display service → compositor → LVGL → gui_showcase` semantics without giving apps raw scanout access. 
- Provide a deterministic, dependency-free P6 parser and CI-friendly harness that fails closed on malformed/mismatched/blank frames. 

### Description

- Add a windowless visual smoke harness `tools/test/qemu_gui_smoke.py` that builds/packages a target from its YAML, launches QEMU with private `-serial` and `-qmp` channels, waits for `[gui] display-ready` and `[gui] first-frame-presented`, issues QMP `screendump`, parses the P6 output, validates dimensions and pixel diversity, retains artifacts, and shuts QEMU down cleanly. 
- Add unit tests `tools/test/test_qemu_gui_smoke.py` covering PPM parsing, malformed cases, dimension checks, uniform-frame rejection, command construction, marker parsing/timeouts, and forced QEMU termination. 
- Document the visual gate and thresholds in `BUILD.md` and `docs/demo/gui-showcase.md`, and record the implemented harness status in `docs/gui/GUI_PRODUCT_P0_PLAN.md`. 
- Keep architecture boundaries intact by using the display-broker/compositor contract (no raw framebuffer privileges, no ABI or kernel policy changes), and place generated artifacts under build outputs (`build/<preset>/artifacts/gui-smoke/`). 

### Testing

- Ran host unit tests with `python3 -m unittest discover -s tools/test -p 'test_*.py' -v`, all 9 tests passed (`PASS`).
- Validated python syntax with `python3 -m py_compile` for the new harness and tests (`PASS`).
- Linted repository contracts with `python3 tools/lint/check_layer_references.py` and `python3 tools/lint/check_cmake_dependencies.py` and ran `python3 tools/abi/syscall_abi.py --check` with no new failures (`PASS`).
- Executed the five-target headless smoke builds and matrix run via the repository runner (`./tools/build.sh ... --smoke` and `python3 tools/run_qemu_matrix.py --headless --smoke --all-arch`) and observed all required headless targets pass their boot contracts (`PASS`).
- Exercised the new visual harness on the canonical x86_64 showcase target with `python3 tools/test/qemu_gui_smoke.py --target delivery/targets/qemu/x86_64_showcase_gui.yaml`, which built, packaged, and launched QEMU but correctly returned nonzero because the packaged init path in this tree did not launch `gui_showcase` or emit the required `[gui] display-ready` / `[gui] first-frame-presented` markers (harness behavior: `FAIL` but expected for current tree state). 
- Evidence and artifacts from runs (when produced) are stored under `build/<preset>/artifacts/gui-smoke/` as `first-frame.ppm`, `serial.log`, and `qemu.log` for later inspection (`SKIPPED` for visual pass until GUI-001 is completed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7dea1fde848320b01a9d6996471911)