### PR TITLE
Fix LVGL build error due to implicit `__linux__` definition

### DIFF
--- a/core/stacks/ui/adapters/lvgl/CMakeLists.txt
+++ b/core/stacks/ui/adapters/lvgl/CMakeLists.txt
@@ -36,6 +36,7 @@ if(BHARAT_UI_LVGL)
     target_compile_definitions(bharat_ui_lvgl_core PUBLIC LV_CONF_INCLUDE_SIMPLE=1)
     target_compile_definitions(bharat_ui_lvgl_core PUBLIC BHARAT_UI_LVGL)
     target_compile_definitions(bharat_ui_lvgl_core PUBLIC "LV_CONF_PATH=\"${CMAKE_SOURCE_DIR}/core/stacks/ui/adapters/lvgl/config/lv_conf_bharat.h\"")
+    target_compile_options(bharat_ui_lvgl_core PRIVATE -U__linux__)
 
     target_link_libraries(bharat_ui_lvgl_core PUBLIC bharat_user_buildopts bharat_libcmin bharat_libruntime bharatc bharat_freestanding)
     if(COMMAND bharat_configure_userspace_library)


### PR DESCRIPTION
Fixes an issue where building the GUI showcase fails during the compilation of LVGL. The failure occurs because the cross-compilation environment defines `__linux__`, causing LVGL to attempt to build `lv_linux.c` with standard POSIX headers (`<stdio.h>`) that are unsupported in the standalone environment. Added `-U__linux__` to the compilation flags to instruct the build correctly.

---
*PR created automatically by Jules for task [408800753145152343](https://jules.google.com/task/408800753145152343) started by @divyang4481*