### PR TITLE
feat(vm): Introduce bh_vm_caps_t and conditionally enable Linux personality

### DIFF
--- a/core/kernel/include/mm/mem_model.h
+++ b/core/kernel/include/mm/mem_model.h
@@ -59,6 +59,28 @@ typedef struct mem_runtime_caps {
     bool supports_hugepage;
 } mem_runtime_caps_t;
 
+typedef struct bh_vm_caps {
+    bool address_translation;
+    bool per_process_aspace;
+    bool user_kernel_isolation;
+
+    bool page_permissions;
+    bool execute_protection;
+
+    bool demand_faults;
+    bool demand_zero;
+
+    bool cow;
+    bool file_mapping;
+    bool shared_mapping;
+
+    bool fixed_mapping;
+    bool mpu_regions;
+} bh_vm_caps_t;
+
+void bh_vm_get_capabilities(bh_vm_caps_t *out_caps);
+bool bh_vm_satisfies(const bh_vm_caps_t *req);
+
 /**
  * Memory Profile Contract
  */

--- a/core/kernel/src/mm/mem_model.c
+++ b/core/kernel/src/mm/mem_model.c
@@ -42,6 +42,61 @@ kstatus_t mem_runtime_caps_from_hal(const struct hal_mem_caps *hal_caps, mem_run
     return K_OK;
 }
 
+void bh_vm_get_capabilities(bh_vm_caps_t *out_caps) {
+    if (!out_caps) return;
+
+    memset(out_caps, 0, sizeof(bh_vm_caps_t));
+
+    mem_model_t model = mem_model_get_current();
+    if (model == MEM_MODEL_MMU_FULL) {
+        out_caps->address_translation = true;
+        out_caps->per_process_aspace = true;
+        out_caps->user_kernel_isolation = true;
+        out_caps->page_permissions = true;
+        out_caps->execute_protection = true;
+        out_caps->demand_faults = true;
+        out_caps->demand_zero = true;
+        out_caps->cow = true;
+        out_caps->file_mapping = true;
+        out_caps->shared_mapping = true;
+        out_caps->fixed_mapping = true;
+    } else if (model == MEM_MODEL_MMU_LITE) {
+        out_caps->address_translation = true;
+        out_caps->per_process_aspace = true;
+        out_caps->user_kernel_isolation = true;
+        out_caps->page_permissions = true;
+        out_caps->execute_protection = true;
+        // Depending on HAL caps or specific sub-profiles, some MMU_LITE might support more.
+        // For baseline MMU_LITE, we leave COW and demand faults as false unless explicitly known.
+    } else if (model == MEM_MODEL_MPU) {
+        out_caps->mpu_regions = true;
+        out_caps->user_kernel_isolation = true;
+        out_caps->page_permissions = true; // Region-based
+        out_caps->execute_protection = true;
+    }
+}
+
+bool bh_vm_satisfies(const bh_vm_caps_t *req) {
+    if (!req) return false;
+    bh_vm_caps_t caps;
+    bh_vm_get_capabilities(&caps);
+
+    if (req->address_translation && !caps.address_translation) return false;
+    if (req->per_process_aspace && !caps.per_process_aspace) return false;
+    if (req->user_kernel_isolation && !caps.user_kernel_isolation) return false;
+    if (req->page_permissions && !caps.page_permissions) return false;
+    if (req->execute_protection && !caps.execute_protection) return false;
+    if (req->demand_faults && !caps.demand_faults) return false;
+    if (req->demand_zero && !caps.demand_zero) return false;
+    if (req->cow && !caps.cow) return false;
+    if (req->file_mapping && !caps.file_mapping) return false;
+    if (req->shared_mapping && !caps.shared_mapping) return false;
+    if (req->fixed_mapping && !caps.fixed_mapping) return false;
+    if (req->mpu_regions && !caps.mpu_regions) return false;
+
+    return true;
+}
+
 kstatus_t mem_profile_contract_from_build(mem_profile_contract_t *out_contract) {
     if (!out_contract) return K_ERR_INVALID_ARG;
 

--- a/core/personalities/compat/linux/linux_personality.c
+++ b/core/personalities/compat/linux/linux_personality.c
@@ -2,6 +2,7 @@
 #include "bh_personality_registry.h"
 #include "bh_personality.h"
 #include "linux_errno.h"
+#include "mm/mem_model.h"
 #include <stddef.h>
 
 extern const bh_personality_syscall_table_t bh_linux_syscall_table;
@@ -44,6 +45,23 @@ const personality_ops_t *personality_linux_get_ops(void) {
     return &linux_personality_ops;
 }
 
+static const bh_vm_caps_t linux_full_requirements = {
+    .address_translation = true,
+    .per_process_aspace  = true,
+    .page_permissions    = true,
+    .execute_protection  = true,
+    .file_mapping        = true,
+    .cow                 = true,
+};
+
+static const bh_vm_caps_t linux_nommu_requirements = {
+    .page_permissions    = true,
+    .execute_protection  = true,
+    .mpu_regions         = true,
+};
+
 void linux_personality_init(void) {
-    bh_personality_registry_register(BH_PERSONALITY_LINUX, &linux_personality_ops);
+    if (bh_vm_satisfies(&linux_full_requirements) || bh_vm_satisfies(&linux_nommu_requirements)) {
+        bh_personality_registry_register(BH_PERSONALITY_LINUX, &linux_personality_ops);
+    }
 }

--- a/core/personalities/compat/linux/linux_syscall.c
+++ b/core/personalities/compat/linux/linux_syscall.c
@@ -48,6 +48,7 @@ static bh_operation_result_t linux_sys_clock_gettime(bh_syscall_ctx_t *ctx) {
 
 
 #include "mm/aspace.h"
+#include "mm/vm_mapping.h"
 
 #define LINUX_MAP_SHARED    0x01
 #define LINUX_MAP_PRIVATE   0x02
@@ -88,7 +89,7 @@ static bh_status_t linux_translate_mmap_request(bh_syscall_ctx_t *ctx, vm_map_re
         req->object_offset = 0;
     } else {
         // file-backed mappings not yet supported in this stub
-        return BH_ERR_UNSUPPORTED;
+        return BH_ERR_NOT_SUPPORTED;
     }
 
     return BH_OK;
@@ -101,11 +102,11 @@ static bh_operation_result_t linux_sys_mmap(bh_syscall_ctx_t *ctx) {
     if (st != BH_OK) return bh_op_result_value(-linux_errno_from_bh_status((kstatus_t)st));
 
     uintptr_t result;
-    if (!ctx->process || !ctx->process->aspace) {
+    if (!ctx->process || !ctx->process->addr_space) {
         return bh_op_result_value(-LINUX_EINVAL);
     }
 
-    kstatus_t kst = vm_map_region(ctx->process->aspace, &req, &result);
+    kstatus_t kst = vm_map_region(ctx->process->addr_space, &req, &result);
 
     if (kst != K_OK) return bh_op_result_value(-linux_errno_from_bh_status((kstatus_t)kst));
 
@@ -116,11 +117,11 @@ static bh_operation_result_t linux_sys_munmap(bh_syscall_ctx_t *ctx) {
     uintptr_t addr = ctx->regs.arg[0];
     size_t length = ctx->regs.arg[1];
 
-    if (!ctx->process || !ctx->process->aspace) {
+    if (!ctx->process || !ctx->process->addr_space) {
         return bh_op_result_value(-LINUX_EINVAL);
     }
 
-    kstatus_t kst = vm_unmap_region(ctx->process->aspace, addr, length);
+    kstatus_t kst = vm_unmap_region(ctx->process->addr_space, addr, length);
     if (kst != K_OK) return bh_op_result_value(-linux_errno_from_bh_status((kstatus_t)kst));
 
     return bh_op_result_value(0);
@@ -131,11 +132,11 @@ static bh_operation_result_t linux_sys_mprotect(bh_syscall_ctx_t *ctx) {
     size_t length = ctx->regs.arg[1];
     uint32_t prot = ctx->regs.arg[2];
 
-    if (!ctx->process || !ctx->process->aspace) {
+    if (!ctx->process || !ctx->process->addr_space) {
         return bh_op_result_value(-LINUX_EINVAL);
     }
 
-    kstatus_t kst = vm_protect_region(ctx->process->aspace, addr, length, linux_prot_to_bh_prot(prot));
+    kstatus_t kst = vm_protect_region(ctx->process->addr_space, addr, length, linux_prot_to_bh_prot(prot));
     if (kst != K_OK) return bh_op_result_value(-linux_errno_from_bh_status((kstatus_t)kst));
 
     return bh_op_result_value(0);


### PR DESCRIPTION
* Added `bh_vm_caps_t` struct and `bh_vm_satisfies()` API to `core/kernel/include/mm/mem_model.h`.
* Implemented `bh_vm_get_capabilities()` to return capabilities derived from the current memory model (`MEM_MODEL_MMU_FULL`, `MEM_MODEL_MMU_LITE`, `MEM_MODEL_MPU`).
* Modified `linux_personality_init()` to explicitly define requirements for `linux_full` and `linux_nommu` tiers and dynamically check capability satisfaction using `bh_vm_satisfies()`.
* Replaced `aspace` with `addr_space` in `linux_syscall.c` and fixed missing headers to ensure compilation succeeds on the `x86_64_desktop_headless` matrix.

---
*PR created automatically by Jules for task [10165592045266505536](https://jules.google.com/task/10165592045266505536) started by @divyang4481*