### PR TITLE
Refactor: Replace generic -1 returns with bharat_status_t enums

### DIFF
--- a/core/services/include/services/power_mode/power_mode.h
+++ b/core/services/include/services/power_mode/power_mode.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <stdbool.h>
 #include <stdint.h>
+#include <bharat/uapi/service_status.h>
 
 #include "services/telemetrymgr/thermal_policy.h"
 
@@ -37,20 +38,20 @@ typedef struct {
     bool critical;
 } power_mode_thermal_state_t;
 
-typedef int (*power_mode_prepare_cb)(power_mode_state_t target);
-typedef int (*power_mode_commit_cb)(power_mode_state_t target);
-typedef int (*power_mode_wake_cb)(power_mode_reason_t reason);
+typedef bharat_status_t (*power_mode_prepare_cb)(power_mode_state_t target);
+typedef bharat_status_t (*power_mode_commit_cb)(power_mode_state_t target);
+typedef bharat_status_t (*power_mode_wake_cb)(power_mode_reason_t reason);
 
-int power_mode_register_client(power_mode_prepare_cb prepare, power_mode_commit_cb commit, power_mode_wake_cb wake);
-int power_mode_request_transition(power_mode_state_t target, power_mode_reason_t reason);
-int power_mode_force_limp_home(power_mode_reason_t reason);
+bharat_status_t power_mode_register_client(power_mode_prepare_cb prepare, power_mode_commit_cb commit, power_mode_wake_cb wake);
+bharat_status_t power_mode_request_transition(power_mode_state_t target, power_mode_reason_t reason);
+bharat_status_t power_mode_force_limp_home(power_mode_reason_t reason);
 power_mode_state_t power_mode_get_current(void);
 
-int power_mode_set_thermal_state(const power_mode_thermal_state_t* thermal_state);
+bharat_status_t power_mode_set_thermal_state(const power_mode_thermal_state_t* thermal_state);
 power_mode_thermal_state_t power_mode_get_thermal_state(void);
 
-int power_mode_register_default_clients(void);
-int power_mode_apply_thermal_policy(const thermal_policy_state_t* state);
+bharat_status_t power_mode_register_default_clients(void);
+bharat_status_t power_mode_apply_thermal_policy(const thermal_policy_state_t* state);
 
 // Internal function to reset state for testing
 void power_mode_reset(void);

--- a/core/services/legacy/net/control_plane.c
+++ b/core/services/legacy/net/control_plane.c
@@ -19,9 +19,9 @@ void net_control_plane_init(void) {
     }
 }
 
-int net_register_interface(const char* name, const uint8_t* mac, uint32_t mtu, uint32_t* out_if_id) {
+bharat_status_t net_register_interface(const char* name, const uint8_t* mac, uint32_t mtu, uint32_t* out_if_id) {
     if (g_num_interfaces >= MAX_INTERFACES) {
-        return -1;
+        return BHARAT_STATUS_ERR_UNSUPPORTED; // Out of resources
     }
 
     uint32_t new_id = g_num_interfaces;
@@ -59,25 +59,25 @@ int net_register_interface(const char* name, const uint8_t* mac, uint32_t mtu, u
         *out_if_id = new_id;
     }
 
-    return 0;
+    return BHARAT_STATUS_OK;
 }
 
-int net_set_link_state(uint32_t if_id, net_link_state_t state) {
+bharat_status_t net_set_link_state(uint32_t if_id, net_link_state_t state) {
     if (if_id >= g_num_interfaces) {
-        return -1; /* Not found */
+        return BHARAT_STATUS_ERR_NOT_FOUND; /* Not found */
     }
 
     g_interfaces[if_id].link_state = state;
-    return 0;
+    return BHARAT_STATUS_OK;
 }
 
-int net_get_stats(uint32_t if_id, netdev_stats_t* out_stats) {
+bharat_status_t net_get_stats(uint32_t if_id, netdev_stats_t* out_stats) {
     if (if_id >= g_num_interfaces || !out_stats) {
-        return -1; /* Not found */
+        return BHARAT_STATUS_ERR_NOT_FOUND; /* Not found */
     }
 
     *out_stats = g_interfaces[if_id].stats;
-    return 0;
+    return BHARAT_STATUS_OK;
 }
 
 net_if_t* net_get_iface(uint32_t if_id) {

--- a/core/services/legacy/net/control_plane.h
+++ b/core/services/legacy/net/control_plane.h
@@ -2,6 +2,7 @@
 #define SERVICES_NET_CONTROL_PLANE_H
 
 #include "net_types.h"
+#include <bharat/uapi/service_status.h>
 
 /*
  * Control Plane API
@@ -13,13 +14,13 @@
 void net_control_plane_init(void);
 
 /* Register a new interface into the interface table */
-int net_register_interface(const char* name, const uint8_t* mac, uint32_t mtu, uint32_t* out_if_id);
+bharat_status_t net_register_interface(const char* name, const uint8_t* mac, uint32_t mtu, uint32_t* out_if_id);
 
 /* Set the link state of an interface (Up/Down) */
-int net_set_link_state(uint32_t if_id, net_link_state_t state);
+bharat_status_t net_set_link_state(uint32_t if_id, net_link_state_t state);
 
 /* Retrieve interface statistics */
-int net_get_stats(uint32_t if_id, netdev_stats_t* out_stats);
+bharat_status_t net_get_stats(uint32_t if_id, netdev_stats_t* out_stats);
 
 /* Internal lookup used by data plane (ideally would be via capabilities/safe handoff) */
 net_if_t* net_get_iface(uint32_t if_id);

--- a/core/services/legacy/net/data_plane.c
+++ b/core/services/legacy/net/data_plane.c
@@ -10,20 +10,20 @@ void net_data_plane_init(void) {
     /* Ready the fast path/dispatch environment */
 }
 
-int net_dp_rx_submit(uint32_t if_id, netbuf_t* buf) {
+bharat_status_t net_dp_rx_submit(uint32_t if_id, netbuf_t* buf) {
     if (!buf) {
-        return -1;
+        return BHARAT_STATUS_ERR_INTERNAL;
     }
 
     net_if_t* iface = net_get_iface(if_id);
     if (!iface) {
         /* Drop frame if interface invalid */
-        return -1;
+        return BHARAT_STATUS_ERR_NOT_FOUND;
     }
 
     if (iface->link_state == NET_LINK_DOWN) {
         iface->stats.rx_dropped++;
-        return -1;
+        return BHARAT_STATUS_ERR_UNSUPPORTED; // Link down
     }
 
     /* Simulate RX process: Increment stats, pass to upper layers */
@@ -33,23 +33,23 @@ int net_dp_rx_submit(uint32_t if_id, netbuf_t* buf) {
     /* Here you would normally route to a net protocol stack handler */
     /* e.g., eth_input(buf); */
 
-    return 0;
+    return BHARAT_STATUS_OK;
 }
 
-int net_dp_tx_submit(uint32_t if_id, netbuf_t* buf) {
+bharat_status_t net_dp_tx_submit(uint32_t if_id, netbuf_t* buf) {
     if (!buf) {
-        return -1;
+        return BHARAT_STATUS_ERR_INTERNAL;
     }
 
     net_if_t* iface = net_get_iface(if_id);
     if (!iface) {
         /* Drop frame if interface invalid */
-        return -1;
+        return BHARAT_STATUS_ERR_NOT_FOUND;
     }
 
     if (iface->link_state == NET_LINK_DOWN) {
         iface->stats.tx_dropped++;
-        return -1;
+        return BHARAT_STATUS_ERR_UNSUPPORTED; // Link down
     }
 
     /* Simulate TX process: enqueue onto driver ring or just increment stats for loopback */
@@ -58,5 +58,5 @@ int net_dp_tx_submit(uint32_t if_id, netbuf_t* buf) {
 
     /* In a real stack, this would place the buffer onto the TX ring or URPC mailbox */
 
-    return 0;
+    return BHARAT_STATUS_OK;
 }

--- a/core/services/legacy/net/data_plane.h
+++ b/core/services/legacy/net/data_plane.h
@@ -3,6 +3,7 @@
 
 #include "net_types.h"
 #include <net/netdev.h>
+#include <bharat/uapi/service_status.h>
 
 /*
  * Data Plane API
@@ -14,9 +15,9 @@
 void net_data_plane_init(void);
 
 /* Submit a packet into the RX path */
-int net_dp_rx_submit(uint32_t if_id, netbuf_t* buf);
+bharat_status_t net_dp_rx_submit(uint32_t if_id, netbuf_t* buf);
 
 /* Submit a packet into the TX path */
-int net_dp_tx_submit(uint32_t if_id, netbuf_t* buf);
+bharat_status_t net_dp_tx_submit(uint32_t if_id, netbuf_t* buf);
 
 #endif /* SERVICES_NET_DATA_PLANE_H */

--- a/core/services/namesvc/main.c
+++ b/core/services/namesvc/main.c
@@ -30,12 +30,13 @@ int main(int argc, char **argv) {
     // Create our endpoint
     bharat_ipc_endpoint_t my_endpoint = service_runtime_create_endpoint(BHARAT_SERVICE_NAMESVC, 0);
     if (!bharat_cap_is_valid(my_endpoint)) {
-        return -1;
+        return BHARAT_STATUS_ERR_INTERNAL;
     }
 
     // Bind to the well-known bootstrap handle
-    if (service_runtime_bind_namesvc_bootstrap(my_endpoint) != BHARAT_STATUS_OK) {
-        return -1;
+    bharat_status_t bind_status = service_runtime_bind_namesvc_bootstrap(my_endpoint);
+    if (bind_status != BHARAT_STATUS_OK) {
+        return bind_status;
     }
 
     namesvc_registry_init();

--- a/core/services/power_mode/clients.c
+++ b/core/services/power_mode/clients.c
@@ -1,25 +1,25 @@
 #include "services/power_mode/power_mode.h"
 
-static int thermal_guard_prepare(power_mode_state_t target) {
+static bharat_status_t thermal_guard_prepare(power_mode_state_t target) {
     power_mode_thermal_state_t thermal = power_mode_get_thermal_state();
 
     if (thermal.critical && target == POWER_MODE_RUN) {
-        return -1;
+        return BHARAT_STATUS_ERR_PERMISSION;
     }
 
-    return 0;
+    return BHARAT_STATUS_OK;
 }
 
-static int thermal_guard_commit(power_mode_state_t target) {
+static bharat_status_t thermal_guard_commit(power_mode_state_t target) {
     (void)target;
-    return 0;
+    return BHARAT_STATUS_OK;
 }
 
-static int thermal_guard_wake(power_mode_reason_t reason) {
+static bharat_status_t thermal_guard_wake(power_mode_reason_t reason) {
     (void)reason;
-    return 0;
+    return BHARAT_STATUS_OK;
 }
 
-int power_mode_register_default_clients(void) {
+bharat_status_t power_mode_register_default_clients(void) {
     return power_mode_register_client(thermal_guard_prepare, thermal_guard_commit, thermal_guard_wake);
 }

--- a/core/services/power_mode/policy.c
+++ b/core/services/power_mode/policy.c
@@ -2,11 +2,11 @@
 
 #include "services/telemetrymgr/thermal_policy.h"
 
-int power_mode_apply_thermal_policy(const thermal_policy_state_t* state) {
+bharat_status_t power_mode_apply_thermal_policy(const thermal_policy_state_t* state) {
     power_mode_thermal_state_t thermal;
 
     if (!state) {
-        return -1;
+        return BHARAT_STATUS_ERR_INTERNAL;
     }
 
     thermal.max_temp_mc = 0;

--- a/core/services/power_mode/state_machine.c
+++ b/core/services/power_mode/state_machine.c
@@ -15,15 +15,15 @@ static int g_num_clients = 0;
 static power_mode_state_t g_current_mode = POWER_MODE_OFF;
 static power_mode_thermal_state_t g_thermal_state = {0};
 
-int power_mode_register_client(power_mode_prepare_cb prepare, power_mode_commit_cb commit, power_mode_wake_cb wake) {
+bharat_status_t power_mode_register_client(power_mode_prepare_cb prepare, power_mode_commit_cb commit, power_mode_wake_cb wake) {
     if (g_num_clients >= MAX_PM_CLIENTS) {
-        return -1;
+        return BHARAT_STATUS_ERR_UNSUPPORTED; // Out of resources
     }
     g_clients[g_num_clients].prepare = prepare;
     g_clients[g_num_clients].commit = commit;
     g_clients[g_num_clients].wake = wake;
     g_num_clients++;
-    return 0;
+    return BHARAT_STATUS_OK;
 }
 
 static bool is_valid_transition(power_mode_state_t current, power_mode_state_t target) {
@@ -51,21 +51,21 @@ static bool is_valid_transition(power_mode_state_t current, power_mode_state_t t
     }
 }
 
-int power_mode_request_transition(power_mode_state_t target, power_mode_reason_t reason) {
+bharat_status_t power_mode_request_transition(power_mode_state_t target, power_mode_reason_t reason) {
     if (!is_valid_transition(g_current_mode, target)) {
-        return -1;
+        return BHARAT_STATUS_ERR_PERMISSION;
     }
 
     if (g_thermal_state.critical && (target == POWER_MODE_RUN || target == POWER_MODE_CRANK)) {
-        return -1;
+        return BHARAT_STATUS_ERR_PERMISSION;
     }
 
     if (target == POWER_MODE_SLEEP || target == POWER_MODE_SLEEP_PREP) {
         // Prepare phase
         for (int i = 0; i < g_num_clients; i++) {
             if (g_clients[i].prepare) {
-                if (g_clients[i].prepare(target) != 0) {
-                    return -1; // Client rejected sleep prep
+                if (g_clients[i].prepare(target) != BHARAT_STATUS_OK) {
+                    return BHARAT_STATUS_ERR_PERMISSION; // Client rejected sleep prep
                 }
             }
         }
@@ -87,10 +87,10 @@ int power_mode_request_transition(power_mode_state_t target, power_mode_reason_t
     }
 
     g_current_mode = target;
-    return 0;
+    return BHARAT_STATUS_OK;
 }
 
-int power_mode_force_limp_home(power_mode_reason_t reason) {
+bharat_status_t power_mode_force_limp_home(power_mode_reason_t reason) {
     return power_mode_request_transition(POWER_MODE_LIMP_HOME, reason);
 }
 
@@ -98,9 +98,9 @@ power_mode_state_t power_mode_get_current(void) {
     return g_current_mode;
 }
 
-int power_mode_set_thermal_state(const power_mode_thermal_state_t* thermal_state) {
+bharat_status_t power_mode_set_thermal_state(const power_mode_thermal_state_t* thermal_state) {
     if (!thermal_state) {
-        return -1;
+        return BHARAT_STATUS_ERR_INTERNAL;
     }
 
     g_thermal_state = *thermal_state;
@@ -109,7 +109,7 @@ int power_mode_set_thermal_state(const power_mode_thermal_state_t* thermal_state
         (void)power_mode_force_limp_home(POWER_REASON_THERMAL_CRITICAL);
     }
 
-    return 0;
+    return BHARAT_STATUS_OK;
 }
 
 power_mode_thermal_state_t power_mode_get_thermal_state(void) {

--- a/core/services/process_manager/tests/test_process_manager_caps.c
+++ b/core/services/process_manager/tests/test_process_manager_caps.c
@@ -5,7 +5,7 @@
 #include <bharat/uapi/ipc/status.h>
 
 int32_t bharat_ipc_send(bharat_ipc_endpoint_t endpoint, const bharat_ipc_msg_header_t *header, const void *payload) { (void)endpoint; (void)header; (void)payload; return 0; }
-int32_t bharat_ipc_recv(bharat_ipc_endpoint_t endpoint, bharat_ipc_msg_header_t *header, void *payload_buf, uint32_t max_size) { (void)endpoint; (void)header; (void)payload_buf; (void)max_size; return -1; }
+int32_t bharat_ipc_recv(bharat_ipc_endpoint_t endpoint, bharat_ipc_msg_header_t *header, void *payload_buf, uint32_t max_size) { (void)endpoint; (void)header; (void)payload_buf; (void)max_size; return BHARAT_IPC_STATUS_ERR_INTERNAL; }
 
 static bharat_cap_status_t fake_backend(
     bharat_cap_handle_t handle,

--- a/core/services/vm_manager/tests/test_vm_manager_caps.c
+++ b/core/services/vm_manager/tests/test_vm_manager_caps.c
@@ -5,7 +5,7 @@
 #include <bharat/uapi/ipc/status.h>
 
 int32_t bharat_ipc_send(bharat_ipc_endpoint_t endpoint, const bharat_ipc_msg_header_t *header, const void *payload) { (void)endpoint; (void)header; (void)payload; return 0; }
-int32_t bharat_ipc_recv(bharat_ipc_endpoint_t endpoint, bharat_ipc_msg_header_t *header, void *payload_buf, uint32_t max_size) { (void)endpoint; (void)header; (void)payload_buf; (void)max_size; return -1; }
+int32_t bharat_ipc_recv(bharat_ipc_endpoint_t endpoint, bharat_ipc_msg_header_t *header, void *payload_buf, uint32_t max_size) { (void)endpoint; (void)header; (void)payload_buf; (void)max_size; return BHARAT_IPC_STATUS_ERR_INTERNAL; }
 
 static bharat_cap_status_t fake_backend(
     bharat_cap_handle_t handle,

--- a/quality/tests/host/services/test_power_mode_callbacks.c
+++ b/quality/tests/host/services/test_power_mode_callbacks.c
@@ -5,16 +5,16 @@
 // Expose internal reset for tests
 void power_mode_reset(void);
 
-static int my_prepare_ok(power_mode_state_t t) { return 0; }
-static int my_prepare_reject(power_mode_state_t t) { return -1; }
+static bharat_status_t my_prepare_ok(power_mode_state_t t) { return BHARAT_STATUS_OK; }
+static bharat_status_t my_prepare_reject(power_mode_state_t t) { return BHARAT_STATUS_ERR_PERMISSION; }
 
 void test_callbacks_ok() {
     power_mode_reset();
     power_mode_register_client(my_prepare_ok, NULL, NULL);
 
     // valid path to sleep
-    assert(power_mode_request_transition(POWER_MODE_RUN, POWER_REASON_IGNITION) == 0);
-    assert(power_mode_request_transition(POWER_MODE_SLEEP_PREP, POWER_REASON_IGNITION) == 0);
+    assert(power_mode_request_transition(POWER_MODE_RUN, POWER_REASON_IGNITION) == BHARAT_STATUS_OK);
+    assert(power_mode_request_transition(POWER_MODE_SLEEP_PREP, POWER_REASON_IGNITION) == BHARAT_STATUS_OK);
 }
 
 void test_callbacks_reject() {
@@ -22,9 +22,9 @@ void test_callbacks_reject() {
     power_mode_register_client(my_prepare_reject, NULL, NULL);
 
     // valid path to sleep prep
-    assert(power_mode_request_transition(POWER_MODE_RUN, POWER_REASON_IGNITION) == 0);
+    assert(power_mode_request_transition(POWER_MODE_RUN, POWER_REASON_IGNITION) == BHARAT_STATUS_OK);
     // sleep prep should be rejected by client
-    assert(power_mode_request_transition(POWER_MODE_SLEEP_PREP, POWER_REASON_IGNITION) == -1);
+    assert(power_mode_request_transition(POWER_MODE_SLEEP_PREP, POWER_REASON_IGNITION) == BHARAT_STATUS_ERR_PERMISSION);
 }
 
 int main() {

--- a/quality/tests/host/services/test_power_mode_limp_home.c
+++ b/quality/tests/host/services/test_power_mode_limp_home.c
@@ -9,23 +9,23 @@ void power_mode_reset(void);
 static bool g_commit_called = false;
 static power_mode_state_t g_last_commit_target = POWER_MODE_OFF;
 
-static int mock_commit_cb(power_mode_state_t target) {
+static bharat_status_t mock_commit_cb(power_mode_state_t target) {
     g_commit_called = true;
     g_last_commit_target = target;
-    return 0;
+    return BHARAT_STATUS_OK;
 }
 
 void test_limp_home_from_run() {
     power_mode_reset();
-    assert(power_mode_request_transition(POWER_MODE_RUN, POWER_REASON_IGNITION) == 0);
+    assert(power_mode_request_transition(POWER_MODE_RUN, POWER_REASON_IGNITION) == BHARAT_STATUS_OK);
 
     // Force limp home due to critical fault
-    assert(power_mode_force_limp_home(POWER_REASON_FAULT_FORCED_LIMP) == 0);
+    assert(power_mode_force_limp_home(POWER_REASON_FAULT_FORCED_LIMP) == BHARAT_STATUS_OK);
     assert(power_mode_get_current() == POWER_MODE_LIMP_HOME);
 
     // Cannot transition to anything but OFF
-    assert(power_mode_request_transition(POWER_MODE_RUN, POWER_REASON_NONE) == -1);
-    assert(power_mode_request_transition(POWER_MODE_OFF, POWER_REASON_NONE) == 0);
+    assert(power_mode_request_transition(POWER_MODE_RUN, POWER_REASON_NONE) == BHARAT_STATUS_ERR_PERMISSION);
+    assert(power_mode_request_transition(POWER_MODE_OFF, POWER_REASON_NONE) == BHARAT_STATUS_OK);
     assert(power_mode_get_current() == POWER_MODE_OFF);
 }
 
@@ -50,32 +50,32 @@ void test_limp_home_from_all_states() {
 
         // For states like SLEEP, we need to get there first.
         if (states[i] == POWER_MODE_ACCESSORY) {
-            assert(power_mode_request_transition(POWER_MODE_ACCESSORY, POWER_REASON_IGNITION) == 0);
+            assert(power_mode_request_transition(POWER_MODE_ACCESSORY, POWER_REASON_IGNITION) == BHARAT_STATUS_OK);
         } else if (states[i] == POWER_MODE_RUN) {
-            assert(power_mode_request_transition(POWER_MODE_RUN, POWER_REASON_IGNITION) == 0);
+            assert(power_mode_request_transition(POWER_MODE_RUN, POWER_REASON_IGNITION) == BHARAT_STATUS_OK);
         } else if (states[i] == POWER_MODE_CRANK) {
-            assert(power_mode_request_transition(POWER_MODE_RUN, POWER_REASON_IGNITION) == 0);
-            assert(power_mode_request_transition(POWER_MODE_CRANK, POWER_REASON_IGNITION) == 0);
+            assert(power_mode_request_transition(POWER_MODE_RUN, POWER_REASON_IGNITION) == BHARAT_STATUS_OK);
+            assert(power_mode_request_transition(POWER_MODE_CRANK, POWER_REASON_IGNITION) == BHARAT_STATUS_OK);
         } else if (states[i] == POWER_MODE_SLEEP_PREP) {
-            assert(power_mode_request_transition(POWER_MODE_RUN, POWER_REASON_IGNITION) == 0);
-            assert(power_mode_request_transition(POWER_MODE_SLEEP_PREP, POWER_REASON_NONE) == 0);
+            assert(power_mode_request_transition(POWER_MODE_RUN, POWER_REASON_IGNITION) == BHARAT_STATUS_OK);
+            assert(power_mode_request_transition(POWER_MODE_SLEEP_PREP, POWER_REASON_NONE) == BHARAT_STATUS_OK);
         } else if (states[i] == POWER_MODE_SLEEP) {
-            assert(power_mode_request_transition(POWER_MODE_RUN, POWER_REASON_IGNITION) == 0);
-            assert(power_mode_request_transition(POWER_MODE_SLEEP_PREP, POWER_REASON_NONE) == 0);
-            assert(power_mode_request_transition(POWER_MODE_SLEEP, POWER_REASON_NONE) == 0);
+            assert(power_mode_request_transition(POWER_MODE_RUN, POWER_REASON_IGNITION) == BHARAT_STATUS_OK);
+            assert(power_mode_request_transition(POWER_MODE_SLEEP_PREP, POWER_REASON_NONE) == BHARAT_STATUS_OK);
+            assert(power_mode_request_transition(POWER_MODE_SLEEP, POWER_REASON_NONE) == BHARAT_STATUS_OK);
         } else if (states[i] == POWER_MODE_WAKE) {
-            assert(power_mode_request_transition(POWER_MODE_RUN, POWER_REASON_IGNITION) == 0);
-            assert(power_mode_request_transition(POWER_MODE_SLEEP_PREP, POWER_REASON_NONE) == 0);
-            assert(power_mode_request_transition(POWER_MODE_SLEEP, POWER_REASON_NONE) == 0);
-            assert(power_mode_request_transition(POWER_MODE_WAKE, POWER_REASON_CAN_WAKE) == 0);
+            assert(power_mode_request_transition(POWER_MODE_RUN, POWER_REASON_IGNITION) == BHARAT_STATUS_OK);
+            assert(power_mode_request_transition(POWER_MODE_SLEEP_PREP, POWER_REASON_NONE) == BHARAT_STATUS_OK);
+            assert(power_mode_request_transition(POWER_MODE_SLEEP, POWER_REASON_NONE) == BHARAT_STATUS_OK);
+            assert(power_mode_request_transition(POWER_MODE_WAKE, POWER_REASON_CAN_WAKE) == BHARAT_STATUS_OK);
         } else if (states[i] == POWER_MODE_LIMP_HOME) {
-            assert(power_mode_force_limp_home(POWER_REASON_FAULT_FORCED_LIMP) == 0);
+            assert(power_mode_force_limp_home(POWER_REASON_FAULT_FORCED_LIMP) == BHARAT_STATUS_OK);
         }
 
         assert(power_mode_get_current() == states[i]);
 
         // Now force limp home
-        assert(power_mode_force_limp_home(POWER_REASON_FAULT_FORCED_LIMP) == 0);
+        assert(power_mode_force_limp_home(POWER_REASON_FAULT_FORCED_LIMP) == BHARAT_STATUS_OK);
         assert(power_mode_get_current() == POWER_MODE_LIMP_HOME);
     }
 }
@@ -85,17 +85,17 @@ void test_limp_home_callbacks() {
     g_commit_called = false;
     power_mode_register_client(NULL, mock_commit_cb, NULL);
 
-    assert(power_mode_request_transition(POWER_MODE_RUN, POWER_REASON_IGNITION) == 0);
+    assert(power_mode_request_transition(POWER_MODE_RUN, POWER_REASON_IGNITION) == BHARAT_STATUS_OK);
     g_commit_called = false; // Reset for the next transition
 
-    assert(power_mode_force_limp_home(POWER_REASON_FAULT_FORCED_LIMP) == 0);
+    assert(power_mode_force_limp_home(POWER_REASON_FAULT_FORCED_LIMP) == BHARAT_STATUS_OK);
     assert(g_commit_called == true);
     assert(g_last_commit_target == POWER_MODE_LIMP_HOME);
 }
 
 void test_thermal_critical_triggers_limp_home() {
     power_mode_reset();
-    assert(power_mode_request_transition(POWER_MODE_RUN, POWER_REASON_IGNITION) == 0);
+    assert(power_mode_request_transition(POWER_MODE_RUN, POWER_REASON_IGNITION) == BHARAT_STATUS_OK);
 
     power_mode_thermal_state_t thermal = {
         .max_temp_mc = 105000,
@@ -103,7 +103,7 @@ void test_thermal_critical_triggers_limp_home() {
         .critical = true
     };
 
-    assert(power_mode_set_thermal_state(&thermal) == 0);
+    assert(power_mode_set_thermal_state(&thermal) == BHARAT_STATUS_OK);
     assert(power_mode_get_current() == POWER_MODE_LIMP_HOME);
 }
 

--- a/quality/tests/host/services/test_power_mode_state_machine.c
+++ b/quality/tests/host/services/test_power_mode_state_machine.c
@@ -7,17 +7,17 @@ void power_mode_reset(void);
 
 void test_valid_transitions() {
     power_mode_reset();
-    assert(power_mode_request_transition(POWER_MODE_ACCESSORY, POWER_REASON_IGNITION) == 0);
+    assert(power_mode_request_transition(POWER_MODE_ACCESSORY, POWER_REASON_IGNITION) == BHARAT_STATUS_OK);
     assert(power_mode_get_current() == POWER_MODE_ACCESSORY);
 
-    assert(power_mode_request_transition(POWER_MODE_RUN, POWER_REASON_IGNITION) == 0);
+    assert(power_mode_request_transition(POWER_MODE_RUN, POWER_REASON_IGNITION) == BHARAT_STATUS_OK);
     assert(power_mode_get_current() == POWER_MODE_RUN);
 }
 
 void test_invalid_transition() {
     power_mode_reset();
     // Cannot go straight to SLEEP from OFF without RUN/SLEEP_PREP (or based on policy)
-    assert(power_mode_request_transition(POWER_MODE_SLEEP, POWER_REASON_NONE) == -1);
+    assert(power_mode_request_transition(POWER_MODE_SLEEP, POWER_REASON_NONE) == BHARAT_STATUS_ERR_PERMISSION);
 }
 
 int main() {


### PR DESCRIPTION
This PR improves error handling by replacing generic `-1` (and `0` for success) return values with expressive status codes defined in `bharat_status_t` and `BHARAT_IPC_STATUS_*`.

The following files and components were updated:
- `test_vm_manager_caps.c` and `test_process_manager_caps.c`: Updated dummy `bharat_ipc_recv` implementations to return `BHARAT_IPC_STATUS_ERR_INTERNAL`.
- `namesvc/main.c`: Updated initialization checks to return `BHARAT_STATUS_ERR_INTERNAL` and appropriate binding status.
- `power_mode` service (`power_mode.h`, `state_machine.c`, `clients.c`, `policy.c`): Replaced `int` return types with `bharat_status_t` and updated return values to `BHARAT_STATUS_OK`, `BHARAT_STATUS_ERR_PERMISSION`, `BHARAT_STATUS_ERR_UNSUPPORTED`, `BHARAT_STATUS_ERR_INTERNAL`, etc. Updated related unit tests to assert the new enums.
- Legacy `net` service (`control_plane.h`, `control_plane.c`, `data_plane.h`, `data_plane.c`): Changed return types to `bharat_status_t` and used `BHARAT_STATUS_ERR_NOT_FOUND`, `BHARAT_STATUS_ERR_UNSUPPORTED`, and `BHARAT_STATUS_ERR_INTERNAL` for failure cases.

---
*PR created automatically by Jules for task [9918110812886876966](https://jules.google.com/task/9918110812886876966) started by @divyang4481*