### PR TITLE
docs: Add critical code quality and architecture audit reports

### DIFF
--- a/docs/audit/01_code_quality_and_architecture_review.md
+++ b/docs/audit/01_code_quality_and_architecture_review.md
@@ -1,0 +1,40 @@
+# Bharat-OS: Critical Code Quality & Architecture Audit
+
+This report highlights code-level defects, structural risks, and technical debt found across the repository, translating them into actionable tasks.
+
+## 1. Oversized & Monolithic Files
+Several core kernel and service components have grown extremely large (1,000+ lines), making them hard to maintain and violating modularity principles.
+
+*   **`core/kernel/src/capability.c` (1380 lines)**: Centralized capability handling needs splitting into `cap_dispatch.c`, `cap_cspace.c`, `cap_revoke.c`.
+*   **`core/kernel/src/sched/sched.c` (1331 lines)** and **`core/kernel/src/sched/sched_core.c` (1155 lines)**: Scheduler monolithic. Needs decoupling of scheduling queues vs scheduling policies.
+*   **`core/kernel/src/mm/pmm/pmm.c` (1235 lines)**: Physical memory manager is too large. Split initialization, buddy allocation, and page fault handling.
+*   **`core/arch/hal/.../hal_pt_*.c` (600-900 lines)**: Page table manipulation logic is highly duplicated across architectures.
+
+## 2. Weak Error Handling
+Multiple services and kernel subsystems use generic `-1` error returns instead of defined, expressive status codes (e.g., `BH_ERR_NOT_FOUND`, `BH_ERR_NO_MEMORY`).
+
+*   **IPC Message Receivers**: `test_vm_manager_caps.c`, `test_process_manager_caps.c`, `namesvc/main.c` return `-1` silently on failure.
+*   **State Machines**: `core/services/power_mode/state_machine.c` returns `-1` continuously.
+*   **Legacy Network**: `core/services/legacy/net/control_plane.c` and `data_plane.c` use `-1` instead of network-specific error codes.
+*   **Actionable fix**: Replace generic `-1` returns with `bharat_status_t` enums across IPC bounds and core internal APIs.
+
+## 3. Hidden Global State
+Significant usage of file-local `static` state (over 2,100 instances), especially large arrays, which prevents multi-tenancy and complicates safe tear-down/restart of services.
+
+*   **VM Manager**: `core/services/vm_manager/vm_manager.c` relies on massive static arrays (`g_vm_spaces`, `g_vm_regions`, `region_table`). This needs dynamic slab allocation or bounded pool initialization at boot to scale.
+*   **Device & Auth State**: Similar static structures found across multiple drivers and unprivileged services.
+
+## 4. CMake Dependency Leaks
+Target linkage relies on `INTERFACE` without encapsulating private dependencies, risking accidental pollution of the global build environment.
+
+*   `core/services/common/runtime/CMakeLists.txt:17` uses naked `target_link_libraries` without scope (`PUBLIC`/`PRIVATE`).
+*   `core/kernel/CMakeLists.txt:693` dumps over 10 subsystems into `kernel.elf` without scoping.
+*   **Actionable fix**: Audit all `CMakeLists.txt` and enforce `PUBLIC`, `PRIVATE`, or `INTERFACE` modifiers.
+
+## 5. Unsafe Casts & Macro Redefinitions
+*   **`NULL` redefinition**: Found `#define NULL ((void*)0)` duplicated in `crypto_registry.c` and standard headers, risking conflicts with system `stddef.h`.
+*   **Raw `(void*)` Casts**: Over 68 raw memory casts observed, especially in `accelmgr/main.c` and `devmgr/device_manager.c` when casting message payloads to response buffers. These need structured `memcpy` bounds checks or zero-copy validation prior to casting.
+
+## 6. Duplicated Fallbacks & "TODO" Debt
+*   Over 120 "fallback" workarounds in the codebase (e.g. software queue fallbacks, default IDs like `42` in `system/filesystem/main.c`).
+*   90+ unresolved `TODO` markers. Crucial missing features like IPC blocking receive (`netmgr/src/main.c`), dynamic vaddr allocation (`aspace.c`), and capability handle rebinding (`service_runtime.c`).

--- a/docs/audit/02_technical_debt_and_remediation_plan.md
+++ b/docs/audit/02_technical_debt_and_remediation_plan.md
@@ -1,0 +1,35 @@
+# Actionable Remediation Plan
+
+Based on the code quality and architecture review, here are the prioritized engineering tasks to close technical debt.
+
+### Task 1: Enforce Strict Status Codes (P1)
+- **Scope**: `core/services/` and `core/kernel/`
+- **Action**: Deprecate `return -1;` for IPC, service endpoints, and internal handlers.
+- **Criteria**: Use `bharat_status_t` (`BH_OK`, `BH_ERR_NO_MEMORY`, `BH_ERR_NOT_FOUND`, etc.). Refactor `namesvc`, `vm_manager`, `power_mode`, and `process_manager` tests/services.
+
+### Task 2: CMake Linkage Hygiene (P1)
+- **Scope**: All `CMakeLists.txt`
+- **Action**: Lint and fix all `target_link_libraries` commands to explicitly use `PRIVATE`, `PUBLIC`, or `INTERFACE`.
+- **Criteria**: Zero warnings when running CMake configuration for missing target scope.
+
+### Task 3: Decouple Monolithic Subsystems (P2)
+- **Scope**: `core/kernel/src/capability.c` & `core/kernel/src/sched/sched.c`
+- **Action**:
+  - Split `capability.c` into `cap_cspace.c` (cnode logic) and `cap_dispatch.c` (validation/invocation).
+  - Split `sched.c` into runqueue management and scheduler API.
+- **Criteria**: Max file size target ~800 lines. Better testability of individual capability/scheduling behaviors.
+
+### Task 4: Safely Bound Payload Casting (P2)
+- **Scope**: IPC Handlers (e.g. `accelmgr/main.c`, `devmgr/device_manager.c`)
+- **Action**: Add explicit bounds-checking helpers before unsafe `(void*)` payload casting.
+- **Criteria**: Reject malformed IPC messages cleanly using `BH_ERR_INVALID_ARGS` instead of triggering potential buffer overflows.
+
+### Task 5: Centralize Standard Definitions (P3)
+- **Scope**: `crypto_registry.c` and other C files redefining `NULL`.
+- **Action**: Remove inline `#define NULL` and rely strictly on `<stddef.h>` or the internal `bharatlibc/include/standard/stddef.h`.
+- **Criteria**: No rogue `#define NULL` found in `.c` sources.
+
+### Task 6: Migrate Static State to Safe Allocation (P3)
+- **Scope**: `core/services/vm_manager/vm_manager.c`
+- **Action**: Remove static arrays like `g_vm_spaces[MAX_SPACES]` and implement boot-time pool allocations using the standard memory APIs.
+- **Criteria**: Services should be safely restarteable without static state contamination.

--- a/docs/audit/03_feature_robustness_gating.md
+++ b/docs/audit/03_feature_robustness_gating.md
@@ -1,0 +1,21 @@
+# Feature Robustness & Gating Analysis
+
+In order to ensure that Bharat-OS remains a composable platform, we need to guarantee that features are safely gated behind configuration flags and do not leak across environments when disabled.
+
+## 1. Feature Flag Sprawl
+Currently, there are over 600 `#ifdef` checks and 200 `#ifndef` checks in the core layer, with 260+ using the `BHARAT_ENABLE_` prefix. While conditional compilation is necessary for an OS, unchecked feature flags can result in dead code or untested combinations (the "ifdef hell").
+
+## 2. Hardcoded Fallbacks
+The system employs numerous silent "fallbacks", where if a hardware feature or dynamic configuration fails, a hardcoded default is used instead of failing cleanly or propagating the error.
+
+*   **Storage Fallbacks**: E.g., `g_system_device_id = 42` used in `core/services/system/filesystem/main.c`. If an invalid storage mount occurs, falling back to a dummy device ID masks the failure and can cause silent data loss or startup failure later.
+*   **Virtual Queues**: E.g., `core/drivers/input/virtio_input/virtio_input.c:329` has a "Software queue fallback" which can silently impact performance predictability if the hypervisor queue is misconfigured.
+
+## 3. Lack of Unified `build_config.json` Mapping
+While there is a `build_config.json` that drives the build, there appears to be drift between what the build system orchestrates and the macros checked inside the C code.
+
+## Actionable Recommendations to Improve Robustness
+
+1.  **Fail-Fast by Default**: Remove silent fallbacks like hardcoded dummy device IDs. If an essential system component (like the root file system or boot device) is missing, the system should cleanly panic or enter a recovery shell, not pretend everything is fine.
+2.  **Centralized Feature Manifest**: Implement a macro checking script in `tools/lint/` that validates all `#ifdef BHARAT_ENABLE_` macros against a known manifest of valid configuration flags, preventing typos or dead flags.
+3.  **Telemetry on Fallbacks**: If a fallback (like software rendering or polled I/O instead of interrupts) *must* be used, it must emit a critical telemetry event. The telemetry manager currently has hooks for `cpu_fallback_count` (in `accelmgr_broker.c`), but this pattern needs to be applied to all hardware drivers.

--- a/docs/audit/04_code_agent_tasks.md
+++ b/docs/audit/04_code_agent_tasks.md
@@ -1,0 +1,81 @@
+# Code-Agent Tasks & Acceptance Criteria
+
+This document translates the critical code quality and architectural issues into distinct, actionable tasks that a code-agent can execute autonomously.
+
+## Task 1: Eliminate Generic Error Returns in IPC Handlers
+**Context**: Multiple services use `return -1;` for IPC failures instead of defined `bharat_status_t` codes.
+**Target Files**:
+- `core/services/vm_manager/tests/test_vm_manager_caps.c`
+- `core/services/namesvc/main.c`
+- `core/services/process_manager/process_manager.c`
+- `core/services/power_mode/state_machine.c`
+- `core/services/legacy/net/control_plane.c`
+**Instructions**:
+1. Search for `return -1;` in the target files.
+2. Replace `-1` with an appropriate `bharat_status_t` error code (e.g., `BH_ERR_NOT_FOUND`, `BH_ERR_NO_MEMORY`, `BH_ERR_UNAUTHORIZED`, or a service-specific error code if applicable).
+**Acceptance Criteria**:
+- No instances of `return -1;` remain in the specified files.
+- The return types and signatures of the functions are respected.
+- The project compiles successfully after changes.
+
+## Task 2: Fix CMake Dependency Scope Leaks
+**Context**: Several `CMakeLists.txt` use `target_link_libraries` without specifying scope (`PRIVATE`, `PUBLIC`, or `INTERFACE`), leading to global scope pollution.
+**Target Files**:
+- `core/services/common/runtime/CMakeLists.txt`
+- `core/kernel/CMakeLists.txt`
+- `core/lib/namesvc/CMakeLists.txt`
+**Instructions**:
+1. Locate `target_link_libraries` calls missing a scope keyword.
+2. Add the `PRIVATE` keyword unless the linked library's headers are exposed in the target's public API (use `PUBLIC`), or if it's an interface-only library (use `INTERFACE`).
+**Acceptance Criteria**:
+- `grep -rn "target_link_libraries(" core/ | grep -v "PRIVATE" | grep -v "PUBLIC" | grep -v "INTERFACE"` returns 0 results.
+- `tools/lint/check_cmake_dependencies.py` passes without new violations.
+- Build completes successfully.
+
+## Task 3: Refactor Unsafe Casts in Subsystem Managers
+**Context**: IPC payload parsing uses raw `(void*)` casts directly on message buffers without bounds checking.
+**Target Files**:
+- `core/services/device/accelmgr/main.c`
+- `core/services/device/devmgr/device_manager.c`
+**Instructions**:
+1. Identify raw casts of message payloads (`(void*)resp_buf`).
+2. Wrap payload parsing with size validation checks to ensure the incoming message length matches the expected structure size before casting.
+**Acceptance Criteria**:
+- Payload unpacking functions validate `msg_length >= sizeof(ExpectedStruct)`.
+- If invalid, the handler returns `BH_ERR_INVALID_ARGS` or equivalent before attempting a cast.
+
+## Task 4: Remove Rogue NULL Redefinitions
+**Context**: `NULL` is manually redefined in C files instead of using standard headers.
+**Target Files**:
+- `core/services/security/crypto/crypto_registry.c`
+**Instructions**:
+1. Remove `#define NULL ((void*)0)` from the target file.
+2. Ensure `<stddef.h>` or `bharatlibc/include/standard/stddef.h` is included instead.
+**Acceptance Criteria**:
+- `grep -rn "#define NULL" core/` only shows results inside header files (like `stddef.h`).
+- The project compiles without missing `NULL` definition errors.
+
+## Task 5: Decouple Capability Registry (Oversized File Refactor)
+**Context**: `core/kernel/src/capability.c` is nearly 1,400 lines long, making it hard to maintain.
+**Target Files**:
+- `core/kernel/src/capability.c`
+**Instructions**:
+1. Extract CSpace and registry-specific logic into a new file `core/kernel/src/cap_cspace.c`.
+2. Extract capability invocation and dispatch logic into `core/kernel/src/cap_dispatch.c`.
+3. Keep core generic initialization in `capability.c`.
+4. Update `core/kernel/CMakeLists.txt` to include the new source files.
+**Acceptance Criteria**:
+- `core/kernel/src/capability.c` is under 800 lines.
+- No functional regressions; the kernel boots and tests pass.
+
+## Task 6: Audit and Remove Hardcoded Fallbacks
+**Context**: Hardcoded IDs (like `g_system_device_id = 42`) mask configuration errors.
+**Target Files**:
+- `core/services/system/filesystem/main.c`
+**Instructions**:
+1. Remove the fallback assignment `g_system_device_id = 42`.
+2. Implement proper error handling if the system device ID is not found or provided via boot configuration.
+3. If not found, gracefully fail the filesystem initialization or enter a degraded state with appropriate logging.
+**Acceptance Criteria**:
+- `g_system_device_id` is initialized dynamically or via configuration, never hardcoded.
+- Storage failures are reported rather than masked.


### PR DESCRIPTION
Adds detailed technical debt and code quality review reports in multiple md files.

---
*PR created automatically by Jules for task [4834859498989752221](https://jules.google.com/task/4834859498989752221) started by @divyang4481*