### PR TITLE
Fix: Remove inline NULL redefinition in crypto_registry

### DIFF
--- a/core/services/security/crypto/crypto_registry.c
+++ b/core/services/security/crypto/crypto_registry.c
@@ -1,4 +1,5 @@
 #include <stdint.h>
+#include <stddef.h>
 #include <lib/base/string.h>
 
 #include <bharat/uapi/sys_errno.h>
@@ -10,10 +11,6 @@
 /* Simple memory allocator stubs to avoid dragging in complex kernel mm */
 extern void *kmalloc(size_t size);
 extern void kfree(void *ptr);
-
-#ifndef NULL
-#define NULL ((void*)0)
-#endif
 
 /*
  * Note: A real kernel would use a spinlock here.


### PR DESCRIPTION
Removed the inline redefinition of `#define NULL ((void*)0)` in `core/services/security/crypto/crypto_registry.c` and included `<stddef.h>` to rely on the standard library definition. This aligns with standard C practices and resolves potential definition conflicts.

---
*PR created automatically by Jules for task [9870678813478418093](https://jules.google.com/task/9870678813478418093) started by @divyang4481*